### PR TITLE
Crate, NAPI: drop `avif` format support

### DIFF
--- a/.changeset/cruel-jars-relax.md
+++ b/.changeset/cruel-jars-relax.md
@@ -1,0 +1,6 @@
+---
+"@takumi-rs/core": minor
+"takumi": minor
+---
+
+drop `avif` format support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
- "rayon",
 ]
 
 [[package]]
@@ -1216,7 +1215,6 @@ dependencies = [
  "png 0.18.0",
  "ravif",
  "rayon",
- "rgb",
  "zune-core",
  "zune-jpeg",
 ]
@@ -1469,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can try out Takumi in [Playground](https://takumi.kane.tw/playground) withou
 - Variable fonts support.
 - COLR font support (e.g. twemoji-colr).
 - WOFF2 font format support.
-- PNG, JPEG, WebP, AVIF output support.
+- PNG, JPEG, WebP output support.
 - WebP, APNG animation rendering support.
 
 ## Goals

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -299,5 +299,5 @@ More discussion can be found in [this X thread by @shuding_](https://x.com/shudi
 - Variable fonts support.
 - COLR font support (e.g. twemoji-colr).
 - WOFF2 font format support.
-- PNG, JPEG, WebP, AVIF output support.
+- PNG, JPEG, WebP output support.
 - WebP, APNG animation rendering support.

--- a/takumi-image-response/src/backends/node.ts
+++ b/takumi-image-response/src/backends/node.ts
@@ -125,13 +125,11 @@ function createStream(component: ReactNode, options?: ImageResponseOptions) {
 
 const contentTypeMapping = {
   webp: "image/webp",
-  avif: "image/avif",
   png: "image/png",
   jpeg: "image/jpeg",
   WebP: "image/webp",
   Jpeg: "image/jpeg",
   Png: "image/png",
-  Avif: "image/avif",
   raw: "application/octet-stream",
 };
 

--- a/takumi-napi-core/Cargo.toml
+++ b/takumi-napi-core/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam-channel = "0.5"
 
 [dependencies.takumi]
 path = "../takumi"
-features = ["woff2", "woff", "svg", "rayon", "avif"]
+features = ["woff2", "woff", "svg", "rayon"]
 default-features = false
 
 [dependencies.napi]
@@ -26,7 +26,6 @@ features = ["napi10", "serde-json"]
 
 [dependencies.napi-derive]
 version = "3"
-features = ["type-def"]
 
 [build-dependencies]
 napi-build = "2"

--- a/takumi-napi-core/src/renderer.rs
+++ b/takumi-napi-core/src/renderer.rs
@@ -81,13 +81,10 @@ pub enum AnimationOutputFormat {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
   webp,
-  avif,
   png,
   jpeg,
   /// @deprecated Use lowercase `webp` instead, may be removed in the future
   WebP,
-  /// @deprecated Use lowercase `avif` instead, may be removed in the future
-  Avif,
   /// @deprecated Use lowercase `jpeg` instead, may be removed in the future
   Jpeg,
   /// @deprecated Use lowercase `png` instead, may be removed in the future
@@ -99,7 +96,6 @@ impl From<OutputFormat> for ImageOutputFormat {
   fn from(format: OutputFormat) -> Self {
     match format {
       OutputFormat::WebP | OutputFormat::webp => ImageOutputFormat::WebP,
-      OutputFormat::Avif | OutputFormat::avif => ImageOutputFormat::Avif,
       OutputFormat::Jpeg | OutputFormat::jpeg => ImageOutputFormat::Jpeg,
       OutputFormat::Png | OutputFormat::png => ImageOutputFormat::Png,
       // SAFETY: It's handled in the render task

--- a/takumi-napi-core/tests/bench/index.tsx
+++ b/takumi-napi-core/tests/bench/index.tsx
@@ -68,15 +68,6 @@ summary(() => {
       format: "webp",
     });
   });
-
-  bench("createNode + render (avif)", async () => {
-    const node = await createNode();
-    return renderer.render(node, {
-      width: 1200,
-      height: 630,
-      format: "avif",
-    });
-  });
 });
 
 summary(() => {

--- a/takumi-napi-core/tests/render.test.ts
+++ b/takumi-napi-core/tests/render.test.ts
@@ -121,15 +121,6 @@ describe("render", () => {
     expect(result).toBeInstanceOf(Buffer);
   });
 
-  test("avif", async () => {
-    const result = await renderer.render(node, {
-      ...options,
-      format: "avif",
-    });
-
-    expect(result).toBeInstanceOf(Buffer);
-  });
-
   test("png", async () => {
     const result = await renderer.render(node, {
       ...options,

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -84,12 +84,11 @@ default-features = false
 features = ["std", "simd"]
 
 [features]
-default = ["woff2", "woff", "svg", "rayon", "avif"]
-avif = ["image/avif"]
+default = ["woff2", "woff", "svg", "rayon"]
 svg = ["dep:resvg"]
 woff2 = ["dep:wuff", "wuff/brotli"]
 woff = ["dep:wuff", "wuff/z"]
-rayon = ["dep:rayon", "image/rayon", "dashmap/rayon", "fast_image_resize/rayon"]
+rayon = ["dep:rayon", "fast_image_resize/rayon"]
 
 [dev-dependencies]
 serde_json = "1"

--- a/takumi/README.md
+++ b/takumi/README.md
@@ -70,7 +70,6 @@ let image = render(options).unwrap();
 - `woff`: Enable WOFF font support.
 - `svg`: Enable SVG support.
 - `rayon`: Enable rayon support.
-- `avif`: Enable AVIF support.
 
 ## Credits
 

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -88,7 +88,6 @@
 //! - `woff`: Enable WOFF font support.
 //! - `svg`: Enable SVG support.
 //! - `rayon`: Enable rayon support.
-//! - `avif`: Enable AVIF support.
 //!
 //! # Credits
 //!

--- a/takumi/src/rendering/write.rs
+++ b/takumi/src/rendering/write.rs
@@ -19,10 +19,6 @@ pub enum ImageOutputFormat {
   /// It is useful for images in web contents.
   WebP,
 
-  /// AVIF typically offers better compression than WebP/PNG but requires significant more CPU time.
-  #[cfg(feature = "avif")]
-  Avif,
-
   /// PNG image format, lossless and widely supported, and its the fastest format to encode.
   Png,
 
@@ -35,8 +31,6 @@ impl ImageOutputFormat {
   pub fn content_type(&self) -> &'static str {
     match self {
       ImageOutputFormat::WebP => "image/webp",
-      #[cfg(feature = "avif")]
-      ImageOutputFormat::Avif => "image/avif",
       ImageOutputFormat::Png => "image/png",
       ImageOutputFormat::Jpeg => "image/jpeg",
     }
@@ -47,8 +41,6 @@ impl From<ImageOutputFormat> for ImageFormat {
   fn from(format: ImageOutputFormat) -> Self {
     match format {
       ImageOutputFormat::WebP => Self::WebP,
-      #[cfg(feature = "avif")]
-      ImageOutputFormat::Avif => Self::Avif,
       ImageOutputFormat::Png => Self::Png,
       ImageOutputFormat::Jpeg => Self::Jpeg,
     }
@@ -120,21 +112,6 @@ pub fn write_image<T: Write>(
 
       let encoder = JpegEncoder::new_with_quality(destination, quality.unwrap_or(75));
       encoder.write_image(&rgb, image.width(), image.height(), ExtendedColorType::Rgb8)?;
-    }
-    #[cfg(feature = "avif")]
-    ImageOutputFormat::Avif => {
-      let encoder = image::codecs::avif::AvifEncoder::new_with_speed_quality(
-        destination,
-        10,
-        quality.unwrap_or(75),
-      );
-
-      encoder.write_image(
-        image.as_raw(),
-        image.width(),
-        image.height(),
-        ExtendedColorType::Rgba8,
-      )?;
     }
     ImageOutputFormat::Png => {
       let has_alpha = has_any_alpha_pixel(image);


### PR DESCRIPTION
- no one is using it
- introduces hugeeeeee dependency tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * AVIF image output format is no longer supported. PNG, JPEG, and WebP remain available for image output.

* **Documentation**
  * Updated supported image formats documentation and feature lists to reflect the removal of AVIF capabilities.

* **Chores**
  * Removed AVIF feature dependencies and internal configurations related to image encoding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->