### PR TITLE
Helpers: drop `react-dom` peer-dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,25 @@ jobs:
           path: takumi-helpers/dist
           if-no-files-found: error
 
+  test-helpers:
+    name: Test @takumi-rs/helpers
+    runs-on: ubuntu-latest
+    needs: build-helpers
+    steps:
+      - uses: actions/checkout@v5
+      
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter ./takumi-helpers
+      
+      - name: Test
+        working-directory: takumi-helpers
+        run: bun test
+
   version-check-helpers:
     name: Check version for @takumi-rs/helpers
     if: github.ref == 'refs/heads/master'
@@ -129,7 +148,7 @@ jobs:
 
   publish-helpers:
     name: Publish @takumi-rs/helpers
-    needs: [build-helpers, version-check-helpers]
+    needs: [build-helpers, test-helpers, version-check-helpers]
     if: github.ref == 'refs/heads/master' && needs.version-check-helpers.outputs.exists == 'false'
     runs-on: ubuntu-latest
     steps:
@@ -510,7 +529,7 @@ jobs:
   pass-test:
     name: Pass Test
     runs-on: ubuntu-latest
-    needs: [biome-lint, test-rust, test-napi, test-wasm]
+    needs: [biome-lint, test-rust, test-napi, test-wasm, test-helpers]
     if: always()
     steps: 
       - run: echo "Pass test"

--- a/bun.lock
+++ b/bun.lock
@@ -87,21 +87,16 @@
       "name": "@takumi-rs/helpers",
       "version": "0.28.1",
       "devDependencies": {
-        "@types/bun": "catalog:",
+        "@types/bun": "^1.2.21",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
         "bun-plugin-dts": "^0.3.0",
         "lucide-react": "^0.542.0",
-        "react": "^19.1.0",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
         "tsup": "^8.5.0",
-        "typescript": "catalog:",
+        "typescript": "^5.9.2",
       },
-      "peerDependencies": {
-        "react-dom": "^19.0.0",
-      },
-      "optionalPeers": [
-        "react-dom",
-      ],
     },
     "takumi-napi-core": {
       "name": "@takumi-rs/core",

--- a/takumi-helpers/package.json
+++ b/takumi-helpers/package.json
@@ -41,11 +41,6 @@
     "tsconfig.json"
   ],
   "license": "MIT",
-  "peerDependenciesMeta": {
-    "react-dom": {
-      "optional": true
-    }
-  },
   "scripts": {
     "build": "tsup-node src/index.ts src/jsx/jsx.ts --minify --dts --format esm,cjs --no-splitting"
   },

--- a/takumi-helpers/package.json
+++ b/takumi-helpers/package.json
@@ -10,17 +10,15 @@
     "url": "git+https://github.com/kane50613/takumi.git"
   },
   "devDependencies": {
-    "@types/bun": "catalog:",
+    "@types/bun": "^1.2.21",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "bun-plugin-dts": "^0.3.0",
     "lucide-react": "^0.542.0",
-    "react": "^19.1.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "tsup": "^8.5.0",
-    "typescript": "catalog:"
-  },
-  "peerDependencies": {
-    "react-dom": "^19.0.0"
+    "typescript": "^5.9.2"
   },
   "exports": {
     ".": {

--- a/takumi-helpers/src/jsx/svg.ts
+++ b/takumi-helpers/src/jsx/svg.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement } from "react";
-import { isReactElement } from "./utils";
+import { camelToKebab, isReactElement } from "./utils";
 
 function isTextNode(node: unknown): node is string | number {
   return typeof node === "string" || typeof node === "number";
@@ -22,84 +22,77 @@ function styleObjectToString(styleObj: Record<string, unknown>): string {
     .join(";");
 }
 
-const svgKebabAttrs = [
-  "stop-color",
-  "stop-opacity",
-  "stroke-width",
-  "stroke-dasharray",
-  "stroke-dashoffset",
-  "stroke-linecap",
-  "stroke-linejoin",
-  "fill-rule",
-  "clip-rule",
-  "color-interpolation-filters",
-  "flood-color",
-  "flood-opacity",
-  "accent-height",
-  "alignment-baseline",
-  "arabic-form",
-  "baseline-shift",
-  "cap-height",
-  "clip-path",
-  "clip-path-units",
-  "color-interpolation",
-  "color-profile",
-  "color-rendering",
-  "enable-background",
-  "fill-opacity",
-  "font-family",
-  "font-size",
-  "font-size-adjust",
-  "font-stretch",
-  "font-style",
-  "font-variant",
-  "font-weight",
-  "glyph-name",
-  "glyph-orientation-horizontal",
-  "glyph-orientation-vertical",
-  "horiz-adv-x",
-  "horiz-origin-x",
-  "image-rendering",
-  "letter-spacing",
-  "lighting-color",
-  "marker-end",
-  "marker-mid",
-  "marker-start",
-  "overline-position",
-  "overline-thickness",
-  "paint-order",
-  "preserve-aspect-ratio",
-  "pointer-events",
-  "shape-rendering",
-  "stroke-miterlimit",
-  "stroke-opacity",
-  "text-anchor",
-  "text-decoration",
-  "text-rendering",
-  "transform-origin",
-  "underline-position",
-  "underline-thickness",
-  "unicode-bidi",
-  "unicode-range",
-  "units-per-em",
-  "vector-effect",
-  "vert-adv-y",
-  "vert-origin-x",
-  "vert-origin-y",
-  "v-alphabetic",
-  "v-hanging",
-  "v-ideographic",
-  "v-mathematical",
-  "word-spacing",
-  "writing-mode",
+const propertiesToKebabCase = [
+  "stopColor",
+  "stopOpacity",
+  "strokeWidth",
+  "strokeDasharray",
+  "strokeDashoffset",
+  "strokeLinecap",
+  "strokeLinejoin",
+  "fillRule",
+  "clipRule",
+  "colorInterpolationFilters",
+  "floodColor",
+  "floodOpacity",
+  "accentHeight",
+  "alignmentBaseline",
+  "arabicForm",
+  "baselineShift",
+  "capHeight",
+  "clipPath",
+  "clipPathUnits",
+  "colorInterpolation",
+  "colorProfile",
+  "colorRendering",
+  "enableBackground",
+  "fillOpacity",
+  "fontFamily",
+  "fontSize",
+  "fontSizeAdjust",
+  "fontStretch",
+  "fontStyle",
+  "fontVariant",
+  "fontWeight",
+  "glyphName",
+  "glyphOrientationHorizontal",
+  "glyphOrientationVertical",
+  "horizAdvX",
+  "horizOriginX",
+  "imageRendering",
+  "letterSpacing",
+  "lightingColor",
+  "markerEnd",
+  "markerMid",
+  "markerStart",
+  "overlinePosition",
+  "overlineThickness",
+  "paintOrder",
+  "preserveAspectRatio",
+  "pointerEvents",
+  "shapeRendering",
+  "strokeMiterlimit",
+  "strokeOpacity",
+  "textAnchor",
+  "textDecoration",
+  "textRendering",
+  "transformOrigin",
+  "underlinePosition",
+  "underlineThickness",
+  "unicodeBidi",
+  "unicodeRange",
+  "unitsPerEm",
+  "vectorEffect",
+  "vertAdvY",
+  "vertOriginX",
+  "vertOriginY",
+  "vAlphabetic",
+  "vHanging",
+  "vIdeographic",
+  "vMathematical",
+  "wordSpacing",
+  "writingMode",
 ];
-
-const svgAttrMap: Record<string, string> = Object.fromEntries(
-  svgKebabAttrs.map((kebab) => {
-    const camel = kebab.replace(/-([a-z])/g, (_m, c) => c.toUpperCase());
-    return [camel, kebab];
-  }),
-);
 
 function serializePropToAttrString(
   key: string,
@@ -111,11 +104,10 @@ function serializePropToAttrString(
   let attrName: string;
   if (key === "className") {
     attrName = "class";
-  } else if (svgAttrMap[key]) {
-    attrName = svgAttrMap[key];
+  } else if (propertiesToKebabCase.includes(key)) {
+    attrName = camelToKebab(key);
   } else {
-    const possibleKebab = key.replace(/([A-Z])/g, "-$1").toLowerCase();
-    attrName = svgKebabAttrs.includes(possibleKebab) ? possibleKebab : key;
+    attrName = key;
   }
 
   if (typeof value === "boolean") {

--- a/takumi-helpers/src/jsx/svg.ts
+++ b/takumi-helpers/src/jsx/svg.ts
@@ -1,0 +1,183 @@
+import type { ComponentProps, ReactElement } from "react";
+import { isReactElement } from "./utils";
+
+function isTextNode(node: unknown): node is string | number {
+  return typeof node === "string" || typeof node === "number";
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function styleObjectToString(styleObj: Record<string, unknown>): string {
+  return Object.keys(styleObj)
+    .map(
+      (k) =>
+        `${k.replace(/([A-Z])/g, "-$1").toLowerCase()}:${String(styleObj[k]).trim()}`,
+    )
+    .join(";");
+}
+
+const svgKebabAttrs = [
+  "stop-color",
+  "stop-opacity",
+  "stroke-width",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "fill-rule",
+  "clip-rule",
+  "color-interpolation-filters",
+  "flood-color",
+  "flood-opacity",
+  "accent-height",
+  "alignment-baseline",
+  "arabic-form",
+  "baseline-shift",
+  "cap-height",
+  "clip-path",
+  "clip-path-units",
+  "color-interpolation",
+  "color-profile",
+  "color-rendering",
+  "enable-background",
+  "fill-opacity",
+  "font-family",
+  "font-size",
+  "font-size-adjust",
+  "font-stretch",
+  "font-style",
+  "font-variant",
+  "font-weight",
+  "glyph-name",
+  "glyph-orientation-horizontal",
+  "glyph-orientation-vertical",
+  "horiz-adv-x",
+  "horiz-origin-x",
+  "image-rendering",
+  "letter-spacing",
+  "lighting-color",
+  "marker-end",
+  "marker-mid",
+  "marker-start",
+  "overline-position",
+  "overline-thickness",
+  "paint-order",
+  "preserve-aspect-ratio",
+  "pointer-events",
+  "shape-rendering",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "text-anchor",
+  "text-decoration",
+  "text-rendering",
+  "transform-origin",
+  "underline-position",
+  "underline-thickness",
+  "unicode-bidi",
+  "unicode-range",
+  "units-per-em",
+  "vector-effect",
+  "vert-adv-y",
+  "vert-origin-x",
+  "vert-origin-y",
+  "v-alphabetic",
+  "v-hanging",
+  "v-ideographic",
+  "v-mathematical",
+  "word-spacing",
+  "writing-mode",
+];
+
+const svgAttrMap: Record<string, string> = Object.fromEntries(
+  svgKebabAttrs.map((kebab) => {
+    const camel = kebab.replace(/-([a-z])/g, (_m, c) => c.toUpperCase());
+    return [camel, kebab];
+  }),
+);
+
+function serializePropToAttrString(
+  key: string,
+  value: unknown,
+): string | undefined {
+  if (key === "children" || value == null) return;
+
+  // Determine the final attribute name (handle className and known SVG mappings)
+  let attrName: string;
+  if (key === "className") {
+    attrName = "class";
+  } else if (svgAttrMap[key]) {
+    attrName = svgAttrMap[key];
+  } else {
+    const possibleKebab = key.replace(/([A-Z])/g, "-$1").toLowerCase();
+    attrName = svgKebabAttrs.includes(possibleKebab) ? possibleKebab : key;
+  }
+
+  if (typeof value === "boolean") {
+    // For SVG serialization we want boolean attributes to be explicit like
+    // `focusable="true"` to match react-dom server output.
+    return `${attrName}="${String(value)}"`;
+  }
+
+  if (key === "style" && typeof value === "object") {
+    const styleString = styleObjectToString(value as Record<string, unknown>);
+    if (styleString) return `style="${escapeAttr(styleString)}"`;
+  }
+
+  return `${attrName}="${escapeAttr(String(value))}"`;
+}
+
+function propsToAttrStrings(props: Record<string, unknown>): string[] {
+  return Object.entries(props)
+    .map(([key, value]) => serializePropToAttrString(key, value))
+    .filter((attr): attr is string => attr !== undefined);
+}
+
+const serializeElementNode = (
+  obj: ReactElement,
+  serializeFn: (n: unknown) => string,
+): string => {
+  const props = (obj.props as Record<string, unknown>) || {};
+
+  const attrs = propsToAttrStrings(props);
+  const children = props.children;
+  const childrenString = Array.isArray(children)
+    ? children.map((c) => serializeFn(c)).join("")
+    : serializeFn(children);
+
+  return `<${obj.type}${attrs.length > 0 ? ` ${attrs.join(" ")}` : ""}>${childrenString}</${obj.type}>`;
+};
+
+const serialize = (node: unknown): string => {
+  if (node === null || node === undefined || node === false) return "";
+  if (isTextNode(node)) return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isReactElement(node)) return "";
+
+  return serializeElementNode(node, serialize);
+};
+
+export function serializeSvg(
+  element: ReactElement<ComponentProps<"svg">>,
+): string {
+  const props = (element.props as Record<string, unknown>) || {};
+
+  if (!("xmlns" in props)) {
+    const cloned: ReactElement = {
+      ...element,
+      props: {
+        ...props,
+        xmlns: "http://www.w3.org/2000/svg",
+      },
+    } as ReactElement;
+
+    return serialize(cloned) || "";
+  }
+
+  return serialize(element) || "";
+}

--- a/takumi-helpers/src/jsx/utils.ts
+++ b/takumi-helpers/src/jsx/utils.ts
@@ -15,3 +15,7 @@ export function isReactElement(element: unknown): element is ReactElement {
     typeof element.type === "string"
   );
 }
+
+export function camelToKebab(camel: string): string {
+  return camel.replace(/([A-Z])/g, "-$1").toLowerCase();
+}

--- a/takumi-helpers/src/jsx/utils.ts
+++ b/takumi-helpers/src/jsx/utils.ts
@@ -1,0 +1,17 @@
+import type { ComponentProps, JSX, ReactElement } from "react";
+
+export function isHtmlElement<T extends keyof JSX.IntrinsicElements>(
+  element: ReactElement,
+  type: T,
+): element is ReactElement<ComponentProps<T>> {
+  return element.type === type;
+}
+
+export function isReactElement(element: unknown): element is ReactElement {
+  return (
+    typeof element === "object" &&
+    element !== null &&
+    "type" in element &&
+    typeof element.type === "string"
+  );
+}

--- a/takumi-helpers/test/jsx/svg-serialize.test.tsx
+++ b/takumi-helpers/test/jsx/svg-serialize.test.tsx
@@ -1,0 +1,86 @@
+/** biome-ignore-all lint/correctness/useUniqueElementIds: This is not in React runtime */
+/** biome-ignore-all lint/a11y/noSvgWithoutTitle: This is not in React runtime */
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { serializeSvg } from "../../src/jsx/svg";
+
+test("serializeSvg matches react-dom server output for SVG", () => {
+  const component = (
+    <svg
+      width="60"
+      height="60"
+      viewBox="0 0 180 180"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Logo</title>
+      <circle cx="90" cy="90" r="86" fill="url(#logo-iconGradient)" />
+      <defs>
+        <linearGradient id="logo-iconGradient" gradientTransform="rotate(45)">
+          <stop offset="45%" stopColor="black" />
+          <stop offset="100%" stopColor="white" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+
+  const expected = renderToStaticMarkup(component);
+  const actual = serializeSvg(component);
+
+  expect(actual).toBe(expected);
+});
+
+test("serializeSvg handles camelCase SVG props and boolean attributes", () => {
+  const component = (
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <filter id="f" colorInterpolationFilters="sRGB">
+          <feDropShadow
+            dx="0"
+            dy="0"
+            stdDeviation="4"
+            floodColor="white"
+            floodOpacity="1"
+          />
+        </filter>
+      </defs>
+      <rect x="0" y="0" width="10" height="10" fillOpacity={0.5} focusable />
+    </svg>
+  );
+
+  const expected = renderToStaticMarkup(component);
+  const actual = serializeSvg(component);
+
+  expect(actual).toBe(expected);
+});
+
+test("serializeSvg preserves style objects and converts camelCase style keys", () => {
+  const component = (
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect style={{ strokeWidth: 2, strokeDasharray: "4 2" }} />
+    </svg>
+  );
+
+  const expected = renderToStaticMarkup(component);
+  const actual = serializeSvg(component);
+
+  expect(actual).toBe(expected);
+});
+
+test("serializeSvg adds xmlns when not provided", () => {
+  const component = (
+    <svg>
+      <rect x="0" y="0" width="10" height="10" />
+    </svg>
+  );
+
+  const expected = renderToStaticMarkup(
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="10" height="10" />
+    </svg>,
+  );
+
+  const actual = serializeSvg(component);
+
+  expect(actual).toBe(expected);
+});


### PR DESCRIPTION
Replace `renderToStaticMarkup()` call with our own `serializeSvg()` function 

`react` / `react-dom` is kept as dev dependencies for testing