### PR TITLE
Crate: accept `:is()` / `:where()` and ignore unsupported pseudo-classes

### DIFF
--- a/.changeset/forgiving-pseudo-selectors.md
+++ b/.changeset/forgiving-pseudo-selectors.md
@@ -1,0 +1,5 @@
+---
+"takumi": minor
+---
+
+Accept `:is()` / `:where()` selectors, and keep rules containing unsupported pseudo-classes/elements (e.g. `:hover`, `::before`) instead of dropping them — they parse but never match, so sibling selectors in the same list (e.g. `a, a:hover`) continue to apply

--- a/.changeset/forgiving-pseudo-selectors.md
+++ b/.changeset/forgiving-pseudo-selectors.md
@@ -2,4 +2,4 @@
 "takumi": minor
 ---
 
-Accept `:is()` / `:where()` selectors, and keep rules containing unsupported pseudo-classes/elements (e.g. `:hover`, `::before`) instead of dropping them — they parse but never match, so sibling selectors in the same list (e.g. `a, a:hover`) continue to apply
+Support `:is()` / `:where()` and stop dropping rules that contain unsupported pseudo-classes/elements

--- a/takumi/src/layout/style/matching.rs
+++ b/takumi/src/layout/style/matching.rs
@@ -316,17 +316,17 @@ impl<'a> Element for ArenaElement<'a> {
   }
   fn match_non_ts_pseudo_class(
     &self,
-    pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass,
+    _pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass,
     _context: &mut MatchingContext<'_, Self::Impl>,
   ) -> bool {
-    match *pc {}
+    false
   }
   fn match_pseudo_element(
     &self,
-    pe: &<Self::Impl as SelectorImpl>::PseudoElement,
+    _pe: &<Self::Impl as SelectorImpl>::PseudoElement,
     _context: &mut MatchingContext<'_, Self::Impl>,
   ) -> bool {
-    match *pe {}
+    false
   }
 
   fn apply_selector_flags(&self, _flags: selectors::matching::ElementSelectorFlags) {}

--- a/takumi/src/layout/style/selector.rs
+++ b/takumi/src/layout/style/selector.rs
@@ -2,7 +2,6 @@ use cssparser::*;
 use precomputed_hash::PrecomputedHash;
 use selectors::parser::{
   NonTSPseudoClass, ParseRelative, PseudoElement, SelectorImpl, SelectorList,
-  SelectorParseErrorKind,
 };
 use std::{
   collections::HashMap,
@@ -99,41 +98,45 @@ impl PrecomputedHash for TakumiIdent {
 #[derive(Debug, Clone)]
 pub(crate) struct TakumiSelectorImpl;
 
+// Parsed but never matched, so rules with `:hover`, `::before`, etc. survive
+// alongside their sibling selectors instead of getting dropped wholesale.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum UnsupportedPseudoClass {}
+pub(crate) struct IgnoredPseudoClass(TakumiIdent);
 
-impl ToCss for UnsupportedPseudoClass {
-  fn to_css<W>(&self, _dest: &mut W) -> fmt::Result
+impl ToCss for IgnoredPseudoClass {
+  fn to_css<W>(&self, dest: &mut W) -> fmt::Result
   where
     W: Write,
   {
-    match *self {}
+    dest.write_char(':')?;
+    self.0.to_css(dest)
   }
 }
 
-impl NonTSPseudoClass for UnsupportedPseudoClass {
+impl NonTSPseudoClass for IgnoredPseudoClass {
   type Impl = TakumiSelectorImpl;
   fn is_active_or_hover(&self) -> bool {
-    match *self {}
+    false
   }
   fn is_user_action_state(&self) -> bool {
-    match *self {}
+    false
   }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum UnsupportedPseudoElement {}
+pub(crate) struct IgnoredPseudoElement(TakumiIdent);
 
-impl ToCss for UnsupportedPseudoElement {
-  fn to_css<W>(&self, _dest: &mut W) -> fmt::Result
+impl ToCss for IgnoredPseudoElement {
+  fn to_css<W>(&self, dest: &mut W) -> fmt::Result
   where
     W: Write,
   {
-    match *self {}
+    dest.write_str("::")?;
+    self.0.to_css(dest)
   }
 }
 
-impl PseudoElement for UnsupportedPseudoElement {
+impl PseudoElement for IgnoredPseudoElement {
   type Impl = TakumiSelectorImpl;
 }
 
@@ -146,8 +149,8 @@ impl SelectorImpl for TakumiSelectorImpl {
   type NamespacePrefix = TakumiIdent;
   type BorrowedNamespaceUrl = TakumiIdent;
   type BorrowedLocalName = TakumiIdent;
-  type NonTSPseudoClass = UnsupportedPseudoClass;
-  type PseudoElement = UnsupportedPseudoElement;
+  type NonTSPseudoClass = IgnoredPseudoClass;
+  type PseudoElement = IgnoredPseudoElement;
 }
 
 struct TakumiSelectorParser;
@@ -164,28 +167,43 @@ impl<'i> selectors::Parser<'i> for TakumiSelectorParser {
     true
   }
 
+  fn parse_is_and_where(&self) -> bool {
+    true
+  }
+
   fn parse_non_ts_pseudo_class(
     &self,
-    location: SourceLocation,
+    _location: SourceLocation,
     name: CowRcStr<'i>,
   ) -> Result<<Self::Impl as SelectorImpl>::NonTSPseudoClass, ParseError<'i, Self::Error>> {
-    Err(
-      location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(
-        name,
-      )),
-    )
+    Ok(IgnoredPseudoClass(TakumiIdent::from(&*name)))
+  }
+
+  fn parse_non_ts_functional_pseudo_class<'t>(
+    &self,
+    name: CowRcStr<'i>,
+    parser: &mut Parser<'i, 't>,
+    _after_part: bool,
+  ) -> Result<<Self::Impl as SelectorImpl>::NonTSPseudoClass, ParseError<'i, Self::Error>> {
+    while parser.next_including_whitespace_and_comments().is_ok() {}
+    Ok(IgnoredPseudoClass(TakumiIdent::from(&*name)))
   }
 
   fn parse_pseudo_element(
     &self,
-    location: SourceLocation,
+    _location: SourceLocation,
     name: CowRcStr<'i>,
   ) -> Result<<Self::Impl as SelectorImpl>::PseudoElement, ParseError<'i, Self::Error>> {
-    Err(
-      location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(
-        name,
-      )),
-    )
+    Ok(IgnoredPseudoElement(TakumiIdent::from(&*name)))
+  }
+
+  fn parse_functional_pseudo_element<'t>(
+    &self,
+    name: CowRcStr<'i>,
+    arguments: &mut Parser<'i, 't>,
+  ) -> Result<<Self::Impl as SelectorImpl>::PseudoElement, ParseError<'i, Self::Error>> {
+    while arguments.next_including_whitespace_and_comments().is_ok() {}
+    Ok(IgnoredPseudoElement(TakumiIdent::from(&*name)))
   }
 }
 
@@ -1680,14 +1698,35 @@ mod tests {
   }
 
   #[test]
-  fn test_unsupported_pseudo_selector_rule_is_rejected() {
+  fn test_ignored_pseudo_selector_rule_is_kept_but_never_matches() {
     let sheet = parse_stylesheet_loosy(
       r#"
         .a:hover { width: 10px; }
+        .a, .a:hover { height: 20px; }
+        .a::before { color: red; }
+        .a:lang(en) { color: blue; }
       "#,
     );
 
-    assert!(sheet.rules.is_empty());
+    assert_eq!(sheet.rules.len(), 4);
+    assert_eq!(selector_text(&sheet.rules[0]), ".a:hover");
+    assert_eq!(selector_text(&sheet.rules[1]), ".a, .a:hover");
+    assert_eq!(selector_text(&sheet.rules[2]), ".a::before");
+    assert_eq!(selector_text(&sheet.rules[3]), ".a:lang");
+  }
+
+  #[test]
+  fn test_is_and_where_selectors_are_accepted() {
+    let sheet = parse_stylesheet_loosy(
+      r#"
+        .a:where(.b) div { background: red; }
+        .a:is(.b, .c) { color: blue; }
+      "#,
+    );
+
+    assert_eq!(sheet.rules.len(), 2);
+    assert_eq!(selector_text(&sheet.rules[0]), ".a:where(.b) div");
+    assert_eq!(selector_text(&sheet.rules[1]), ".a:is(.b, .c)");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Closes #708.

- Opt into the `selectors` crate's `parse_is_and_where`, so `:is(...)` and `:where(...)` parse correctly. The matching engine already supports them via the existing `Element` impl.
- Replace the uninhabited `UnsupportedPseudoClass` / `UnsupportedPseudoElement` enums with `IgnoredPseudoClass` / `IgnoredPseudoElement` placeholders. Unknown pseudo-classes (`:hover`, `:focus`, `:checked`, …) and pseudo-elements (`::before`, `::after`, …) now parse cleanly and never match, instead of rejecting the whole rule.

The second change preserves sibling selectors in the same selector list. Previously `a, a:hover { color: red }` was dropped entirely because `:hover` failed to parse; now the `a` selector still applies. This makes modern CSS (Svelte scoped styles emitting `:where(.svelte-HASH)`, Tailwind Preflight, modern-normalize, etc.) work end-to-end on a static renderer.

## Test plan

- [x] `cargo test -p takumi --lib`
- [x] `cargo clippy -p takumi --lib --tests -- -D warnings`
- [x] New unit tests: `:is()` / `:where()` round-trip, and rules containing `:hover`, `::before`, `:lang(en)` are kept (with the old test that asserted they were rejected updated accordingly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `:is()` and `:where()` pseudo-selectors
  * CSS rules containing unsupported pseudo-classes and pseudo-elements are now preserved and serialized instead of being dropped

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->