### PR TITLE
JS: expose `takumi-js/helpers/html` subpath export

### DIFF
--- a/.changeset/takumi-js-helpers-html-export.md
+++ b/.changeset/takumi-js-helpers-html-export.md
@@ -1,0 +1,5 @@
+---
+"takumi-js": patch
+---
+
+Expose `takumi-js/helpers/html` subpath export

--- a/takumi-js/package.json
+++ b/takumi-js/package.json
@@ -77,6 +77,12 @@
       "import": "./dist/helpers/jsx.mjs",
       "require": "./dist/helpers/jsx.cjs",
       "default": "./dist/helpers/jsx.mjs"
+    },
+    "./helpers/html": {
+      "types": "./dist/helpers/html.d.mts",
+      "import": "./dist/helpers/html.mjs",
+      "require": "./dist/helpers/html.cjs",
+      "default": "./dist/helpers/html.mjs"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

- `takumi-js/src/helpers/html.ts` re-exports `@takumi-rs/helpers/html` and `tsdown.config.ts` emits `dist/helpers/html.{mjs,cjs,d.mts}`, but `package.json` `exports` never listed `./helpers/html` — so `import { fromHtml } from "takumi-js/helpers/html"` failed to resolve.
- Add the `./helpers/html` subpath alongside the existing `./helpers/emoji` and `./helpers/jsx` entries.

Surfaced by #716 which documents `fromHtml` via this path.

## Test plan

- [x] `bun run build` in `takumi-js/` — `publint` passes, `dist/helpers/html.{mjs,cjs,d.mts}` emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed `takumi-js/helpers/html` as a new subpath export, enabling direct imports of HTML utilities from this dedicated entry point.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->