### PR TITLE
Crate: drop whitespace-only text nodes in block containers (#711)

### DIFF
--- a/.changeset/abs-whitespace-block-container.md
+++ b/.changeset/abs-whitespace-block-container.md
@@ -1,0 +1,5 @@
+---
+"takumi": patch
+---
+
+Drop whitespace-only text nodes in block containers #711

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -1183,18 +1183,11 @@ impl<'g> RenderNode<'g> {
           }
         } else {
           // https://github.com/kane50613/takumi/issues/711
-          let has_block_level = children
+          if children
             .iter()
-            .any(|child| !child.participates_in_inline_formatting_context());
-          if has_block_level
-            && children
-              .iter()
-              .any(RenderNode::is_whitespace_only_text_node)
+            .any(|child| !child.participates_in_inline_formatting_context())
           {
-            children = Vec::from(children)
-              .into_iter()
-              .filter(|child| !child.is_whitespace_only_text_node())
-              .collect();
+            children = drop_block_boundary_whitespace(Vec::from(children)).into_boxed_slice();
           }
 
           let has_inline = children
@@ -1716,6 +1709,33 @@ fn flush_inline_group<'g>(
     parent_render_context,
     take(inline_group),
   ));
+}
+
+fn drop_block_boundary_whitespace<'g>(input: Vec<RenderNode<'g>>) -> Vec<RenderNode<'g>> {
+  let mut result = Vec::with_capacity(input.len());
+  let mut run: Vec<RenderNode<'g>> = Vec::new();
+
+  fn flush<'g>(run: &mut Vec<RenderNode<'g>>, out: &mut Vec<RenderNode<'g>>) {
+    let has_meaningful_inline = run.iter().any(|c| {
+      c.participates_in_inflow_inline_formatting_context() && !c.is_whitespace_only_text_node()
+    });
+    if has_meaningful_inline {
+      out.append(run);
+    } else {
+      out.extend(run.drain(..).filter(|c| !c.is_whitespace_only_text_node()));
+    }
+  }
+
+  for child in input {
+    if !child.participates_in_inline_formatting_context() {
+      flush(&mut run, &mut result);
+      result.push(child);
+    } else {
+      run.push(child);
+    }
+  }
+  flush(&mut run, &mut result);
+  result
 }
 
 #[cfg(test)]

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -826,6 +826,13 @@ impl<'g> RenderNode<'g> {
     self.anonymous_text_content.is_some() && self.node.is_none()
   }
 
+  fn is_whitespace_only_text_node(&self) -> bool {
+    self
+      .node
+      .as_ref()
+      .is_some_and(Node::is_whitespace_only_text)
+  }
+
   fn has_anonymous_text_item_child(&self) -> bool {
     self
       .children
@@ -1175,6 +1182,21 @@ impl<'g> RenderNode<'g> {
             force_inline_layout: false,
           }
         } else {
+          // https://github.com/kane50613/takumi/issues/711
+          let has_block_level = children
+            .iter()
+            .any(|child| !child.participates_in_inline_formatting_context());
+          if has_block_level
+            && children
+              .iter()
+              .any(RenderNode::is_whitespace_only_text_node)
+          {
+            children = Vec::from(children)
+              .into_iter()
+              .filter(|child| !child.is_whitespace_only_text_node())
+              .collect();
+          }
+
           let has_inline = children
             .iter()
             .any(RenderNode::participates_in_inline_formatting_context);

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1752,3 +1752,45 @@ fn test_block_container_drops_whitespace_between_absolute_and_in_flow_sibling() 
 
   assert_eq!(with_result, without_result);
 }
+
+// https://github.com/kane50613/takumi/issues/711
+#[test]
+fn test_block_container_preserves_whitespace_between_inline_siblings() {
+  let inline_span = |label: &'static str| {
+    Node::text(label.to_string())
+      .with_style(Style::default().with(StyleDeclaration::display(Display::Inline)))
+  };
+  let block_child = || {
+    Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Block))
+        .with(StyleDeclaration::width(Px(50.0)))
+        .with(StyleDeclaration::height(Px(50.0))),
+    )
+  };
+  let block_style = || {
+    Style::default()
+      .with(StyleDeclaration::display(Display::Block))
+      .with(StyleDeclaration::width(Px(400.0)))
+  };
+
+  let with_space = Node::container([
+    inline_span("a"),
+    Node::text(" ".to_string()),
+    inline_span("b"),
+    block_child(),
+  ])
+  .with_style(block_style());
+
+  let without_space =
+    Node::container([inline_span("a"), inline_span("b"), block_child()]).with_style(block_style());
+
+  let with_result = measure(with_space, create_measure_viewport());
+  let without_result = measure(without_space, create_measure_viewport());
+
+  assert!(
+    with_result.height > without_result.height
+      || with_result.children[0] != without_result.children[0],
+    "inline-interior whitespace should change layout (preserved space between siblings)"
+  );
+}

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1709,3 +1709,46 @@ fn test_flex_container_drops_whitespace_only_text_children() {
   assert_eq!(without_result.children.len(), 2);
   assert_close(with_result.height, without_result.height);
 }
+
+// https://github.com/kane50613/takumi/issues/711
+#[test]
+fn test_block_container_drops_whitespace_between_absolute_and_in_flow_sibling() {
+  let absolute_child = || {
+    Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Block))
+        .with(StyleDeclaration::position(Position::Absolute))
+        .with(StyleDeclaration::width(Px(40.0)))
+        .with(StyleDeclaration::height(Px(40.0))),
+    )
+  };
+  let in_flow_child = || {
+    Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Block))
+        .with(StyleDeclaration::width(Px(100.0)))
+        .with(StyleDeclaration::height(Px(100.0))),
+    )
+  };
+  let block_style = || {
+    Style::default()
+      .with(StyleDeclaration::display(Display::Block))
+      .with(StyleDeclaration::position(Position::Relative))
+      .with(StyleDeclaration::width(Px(200.0)))
+  };
+
+  let with_whitespace = Node::container([
+    absolute_child(),
+    Node::text("\n  \t".to_string()),
+    in_flow_child(),
+  ])
+  .with_style(block_style());
+
+  let without_whitespace =
+    Node::container([absolute_child(), in_flow_child()]).with_style(block_style());
+
+  let with_result = measure(with_whitespace, create_measure_viewport());
+  let without_result = measure(without_whitespace, create_measure_viewport());
+
+  assert_eq!(with_result, without_result);
+}


### PR DESCRIPTION
Fixes #711. Extends the #695 fix to block containers — drop whitespace-only text when any sibling is block-level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a layout issue where whitespace-only text nodes between block-level siblings caused absolutely positioned children to be incorrectly removed from the layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->