### PR TITLE
NAPI: fix broken type definitions for @takumi-rs/core

### DIFF
--- a/.changeset/napi-core-publish-index-dts.md
+++ b/.changeset/napi-core-publish-index-dts.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/core": patch
+---
+
+Fix broken type definitions for `@takumi-rs/core` (#715)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,37 @@ jobs:
           docker run --rm -v $PWD:/workspace -w /workspace/takumi-napi-core \
             oven/bun:alpine bun test
 
+  verify-napi-pkg:
+    name: Verify @takumi-rs/core package
+    needs: [build-napi, build-helpers]
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@main
+        with:
+          bun-version: latest
+
+      - name: Download helpers artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: helpers-dist
+          path: takumi-helpers/dist
+
+      - name: Download N-API bindings artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: bindings-x86_64-unknown-linux-gnu
+          path: takumi-napi-core
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter ./takumi-napi-core
+
+      - name: Verify published package contents and types
+        working-directory: takumi-napi-core
+        run: bun run verify:pkg
+
   build-wasm:
     name: Build @takumi-rs/wasm
     runs-on: ubuntu-latest
@@ -687,6 +718,7 @@ jobs:
         test-js,
         build-image-response,
         test-napi,
+        verify-napi-pkg,
         test-template,
         test-examples,
         test-wasm,

--- a/bun.lock
+++ b/bun.lock
@@ -225,11 +225,11 @@
     },
     "takumi": {
       "name": "takumi",
-      "version": "1.1.2",
+      "version": "1.3.0",
     },
     "takumi-helpers": {
       "name": "@takumi-rs/helpers",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/react": "catalog:",
@@ -253,7 +253,7 @@
     },
     "takumi-image-response": {
       "name": "@takumi-rs/image-response",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "dependencies": {
         "takumi-js": "workspace:*",
       },
@@ -266,7 +266,7 @@
     },
     "takumi-js": {
       "name": "takumi-js",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "dependencies": {
         "@takumi-rs/core": "workspace:*",
         "@takumi-rs/helpers": "workspace:*",
@@ -282,11 +282,12 @@
     },
     "takumi-napi-core": {
       "name": "@takumi-rs/core",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
       },
       "devDependencies": {
+        "@arethetypeswrong/core": "^0.18.2",
         "@napi-rs/cli": "3.6.2",
         "@types/bun": "catalog:",
         "@types/react": "catalog:",
@@ -294,6 +295,7 @@
         "csstype": "^3.2.3",
         "lucide-react": "catalog:",
         "mitata": "^1.0.34",
+        "publint": "^0.3.21",
         "react": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
@@ -316,7 +318,7 @@
     },
     "takumi-wasm": {
       "name": "@takumi-rs/wasm",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
       },

--- a/takumi-napi-core/package.json
+++ b/takumi-napi-core/package.json
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist",
+    "index.d.ts",
     "not-available.js"
   ],
   "type": "module",
@@ -56,12 +57,14 @@
     "build:js": "tsdown && tsc -p tsconfig.dts.json && bun scripts/patch-dist-loader.ts",
     "prepublishOnly": "jq '.dependencies[\"@takumi-rs/helpers\"] = .version' package.json > tmp.json && mv tmp.json package.json && bun artifacts && napi prepublish -t npm --no-gh-release",
     "artifacts": "napi create-npm-dirs && napi artifacts && napi version",
-    "bench": "bun tests/bench/index.tsx"
+    "bench": "bun tests/bench/index.tsx",
+    "verify:pkg": "bun scripts/verify-pkg.ts"
   },
   "dependencies": {
     "@takumi-rs/helpers": "workspace:*"
   },
   "devDependencies": {
+    "@arethetypeswrong/core": "^0.18.2",
     "@napi-rs/cli": "3.6.2",
     "@types/bun": "catalog:",
     "@types/react": "catalog:",
@@ -69,6 +72,7 @@
     "csstype": "^3.2.3",
     "lucide-react": "catalog:",
     "mitata": "^1.0.34",
+    "publint": "^0.3.21",
     "react": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/takumi-napi-core/scripts/verify-pkg.ts
+++ b/takumi-napi-core/scripts/verify-pkg.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
+import { Package, checkPackage } from "@arethetypeswrong/core";
+import { publint } from "publint";
+import { formatMessage } from "publint/utils";
+
+// @arethetypeswrong/core's built-in tarball parser drops chunks for some
+// gzip outputs (see https://github.com/101arrowz/fflate/issues/207); decompress
+// and untar manually, then feed the file map to the Package constructor.
+const TAR_HEADER_SIZE = 512;
+const TAR_NAME_END = 100;
+const TAR_SIZE_START = 124;
+const TAR_SIZE_END = 136;
+
+// Problem kinds that are not regressions in the published .d.ts itself.
+// CJSResolvesToESM is a separate, pre-existing concern about the dual exports
+// map; tracking it is fine but it should not block CI on this guard.
+const IGNORED_PROBLEM_KINDS = new Set(["CJSResolvesToESM"]);
+
+const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkgJson = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+
+let failed = false;
+
+const { messages } = await publint({ pkgDir });
+if (messages.length > 0) {
+  console.log("publint:");
+  for (const msg of messages) {
+    const formatted = formatMessage(msg, pkgJson) ?? msg.code;
+    console.log(`  [${msg.type}] ${formatted}`);
+    if (msg.type === "error") failed = true;
+  }
+}
+
+const tmp = mkdtempSync(join(tmpdir(), "verify-napi-pkg-"));
+try {
+  execFileSync("bun", ["pm", "pack", "--ignore-scripts", "--destination", tmp, "--quiet"], {
+    cwd: pkgDir,
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  const tarballName = readdirSync(tmp).find((f) => f.endsWith(".tgz"));
+  if (!tarballName) throw new Error("bun pm pack did not produce a tarball");
+  const tarBuf = gunzipSync(readFileSync(join(tmp, tarballName)));
+
+  const files: Record<string, Uint8Array> = {};
+  let prefix = "";
+  let offset = 0;
+  while (offset < tarBuf.length) {
+    const header = tarBuf.subarray(offset, offset + TAR_HEADER_SIZE);
+    const name = header.subarray(0, TAR_NAME_END).toString("utf8").replace(/\0.*$/, "");
+    if (!name) break;
+    const sizeOctal = header
+      .subarray(TAR_SIZE_START, TAR_SIZE_END)
+      .toString("utf8")
+      .replace(/\0.*$/, "")
+      .trim();
+    const size = parseInt(sizeOctal || "0", 8);
+    if (!prefix) prefix = name.slice(0, name.indexOf("/") + 1);
+    const innerPath = name.slice(prefix.length);
+    files[`/node_modules/${pkgJson.name}/${innerPath}`] = new Uint8Array(
+      tarBuf.subarray(offset + TAR_HEADER_SIZE, offset + TAR_HEADER_SIZE + size),
+    );
+    offset += TAR_HEADER_SIZE + Math.ceil(size / TAR_HEADER_SIZE) * TAR_HEADER_SIZE;
+  }
+
+  const pkg = new Package(files, pkgJson.name, pkgJson.version);
+  const result = await checkPackage(pkg);
+
+  if ("problems" in result && result.problems.length > 0) {
+    const fatal = result.problems.filter((p) => !IGNORED_PROBLEM_KINDS.has(p.kind));
+    const ignored = result.problems.filter((p) => IGNORED_PROBLEM_KINDS.has(p.kind));
+    if (ignored.length > 0) {
+      console.log("attw (ignored):");
+      for (const p of ignored) console.log(`  [${p.kind}]`);
+    }
+    if (fatal.length > 0) {
+      console.log("attw:");
+      for (const p of fatal) console.log(`  [${p.kind}] ${JSON.stringify(p)}`);
+      failed = true;
+    }
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+if (failed) {
+  console.error("\nPackage verification failed.");
+  process.exit(1);
+}
+
+console.log("Package verification passed.");

--- a/takumi-napi-core/src/export.ts
+++ b/takumi-napi-core/src/export.ts
@@ -1,6 +1,6 @@
-import type { Font, FontDetails, ImageSource } from "../index";
-export type * from "../index";
-import { Renderer as NativeRenderer } from "../index";
+import type { Font, FontDetails, ImageSource } from "../index.js";
+export type * from "../index.js";
+import { Renderer as NativeRenderer } from "../index.js";
 
 export { extractResourceUrls } from "@takumi-rs/helpers";
 


### PR DESCRIPTION
## Summary

Fixes #715.

`dist/export.d.ts` was emitted with `import { Renderer } from \"../index\"`, but `index.d.ts` wasn't in the published `files` array — so consumers saw `Renderer` as `any`. Two changes restore the types:

1. Add `index.d.ts` to `files` so the napi-generated declarations ship with the package.
2. Change the source imports to `../index.js` so node16 ESM module resolution can find the file (extensionless paths fail in strict ESM resolution).

## Guard

A new `verify-napi-pkg` CI job runs `publint` + `@arethetypeswrong/core` against the packed tarball and would have caught this regression: it reported `InternalResolutionError` for `../index` across all three resolution modes (node10, node16, bundler) when reverted to the broken state.

The job is wired into `pass-test` so it blocks merge.

## Test plan

- [x] `bun run verify:pkg` passes on the fix
- [x] `bun run verify:pkg` fails on the pre-fix state (verified locally)
- [x] `bun test ./tests/` in `takumi-napi-core` — 55 pass, 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broken type definitions for `@takumi-rs/core`.

* **Chores**
  * Updated module specifiers for ESM compatibility.
  * Added automated package verification to CI pipeline to validate published package contents and types.
  * Added type checking tools to development dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->