### PR TITLE
perf(crate): gradient rendering improve, `FastImageBlend`

### DIFF
--- a/takumi/src/node/border.rs
+++ b/takumi/src/node/border.rs
@@ -1,12 +1,12 @@
 use image::{GenericImage, GenericImageView, Rgba, RgbaImage};
-use imageproc::drawing::Blend;
 use imageproc::rect::Rect;
 use taffy::Layout;
 
 use crate::border_radius::{BorderRadius, apply_border_radius_antialiased};
 use crate::color::ColorInput;
 use crate::node::draw::{
-  create_image_from_color_input, draw_filled_rect_from_color_input, draw_image_overlay_fast,
+  FastBlendImage, create_image_from_color_input, draw_filled_rect_from_color_input,
+  draw_image_overlay_fast,
 };
 use crate::node::style::Style;
 
@@ -19,7 +19,7 @@ use crate::node::style::Style;
 /// * `style` - The style containing border properties
 /// * `canvas` - The canvas to draw on
 /// * `layout` - The layout information for positioning
-pub fn draw_border(style: &Style, canvas: &mut Blend<RgbaImage>, layout: &Layout) {
+pub fn draw_border(style: &Style, canvas: &mut FastBlendImage, layout: &Layout) {
   if layout.border.top == 0.0
     && layout.border.right == 0.0
     && layout.border.bottom == 0.0
@@ -44,7 +44,7 @@ pub fn draw_border(style: &Style, canvas: &mut Blend<RgbaImage>, layout: &Layout
 }
 
 /// Draws a rectangular border without rounded corners.
-fn draw_rectangular_border(canvas: &mut Blend<RgbaImage>, layout: &Layout, color: &ColorInput) {
+fn draw_rectangular_border(canvas: &mut FastBlendImage, layout: &Layout, color: &ColorInput) {
   // Top border
   if layout.border.top > 0.0 {
     draw_filled_rect_from_color_input(
@@ -103,7 +103,7 @@ fn draw_rectangular_border(canvas: &mut Blend<RgbaImage>, layout: &Layout, color
 
 /// Draws a rounded border with border radius.
 fn draw_rounded_border(
-  canvas: &mut Blend<RgbaImage>,
+  canvas: &mut FastBlendImage,
   layout: &Layout,
   color: &ColorInput,
   radius: BorderRadius,

--- a/takumi/src/render.rs
+++ b/takumi/src/render.rs
@@ -1,10 +1,13 @@
 use image::{ImageBuffer, RgbaImage};
-use imageproc::drawing::Blend;
 use taffy::{AvailableSpace, NodeId, Point, TaffyTree, geometry::Size};
 
 use crate::{
   context::Context,
-  node::{ContainerNode, Node, draw::draw_debug_border, style::ValuePercentageAuto},
+  node::{
+    ContainerNode, Node,
+    draw::{FastBlendImage, draw_debug_border},
+    style::ValuePercentageAuto,
+  },
 };
 
 /// Type alias for a TaffyTree that uses `Box<dyn Node>` as its node type
@@ -87,7 +90,7 @@ impl ImageRenderer {
     taffy: &mut TaffyTreeWithNodes,
     root_node_id: NodeId,
   ) -> RgbaImage {
-    let mut canvas = Blend(ImageBuffer::new(self.content_width, self.content_height));
+    let mut canvas = FastBlendImage(ImageBuffer::new(self.content_width, self.content_height));
 
     let available_space = Size {
       width: AvailableSpace::Definite(self.content_width as f32),
@@ -136,7 +139,7 @@ impl ImageRenderer {
 /// * `relative_offset` - The offset from the parent node's position
 fn draw_from_node_id_with_layout(
   context: &Context,
-  canvas: &mut Blend<RgbaImage>,
+  canvas: &mut FastBlendImage,
   taffy: &mut TaffyTreeWithNodes,
   node_id: NodeId,
   relative_offset: Point<f32>,


### PR DESCRIPTION
- skip blending if alpha is 255
- skip rendering if alpha is 0
- always create gradient image in parallel