### PR TITLE
Crate: resolve `rem` against the root element's computed font-size

### DIFF
--- a/.changeset/short-geckos-happen.md
+++ b/.changeset/short-geckos-happen.md
@@ -1,0 +1,5 @@
+---
+"takumi": patch
+---
+
+Ｒesolve `rem` against the root element's computed font-size

--- a/takumi/src/layout/style/animation.rs
+++ b/takumi/src/layout/style/animation.rs
@@ -660,6 +660,7 @@ mod tests {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/properties/filter.rs
+++ b/takumi/src/layout/style/properties/filter.rs
@@ -956,6 +956,7 @@ mod tests {
       viewport,
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let mut buffer_pool = BufferPool::default();

--- a/takumi/src/layout/style/properties/font_size.rs
+++ b/takumi/src/layout/style/properties/font_size.rs
@@ -196,6 +196,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 

--- a/takumi/src/layout/style/properties/length.rs
+++ b/takumi/src/layout/style/properties/length.rs
@@ -334,7 +334,7 @@ impl CalcFormula {
 
     CalcLinear {
       px: self.px * sizing.viewport.device_pixel_ratio
-        + self.rem * sizing.viewport.font_size * sizing.viewport.device_pixel_ratio
+        + self.rem * sizing.rem_basis() * sizing.viewport.device_pixel_ratio
         + self.em * sizing.font_size
         + self.vh * viewport_height / 100.0
         + self.vw * viewport_width / 100.0
@@ -777,7 +777,7 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
       Length::Auto => 0.0,
       Length::Px(value) => value,
       Length::Percentage(value) => (value / 100.0) * percentage_full_px,
-      Length::Rem(value) => value * sizing.viewport.font_size,
+      Length::Rem(value) => value * sizing.rem_basis(),
       Length::Em(value) => value * sizing.font_size,
       Length::Vh(value) => value * sizing.viewport.size.height.unwrap_or_default() as f32 / 100.0,
       Length::Vw(value) => value * sizing.viewport.size.width.unwrap_or_default() as f32 / 100.0,
@@ -822,9 +822,9 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
     match self {
       Length::Auto => CompactLength::auto(),
       Length::Percentage(value) => CompactLength::percent(value / 100.0),
-      Length::Rem(value) => CompactLength::length(
-        value * sizing.viewport.font_size * sizing.viewport.device_pixel_ratio,
-      ),
+      Length::Rem(value) => {
+        CompactLength::length(value * sizing.rem_basis() * sizing.viewport.device_pixel_ratio)
+      }
       Length::Em(value) => CompactLength::length(value * sizing.font_size),
       Length::Vh(value) => CompactLength::length(
         sizing.viewport.size.height.unwrap_or_default() as f32 * value / 100.0,
@@ -970,6 +970,7 @@ mod tests {
       },
       container_size: Size::NONE,
       font_size: 10.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/properties/linear_gradient.rs
+++ b/takumi/src/layout/style/properties/linear_gradient.rs
@@ -818,6 +818,7 @@ mod tests {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/properties/vertical_align.rs
+++ b/takumi/src/layout/style/properties/vertical_align.rs
@@ -235,6 +235,7 @@ mod tests {
       },
       container_size: Size::NONE,
       font_size: 10.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/selector.rs
+++ b/takumi/src/layout/style/selector.rs
@@ -591,6 +591,7 @@ impl MediaQueryList {
       viewport,
       container_size: Size::NONE,
       font_size: viewport.font_size,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 

--- a/takumi/src/layout/style/stylesheets.rs
+++ b/takumi/src/layout/style/stylesheets.rs
@@ -2488,6 +2488,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let border_box = Size {
@@ -2518,6 +2519,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let border_box = Size {
@@ -2541,6 +2543,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let border_box = Size {
@@ -2586,6 +2589,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 
@@ -2606,6 +2610,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 32.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     });
 
@@ -2614,6 +2619,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 32.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let inherited_font_size = inherited_child
@@ -2627,6 +2633,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 10.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 
@@ -2811,6 +2818,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let radius = style.border_top_left_radius.x.to_px(

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -1010,11 +1010,16 @@ impl<'g> RenderNode<'g> {
       );
       let mut style = style_layers.inherit(&inherited_parent);
 
+      // On the root element, `parent_root_font_size` is `None` so `rem` inside
+      // its own `font-size` falls back to `viewport.font_size`, per CSS Values 4
+      // §6.1. Descendants see `Some(root_font_size)`.
+      let parent_root_font_size = parent_context.sizing.root_font_size;
       let font_size = style
         .font_size
         .to_px(&parent_context.sizing, parent_context.sizing.font_size);
       let child_sizing = Sizing {
         font_size,
+        root_font_size: parent_root_font_size,
         ..parent_context.sizing.clone()
       };
       let child_current_color = style.color.resolve(parent_context.current_color);
@@ -1035,6 +1040,7 @@ impl<'g> RenderNode<'g> {
       let font_size = style.font_size.to_px(&child_sizing, child_sizing.font_size);
       let sizing = Sizing {
         font_size,
+        root_font_size: Some(parent_root_font_size.unwrap_or(font_size)),
         ..parent_context.sizing.clone()
       };
       let current_color = style.color.resolve(parent_context.current_color);

--- a/takumi/src/layout/viewport.rs
+++ b/takumi/src/layout/viewport.rs
@@ -12,7 +12,8 @@ pub const DEFAULT_DEVICE_PIXEL_RATIO: f32 = 1.0;
 pub struct Viewport {
   /// Size of the viewport
   pub size: ViewportSize,
-  /// The font size in pixels, used for em and rem units.
+  /// Initial font size in pixels, used as the fallback when no root element
+  /// has set its computed `font-size` (see CSS Values 4 §6.1 for `rem`).
   pub font_size: f32,
   /// The device pixel ratio.
   pub device_pixel_ratio: f32,

--- a/takumi/src/rendering/background_drawing.rs
+++ b/takumi/src/rendering/background_drawing.rs
@@ -886,6 +886,7 @@ mod tests {
       viewport,
       container_size: Size::NONE,
       font_size: viewport.font_size,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/rendering/image_drawing.rs
+++ b/takumi/src/rendering/image_drawing.rs
@@ -341,6 +341,7 @@ mod tests {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
+      root_font_size: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/rendering/mod.rs
+++ b/takumi/src/rendering/mod.rs
@@ -58,11 +58,20 @@ pub(crate) struct Sizing {
   pub(crate) container_size: Size<Option<f32>>,
   /// The font size in pixels.
   pub(crate) font_size: f32,
+  /// Computed `font-size` of the root element in device pixels. `None` before
+  /// the root has been resolved; readers should fall back to `viewport.font_size`.
+  /// https://www.w3.org/TR/css-values-4/#rem
+  pub(crate) root_font_size: Option<f32>,
   /// The calc arena shared by the current layout tree.
   pub(crate) calc_arena: Rc<CalcArena>,
 }
 
 impl Sizing {
+  /// Pixel basis for the `rem` unit.
+  pub(crate) fn rem_basis(&self) -> f32 {
+    self.root_font_size.unwrap_or(self.viewport.font_size)
+  }
+
   pub(crate) fn query_container_width(&self) -> f32 {
     self
       .container_size
@@ -115,6 +124,7 @@ impl<'g> RenderContext<'g> {
         viewport,
         container_size: Size::NONE,
         font_size: viewport.font_size,
+        root_font_size: None,
         calc_arena: Rc::new(CalcArena::default()),
       },
       transform: Affine::IDENTITY,

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1335,6 +1335,34 @@ fn test_measure_text_node_rem_font_size_matches_px_when_dpr_is_below_one() {
 }
 
 #[test]
+fn test_measure_rem_resolves_against_root_computed_font_size() {
+  // CSS Values 4 §6.1: `rem` is the computed value of `font-size` on the root
+  // element. Setting font-size on the root should change what `1rem` means for
+  // descendants, regardless of the viewport's default font size.
+  let viewport = create_measure_viewport();
+
+  let result = measure(
+    Node::container([Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::width(Rem(1.0)))
+        .with(StyleDeclaration::height(Rem(1.0))),
+    )])
+    .with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::font_size(Px(22.0).into())),
+    ),
+    viewport,
+  );
+
+  assert_eq!(result.children.len(), 1);
+  let inner = &result.children[0];
+  assert_close(inner.width, 22.0);
+  assert_close(inner.height, 22.0);
+}
+
+#[test]
 fn test_measure_nested_em_font_size_inherits_correctly_from_rem_when_dpr_is_below_one() {
   let viewport = create_measure_viewport_with_dpr(0.75);
 


### PR DESCRIPTION
Per CSS Values 4 §6.1, `1rem` is the computed `font-size` of the root
element, not the viewport's initial font size. Track `root_font_size`
on `Sizing` and use it as the `rem` basis; the root element itself
keeps falling back to `viewport.font_size` so `rem` inside its own
`font-size` resolves to the initial value.

Fixes #696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * rem units now resolve against the root element’s computed font-size (not the viewport), matching CSS spec.

* **Tests**
  * Added/updated tests to verify rem resolution against the root font-size and related sizing behaviors.

* **Chores**
  * Released a patch version note recording the rem-resolution fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->