### PR TITLE
JS: remove `ReadableStream.type` param

### DIFF
--- a/.changeset/spicy-timers-compare.md
+++ b/.changeset/spicy-timers-compare.md
@@ -1,0 +1,5 @@
+---
+"takumi-js": patch
+---
+
+Remove `ReadableStream.type` param

--- a/takumi-js/src/response/index.ts
+++ b/takumi-js/src/response/index.ts
@@ -89,7 +89,6 @@ export function createImageResponse(defaultOptions?: ImageResponseOptions): Imag
     });
 
     const stream = new ReadableStream({
-      type: "bytes",
       async start(controller) {
         try {
           const image = await render(element, mergedOptions);


### PR DESCRIPTION
hopefully fixes #672 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image response streaming for greater stability and compatibility.

* **Chores**
  * Recorded a patch-level metadata entry documenting the streaming parameter removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->