### PR TITLE
Helpers: per-request timeout in `fetchResources`

### DIFF
--- a/.changeset/per-request-fetch-timeout.md
+++ b/.changeset/per-request-fetch-timeout.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/helpers": patch
+---
+
+Use a per-request timeout in `fetchResources` so one slow URL no longer consumes the whole batch's timeout budget

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -89,7 +89,7 @@ export type FetchResourcesOptions = {
  * @returns Array of { src: string, data: ArrayBuffer }
  */
 export async function fetchResources(urls: string[], options?: FetchResourcesOptions) {
-  const signal = AbortSignal.timeout(options?.timeout ?? defaultTimeout);
+  const timeout = options?.timeout ?? defaultTimeout;
   const fetch = options?.fetch ?? globalThis.fetch;
   const throwOnError = options?.throwOnError ?? true;
 
@@ -105,7 +105,7 @@ export async function fetchResources(urls: string[], options?: FetchResourcesOpt
       }
     }
 
-    const response = await fetch(url, { signal });
+    const response = await fetch(url, { signal: AbortSignal.timeout(timeout) });
 
     // Validate HTTP status
     if (!response.ok) {

--- a/takumi-helpers/test/utils/fetch-resources.test.ts
+++ b/takumi-helpers/test/utils/fetch-resources.test.ts
@@ -141,7 +141,7 @@ describe("fetchResources", () => {
     });
   });
 
-  test("all requests share the same AbortSignal", async () => {
+  test("each request gets its own timeout AbortSignal", async () => {
     const signals: AbortSignal[] = [];
 
     const mockFetch = mock((_url: string, init?: RequestInit) => {
@@ -155,9 +155,9 @@ describe("fetchResources", () => {
       fetch: mockFetch,
     });
 
-    // All requests share the same signal instance
+    // Per-request signals so one slow URL can't consume the whole batch's budget
     expect(signals.length).toBe(2);
-    expect(signals[0]).toBe(signals[1]);
+    expect(signals[0]).not.toBe(signals[1]);
   });
 
   test("deduplicates URLs before fetching", async () => {


### PR DESCRIPTION
`fetchResources` created a single `AbortSignal.timeout` shared across the whole batch, so one slow URL ate every other request's timeout budget. Now each request gets its own timeout signal. Flips the test that previously asserted the shared-signal behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeout handling to apply timeouts individually per request, preventing slower endpoints from consuming the entire timeout budget for concurrent requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->