### PR TITLE
Helpers: add declarative `googleFont()` helper

### DIFF
--- a/.changeset/declarative-font-helpers.md
+++ b/.changeset/declarative-font-helpers.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/helpers": minor
+---
+
+Add `googleFont()` and `font()` helpers that resolve fonts (Google Fonts, URL, filesystem path, or raw bytes) into ready-to-use descriptors with caching, replacing the hand-rolled fetch-and-build boilerplate

--- a/.changeset/declarative-font-helpers.md
+++ b/.changeset/declarative-font-helpers.md
@@ -2,4 +2,4 @@
 "@takumi-rs/helpers": minor
 ---
 
-Add `googleFont()` and `font()` helpers that resolve fonts (Google Fonts, URL, filesystem path, or raw bytes) into ready-to-use descriptors with caching, replacing the hand-rolled fetch-and-build boilerplate
+Add `googleFont()` helper to load Google Fonts (static or variable) as ready-to-use font descriptors

--- a/.changeset/declarative-font-helpers.md
+++ b/.changeset/declarative-font-helpers.md
@@ -2,4 +2,4 @@
 "@takumi-rs/helpers": minor
 ---
 
-Add `googleFont()` helper to load Google Fonts (static or variable) as ready-to-use font descriptors
+Add `googleFont()` to load Google Fonts (static or variable) as font descriptors

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -27,13 +27,14 @@ type FontStyle = "normal" | "italic";
 
 export type GoogleFontOptions = FontOptions & {
   /**
-   * `400` for one weight, `[400, 700]` for several, or a range like `"100..900"` to fetch
-   * the variable font (weight stays fluid, driven by CSS `font-weight`). @default 400
+   * `400` for one weight, `[400, 700]` for several, or a range like `"100..900"` to load
+   * the variable font. A range leaves the weight unset so CSS `font-weight` controls it.
+   * @default 400
    */
   weight?: number | number[] | `${number}..${number}`;
   /** `"normal"`, `"italic"`, or both. @default "normal" */
   style?: FontStyle | FontStyle[];
-  /** Subset the download to just the glyphs in this text — recommended for OG images. */
+  /** Limit the download to the glyphs used in this text. Recommended for OG images. */
   text?: string;
   /** `font-display` strategy passed through to the CSS request. */
   display?: "auto" | "block" | "swap" | "fallback" | "optional";
@@ -101,7 +102,7 @@ function parseFontFaces(css: string) {
     }
     seen.add(url);
 
-    // A range (`100 900`) marks a variable file — leave weight unset so the engine keeps it fluid.
+    // A range like `100 900` means a variable file. Leave weight unset so CSS controls it.
     const weight = body.match(/font-weight:\s*(\d+)(?:\s+(\d+))?/);
     faces.push({
       url,
@@ -114,9 +115,9 @@ function parseFontFaces(css: string) {
 }
 
 /**
- * Resolve a Google Font into lazy, dedup-keyed loaders — handles the CSS lookup, `woff2`
- * URL extraction, and weight/style expansion that OG repos otherwise hand-roll. Only the CSS
- * is fetched eagerly; each file downloads lazily and the renderer skips ones already loaded.
+ * Load a Google Font as descriptors you can pass to a renderer's `fonts`. Fetches the
+ * Google Fonts CSS, reads the `woff2` URLs, and returns one loader per file. Each file
+ * downloads when the renderer first needs it; the renderer skips files it already loaded.
  *
  * @example
  * fonts: await googleFont("Inter", { weight: [400, 700] })

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,0 +1,186 @@
+// Chrome UA so the Google Fonts CSS API returns `woff2` `src` URLs.
+const chromeUserAgent =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type FontSource = string | URL | ArrayBuffer | Uint8Array;
+
+export type FontDescriptor = {
+  /** Font family name matched against `fontFamily`. Falls back to the name in the font file. */
+  name?: string;
+  /** Font weight. Falls back to the weight in the font file. */
+  weight?: number;
+  /** Font style, e.g. `"normal"` or `"italic"`. Falls back to the style in the font file. */
+  style?: string;
+};
+
+/** A resolved font descriptor, ready to pass to `ImageResponse`/`Renderer` `fonts`. */
+export type FontData = FontDescriptor & {
+  data: ArrayBuffer | Uint8Array;
+};
+
+const bytesCache = new Map<string, Promise<ArrayBuffer>>();
+const cssCache = new Map<string, Promise<string>>();
+
+function fetchBytes(url: string, fetchImpl: FetchLike): Promise<ArrayBuffer> {
+  const cached = bytesCache.get(url);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = fetchImpl(url).then((response) => {
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} fetching font: ${url}`);
+    }
+    return response.arrayBuffer();
+  });
+
+  bytesCache.set(url, pending);
+  return pending;
+}
+
+async function resolveSource(
+  source: FontSource,
+  fetchImpl: FetchLike,
+): Promise<ArrayBuffer | Uint8Array> {
+  if (source instanceof Uint8Array || source instanceof ArrayBuffer) {
+    return source;
+  }
+
+  const location = source instanceof URL ? source.href : source;
+
+  if (/^https?:\/\//.test(location)) {
+    return fetchBytes(location, fetchImpl);
+  }
+
+  // Local filesystem path (Node-only); imported lazily so edge/WASM bundles stay clean.
+  const { readFile } = await import("node:fs/promises");
+  return readFile(location);
+}
+
+export type FontOptions = {
+  /** Custom fetch implementation. @default globalThis.fetch */
+  fetch?: FetchLike;
+};
+
+/**
+ * Resolve a single font from a URL, filesystem path, or raw bytes into a descriptor.
+ *
+ * @example
+ * fonts: [await font("./Inter.ttf", { name: "Inter", weight: 400 })]
+ */
+export async function font(
+  source: FontSource,
+  descriptor: FontDescriptor = {},
+  options: FontOptions = {},
+): Promise<FontData> {
+  const data = await resolveSource(source, options.fetch ?? globalThis.fetch);
+  return { ...descriptor, data };
+}
+
+export type GoogleFontOptions = FontOptions & {
+  /** Weights to fetch. @default [400] */
+  weights?: number[];
+  /** Styles to fetch. @default ["normal"] */
+  styles?: ("normal" | "italic")[];
+  /** Restrict the download to the glyphs needed for this text. */
+  text?: string;
+  /** `font-display` strategy passed through to the CSS request. */
+  display?: "auto" | "block" | "swap" | "fallback" | "optional";
+};
+
+function buildCssUrl(family: string, options: GoogleFontOptions): string {
+  const weights = options.weights ?? [400];
+  const styles = options.styles ?? ["normal"];
+
+  let axis: string;
+  if (styles.includes("italic")) {
+    const italics = styles.includes("normal") ? [0, 1] : [1];
+    axis = `ital,wght@${italics
+      .flatMap((ital) => weights.map((weight) => `${ital},${weight}`))
+      .sort()
+      .join(";")}`;
+  } else {
+    axis = `wght@${[...weights].sort((a, b) => a - b).join(";")}`;
+  }
+
+  let url = `https://fonts.googleapis.com/css2?family=${family.replace(/ /g, "+")}:${axis}`;
+  if (options.display) {
+    url += `&display=${options.display}`;
+  }
+  if (options.text) {
+    url += `&text=${encodeURIComponent(options.text)}`;
+  }
+  return url;
+}
+
+function fetchCss(url: string, fetchImpl: FetchLike): Promise<string> {
+  const cached = cssCache.get(url);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = fetchImpl(url, { headers: { "User-Agent": chromeUserAgent } }).then(
+    (response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching Google Fonts CSS: ${url}`);
+      }
+      return response.text();
+    },
+  );
+
+  cssCache.set(url, pending);
+  return pending;
+}
+
+const fontFacePattern = /@font-face\s*\{([^}]*)\}/g;
+
+function parseFontFaces(css: string): { url: string; weight?: number; style?: string }[] {
+  const faces: { url: string; weight?: number; style?: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const [, body] of css.matchAll(fontFacePattern)) {
+    const url = body
+      .match(/src:\s*url\(([^)]+)\)/)?.[1]
+      ?.replace(/['"]/g, "")
+      .trim();
+    if (!url || seen.has(url)) {
+      continue;
+    }
+    seen.add(url);
+
+    const weight = body.match(/font-weight:\s*(\d+)/)?.[1];
+    faces.push({
+      url,
+      weight: weight ? Number(weight) : undefined,
+      style: body.match(/font-style:\s*([a-z]+)/i)?.[1],
+    });
+  }
+
+  return faces;
+}
+
+/**
+ * Resolve a Google Font into ready-to-use descriptors — handles the CSS lookup, `woff2`
+ * URL extraction, and multi-weight expansion that OG repos otherwise hand-roll.
+ *
+ * @example
+ * fonts: await googleFont("Inter", { weights: [400, 700] })
+ */
+export async function googleFont(
+  family: string,
+  options: GoogleFontOptions = {},
+): Promise<FontData[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const css = await fetchCss(buildCssUrl(family, options), fetchImpl);
+
+  return Promise.all(
+    parseFontFaces(css).map(async (face) => ({
+      name: family,
+      data: await fetchBytes(face.url, fetchImpl),
+      weight: face.weight,
+      style: face.style,
+    })),
+  );
+}

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,29 +1,11 @@
-import type { FetchLike } from "./utils";
+import { fetchOk, type FetchOptions } from "./utils";
 
 const chromeUserAgent =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
-export type FontOptions = {
-  /** Custom fetch implementation. @default globalThis.fetch */
-  fetch?: FetchLike;
-  /** Abort each underlying request after this many milliseconds. */
-  timeout?: number;
-};
-
-const timeoutSignal = (timeout?: number) =>
-  timeout === undefined ? undefined : AbortSignal.timeout(timeout);
-
-async function fetchBytes(url: string, fetchImpl: FetchLike, timeout?: number) {
-  const response = await fetchImpl(url, { signal: timeoutSignal(timeout) });
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} fetching font: ${url}`);
-  }
-  return response.arrayBuffer();
-}
-
 type FontStyle = "normal" | "italic";
 
-export type GoogleFontOptions = FontOptions & {
+export type GoogleFontOptions = FetchOptions & {
   /**
    * `400` for one weight, `[400, 700]` for several, or a range like `"100..900"` to load
    * the variable font. A range leaves the weight unset so CSS `font-weight` controls it.
@@ -68,15 +50,11 @@ function buildCssUrl(
   return url;
 }
 
-async function fetchCss(url: string, fetchImpl: FetchLike, timeout?: number) {
-  const response = await fetchImpl(url, {
-    headers: { "User-Agent": chromeUserAgent },
-    signal: timeoutSignal(timeout),
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} fetching Google Fonts CSS: ${url}`);
-  }
-  return response.text();
+function fetchCss(url: string, options: FetchOptions) {
+  return fetchOk(url, {
+    ...options,
+    init: { headers: { "User-Agent": chromeUserAgent } },
+  }).then((r) => r.text());
 }
 
 const fontFacePattern = /@font-face\s*\{([^}]*)\}/g;
@@ -124,14 +102,13 @@ function parseFontFaces(css: string) {
  * fonts: await googleFont("Inter", { weight: 700, style: "italic", text: "Hello" })
  */
 export async function googleFont(family: string, options: GoogleFontOptions = {}) {
-  const fetchImpl = options.fetch ?? globalThis.fetch;
-  const css = await fetchCss(buildCssUrl(family, options), fetchImpl, options.timeout);
+  const css = await fetchCss(buildCssUrl(family, options), options);
 
   return parseFontFaces(css).map((face) => ({
     name: family,
     key: face.url,
     weight: face.weight,
     style: face.style,
-    data: () => fetchBytes(face.url, fetchImpl, options.timeout),
+    data: () => fetchOk(face.url, options).then((r) => r.arrayBuffer()),
   }));
 }

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,8 +1,7 @@
-// Chrome UA so the Google Fonts CSS API returns `woff2` `src` URLs.
+import type { FetchLike } from "./utils";
+
 const chromeUserAgent =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-
-type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
 export type FontOptions = {
   /** Custom fetch implementation. @default globalThis.fetch */
@@ -11,12 +10,11 @@ export type FontOptions = {
   timeout?: number;
 };
 
-function withTimeout(init: RequestInit, timeout?: number): RequestInit {
-  return timeout === undefined ? init : { ...init, signal: AbortSignal.timeout(timeout) };
-}
+const timeoutSignal = (timeout?: number) =>
+  timeout === undefined ? undefined : AbortSignal.timeout(timeout);
 
 async function fetchBytes(url: string, fetchImpl: FetchLike, timeout?: number) {
-  const response = await fetchImpl(url, withTimeout({}, timeout));
+  const response = await fetchImpl(url, { signal: timeoutSignal(timeout) });
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} fetching font: ${url}`);
   }
@@ -71,10 +69,10 @@ function buildCssUrl(
 }
 
 async function fetchCss(url: string, fetchImpl: FetchLike, timeout?: number) {
-  const response = await fetchImpl(
-    url,
-    withTimeout({ headers: { "User-Agent": chromeUserAgent } }, timeout),
-  );
+  const response = await fetchImpl(url, {
+    headers: { "User-Agent": chromeUserAgent },
+    signal: timeoutSignal(timeout),
+  });
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} fetching Google Fonts CSS: ${url}`);
   }
@@ -102,7 +100,6 @@ function parseFontFaces(css: string) {
     }
     seen.add(url);
 
-    // A range like `100 900` means a variable file. Leave weight unset so CSS controls it.
     const weight = body.match(/font-weight:\s*(\d+)(?:\s+(\d+))?/);
     faces.push({
       url,

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -60,7 +60,7 @@ function buildCssUrl(
     axis = `wght@${weights.join(";")}`;
   }
 
-  let url = `https://fonts.googleapis.com/css2?family=${family.replace(/ /g, "+")}:${axis}`;
+  let url = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:${axis}`;
   if (display) {
     url += `&display=${display}`;
   }

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -4,143 +4,94 @@ const chromeUserAgent =
 
 type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
-export type FontSource = string | URL | ArrayBuffer | Uint8Array;
-
-export type FontDescriptor = {
-  /** Font family name matched against `fontFamily`. Falls back to the name in the font file. */
-  name?: string;
-  /** Font weight. Falls back to the weight in the font file. */
-  weight?: number;
-  /** Font style, e.g. `"normal"` or `"italic"`. Falls back to the style in the font file. */
-  style?: string;
-};
-
-/** A resolved font descriptor, ready to pass to `ImageResponse`/`Renderer` `fonts`. */
-export type FontData = FontDescriptor & {
-  data: ArrayBuffer | Uint8Array;
-};
-
-const bytesCache = new Map<string, Promise<ArrayBuffer>>();
-const cssCache = new Map<string, Promise<string>>();
-
-function fetchBytes(url: string, fetchImpl: FetchLike): Promise<ArrayBuffer> {
-  const cached = bytesCache.get(url);
-  if (cached) {
-    return cached;
-  }
-
-  const pending = fetchImpl(url).then((response) => {
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} fetching font: ${url}`);
-    }
-    return response.arrayBuffer();
-  });
-
-  bytesCache.set(url, pending);
-  return pending;
-}
-
-async function resolveSource(
-  source: FontSource,
-  fetchImpl: FetchLike,
-): Promise<ArrayBuffer | Uint8Array> {
-  if (source instanceof Uint8Array || source instanceof ArrayBuffer) {
-    return source;
-  }
-
-  const location = source instanceof URL ? source.href : source;
-
-  if (/^https?:\/\//.test(location)) {
-    return fetchBytes(location, fetchImpl);
-  }
-
-  // Local filesystem path (Node-only); imported lazily so edge/WASM bundles stay clean.
-  const { readFile } = await import("node:fs/promises");
-  return readFile(location);
-}
-
 export type FontOptions = {
   /** Custom fetch implementation. @default globalThis.fetch */
   fetch?: FetchLike;
+  /** Abort each underlying request after this many milliseconds. */
+  timeout?: number;
 };
 
-/**
- * Resolve a single font from a URL, filesystem path, or raw bytes into a descriptor.
- *
- * @example
- * fonts: [await font("./Inter.ttf", { name: "Inter", weight: 400 })]
- */
-export async function font(
-  source: FontSource,
-  descriptor: FontDescriptor = {},
-  options: FontOptions = {},
-): Promise<FontData> {
-  const data = await resolveSource(source, options.fetch ?? globalThis.fetch);
-  return { ...descriptor, data };
+function withTimeout(init: RequestInit, timeout?: number): RequestInit {
+  return timeout === undefined ? init : { ...init, signal: AbortSignal.timeout(timeout) };
 }
 
+async function fetchBytes(url: string, fetchImpl: FetchLike, timeout?: number) {
+  const response = await fetchImpl(url, withTimeout({}, timeout));
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching font: ${url}`);
+  }
+  return response.arrayBuffer();
+}
+
+type FontStyle = "normal" | "italic";
+
 export type GoogleFontOptions = FontOptions & {
-  /** Weights to fetch. @default [400] */
-  weights?: number[];
-  /** Styles to fetch. @default ["normal"] */
-  styles?: ("normal" | "italic")[];
-  /** Restrict the download to the glyphs needed for this text. */
+  /**
+   * `400` for one weight, `[400, 700]` for several, or a range like `"100..900"` to fetch
+   * the variable font (weight stays fluid, driven by CSS `font-weight`). @default 400
+   */
+  weight?: number | number[] | `${number}..${number}`;
+  /** `"normal"`, `"italic"`, or both. @default "normal" */
+  style?: FontStyle | FontStyle[];
+  /** Subset the download to just the glyphs in this text — recommended for OG images. */
   text?: string;
   /** `font-display` strategy passed through to the CSS request. */
   display?: "auto" | "block" | "swap" | "fallback" | "optional";
 };
 
-function buildCssUrl(family: string, options: GoogleFontOptions): string {
-  const weights = options.weights ?? [400];
-  const styles = options.styles ?? ["normal"];
+function buildCssUrl(
+  family: string,
+  { weight = 400, style = "normal", display, text }: GoogleFontOptions,
+) {
+  const weights = (Array.isArray(weight) ? [...weight].sort((a, b) => a - b) : [weight]).map(
+    String,
+  );
+  const styles = Array.isArray(style) ? style : [style];
 
   let axis: string;
   if (styles.includes("italic")) {
     const italics = styles.includes("normal") ? [0, 1] : [1];
     axis = `ital,wght@${italics
-      .flatMap((ital) => weights.map((weight) => `${ital},${weight}`))
+      .flatMap((ital) => weights.map((w) => `${ital},${w}`))
       .sort()
       .join(";")}`;
   } else {
-    axis = `wght@${[...weights].sort((a, b) => a - b).join(";")}`;
+    axis = `wght@${weights.join(";")}`;
   }
 
   let url = `https://fonts.googleapis.com/css2?family=${family.replace(/ /g, "+")}:${axis}`;
-  if (options.display) {
-    url += `&display=${options.display}`;
+  if (display) {
+    url += `&display=${display}`;
   }
-  if (options.text) {
-    url += `&text=${encodeURIComponent(options.text)}`;
+  if (text) {
+    url += `&text=${encodeURIComponent(text)}`;
   }
   return url;
 }
 
-function fetchCss(url: string, fetchImpl: FetchLike): Promise<string> {
-  const cached = cssCache.get(url);
-  if (cached) {
-    return cached;
-  }
-
-  const pending = fetchImpl(url, { headers: { "User-Agent": chromeUserAgent } }).then(
-    (response) => {
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status} fetching Google Fonts CSS: ${url}`);
-      }
-      return response.text();
-    },
+async function fetchCss(url: string, fetchImpl: FetchLike, timeout?: number) {
+  const response = await fetchImpl(
+    url,
+    withTimeout({ headers: { "User-Agent": chromeUserAgent } }, timeout),
   );
-
-  cssCache.set(url, pending);
-  return pending;
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching Google Fonts CSS: ${url}`);
+  }
+  return response.text();
 }
 
 const fontFacePattern = /@font-face\s*\{([^}]*)\}/g;
 
-function parseFontFaces(css: string): { url: string; weight?: number; style?: string }[] {
+function parseFontFaces(css: string) {
   const faces: { url: string; weight?: number; style?: string }[] = [];
   const seen = new Set<string>();
 
-  for (const [, body] of css.matchAll(fontFacePattern)) {
+  for (const match of css.matchAll(fontFacePattern)) {
+    const body = match[1];
+    if (!body) {
+      continue;
+    }
+
     const url = body
       .match(/src:\s*url\(([^)]+)\)/)?.[1]
       ?.replace(/['"]/g, "")
@@ -150,10 +101,11 @@ function parseFontFaces(css: string): { url: string; weight?: number; style?: st
     }
     seen.add(url);
 
-    const weight = body.match(/font-weight:\s*(\d+)/)?.[1];
+    // A range (`100 900`) marks a variable file — leave weight unset so the engine keeps it fluid.
+    const weight = body.match(/font-weight:\s*(\d+)(?:\s+(\d+))?/);
     faces.push({
       url,
-      weight: weight ? Number(weight) : undefined,
+      weight: weight && !weight[2] ? Number(weight[1]) : undefined,
       style: body.match(/font-style:\s*([a-z]+)/i)?.[1],
     });
   }
@@ -162,25 +114,26 @@ function parseFontFaces(css: string): { url: string; weight?: number; style?: st
 }
 
 /**
- * Resolve a Google Font into ready-to-use descriptors — handles the CSS lookup, `woff2`
- * URL extraction, and multi-weight expansion that OG repos otherwise hand-roll.
+ * Resolve a Google Font into lazy, dedup-keyed loaders — handles the CSS lookup, `woff2`
+ * URL extraction, and weight/style expansion that OG repos otherwise hand-roll. Only the CSS
+ * is fetched eagerly; each file downloads lazily and the renderer skips ones already loaded.
  *
  * @example
- * fonts: await googleFont("Inter", { weights: [400, 700] })
+ * fonts: await googleFont("Inter", { weight: [400, 700] })
+ * @example
+ * fonts: await googleFont("Inter", { weight: "100..900" }) // variable
+ * @example
+ * fonts: await googleFont("Inter", { weight: 700, style: "italic", text: "Hello" })
  */
-export async function googleFont(
-  family: string,
-  options: GoogleFontOptions = {},
-): Promise<FontData[]> {
+export async function googleFont(family: string, options: GoogleFontOptions = {}) {
   const fetchImpl = options.fetch ?? globalThis.fetch;
-  const css = await fetchCss(buildCssUrl(family, options), fetchImpl);
+  const css = await fetchCss(buildCssUrl(family, options), fetchImpl, options.timeout);
 
-  return Promise.all(
-    parseFontFaces(css).map(async (face) => ({
-      name: family,
-      data: await fetchBytes(face.url, fetchImpl),
-      weight: face.weight,
-      style: face.style,
-    })),
-  );
+  return parseFontFaces(css).map((face) => ({
+    name: family,
+    key: face.url,
+    weight: face.weight,
+    style: face.style,
+    data: () => fetchBytes(face.url, fetchImpl, options.timeout),
+  }));
 }

--- a/takumi-helpers/src/index.ts
+++ b/takumi-helpers/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./fonts";
 export * from "./helpers";
 export * from "./types";
 export * from "./utils";

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -57,6 +57,8 @@ export function extractResourceUrls(node: Node): string[] {
   return [...urls];
 }
 
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
 export type FetchResourcesOptions = {
   /**
    * Timeout in milliseconds.
@@ -67,7 +69,7 @@ export type FetchResourcesOptions = {
    * Custom fetch function.
    * @default {globalThis.fetch}
    */
-  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
+  fetch?: FetchLike;
   /**
    * Whether to throw on any fetch failure. If false, returns only successful fetches.
    * @default true

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -59,17 +59,26 @@ export function extractResourceUrls(node: Node): string[] {
 
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
-export type FetchResourcesOptions = {
-  /**
-   * Timeout in milliseconds.
-   * @default 5000
-   */
-  timeout?: number;
-  /**
-   * Custom fetch function.
-   * @default {globalThis.fetch}
-   */
+export type FetchOptions = {
+  /** Custom fetch implementation. @default globalThis.fetch */
   fetch?: FetchLike;
+  /** Abort the request after this many milliseconds. */
+  timeout?: number;
+};
+
+/** Fetches a URL, applying a timeout signal and throwing on a non-OK status. */
+export async function fetchOk(url: string, options: FetchOptions & { init?: RequestInit } = {}) {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const signal =
+    options.timeout === undefined ? options.init?.signal : AbortSignal.timeout(options.timeout);
+  const response = await fetchImpl(url, { ...options.init, signal });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText} fetching ${url}`);
+  }
+  return response;
+}
+
+export type FetchResourcesOptions = FetchOptions & {
   /**
    * Whether to throw on any fetch failure. If false, returns only successful fetches.
    * @default true
@@ -83,23 +92,18 @@ export type FetchResourcesOptions = {
 };
 
 /**
- * Fetches multiple resources concurrently.
- * Validates HTTP status codes and automatically deduplicates URLs.
+ * Fetches multiple resources concurrently, deduplicating URLs.
  *
  * @param urls - URLs to fetch
- * @param options - Fetch options
+ * @param options - Fetch options; `timeout` defaults to 5000ms
  * @returns Array of { src: string, data: ArrayBuffer }
  */
 export async function fetchResources(urls: string[], options?: FetchResourcesOptions) {
-  const timeout = options?.timeout ?? defaultTimeout;
-  const fetch = options?.fetch ?? globalThis.fetch;
   const throwOnError = options?.throwOnError ?? true;
+  // Per-request timeout so one slow URL can't consume the whole batch's budget.
+  const timeout = options?.timeout ?? defaultTimeout;
 
-  // Deduplicate URLs to avoid redundant fetches
-  const uniqueUrls = [...new Set(urls)];
-
-  const promises = uniqueUrls.map(async (url) => {
-    // Check cache first if provided
+  const promises = [...new Set(urls)].map(async (url) => {
     if (options?.cache?.has(url)) {
       const cached = options.cache.get(url);
       if (cached) {
@@ -107,27 +111,17 @@ export async function fetchResources(urls: string[], options?: FetchResourcesOpt
       }
     }
 
-    const response = await fetch(url, { signal: AbortSignal.timeout(timeout) });
-
-    // Validate HTTP status
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText} for ${url}`);
-    }
-
-    const buffer = await response.arrayBuffer();
-
-    // Store in cache if provided
+    const buffer = await fetchOk(url, { fetch: options?.fetch, timeout }).then((r) =>
+      r.arrayBuffer(),
+    );
     options?.cache?.set(url, buffer);
-
     return { src: url, data: buffer };
   });
 
   if (throwOnError) {
-    // Original behavior: throw on any error
     return Promise.all(promises);
   }
 
-  // Graceful error handling: return successful fetches only
   const results = await Promise.allSettled(promises);
   return results
     .filter(

--- a/takumi-helpers/test/fonts.test.ts
+++ b/takumi-helpers/test/fonts.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, mock, test } from "bun:test";
+import { font, googleFont } from "../src/fonts";
+
+const bytes = (s: string) => new TextEncoder().encode(s).buffer;
+
+describe("font", () => {
+  test("passes raw bytes through with descriptor", async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const result = await font(data, { name: "Inter", weight: 700 });
+    expect(result).toEqual({ name: "Inter", weight: 700, data });
+  });
+
+  test("fetches a URL source", async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(bytes("ttf"))));
+    const result = await font(
+      "https://fonts.example.com/a.woff2",
+      { name: "A" },
+      { fetch: fetchMock },
+    );
+    expect(fetchMock).toHaveBeenCalled();
+    expect(new TextDecoder().decode(result.data as ArrayBuffer)).toBe("ttf");
+  });
+
+  test("throws on non-ok response", () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 404 })));
+    expect(
+      font("https://fonts.example.com/missing.woff2", {}, { fetch: fetchMock }),
+    ).rejects.toThrow("HTTP 404");
+  });
+});
+
+describe("googleFont", () => {
+  const css = `
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 400;
+      src: url(https://fonts.gstatic.com/inter-400.woff2) format('woff2');
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 700;
+      src: url(https://fonts.gstatic.com/inter-700.woff2) format('woff2');
+    }
+  `;
+
+  test("resolves every weight in the CSS to a descriptor", async () => {
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(
+        url.endsWith(".css2") || url.includes("/css2")
+          ? new Response(css)
+          : new Response(bytes(url)),
+      ),
+    );
+
+    const fonts = await googleFont("Inter", { weights: [400, 700], fetch: fetchMock });
+
+    expect(fonts).toHaveLength(2);
+    expect(fonts.map((f) => f.weight).sort()).toEqual([400, 700]);
+    expect(fonts.every((f) => f.name === "Inter")).toBe(true);
+  });
+
+  test("requests the right family/axis and a woff2 UA", async () => {
+    let requestedUrl = "";
+    let ua: string | null = null;
+    const fetchMock = mock((url: string, init?: RequestInit) => {
+      if (url.includes("/css2")) {
+        requestedUrl = url;
+        ua = new Headers(init?.headers).get("User-Agent");
+        return Promise.resolve(new Response(css));
+      }
+      return Promise.resolve(new Response(bytes(url)));
+    });
+
+    await googleFont("Open Sans", {
+      weights: [700, 400],
+      styles: ["normal", "italic"],
+      fetch: fetchMock,
+    });
+
+    expect(requestedUrl).toContain("family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700");
+    expect(ua).toContain("Chrome");
+  });
+});

--- a/takumi-helpers/test/fonts.test.ts
+++ b/takumi-helpers/test/fonts.test.ts
@@ -91,7 +91,7 @@ describe("googleFont", () => {
       fetch: fetchMock,
     });
 
-    expect(requestedUrl).toContain("family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700");
+    expect(requestedUrl).toContain("family=Open%20Sans:ital,wght@0,400;0,700;1,400;1,700");
     expect(ua).toContain("Chrome");
   });
 

--- a/takumi-helpers/test/fonts.test.ts
+++ b/takumi-helpers/test/fonts.test.ts
@@ -1,33 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
-import { font, googleFont } from "../src/fonts";
+import { googleFont } from "../src/fonts";
 
 const bytes = (s: string) => new TextEncoder().encode(s).buffer;
-
-describe("font", () => {
-  test("passes raw bytes through with descriptor", async () => {
-    const data = new Uint8Array([1, 2, 3]);
-    const result = await font(data, { name: "Inter", weight: 700 });
-    expect(result).toEqual({ name: "Inter", weight: 700, data });
-  });
-
-  test("fetches a URL source", async () => {
-    const fetchMock = mock(() => Promise.resolve(new Response(bytes("ttf"))));
-    const result = await font(
-      "https://fonts.example.com/a.woff2",
-      { name: "A" },
-      { fetch: fetchMock },
-    );
-    expect(fetchMock).toHaveBeenCalled();
-    expect(new TextDecoder().decode(result.data as ArrayBuffer)).toBe("ttf");
-  });
-
-  test("throws on non-ok response", () => {
-    const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 404 })));
-    expect(
-      font("https://fonts.example.com/missing.woff2", {}, { fetch: fetchMock }),
-    ).rejects.toThrow("HTTP 404");
-  });
-});
 
 describe("googleFont", () => {
   const css = `
@@ -45,41 +19,116 @@ describe("googleFont", () => {
     }
   `;
 
-  test("resolves every weight in the CSS to a descriptor", async () => {
+  test("resolves every weight in the CSS to a keyed loader", async () => {
     const fetchMock = mock((url: string) =>
-      Promise.resolve(
-        url.endsWith(".css2") || url.includes("/css2")
-          ? new Response(css)
-          : new Response(bytes(url)),
-      ),
+      Promise.resolve(url.includes("/css2") ? new Response(css) : new Response(bytes(url))),
     );
 
-    const fonts = await googleFont("Inter", { weights: [400, 700], fetch: fetchMock });
+    const fonts = await googleFont("Inter", { weight: [400, 700], fetch: fetchMock });
 
     expect(fonts).toHaveLength(2);
     expect(fonts.map((f) => f.weight).sort()).toEqual([400, 700]);
     expect(fonts.every((f) => f.name === "Inter")).toBe(true);
+    expect(fonts.map((f) => f.key).sort()).toEqual([
+      "https://fonts.gstatic.com/inter-400.woff2",
+      "https://fonts.gstatic.com/inter-700.woff2",
+    ]);
+  });
+
+  test("downloads bytes lazily — only the CSS is fetched up front", async () => {
+    const robotoCss = `
+      @font-face {
+        font-family: 'Roboto';
+        font-style: normal;
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/roboto-400.woff2) format('woff2');
+      }
+    `;
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(url.includes("/css2") ? new Response(robotoCss) : new Response(bytes(url))),
+    );
+
+    const fonts = await googleFont("Roboto", { weight: 400, fetch: fetchMock });
+
+    // Only the CSS request so far — no font bytes fetched until data() is called.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [loader] = fonts;
+    const data = await loader!.data();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new TextDecoder().decode(data)).toBe("https://fonts.gstatic.com/roboto-400.woff2");
+  });
+
+  test("attaches an abort signal to every request when timeout is set", async () => {
+    const inits: (RequestInit | undefined)[] = [];
+    const fetchMock = mock((url: string, init?: RequestInit) => {
+      inits.push(init);
+      return Promise.resolve(url.includes("/css2") ? new Response(css) : new Response(bytes(url)));
+    });
+
+    const fonts = await googleFont("Inter", { weight: 400, timeout: 5000, fetch: fetchMock });
+    await fonts[0]!.data();
+
+    expect(inits).toHaveLength(2);
+    expect(inits.every((init) => init?.signal instanceof AbortSignal)).toBe(true);
   });
 
   test("requests the right family/axis and a woff2 UA", async () => {
     let requestedUrl = "";
-    let ua: string | null = null;
+    let ua = "";
     const fetchMock = mock((url: string, init?: RequestInit) => {
       if (url.includes("/css2")) {
         requestedUrl = url;
-        ua = new Headers(init?.headers).get("User-Agent");
+        ua = new Headers(init?.headers).get("User-Agent") ?? "";
         return Promise.resolve(new Response(css));
       }
       return Promise.resolve(new Response(bytes(url)));
     });
 
     await googleFont("Open Sans", {
-      weights: [700, 400],
-      styles: ["normal", "italic"],
+      weight: [700, 400],
+      style: ["normal", "italic"],
       fetch: fetchMock,
     });
 
     expect(requestedUrl).toContain("family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700");
     expect(ua).toContain("Chrome");
+  });
+
+  test("a single weight builds a `wght@<n>` axis", async () => {
+    let requestedUrl = "";
+    const fetchMock = mock((url: string) => {
+      if (url.includes("/css2")) requestedUrl = url;
+      return Promise.resolve(url.includes("/css2") ? new Response(css) : new Response(bytes(url)));
+    });
+
+    await googleFont("Inter", { weight: 700, fetch: fetchMock });
+
+    expect(requestedUrl).toContain("family=Inter:wght@700");
+  });
+
+  test("a weight range requests the variable font and leaves weight unset", async () => {
+    const variableCss = `
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 100 900;
+        src: url(https://fonts.gstatic.com/inter-variable.woff2) format('woff2');
+      }
+    `;
+    let requestedUrl = "";
+    const fetchMock = mock((url: string) => {
+      if (url.includes("/css2")) requestedUrl = url;
+      return Promise.resolve(
+        url.includes("/css2") ? new Response(variableCss) : new Response(bytes(url)),
+      );
+    });
+
+    const fonts = await googleFont("Inter", { weight: "100..900", fetch: fetchMock });
+
+    expect(requestedUrl).toContain("family=Inter:wght@100..900");
+    expect(fonts).toHaveLength(1);
+    expect(fonts[0]!.weight).toBeUndefined();
+    expect(fonts[0]!.key).toBe("https://fonts.gstatic.com/inter-variable.woff2");
   });
 });


### PR DESCRIPTION
Adds `googleFont()` to `@takumi-rs/helpers` for loading Google Fonts. It fetches the Google Fonts CSS, reads the woff2 URLs, and returns descriptors you pass straight to `fonts`.

```ts
fonts: await googleFont("Inter", { weight: [400, 700] })
fonts: await googleFont("Inter", { weight: "100..900" })                          // variable
fonts: await googleFont("Inter", { weight: 700, style: "italic", text: "Hello" })
```

- `weight`: a value (`400`), a list (`[400, 700]`), or a range (`"100..900"`). A range loads the variable font and leaves the weight unset so CSS `font-weight` controls it.
- Also `style`, `text` subsetting, `display`, a custom `fetch`, and a request `timeout`.
- Each file downloads when the renderer first needs it. The renderer dedups by URL and skips files it already loaded, so the helper keeps no cache of its own.

Load several families by spreading:

```ts
fonts: (await Promise.all([
  googleFont("Inter", { weight: [400, 700] }),
  googleFont("JetBrains Mono"),
])).flat()
```

Additive. No existing APIs change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a googleFont() helper to streamline loading Google Fonts (supports static and variable fonts), with options for weight/style/display/text, eager CSS fetch and lazy font-byte loading, plus request timeout behavior.

* **Tests**
  * Added tests for parsing, lazy download behavior, timeout/abort propagation, and CSS request formation.

* **Documentation**
  * Added a changeset entry documenting the minor release and the new helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->