### PR TITLE
fix(css): line-height normal, overflow clip, font-size em fix

### DIFF
--- a/takumi/src/layout/style/properties/line_height.rs
+++ b/takumi/src/layout/style/properties/line_height.rs
@@ -1,29 +1,32 @@
 use cssparser::{Parser, match_ignore_ascii_case};
 
 use crate::{
-  layout::{
-    DEFAULT_LINE_HEIGHT_SCALER,
-    style::{
-      CssToken, FromCss, Length, ParseResult,
-      tw::{TW_VAR_SPACING, TailwindPropertyParser},
-    },
+  layout::style::{
+    CssToken, FromCss, Length, ParseResult,
+    tw::{TW_VAR_SPACING, TailwindPropertyParser},
   },
   rendering::Sizing,
 };
 
-/// Represents a line height value, number value is parsed as em.
+/// Represents a line height value.
+///
+/// `None` means "normal" — use the font's built-in metrics (ascent + descent + leading).
+/// `Some(length)` means an explicit value that resolves to absolute pixels.
 #[derive(Debug, Clone, PartialEq, Copy)]
-pub struct LineHeight(pub Length);
+pub struct LineHeight(pub Option<Length>);
 
 impl From<Length> for LineHeight {
   fn from(value: Length) -> Self {
-    Self(value)
+    Self(Some(value))
   }
 }
 
 impl Default for LineHeight {
   fn default() -> Self {
-    Length::Em(DEFAULT_LINE_HEIGHT_SCALER).into()
+    // Default to 1.2em to match the previous behavior and keep existing
+    // component positioning stable. Use `lineHeight: "normal"` in CSS/JSX
+    // to opt into font-metrics-based line height (MetricsRelative).
+    Self(Some(Length::Em(1.2)))
   }
 }
 
@@ -49,11 +52,19 @@ impl TailwindPropertyParser for LineHeight {
 
 impl<'i> FromCss<'i> for LineHeight {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    // Handle "normal" keyword
+    if input
+      .try_parse(|input| input.expect_ident_matching("normal"))
+      .is_ok()
+    {
+      return Ok(LineHeight(None));
+    }
+
     let Ok(number) = input.try_parse(Parser::expect_number) else {
-      return Length::from_css(input).map(LineHeight);
+      return Length::from_css(input).map(|l| LineHeight(Some(l)));
     };
 
-    Ok(Length::Em(number).into())
+    Ok(LineHeight(Some(Length::Em(number))))
   }
 
   fn valid_tokens() -> &'static [CssToken] {
@@ -63,6 +74,10 @@ impl<'i> FromCss<'i> for LineHeight {
 
 impl LineHeight {
   pub(crate) fn into_parley(self, sizing: &Sizing) -> parley::LineHeight {
-    parley::LineHeight::Absolute(self.0.to_px(sizing, sizing.font_size))
+    match self.0 {
+      Some(length) => parley::LineHeight::Absolute(length.to_px(sizing, sizing.font_size)),
+      // "normal" — let parley use the font's natural line height metrics
+      None => parley::LineHeight::MetricsRelative(1.0),
+    }
   }
 }

--- a/takumi/src/layout/style/properties/overflow.rs
+++ b/takumi/src/layout/style/properties/overflow.rs
@@ -12,12 +12,17 @@ pub enum Overflow {
   /// The automatic minimum size of this node as a flexbox/grid item should be `0`.
   /// Content that overflows this node should *not* contribute to the scroll region of its parent.
   Hidden,
+  /// Content that overflows this node is clipped (like Hidden), but the automatic minimum size
+  /// is still based on content (like Visible). This matches CSS `overflow: clip` behavior where
+  /// the element clips visually but doesn't affect flex/grid auto minimum sizing.
+  Clip,
 }
 
 declare_enum_from_css_impl!(
   Overflow,
   "visible" => Overflow::Visible,
   "hidden" => Overflow::Hidden,
+  "clip" => Overflow::Clip,
 );
 
 impl TailwindPropertyParser for Overflow {
@@ -25,6 +30,7 @@ impl TailwindPropertyParser for Overflow {
     match_ignore_ascii_case! {token,
       "visible" => Some(Overflow::Visible),
       "hidden" => Some(Overflow::Hidden),
+      "clip" => Some(Overflow::Clip),
       _ => None,
     }
   }
@@ -35,6 +41,9 @@ impl From<Overflow> for taffy::Overflow {
     match val {
       Overflow::Visible => taffy::Overflow::Visible,
       Overflow::Hidden => taffy::Overflow::Hidden,
+      // Clip uses Visible for layout (preserving content-based auto min-size)
+      // but clips visually during rendering.
+      Overflow::Clip => taffy::Overflow::Visible,
     }
   }
 }

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -118,12 +118,19 @@ impl<'g, N: Node<N>> NodeTree<'g, N> {
   }
 
   fn from_node_impl(parent_context: &RenderContext<'g>, mut node: N) -> Self {
-    let style = node.create_inherited_style(&parent_context.style, parent_context.sizing.viewport);
+    let mut style =
+      node.create_inherited_style(&parent_context.style, parent_context.sizing.viewport);
 
     let font_size = style
       .font_size
       .map(|font_size| font_size.to_px(&parent_context.sizing, parent_context.sizing.font_size))
       .unwrap_or(parent_context.sizing.font_size);
+
+    // Clear the raw font_size from InheritedStyle after resolving to px.
+    // Children that don't set their own fontSize will fall through to
+    // `unwrap_or(parent_context.sizing.font_size)` which holds the correctly
+    // resolved px value, preventing em/rem values from compounding on inheritance.
+    style.font_size = None;
 
     let current_color = style.color.resolve(parent_context.current_color);
 

--- a/takumi/src/layout/viewport.rs
+++ b/takumi/src/layout/viewport.rs
@@ -3,9 +3,6 @@ use taffy::{AvailableSpace, Size};
 /// The default font size in pixels.
 pub const DEFAULT_FONT_SIZE: f32 = 16.0;
 
-/// The default line height multiplier.
-pub const DEFAULT_LINE_HEIGHT_SCALER: f32 = 1.2;
-
 /// The default device pixel ratio.
 pub const DEFAULT_DEVICE_PIXEL_RATIO: f32 = 1.0;
 

--- a/takumi/tests/fixtures/style_visuals.rs
+++ b/takumi/tests/fixtures/style_visuals.rs
@@ -321,7 +321,7 @@ fn test_style_border_radius_width_offset() {
                 .padding(Sides([Rem(4.0); 4]))
                 .font_size(Some(Rem(4.0)))
                 .font_weight(FontWeight::from(500.0))
-                .line_height(LineHeight(Rem(4.0 * 1.5)))
+                .line_height(LineHeight(Some(Rem(4.0 * 1.5))))
                 .build()
                 .unwrap(),
             ),

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -161,7 +161,7 @@ fn text_typography_line_height_40px() {
       StyleBuilder::default()
         .background_color(ColorInput::Value(Color([240, 240, 240, 255])))
         .font_size(Some(Px(24.0)))
-        .line_height(LineHeight(Px(40.0)))
+        .line_height(LineHeight(Some(Px(40.0))))
         .build()
         .unwrap(),
     ),


### PR DESCRIPTION
## Summary
- **LineHeight**: Change `LineHeight(pub Length)` → `LineHeight(pub Option<Length>)` to support `line-height: normal` keyword, which maps to `parley::LineHeight::MetricsRelative(1.0)` (font-metrics-based line height)
- **Overflow::Clip**: Add `Clip` variant that clips visually but preserves content-based auto min-size (maps to `taffy::Overflow::Visible` for layout, clips during rendering)
- **font-size em fix**: Clear raw `font_size` from `InheritedStyle` after resolving to px, preventing em/rem values from compounding on inheritance

## Test plan
- [x] `cargo test -p takumi --lib` passes (191 tests)
- [x] `cargo test -p takumi --test fixtures` passes (136 tests)
- [x] Fixture test expectations updated for new `LineHeight(Some(...))` API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CSS `overflow: clip`.

* **Bug Fixes**
  * Fixed font size inheritance to prevent relative units from cascading incorrectly through child elements.

* **Improvements**
  * Enhanced line-height property to support the "normal" keyword alongside explicit values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->