### PR TITLE
Add Apple Color Emoji font to fix emoji rendering

### DIFF
--- a/takumi-napi-core/src/renderer.rs
+++ b/takumi-napi-core/src/renderer.rs
@@ -136,8 +136,8 @@ const EMBEDDED_FONTS: &[(&[u8], &str, GenericFamily)] = &[
     GenericFamily::Monospace,
   ),
   (
-    include_bytes!("../../assets/fonts/emoji/AppleColorEmoji.ttf"),
-    "Apple Color Emoji",
+    include_bytes!("../../assets/fonts/noto-sans/NotoColorEmoji.ttf"),
+    "Noto Color Emoji",
     GenericFamily::Emoji,
   ),
 ];

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -41,11 +41,6 @@ const TEST_FONTS: &[(&str, &str, GenericFamily)] = &[
     "Noto Color Emoji",
     GenericFamily::Emoji,
   ),
-  (
-    "fonts/emoji/AppleColorEmoji.ttf",
-    "Apple Color Emoji",
-    GenericFamily::Emoji,
-  ),
 ];
 
 fn create_test_context() -> GlobalContext {


### PR DESCRIPTION
Emojis aren't looking very nice 😢😿😭😞 
<img width="1514" height="867" alt="Screenshot 2025-11-21 at 4 16 35 pm" src="https://github.com/user-attachments/assets/aace2e16-dc8f-477d-b6ef-7c98f8865cb6" />

This pr: 
- Add Apple Color Emoji font file to assets
- Include Apple Color Emoji in takumi-napi-core/src/renderer.rs
- Update test utilities to also include Apple Color Emoji font

I grabbed the apple color emoji from https://github.com/samuelngs/apple-emoji-linux

I did this fix with mutliple qwen terminals and tested the binaries locally and it seemed to have fixed it but i'm never touched rust before 🙏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Apple Color Emoji font into the default font loading sequence, enabling proper emoji rendering throughout the application without requiring additional configuration.

* **Tests**
  * Enhanced test coverage to validate emoji font rendering alongside existing font configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->