### PR TITLE
refactor(helpers): update twemoji to v17

### DIFF
--- a/.changeset/vast-places-mix.md
+++ b/.changeset/vast-places-mix.md
@@ -1,5 +1,5 @@
 ---
-"@takumi-rs/helpers": major
+"@takumi-rs/helpers": patch
 ---
 
 Update Twemoji to v17

--- a/.changeset/vast-places-mix.md
+++ b/.changeset/vast-places-mix.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/helpers": major
+---
+
+Update Twemoji to v17

--- a/takumi-helpers/src/emoji.ts
+++ b/takumi-helpers/src/emoji.ts
@@ -29,7 +29,7 @@ function getIconCode(char: string) {
 
 const apis = {
   twemoji: (code: string) =>
-    `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${code.toLowerCase()}.svg`,
+    `https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/${code.toLowerCase()}.svg`,
   openmoji: "https://cdn.jsdelivr.net/npm/@svgmoji/openmoji@2.0.0/svg/",
   blobmoji: "https://cdn.jsdelivr.net/npm/@svgmoji/blob@2.0.0/svg/",
   noto: "https://cdn.jsdelivr.net/gh/svgmoji/svgmoji/packages/svgmoji__noto/svg/",

--- a/takumi-helpers/test/emoji.test.ts
+++ b/takumi-helpers/test/emoji.test.ts
@@ -20,7 +20,7 @@ describe("emoji", () => {
           children: [
             text("Hello "),
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f600.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f600.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -43,7 +43,7 @@ describe("emoji", () => {
         container({
           children: [
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f600.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f600.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -54,7 +54,7 @@ describe("emoji", () => {
             }),
             text(" transformation "),
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f680.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f680.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -78,7 +78,7 @@ describe("emoji", () => {
         container({
           children: [
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f468-200d-1f469-200d-1f467-200d-1f466.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f468-200d-1f469-200d-1f467-200d-1f466.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -102,7 +102,7 @@ describe("emoji", () => {
           children: [
             text("US flag "),
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f1fa-1f1f8.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f1fa-1f1f8.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -126,7 +126,7 @@ describe("emoji", () => {
           children: [
             text("Press "),
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/31-20e3.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/31-20e3.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -146,7 +146,7 @@ describe("emoji", () => {
       const configs = [
         {
           type: "twemoji",
-          expectedSrc: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f600.svg",
+          expectedSrc: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f600.svg",
         },
         {
           type: "blobmoji",
@@ -212,7 +212,7 @@ describe("emoji", () => {
           style: { color: "red" },
           children: [
             image({
-              src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f600.svg",
+              src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f600.svg",
               style: {
                 display: "inline-block",
                 width: "1em",
@@ -250,7 +250,7 @@ describe("emoji", () => {
                   children: [
                     text("Nested "),
                     image({
-                      src: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f600.svg",
+                      src: "https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f600.svg",
                       style: {
                         display: "inline-block",
                         width: "1em",


### PR DESCRIPTION
Twemoji was forked by the original team that created it (before being laid off) and has been getting maintained since then.

As such, I have updated the link for the Twemoji SVGs.

See here for more details: https://github.com/jdecked/twemoji

> [!IMPORTANT]
> The changeset CLI (`bunx changeset`) thinks this is a major bump. However, I believe this to be incorrect.
>
> I have mentioned this below also: https://github.com/kane50613/takumi/pull/658#discussion_r3073581942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated emoji asset source to Twemoji v17.0.2 via a new CDN path for improved coverage and stability.
  * Added a changeset recording a patch release that updates Twemoji to v17.0.2.
* **Tests**
  * Updated emoji-related test expectations to reference the new Twemoji v17.0.2 asset URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->