### PR TITLE
Helpers: type the `textFit` style property

### DIFF
--- a/.changeset/style-textfit.md
+++ b/.changeset/style-textfit.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/helpers": minor
+---
+
+Type the `textFit` style property on React's `CSSProperties` so it no longer needs a cast

--- a/docs/app/components/playground/component-editor.tsx
+++ b/docs/app/components/playground/component-editor.tsx
@@ -42,30 +42,6 @@ declare namespace React {
 }
 `;
 
-const patchedCssTypings = `${cssTypings}
-
-export namespace Property {
-  export type TextFit =
-    | Globals
-    | "none"
-    | "grow"
-    | "shrink"
-    | "consistent"
-    | "per-line"
-    | "per-line-all"
-    | \`\${number}%\`
-    | (string & {});
-}
-
-export interface StandardLonghandProperties<TLength = (string & {}) | 0, TTime = string & {}> {
-  textFit?: Property.TextFit | undefined;
-}
-
-export interface StandardLonghandPropertiesHyphen<TLength = (string & {}) | 0, TTime = string & {}> {
-  "text-fit"?: Property.TextFit | undefined;
-}
-`;
-
 export function ComponentEditor({
   code,
   setCode,
@@ -134,7 +110,7 @@ export function ComponentEditor({
             filePath: "file:///node_modules/react/jsx-runtime.d.ts",
           },
           {
-            content: patchedCssTypings,
+            content: cssTypings,
             filePath: "file:///node_modules/csstype/index.d.ts",
           },
           {

--- a/example/twitter-images/components/text-fit.tsx
+++ b/example/twitter-images/components/text-fit.tsx
@@ -25,7 +25,6 @@ export default function TextFit() {
       <div
         tw="font-semibold leading-[1.2] text-balance w-[85%] font-mono"
         style={{
-          // @ts-expect-error: text-fit is not yet in the type definitions
           textFit: "grow per-line-all",
           whiteSpace: "pre-wrap",
         }}

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -1,5 +1,26 @@
 import type { CSSProperties } from "react";
 
+/**
+ * Value of the `text-fit` longhand: `[ none | grow | shrink ] [ consistent | per-line | per-line-all ]? <percentage>?`.
+ *
+ * @see https://drafts.csswg.org/css-text-4/#text-fit-property
+ */
+export type TextFit =
+  | "none"
+  | "grow"
+  | "shrink"
+  | "consistent"
+  | "per-line"
+  | "per-line-all"
+  | `${number}%`
+  | (string & {});
+
+declare module "react" {
+  interface CSSProperties {
+    textFit?: TextFit;
+  }
+}
+
 export type NodeAttributes = Record<string, string>;
 
 export type ReactElementLike = {


### PR DESCRIPTION
`textFit` (the `text-fit` longhand) works at runtime, but React's `CSSProperties` doesn't know about it, so styles needed a cast / `@ts-expect-error`.

This augments React's `CSSProperties` with `textFit` (same pattern as the existing `tw` augmentation) and exports a `TextFit` type, so `style={{ textFit }}` typechecks in both the helper functions and JSX. Additive — existing styles keep compiling.

Also drops the now-unneeded `@ts-expect-error` in the twitter-images example and the hand-rolled `csstype` override in the playground editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `TextFit` type supporting `text-fit` CSS property values with keyword and percentage options.

* **Bug Fixes**
  * Removed need for TypeScript error suppressions when using the `textFit` property in styles, now properly typed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->