### PR TITLE
Crate: fix double-DPR scaling for `rem` units in descendants

### DIFF
--- a/.changeset/fix-rem-double-dpr.md
+++ b/.changeset/fix-rem-double-dpr.md
@@ -1,0 +1,5 @@
+---
+"takumi": patch
+---
+
+Fix `rem` units double-applying device-pixel ratio on descendant elements

--- a/takumi/src/layout/style/properties/font_size.rs
+++ b/takumi/src/layout/style/properties/font_size.rs
@@ -230,4 +230,30 @@ mod tests {
 
     assert_eq!(FontSize::default().to_px(&sizing, sizing.font_size), 16.0);
   }
+
+  #[test]
+  fn rem_font_size_in_descendant_does_not_double_apply_dpr() {
+    use crate::layout::viewport::DEFAULT_FONT_SIZE;
+
+    let viewport = Viewport::new((1200, 630)).with_device_pixel_ratio(2.0);
+    let root_font_size_device_px = DEFAULT_FONT_SIZE * viewport.device_pixel_ratio;
+    let sizing = Sizing {
+      viewport,
+      container_size: Size::NONE,
+      font_size: root_font_size_device_px,
+      root_font_size: Some(root_font_size_device_px),
+      line_height: 0.0,
+      root_line_height: None,
+      calc_arena: Rc::new(CalcArena::default()),
+    };
+
+    assert_eq!(
+      FontSize::Length(Length::Rem(0.5)).to_px(&sizing, sizing.font_size),
+      16.0
+    );
+    assert_eq!(
+      FontSize::Length(Length::Rem(1.0)).to_px(&sizing, sizing.font_size),
+      32.0
+    );
+  }
 }

--- a/takumi/src/layout/style/properties/length.rs
+++ b/takumi/src/layout/style/properties/length.rs
@@ -358,7 +358,7 @@ impl CalcFormula {
 
     CalcLinear {
       px: self.px * sizing.viewport.device_pixel_ratio
-        + self.rem * sizing.rem_basis() * sizing.viewport.device_pixel_ratio
+        + self.rem * sizing.rem_basis()
         + self.em * sizing.font_size
         + self.lh * sizing.line_height
         + self.rlh * sizing.root_line_height_basis()
@@ -951,9 +951,7 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
     match self {
       Length::Auto => CompactLength::auto(),
       Length::Percentage(value) => CompactLength::percent(value / 100.0),
-      Length::Rem(value) => {
-        CompactLength::length(value * sizing.rem_basis() * sizing.viewport.device_pixel_ratio)
-      }
+      Length::Rem(value) => CompactLength::length(value * sizing.rem_basis()),
       Length::Em(value) => CompactLength::length(value * sizing.font_size),
       Length::Lh(value) => CompactLength::length(value * sizing.line_height),
       Length::Rlh(value) => CompactLength::length(value * sizing.root_line_height_basis()),
@@ -1035,6 +1033,7 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
         | Length::VMin(_)
         | Length::VMax(_)
         | Length::Em(_)
+        | Length::Rem(_)
         | Length::Lh(_)
         | Length::Rlh(_)
         | Length::Calc(_)
@@ -1261,6 +1260,61 @@ mod tests {
   fn to_px_applies_device_pixel_ratio_for_absolute_units() {
     let px = Length::<true>::Rem(2.0).to_px(&sizing(), 100.0);
     assert_near(px, 64.0);
+  }
+
+  fn descendant_sizing() -> Sizing {
+    let mut sizing = sizing();
+    sizing.root_font_size = Some(32.0);
+    sizing
+  }
+
+  #[test]
+  fn rem_to_px_does_not_double_apply_dpr_when_root_font_size_set() {
+    let sizing = descendant_sizing();
+    assert_near(Length::<true>::Rem(1.0).to_px(&sizing, 0.0), 32.0);
+    assert_near(Length::<true>::Rem(2.0).to_px(&sizing, 0.0), 64.0);
+    assert_near(Length::<true>::Rem(0.5).to_px(&sizing, 0.0), 16.0);
+  }
+
+  #[test]
+  fn rem_to_compact_length_does_not_double_apply_dpr_when_root_font_size_set() {
+    let sizing = descendant_sizing();
+    let compact = Length::<true>::Rem(1.0).to_compact_length(&sizing);
+    assert_near(compact.value(), 32.0);
+  }
+
+  #[test]
+  fn calc_with_rem_does_not_double_apply_dpr_when_root_font_size_set() {
+    let sizing = descendant_sizing();
+    let value: Length<true> = Length::Calc(CalcFormula {
+      rem: 1.0,
+      ..Default::default()
+    });
+    assert_near(value.to_px(&sizing, 0.0), 32.0);
+  }
+
+  #[test]
+  fn calc_with_rem_and_px_does_not_double_apply_dpr_when_root_font_size_set() {
+    let sizing = descendant_sizing();
+    let value: Length<true> = Length::Calc(CalcFormula {
+      rem: 1.0,
+      px: 5.0,
+      ..Default::default()
+    });
+    assert_near(value.to_px(&sizing, 0.0), 42.0);
+  }
+
+  #[test]
+  fn make_computed_calc_with_rem_collapses_correctly_when_root_font_size_set() {
+    let mut value: Length<true> = Length::Calc(CalcFormula {
+      rem: 1.0,
+      px: 5.0,
+      ..Default::default()
+    });
+    let sizing = descendant_sizing();
+    value.make_computed(&sizing);
+    assert_eq!(value, Length::Px(21.0));
+    assert_near(value.to_px(&sizing, 0.0), 42.0);
   }
 
   #[test]

--- a/takumi/src/rendering/mod.rs
+++ b/takumi/src/rendering/mod.rs
@@ -71,9 +71,11 @@ pub(crate) struct Sizing {
 }
 
 impl Sizing {
-  /// Pixel basis for the `rem` unit.
+  /// Device-pixel basis for the `rem` unit.
   pub(crate) fn rem_basis(&self) -> f32 {
-    self.root_font_size.unwrap_or(self.viewport.font_size)
+    self
+      .root_font_size
+      .unwrap_or(self.viewport.font_size * self.viewport.device_pixel_ratio)
   }
 
   pub(crate) fn root_line_height_basis(&self) -> f32 {


### PR DESCRIPTION
## Summary

- `Sizing::rem_basis()` returned `root_font_size` (stored in device pixels by `tree.rs`), but every call site multiplied the result by DPR again — descendants got `rem * device_px * DPR` instead of `rem * device_px`.
- Made `rem` symmetric with `em`/`lh`/`rlh`: `rem_basis()` now consistently returns device pixels (DPR-scales the `viewport.font_size` fallback), the explicit `* DPR` is dropped from the three resolution sites (`CalcLinear::resolve`, `Length::to_compact_length`, `Length::to_px`), and `Length::Rem` joins the skip-DPR set in `to_px`.

## Test plan

- [x] 6 new guard tests (failed before the fix, pass after): `rem.to_px`, `rem.to_compact_length`, `calc(rem)`, `calc(rem + px)`, `make_computed(calc(rem + px))`, descendant `font-size: 0.5rem`
- [x] `cargo test --workspace` — 857 passed
- [x] `cargo clippy --workspace --all-targets --no-deps` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rem-based sizing so descendant elements no longer get device-pixel-ratio applied twice, restoring accurate on-screen sizes.

* **Tests**
  * Added tests validating rem resolution for descendant elements and various calc/rem scenarios to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->