### PR TITLE
IR: correct `onError` example in README

### DIFF
--- a/.changeset/onerror-docs.md
+++ b/.changeset/onerror-docs.md
@@ -2,4 +2,4 @@
 "@takumi-rs/image-response": patch
 ---
 
-Fix `onError` docs: it's a post-failure notification hook, not a fallback-render
+Correct `onError` example in README

--- a/.changeset/onerror-docs.md
+++ b/.changeset/onerror-docs.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/image-response": patch
+---
+
+Fix `onError` docs: it's a post-failure notification hook, not a fallback-render

--- a/takumi-image-response/README.md
+++ b/takumi-image-response/README.md
@@ -124,10 +124,17 @@ await response.ready;
 return response;
 ```
 
-You can also provide `onError` to render a fallback image instead of failing the response stream.
+You can also provide `onError`, a notification hook that runs after rendering fails. It's for side effects like logging; its return value is ignored and the response stream still errors, so it cannot substitute a fallback image. To serve a fallback, catch the `ready` rejection and return your own response.
 
 ```tsx
 const response = new ImageResponse(<OgImage />, {
-  onError: () => <div>Failed to generate image</div>,
+  onError: (error) => console.error(error),
 });
+
+try {
+  await response.ready;
+  return response;
+} catch {
+  return new Response("Failed to generate image", { status: 500 });
+}
 ```


### PR DESCRIPTION
The README claimed `onError` renders a fallback image. It doesn't: the handler runs *after* `controller.error()` and its return value is discarded (`takumi-js/src/response/index.ts:98-104`). Corrected to describe it as a post-failure notification hook and show the real fallback pattern (catch the `ready` rejection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `onError` is a post-failure notification hook (its return value is ignored) and not a fallback rendering mechanism.
  * Added an example showing proper error handling by catching response stream failures and returning a custom error response.
* **Chores**
  * Added a patch release entry for the image-response package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kane50613/takumi/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->