### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/docs/content/docs/layout-engine.mdx
+++ b/docs/content/docs/layout-engine.mdx
@@ -45,7 +45,7 @@ import { ImageResponse } from "takumi-js/response";
 
 export function GET() {
   return new ImageResponse(
-    <img src="https://via.placeholder.com/1200x600" width={1200} height={600} />,
+    <img src="https://placehold.co/1200x600" width={1200} height={600} />,
   );
 }
 ```


### PR DESCRIPTION
`docs/content/docs/layout-engine.mdx` references `via.placeholder.com/...` URLs. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Browsers render a broken-image icon in place of the intended placeholder.

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo 'connection refused / DNS gone'
```

#### What this PR changes

Fixes the `<img>` inside the `ImageResponse` example in the layout-engine docs so takumi's docs site renders a real output image for the example.

#### Replacement details

Docs-only. Same 1200×600 dimensions, same surrounding width/height attributes.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** introduced as a dependency by this PR — the diff uses the dependency-free canonical replacement domain. If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering the broader broken-placeholder landscape: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example code in the layout engine documentation with a corrected image placeholder URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->