### PR TITLE
Docs: Add Nitro SSR documentation for Takumi integration

### DIFF
--- a/docs/content/docs/getting-started/nitro-ssr.mdx
+++ b/docs/content/docs/getting-started/nitro-ssr.mdx
@@ -5,7 +5,7 @@ description: Integrate Takumi with Nitro-based full‑stack frameworks (e.g., Ta
 
 Takumi provides [N-API bindings](https://napi.rs/) for Node.js and Bun, leveraging Node.js's libuv thread pool for multi-threaded image generation.
 
-Check out the [Next.js example](https://github.com/kane50613/takumi/blob/master/example/nextjs) for a full‑functioning example of using Takumi in a Node.js environment.
+Check out the [TanStack Start example](https://github.com/kane50613/takumi/blob/master/example/tanstack-start) for a full‑functioning example of using Takumi in SSR.
 
 <Callout>
 If you are considering using Takumi in any framework or as an endpoint, see the **From Next.js ImageResponse** guide for usage of the `@takumi-rs/image-response` package.


### PR DESCRIPTION
Added documentation for integrating Takumi with Nitro-based frameworks, including installation and configuration instructions.