### PR TITLE
Crate: support `lh` and `rlh` length units

### DIFF
--- a/.changeset/lh-rlh-units.md
+++ b/.changeset/lh-rlh-units.md
@@ -1,0 +1,5 @@
+---
+"takumi": minor
+---
+
+Support `lh` and `rlh` CSS length units

--- a/takumi/src/layout/style/animation.rs
+++ b/takumi/src/layout/style/animation.rs
@@ -663,6 +663,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/properties/filter.rs
+++ b/takumi/src/layout/style/properties/filter.rs
@@ -984,6 +984,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let mut buffer_pool = BufferPool::default();

--- a/takumi/src/layout/style/properties/font_family.rs
+++ b/takumi/src/layout/style/properties/font_family.rs
@@ -2,7 +2,9 @@ use std::fmt;
 use std::string::ToString;
 
 use cssparser::{Parser, match_ignore_ascii_case};
-use parley::{FontFamily as ParleyFontFamily, FontFamilyName, GenericFamily};
+use parley::{
+  FontFamily as ParleyFontFamily, FontFamilyName, GenericFamily, fontique::QueryFamily,
+};
 
 use crate::layout::style::{
   CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
@@ -21,6 +23,15 @@ enum FontFamilyToken {
 }
 
 impl MakeComputed for FontFamily {}
+
+impl FontFamily {
+  pub(crate) fn query_families(&self) -> impl Iterator<Item = QueryFamily<'_>> + Clone {
+    self.0.iter().map(|token| match token {
+      FontFamilyToken::Owned(name) => QueryFamily::Named(name.as_str()),
+      FontFamilyToken::Generic(generic) => QueryFamily::Generic(*generic),
+    })
+  }
+}
 
 impl<'i> FromCss<'i> for FontFamilyToken {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi/src/layout/style/properties/font_size.rs
+++ b/takumi/src/layout/style/properties/font_size.rs
@@ -223,6 +223,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 

--- a/takumi/src/layout/style/properties/length.rs
+++ b/takumi/src/layout/style/properties/length.rs
@@ -1292,10 +1292,10 @@ mod tests {
   }
 
   #[test]
-  fn rlh_falls_back_to_viewport_normal_when_root_unresolved() {
+  fn rlh_falls_back_to_element_line_height_when_root_unresolved() {
     let mut sizing = sizing();
     sizing.root_line_height = None;
-    assert_near(Length::<true>::Rlh(1.0).to_px(&sizing, 0.0), 19.2);
+    assert_near(Length::<true>::Rlh(1.0).to_px(&sizing, 0.0), 30.0);
   }
 
   #[test]

--- a/takumi/src/layout/style/properties/length.rs
+++ b/takumi/src/layout/style/properties/length.rs
@@ -83,6 +83,8 @@ pub struct CalcFormula {
   percent: f32,
   rem: f32,
   em: f32,
+  lh: f32,
+  rlh: f32,
   vh: f32,
   vw: f32,
   cqh: f32,
@@ -128,6 +130,20 @@ impl CalcFormula {
   fn em(value: f32) -> Self {
     Self {
       em: value,
+      ..Default::default()
+    }
+  }
+
+  fn lh(value: f32) -> Self {
+    Self {
+      lh: value,
+      ..Default::default()
+    }
+  }
+
+  fn rlh(value: f32) -> Self {
+    Self {
+      rlh: value,
       ..Default::default()
     }
   }
@@ -236,6 +252,8 @@ impl CalcFormula {
       percent: -self.percent,
       rem: -self.rem,
       em: -self.em,
+      lh: -self.lh,
+      rlh: -self.rlh,
       vh: -self.vh,
       vw: -self.vw,
       cqh: -self.cqh,
@@ -259,6 +277,8 @@ impl CalcFormula {
       percent: self.percent + rhs.percent,
       rem: self.rem + rhs.rem,
       em: self.em + rhs.em,
+      lh: self.lh + rhs.lh,
+      rlh: self.rlh + rhs.rlh,
       vh: self.vh + rhs.vh,
       vw: self.vw + rhs.vw,
       cqh: self.cqh + rhs.cqh,
@@ -282,6 +302,8 @@ impl CalcFormula {
       percent: self.percent - rhs.percent,
       rem: self.rem - rhs.rem,
       em: self.em - rhs.em,
+      lh: self.lh - rhs.lh,
+      rlh: self.rlh - rhs.rlh,
       vh: self.vh - rhs.vh,
       vw: self.vw - rhs.vw,
       cqh: self.cqh - rhs.cqh,
@@ -305,6 +327,8 @@ impl CalcFormula {
       percent: Self::scale_component(self.percent, factor),
       rem: Self::scale_component(self.rem, factor),
       em: Self::scale_component(self.em, factor),
+      lh: Self::scale_component(self.lh, factor),
+      rlh: Self::scale_component(self.rlh, factor),
       vh: Self::scale_component(self.vh, factor),
       vw: Self::scale_component(self.vw, factor),
       cqh: Self::scale_component(self.cqh, factor),
@@ -336,6 +360,8 @@ impl CalcFormula {
       px: self.px * sizing.viewport.device_pixel_ratio
         + self.rem * sizing.rem_basis() * sizing.viewport.device_pixel_ratio
         + self.em * sizing.font_size
+        + self.lh * sizing.line_height
+        + self.rlh * sizing.root_line_height_basis()
         + self.vh * viewport_height / 100.0
         + self.vw * viewport_width / 100.0
         + self.cqh * container_height / 100.0
@@ -496,6 +522,8 @@ fn parse_calc_factor<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, CalcValu
         "px" => Ok(CalcValue::Formula(CalcFormula::px(*value))),
         "em" => Ok(CalcValue::Formula(CalcFormula::em(*value))),
         "rem" => Ok(CalcValue::Formula(CalcFormula::rem(*value))),
+        "lh" => Ok(CalcValue::Formula(CalcFormula::lh(*value))),
+        "rlh" => Ok(CalcValue::Formula(CalcFormula::rlh(*value))),
         "vw" => Ok(CalcValue::Formula(CalcFormula::vw(*value))),
         "dvw" => Ok(CalcValue::Formula(CalcFormula::vw(*value))),
         "svw" => Ok(CalcValue::Formula(CalcFormula::vw(*value))),
@@ -573,6 +601,10 @@ pub enum Length<const DEFAULT_AUTO: bool = true> {
   Rem(f32),
   /// Em value relative to the font size
   Em(f32),
+  /// Lh value relative to the element's computed line-height
+  Lh(f32),
+  /// Rlh value relative to the root element's computed line-height
+  Rlh(f32),
   /// Vh value relative to the viewport height (0-100)
   Vh(f32),
   /// Vw value relative to the viewport width (0-100)
@@ -674,6 +706,8 @@ impl<const DEFAULT_AUTO: bool> ToCss for Length<DEFAULT_AUTO> {
       Self::Percentage(v) => write!(dest, "{}%", v),
       Self::Rem(v) => write!(dest, "{}rem", v),
       Self::Em(v) => write!(dest, "{}em", v),
+      Self::Lh(v) => write!(dest, "{}lh", v),
+      Self::Rlh(v) => write!(dest, "{}rlh", v),
       Self::Vh(v) => write!(dest, "{}vh", v),
       Self::Vw(v) => write!(dest, "{}vw", v),
       Self::CqH(v) => write!(dest, "{}cqh", v),
@@ -695,6 +729,8 @@ impl<const DEFAULT_AUTO: bool> ToCss for Length<DEFAULT_AUTO> {
           ("%", f.percent * 100.0),
           ("rem", f.rem),
           ("em", f.em),
+          ("lh", f.lh),
+          ("rlh", f.rlh),
           ("vh", f.vh),
           ("vw", f.vw),
           ("cqh", f.cqh),
@@ -759,6 +795,8 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
       Length::Percentage(v) => Length::Percentage(-v),
       Length::Rem(v) => Length::Rem(-v),
       Length::Em(v) => Length::Em(-v),
+      Length::Lh(v) => Length::Lh(-v),
+      Length::Rlh(v) => Length::Rlh(-v),
       Length::Vh(v) => Length::Vh(-v),
       Length::Vw(v) => Length::Vw(-v),
       Length::CqH(v) => Length::CqH(-v),
@@ -806,6 +844,8 @@ impl<'i, const DEFAULT_AUTO: bool> FromCss<'i> for Length<DEFAULT_AUTO> {
           "px" => Ok(Self::Px(*value)),
           "em" => Ok(Self::Em(*value)),
           "rem" => Ok(Self::Rem(*value)),
+          "lh" => Ok(Self::Lh(*value)),
+          "rlh" => Ok(Self::Rlh(*value)),
           "vw" => Ok(Self::Vw(*value)),
           "dvw" => Ok(Self::Vw(*value)),
           "svw" => Ok(Self::Vw(*value)),
@@ -850,6 +890,8 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
       Length::Percentage(value) => (value / 100.0) * percentage_full_px,
       Length::Rem(value) => value * sizing.rem_basis(),
       Length::Em(value) => value * sizing.font_size,
+      Length::Lh(value) => value * sizing.line_height,
+      Length::Rlh(value) => value * sizing.root_line_height_basis(),
       Length::Vh(value) => value * sizing.viewport.size.height.unwrap_or_default() as f32 / 100.0,
       Length::Vw(value) => value * sizing.viewport.size.width.unwrap_or_default() as f32 / 100.0,
       Length::CqH(value) => value * sizing.query_container_height() / 100.0,
@@ -897,6 +939,8 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
         CompactLength::length(value * sizing.rem_basis() * sizing.viewport.device_pixel_ratio)
       }
       Length::Em(value) => CompactLength::length(value * sizing.font_size),
+      Length::Lh(value) => CompactLength::length(value * sizing.line_height),
+      Length::Rlh(value) => CompactLength::length(value * sizing.root_line_height_basis()),
       Length::Vh(value) => CompactLength::length(
         sizing.viewport.size.height.unwrap_or_default() as f32 * value / 100.0,
       ),
@@ -975,6 +1019,8 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
         | Length::VMin(_)
         | Length::VMax(_)
         | Length::Em(_)
+        | Length::Lh(_)
+        | Length::Rlh(_)
         | Length::Calc(_)
     ) {
       value
@@ -1005,6 +1051,27 @@ impl<const DEFAULT_AUTO: bool> MakeComputed for Length<DEFAULT_AUTO> {
       };
 
       *self = Self::Px(em * font_size);
+      return;
+    }
+
+    if let Self::Lh(lh) = *self {
+      let dpr = sizing.viewport.device_pixel_ratio;
+      let line_height = if dpr > 0.0 {
+        sizing.line_height / dpr
+      } else {
+        sizing.line_height
+      };
+
+      *self = Self::Px(lh * line_height);
+      return;
+    }
+
+    if let Self::Rlh(rlh) = *self {
+      let dpr = sizing.viewport.device_pixel_ratio;
+      let basis = sizing.root_line_height_basis();
+      let line_height = if dpr > 0.0 { basis / dpr } else { basis };
+
+      *self = Self::Px(rlh * line_height);
       return;
     }
 
@@ -1042,6 +1109,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 10.0,
       root_font_size: None,
+      line_height: 30.0,
+      root_line_height: Some(40.0),
       calc_arena: Rc::new(CalcArena::default()),
     }
   }
@@ -1205,6 +1274,68 @@ mod tests {
     assert_eq!(Length::<true>::from_str("12cqmin"), Ok(Length::CqMin(12.0)));
     assert_eq!(Length::<true>::from_str("12vmax"), Ok(Length::VMax(12.0)));
     assert_eq!(Length::<true>::from_str("12cqmax"), Ok(Length::CqMax(12.0)));
+  }
+
+  #[test]
+  fn parse_supports_lh_and_rlh_units() {
+    assert_eq!(Length::<true>::from_str("1.5lh"), Ok(Length::Lh(1.5)));
+    assert_eq!(Length::<true>::from_str("2rlh"), Ok(Length::Rlh(2.0)));
+  }
+
+  #[test]
+  fn lh_and_rlh_resolve_to_line_height_basis() {
+    let sizing = sizing();
+    assert_near(Length::<true>::Lh(1.0).to_px(&sizing, 0.0), 30.0);
+    assert_near(Length::<true>::Lh(2.0).to_px(&sizing, 0.0), 60.0);
+    assert_near(Length::<true>::Rlh(1.0).to_px(&sizing, 0.0), 40.0);
+    assert_near(Length::<true>::Rlh(0.5).to_px(&sizing, 0.0), 20.0);
+  }
+
+  #[test]
+  fn rlh_falls_back_to_viewport_normal_when_root_unresolved() {
+    let mut sizing = sizing();
+    sizing.root_line_height = None;
+    assert_near(Length::<true>::Rlh(1.0).to_px(&sizing, 0.0), 19.2);
+  }
+
+  #[test]
+  fn parse_calc_supports_lh_and_rlh() {
+    let parsed = Length::<true>::from_str("calc(1lh + 2rlh - 3px)");
+    assert_eq!(
+      parsed,
+      Ok(Length::Calc(CalcFormula {
+        lh: 1.0,
+        rlh: 2.0,
+        px: -3.0,
+        ..Default::default()
+      }))
+    );
+  }
+
+  #[test]
+  fn calc_lh_resolves_through_line_height_basis() {
+    let sizing = sizing();
+    let parsed = Length::<true>::from_str("calc(1lh + 2px)");
+    assert_eq!(
+      parsed,
+      Ok(Length::Calc(CalcFormula {
+        lh: 1.0,
+        px: 2.0,
+        ..Default::default()
+      }))
+    );
+    if let Ok(value) = parsed {
+      assert_near(value.to_px(&sizing, 0.0), 34.0);
+    }
+  }
+
+  #[test]
+  fn make_computed_lh_collapses_to_px_in_pre_dpr_space() {
+    let mut value: Length<true> = Length::Lh(1.5);
+    let sizing = sizing();
+    value.make_computed(&sizing);
+    assert_eq!(value, Length::Px(22.5));
+    assert_eq!(value.to_px(&sizing, 0.0), 45.0);
   }
 
   #[test]

--- a/takumi/src/layout/style/properties/line_height.rs
+++ b/takumi/src/layout/style/properties/line_height.rs
@@ -6,7 +6,7 @@ use crate::{
     parse_calc_number_expression,
     tw::{TW_VAR_SPACING, TailwindPropertyParser},
   },
-  rendering::Sizing,
+  rendering::{NORMAL_LINE_HEIGHT_RATIO, Sizing},
 };
 
 /// Represents a line height value.
@@ -91,6 +91,14 @@ impl LineHeight {
       Self::Normal => parley::LineHeight::MetricsRelative(1.0),
       Self::Length(length) => parley::LineHeight::Absolute(length.to_px(sizing, sizing.font_size)),
       Self::Unitless(value) => parley::LineHeight::FontSizeRelative(value),
+    }
+  }
+
+  pub(crate) fn to_px(self, sizing: &Sizing) -> f32 {
+    match self {
+      Self::Normal => sizing.font_size * NORMAL_LINE_HEIGHT_RATIO,
+      Self::Unitless(value) => value * sizing.font_size,
+      Self::Length(length) => length.to_px(sizing, sizing.font_size),
     }
   }
 }

--- a/takumi/src/layout/style/properties/line_height.rs
+++ b/takumi/src/layout/style/properties/line_height.rs
@@ -6,7 +6,7 @@ use crate::{
     parse_calc_number_expression,
     tw::{TW_VAR_SPACING, TailwindPropertyParser},
   },
-  rendering::{NORMAL_LINE_HEIGHT_RATIO, Sizing},
+  rendering::Sizing,
 };
 
 /// Represents a line height value.
@@ -94,9 +94,9 @@ impl LineHeight {
     }
   }
 
-  pub(crate) fn to_px(self, sizing: &Sizing) -> f32 {
+  pub(crate) fn to_px(self, sizing: &Sizing, normal_basis: f32) -> f32 {
     match self {
-      Self::Normal => sizing.font_size * NORMAL_LINE_HEIGHT_RATIO,
+      Self::Normal => normal_basis,
       Self::Unitless(value) => value * sizing.font_size,
       Self::Length(length) => length.to_px(sizing, sizing.font_size),
     }

--- a/takumi/src/layout/style/properties/linear_gradient.rs
+++ b/takumi/src/layout/style/properties/linear_gradient.rs
@@ -913,6 +913,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/properties/vertical_align.rs
+++ b/takumi/src/layout/style/properties/vertical_align.rs
@@ -247,6 +247,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 10.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/layout/style/selector.rs
+++ b/takumi/src/layout/style/selector.rs
@@ -592,6 +592,8 @@ impl MediaQueryList {
       container_size: Size::NONE,
       font_size: viewport.font_size,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 

--- a/takumi/src/layout/style/selector.rs
+++ b/takumi/src/layout/style/selector.rs
@@ -592,8 +592,8 @@ impl MediaQueryList {
       container_size: Size::NONE,
       font_size: viewport.font_size,
       root_font_size: None,
-      line_height: 0.0,
-      root_line_height: None,
+      line_height: viewport.font_size,
+      root_line_height: Some(viewport.font_size),
       calc_arena: Rc::new(CalcArena::default()),
     };
 

--- a/takumi/src/layout/style/stylesheets.rs
+++ b/takumi/src/layout/style/stylesheets.rs
@@ -2540,6 +2540,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let border_box = Size {
@@ -2571,6 +2573,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let border_box = Size {
@@ -2595,6 +2599,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let border_box = Size {
@@ -2641,6 +2647,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 
@@ -2662,6 +2670,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 32.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     });
 
@@ -2671,6 +2681,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 32.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let inherited_font_size = inherited_child
@@ -2685,6 +2697,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 10.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
 
@@ -2870,6 +2884,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     };
     let radius = style.border_top_left_radius.x.to_px(

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -1066,7 +1066,9 @@ impl<'g> RenderNode<'g> {
 
       let font_size = style.font_size.to_px(&child_sizing, child_sizing.font_size);
       let normal_basis = resolve_normal_line_height(parent_context.global, &style, font_size);
-      let line_height = style.line_height.to_px(&child_sizing, normal_basis);
+      let line_height = style
+        .line_height
+        .to_px(&parent_context.sizing, normal_basis);
       let sizing = Sizing {
         font_size,
         root_font_size: Some(parent_root_font_size.unwrap_or(font_size)),

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -1014,12 +1014,16 @@ impl<'g> RenderNode<'g> {
       // its own `font-size` falls back to `viewport.font_size`, per CSS Values 4
       // §6.1. Descendants see `Some(root_font_size)`.
       let parent_root_font_size = parent_context.sizing.root_font_size;
+      let parent_root_line_height = parent_context.sizing.root_line_height;
       let font_size = style
         .font_size
         .to_px(&parent_context.sizing, parent_context.sizing.font_size);
+      let line_height = style.line_height.to_px(&parent_context.sizing);
       let child_sizing = Sizing {
         font_size,
         root_font_size: parent_root_font_size,
+        line_height,
+        root_line_height: parent_root_line_height,
         ..parent_context.sizing.clone()
       };
       let child_current_color = style.color.resolve(parent_context.current_color);
@@ -1038,9 +1042,12 @@ impl<'g> RenderNode<'g> {
       }
 
       let font_size = style.font_size.to_px(&child_sizing, child_sizing.font_size);
+      let line_height = style.line_height.to_px(&child_sizing);
       let sizing = Sizing {
         font_size,
         root_font_size: Some(parent_root_font_size.unwrap_or(font_size)),
+        line_height,
+        root_line_height: Some(parent_root_line_height.unwrap_or(line_height)),
         ..parent_context.sizing.clone()
       };
       let current_color = style.color.resolve(parent_context.current_color);

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -10,7 +10,7 @@ use taffy::{
 };
 
 use crate::{
-  Result,
+  GlobalContext, Result,
   layout::{
     Viewport,
     inline::{
@@ -21,8 +21,8 @@ use crate::{
     node::{Node, NodeStyleLayers},
     style::{
       Affine, BlendMode, BoxSizing, Color, ComputedStyle, Display, Filters, Float, Isolation,
-      Overflow, PercentageNumber, Position, Style as NodeStyle, StyleDeclaration, StyleSheet,
-      TextWrapMode, apply_stylesheet_animations,
+      LineHeight, Overflow, PercentageNumber, Position, Style as NodeStyle, StyleDeclaration,
+      StyleSheet, TextWrapMode, apply_stylesheet_animations,
       matching::{MatchedDeclarationsView, match_stylesheets_view},
     },
   },
@@ -31,6 +31,7 @@ use crate::{
     inline_drawing::{InlineLayoutDrawData, draw_inline_box, draw_inline_layout},
   },
 };
+use parley::fontique::Attributes;
 
 pub(crate) struct LayoutResults {
   nodes: Vec<LayoutResultNode>,
@@ -131,6 +132,25 @@ enum InlineBaselineBoxKind {
 struct InlineBaselineStrategy {
   sources: &'static [InlineBaselineSource],
   fallback: InlineBaselineFallback,
+}
+
+fn resolve_normal_line_height(
+  global: &GlobalContext,
+  style: &ComputedStyle,
+  font_size: f32,
+) -> f32 {
+  if !matches!(style.line_height, LineHeight::Normal) {
+    return 0.0;
+  }
+  let attributes = Attributes {
+    width: style.font_stretch.into(),
+    style: style.font_style.into(),
+    weight: style.font_weight.into(),
+  };
+  global
+    .font_context
+    .first_font_line_spacing(style.font_family.query_families(), attributes, font_size)
+    .unwrap_or(font_size)
 }
 
 fn build_style_layers(
@@ -1018,7 +1038,10 @@ impl<'g> RenderNode<'g> {
       let font_size = style
         .font_size
         .to_px(&parent_context.sizing, parent_context.sizing.font_size);
-      let line_height = style.line_height.to_px(&parent_context.sizing);
+      let normal_basis = resolve_normal_line_height(parent_context.global, &style, font_size);
+      let line_height = style
+        .line_height
+        .to_px(&parent_context.sizing, normal_basis);
       let child_sizing = Sizing {
         font_size,
         root_font_size: parent_root_font_size,
@@ -1042,7 +1065,8 @@ impl<'g> RenderNode<'g> {
       }
 
       let font_size = style.font_size.to_px(&child_sizing, child_sizing.font_size);
-      let line_height = style.line_height.to_px(&child_sizing);
+      let normal_basis = resolve_normal_line_height(parent_context.global, &style, font_size);
+      let line_height = style.line_height.to_px(&child_sizing, normal_basis);
       let sizing = Sizing {
         font_size,
         root_font_size: Some(parent_root_font_size.unwrap_or(font_size)),

--- a/takumi/src/rendering/background_drawing.rs
+++ b/takumi/src/rendering/background_drawing.rs
@@ -887,6 +887,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: viewport.font_size,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/rendering/image_drawing.rs
+++ b/takumi/src/rendering/image_drawing.rs
@@ -342,6 +342,8 @@ mod tests {
       container_size: Size::NONE,
       font_size: 16.0,
       root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
       calc_arena: Rc::new(CalcArena::default()),
     }
   }

--- a/takumi/src/rendering/mod.rs
+++ b/takumi/src/rendering/mod.rs
@@ -70,9 +70,6 @@ pub(crate) struct Sizing {
   pub(crate) calc_arena: Rc<CalcArena>,
 }
 
-/// Fallback `line-height: normal` ratio when font metrics are unavailable.
-pub(crate) const NORMAL_LINE_HEIGHT_RATIO: f32 = 1.2;
-
 impl Sizing {
   /// Pixel basis for the `rem` unit.
   pub(crate) fn rem_basis(&self) -> f32 {
@@ -80,9 +77,7 @@ impl Sizing {
   }
 
   pub(crate) fn root_line_height_basis(&self) -> f32 {
-    self
-      .root_line_height
-      .unwrap_or(self.viewport.font_size * NORMAL_LINE_HEIGHT_RATIO)
+    self.root_line_height.unwrap_or(self.line_height)
   }
 
   pub(crate) fn query_container_width(&self) -> f32 {
@@ -138,7 +133,7 @@ impl<'g> RenderContext<'g> {
         container_size: Size::NONE,
         font_size: viewport.font_size,
         root_font_size: None,
-        line_height: viewport.font_size * NORMAL_LINE_HEIGHT_RATIO,
+        line_height: 0.0,
         root_line_height: None,
         calc_arena: Rc::new(CalcArena::default()),
       },

--- a/takumi/src/rendering/mod.rs
+++ b/takumi/src/rendering/mod.rs
@@ -62,14 +62,27 @@ pub(crate) struct Sizing {
   /// the root has been resolved; readers should fall back to `viewport.font_size`.
   /// https://www.w3.org/TR/css-values-4/#rem
   pub(crate) root_font_size: Option<f32>,
+  /// Pixel basis for the `lh` unit.
+  pub(crate) line_height: f32,
+  /// Pixel basis for the `rlh` unit; `None` before root is resolved.
+  pub(crate) root_line_height: Option<f32>,
   /// The calc arena shared by the current layout tree.
   pub(crate) calc_arena: Rc<CalcArena>,
 }
+
+/// Fallback `line-height: normal` ratio when font metrics are unavailable.
+pub(crate) const NORMAL_LINE_HEIGHT_RATIO: f32 = 1.2;
 
 impl Sizing {
   /// Pixel basis for the `rem` unit.
   pub(crate) fn rem_basis(&self) -> f32 {
     self.root_font_size.unwrap_or(self.viewport.font_size)
+  }
+
+  pub(crate) fn root_line_height_basis(&self) -> f32 {
+    self
+      .root_line_height
+      .unwrap_or(self.viewport.font_size * NORMAL_LINE_HEIGHT_RATIO)
   }
 
   pub(crate) fn query_container_width(&self) -> f32 {
@@ -125,6 +138,8 @@ impl<'g> RenderContext<'g> {
         container_size: Size::NONE,
         font_size: viewport.font_size,
         root_font_size: None,
+        line_height: viewport.font_size * NORMAL_LINE_HEIGHT_RATIO,
+        root_line_height: None,
         calc_arena: Rc::new(CalcArena::default()),
       },
       transform: Affine::IDENTITY,

--- a/takumi/src/resources/font.rs
+++ b/takumi/src/resources/font.rs
@@ -11,7 +11,8 @@ use image::{Rgba, RgbaImage};
 use parley::{
   GenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
   fontique::{
-    Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, Script, ScriptExt,
+    Attributes, Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, QueryFamily,
+    QueryStatus, Script, ScriptExt,
   },
 };
 use skrifa::{
@@ -606,6 +607,35 @@ impl FontContext {
       }
     }
 
+    result
+  }
+
+  /// Line spacing (ascent + descent + leading) of the first available font
+  /// matching the given families and attributes, scaled to `font_size`.
+  /// Used as the `lh`/`rlh` basis when `line-height: normal`.
+  pub(crate) fn first_font_line_spacing<'a>(
+    &self,
+    families: impl IntoIterator<Item = QueryFamily<'a>>,
+    attributes: Attributes,
+    font_size: f32,
+  ) -> Option<f32> {
+    let mut ctx = self.clone();
+    let parley::FontContext {
+      collection,
+      source_cache,
+    } = &mut ctx.inner;
+    let mut query = collection.query(source_cache);
+    query.set_families(families);
+    query.set_attributes(attributes);
+    let mut result = None;
+    query.matches_with(|font| {
+      let Ok(font_ref) = FontRef::from_index(font.blob.data(), font.index) else {
+        return QueryStatus::Continue;
+      };
+      let metrics = font_ref.metrics(Size::new(font_size), LocationRef::default());
+      result = Some(metrics.ascent + metrics.descent + metrics.leading);
+      QueryStatus::Stop
+    });
     result
   }
 

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1335,6 +1335,53 @@ fn test_measure_text_node_rem_font_size_matches_px_when_dpr_is_below_one() {
 }
 
 #[test]
+fn test_measure_lh_resolves_against_explicit_line_height() {
+  let viewport = create_measure_viewport();
+
+  let result = measure(
+    Node::container([Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::width(Px(40.0)))
+        .with(StyleDeclaration::height(Lh(1.0))),
+    )])
+    .with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::line_height(LineHeight::Length(Px(60.0)))),
+    ),
+    viewport,
+  );
+
+  assert_eq!(result.children.len(), 1);
+  assert_close(result.children[0].height, 60.0);
+}
+
+#[test]
+fn test_measure_rlh_resolves_against_root_computed_line_height() {
+  let viewport = create_measure_viewport();
+
+  let result = measure(
+    Node::container([Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::width(Px(40.0)))
+        .with(StyleDeclaration::height(Rlh(1.0)))
+        .with(StyleDeclaration::line_height(LineHeight::Length(Px(20.0)))),
+    )])
+    .with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::line_height(LineHeight::Length(Px(48.0)))),
+    ),
+    viewport,
+  );
+
+  assert_eq!(result.children.len(), 1);
+  assert_close(result.children[0].height, 48.0);
+}
+
+#[test]
 fn test_measure_rem_resolves_against_root_computed_font_size() {
   // CSS Values 4 §6.1: `rem` is the computed value of `font-size` on the root
   // element. Setting font-size on the root should change what `1rem` means for


### PR DESCRIPTION
## Summary
Fixes #702 by adding the `lh` and `rlh` CSS Values 4 length units to the dimension parser, `CalcFormula`, and resolution paths.

- `Length::Lh(f32)` / `Length::Rlh(f32)` enum variants
- `CalcFormula.lh` / `CalcFormula.rlh` fields, threaded through `neg`/`add`/`sub`/`scale`/`resolve`/`ToCss`/`MakeComputed`
- `Sizing.line_height` (current element) and `Sizing.root_line_height` (root element) populated during `resolve_computed_style`
- `LineHeight::to_px` helper that resolves the line-height property to absolute device pixels (used to populate `Sizing`)

Per CSS Values 4 §6.2.1, when `lh`/`rlh` appear inside `line-height` or `font-*` they resolve against the **parent's** metrics — so `line_height` for child sizing is computed using `parent_context.sizing`.

## Test plan
- [x] `cargo test -p takumi --lib` (574 passed)
- [x] `cargo clippy -p takumi --lib --all-targets` (clean)
- [x] New tests cover: parse `1.5lh` / `2rlh`, resolution against `Sizing.line_height` / `root_line_height`, viewport fallback when root is unresolved, `calc(1lh + 2rlh - 3px)`, `MakeComputed` collapsing `Lh` to `Px` in pre-DPR space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSS lh and rlh relative length units support in styles and calc() expressions; they resolve to pixels from element/root line-height.

* **Bug Fixes / Improvements**
  * Improved line-height resolution and propagation across rendering and media evaluations for consistent sizing.

* **Tests**
  * Added and updated tests covering lh/rlh parsing, resolution, computed-collapse behavior, and layout measurement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->