### PR TITLE
Helpers: fix `<pre>` default preset omitting `white-space: pre`

### DIFF
--- a/.changeset/fix-pre-whitespace.md
+++ b/.changeset/fix-pre-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/helpers": patch
+---
+
+Fix `<pre>` default preset omitting `white-space: pre`

--- a/takumi-helpers/src/jsx/style-presets.ts
+++ b/takumi-helpers/src/jsx/style-presets.ts
@@ -43,6 +43,44 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
     marginRight: 40,
     display: "block",
   },
+  figure: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    marginLeft: 40,
+    marginRight: 40,
+    display: "block",
+  },
+  figcaption: {
+    display: "block",
+  },
+  address: {
+    fontStyle: "italic",
+    display: "block",
+  },
+  article: {
+    display: "block",
+  },
+  aside: {
+    display: "block",
+  },
+  footer: {
+    display: "block",
+  },
+  header: {
+    display: "block",
+  },
+  hgroup: {
+    display: "block",
+  },
+  main: {
+    display: "block",
+  },
+  nav: {
+    display: "block",
+  },
+  section: {
+    display: "block",
+  },
   center: {
     textAlign: "center",
     display: "block",
@@ -124,14 +162,24 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
   em: {
     fontStyle: "italic",
   },
+  cite: {
+    fontStyle: "italic",
+  },
+  dfn: {
+    fontStyle: "italic",
+  },
   code: {
     fontFamily: "monospace",
   },
   kbd: {
     fontFamily: "monospace",
   },
+  samp: {
+    fontFamily: "monospace",
+  },
   pre: {
     fontFamily: "monospace",
+    whiteSpace: "pre",
     margin: "1em 0",
     display: "block",
   },

--- a/takumi-helpers/test/jsx/style-presets-override.test.tsx
+++ b/takumi-helpers/test/jsx/style-presets-override.test.tsx
@@ -44,6 +44,10 @@ describe("fromJsx - stylePresets overriding", () => {
         preset: defaultStylePresets.span,
       } satisfies TextNode);
     });
+
+    test("pre element preset includes white-space: pre", () => {
+      expect(defaultStylePresets.pre?.whiteSpace).toBe("pre");
+    });
   });
 
   describe("disabling default styles with false", () => {


### PR DESCRIPTION
## Summary
- Adds `whiteSpace: "pre"` to the `<pre>` default preset so indentation and runs of whitespace are preserved (e.g. Shiki code blocks).
- Adds UA-default presets from Blink's `html.css` that were missing: semantic block elements (`article`, `aside`, `footer`, `header`, `hgroup`, `main`, `nav`, `section`), `address` (block + italic), `figure`/`figcaption`, italic for `cite`/`dfn`, monospace for `samp`.

Closes #704

## Test plan
- [x] `bun test takumi-helpers/` — 98 pass, includes new assertion that `defaultStylePresets.pre.whiteSpace === "pre"`
- [x] `tsc --noEmit` clean
- [x] `oxlint` / `oxfmt --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `<pre>` element to properly preserve whitespace formatting

* **New Features**
  * Added default display and margin styling for semantic HTML elements
  * Enhanced typography styling with italic formatting for citations and monospace font for code samples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->