### PR TITLE
Crate: use stable `assert_matches!` for pattern assertions

### DIFF
--- a/takumi/src/keyframes.rs
+++ b/takumi/src/keyframes.rs
@@ -211,6 +211,8 @@ fn unsupported_keyframe_selector(selector: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+  use std::assert_matches;
+
   use serde::Deserialize;
   use serde_json::from_value;
 
@@ -245,10 +247,10 @@ mod tests {
       result.is_err(),
       "expected empty selector to fail: {result:?}"
     );
-    assert!(matches!(
+    assert_matches!(
       result.as_ref(),
       Err(error) if error.to_string().contains("empty keyframe selector")
-    ));
+    );
   }
 
   #[test]

--- a/takumi/src/layout/node/image.rs
+++ b/takumi/src/layout/node/image.rs
@@ -214,6 +214,8 @@ pub(crate) fn resolve_image(src: &str, context: &RenderContext) -> ImageResult {
 
 #[cfg(test)]
 mod tests {
+  use std::assert_matches;
+
   use image::RgbaImage;
   use serde_json::from_value;
   use taffy::{AvailableSpace, Dimension, Size, Style};
@@ -235,7 +237,7 @@ mod tests {
       "src": "https://example.com/image.png"
     }))?;
 
-    assert!(matches!(image.src, ImageSourceInput::Url(_)));
+    assert_matches!(image.src, ImageSourceInput::Url(_));
     let src = match image.src {
       ImageSourceInput::Url(src) => src,
       _ => return Ok(()),
@@ -260,7 +262,7 @@ mod tests {
       "src": [137, 80, 78, 71]
     }))?;
 
-    assert!(matches!(image.src, ImageSourceInput::Buffer(_)));
+    assert_matches!(image.src, ImageSourceInput::Buffer(_));
     let data = match image.src {
       ImageSourceInput::Buffer(data) => data,
       _ => return Ok(()),
@@ -305,7 +307,7 @@ mod tests {
     // PNG signature: invalid UTF-8, so it can't be captured as a URL string.
     let src = ImageSourceInput::deserialize(BytesValue(&[0x89, 0x50, 0x4e, 0x47]))?;
 
-    assert!(matches!(src, ImageSourceInput::Buffer(_)));
+    assert_matches!(src, ImageSourceInput::Buffer(_));
     let data = match src {
       ImageSourceInput::Buffer(data) => data,
       _ => return Ok(()),
@@ -319,10 +321,7 @@ mod tests {
     let bitmap = RgbaImage::new(2, 2);
     let image = ImageData::from(bitmap);
 
-    assert!(matches!(
-      image.src,
-      ImageSourceInput::Loaded(ImageSource::Bitmap(_))
-    ));
+    assert_matches!(image.src, ImageSourceInput::Loaded(ImageSource::Bitmap(_)));
   }
 
   #[test]

--- a/takumi/src/layout/style/properties/animation.rs
+++ b/takumi/src/layout/style/properties/animation.rs
@@ -724,6 +724,8 @@ impl ToCss for Animation {
 
 #[cfg(test)]
 mod tests {
+  use std::assert_matches;
+
   use super::*;
 
   #[test]
@@ -740,26 +742,26 @@ mod tests {
 
   #[test]
   fn parse_animation_names() {
-    assert!(matches!(
+    assert_matches!(
       AnimationNames::from_str("fade, slide"),
       Ok(names) if names.as_ref() == [Some("fade".to_string()), Some("slide".to_string())]
-    ));
+    );
   }
 
   #[test]
   fn parse_quoted_animation_names() {
-    assert!(matches!(
+    assert_matches!(
       AnimationNames::from_str("\"fade\", slide"),
       Ok(names) if names.as_ref() == [Some("fade".to_string()), Some("slide".to_string())]
-    ));
+    );
   }
 
   #[test]
   fn parse_animation_names_with_none_entry() {
-    assert!(matches!(
+    assert_matches!(
       AnimationNames::from_str("none, slide"),
       Ok(names) if names.as_ref() == [None, Some("slide".to_string())]
-    ));
+    );
   }
 
   #[test]

--- a/takumi/src/layout/style/properties/clip_path.rs
+++ b/takumi/src/layout/style/properties/clip_path.rs
@@ -515,6 +515,8 @@ impl ToCss for BasicShape {
 
 #[cfg(test)]
 mod tests {
+  use std::assert_matches;
+
   use super::*;
   use Length::*;
 
@@ -633,7 +635,7 @@ mod tests {
 
   #[test]
   fn test_parse_polygon_triangle() {
-    assert!(matches!(
+    assert_matches!(
       BasicShape::from_str("polygon(50% 0%, 0% 100%, 100% 100%)"),
       Ok(BasicShape::Polygon(PolygonShape {
         fill_rule: None,
@@ -642,18 +644,18 @@ mod tests {
             coords[0] == SpacePair { x: Length::Percentage(50.0), y: Length::Percentage(0.0) } &&
             coords[1] == SpacePair { x: Length::Percentage(0.0), y: Length::Percentage(100.0) } &&
             coords[2] == SpacePair { x: Length::Percentage(100.0), y: Length::Percentage(100.0) }
-    ));
+    );
   }
 
   #[test]
   fn test_parse_polygon_with_fill_rule() {
-    assert!(matches!(
+    assert_matches!(
       BasicShape::from_str("polygon(evenodd, 50% 0%, 0% 100%, 100% 100%)"),
       Ok(BasicShape::Polygon(PolygonShape {
         fill_rule: Some(FillRule::EvenOdd),
         coordinates: coords,
       })) if coords.len() == 3
-    ));
+    );
   }
 
   #[test]

--- a/takumi/src/layout/style/properties/content.rs
+++ b/takumi/src/layout/style/properties/content.rs
@@ -188,6 +188,8 @@ impl ToCss for AttrRef {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::expect_used)]
 mod tests {
+  use std::assert_matches;
+
   use super::*;
 
   fn parse(input: &str) -> ContentValue {
@@ -245,10 +247,10 @@ mod tests {
     let ContentValue::Items(items) = parse("url(\"icon.png\")") else {
       panic!("expected items");
     };
-    assert!(matches!(
+    assert_matches!(
       &items[0],
-      ContentItem::Image(image) if matches!(**image, BackgroundImage::Url(_)),
-    ));
+      ContentItem::Image(image) if matches!(**image, BackgroundImage::Url(_))
+    );
   }
 
   #[test]

--- a/takumi/src/layout/style/properties/length.rs
+++ b/takumi/src/layout/style/properties/length.rs
@@ -1107,7 +1107,7 @@ impl<const DEFAULT_AUTO: bool> MakeComputed for Length<DEFAULT_AUTO> {
 
 #[cfg(test)]
 mod tests {
-  use std::rc::Rc;
+  use std::{assert_matches, rc::Rc};
 
   use taffy::Size;
 
@@ -1454,13 +1454,13 @@ mod tests {
     );
 
     let inf = Length::<true>::from_str("calc(infinity)");
-    assert!(matches!(inf, Ok(Length::Px(v)) if v.is_infinite() && v.is_sign_positive()));
+    assert_matches!(inf, Ok(Length::Px(v)) if v.is_infinite() && v.is_sign_positive());
 
     let neg_inf = Length::<true>::from_str("calc(-infinity)");
-    assert!(matches!(neg_inf, Ok(Length::Px(v)) if v.is_infinite() && v.is_sign_negative()));
+    assert_matches!(neg_inf, Ok(Length::Px(v)) if v.is_infinite() && v.is_sign_negative());
 
     let nan = Length::<true>::from_str("calc(nan)");
-    assert!(matches!(nan, Ok(Length::Px(v)) if v.is_nan()));
+    assert_matches!(nan, Ok(Length::Px(v)) if v.is_nan());
   }
 
   #[test]

--- a/takumi/src/layout/style/tw/mod.rs
+++ b/takumi/src/layout/style/tw/mod.rs
@@ -1742,6 +1742,8 @@ impl TailwindProperty {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+  use std::assert_matches;
+
   use crate::layout::style::{ComputedStyle, LonghandId, Style, properties::BackgroundImage};
 
   use super::*;
@@ -1853,7 +1855,7 @@ mod tests {
 
   #[test]
   fn test_parse_tailwind_animation_preset() {
-    assert!(matches!(
+    assert_matches!(
       TailwindProperty::parse("animate-spin"),
       Some(TailwindProperty::Animation(animations))
         if animations.as_ref() == [Animation {
@@ -1863,12 +1865,12 @@ mod tests {
           name: Some("spin".to_string()),
           ..Animation::default()
         }]
-    ));
+    );
   }
 
   #[test]
   fn test_parse_tailwind_animation_arbitrary_value() {
-    assert!(matches!(
+    assert_matches!(
       TailwindProperty::parse("animate-[wiggle_1s_ease-in-out_infinite]"),
       Some(TailwindProperty::Animation(animations))
         if animations.as_ref() == [Animation {
@@ -1878,7 +1880,7 @@ mod tests {
           name: Some("wiggle".to_string()),
           ..Animation::default()
         }]
-    ));
+    );
   }
 
   #[test]

--- a/takumi/src/rendering/components/blur.rs
+++ b/takumi/src/rendering/components/blur.rs
@@ -632,6 +632,8 @@ fn compute_mul_shg(d: u32) -> (u32, i32) {
 
 #[cfg(test)]
 mod tests {
+  use std::assert_matches;
+
   use super::{BlurType, apply_blur_rgba_bytes, blur_downsample_scale, upsample_rgba_bilinear};
   use crate::{Error, rendering::BufferPool};
 
@@ -640,13 +642,13 @@ mod tests {
     let mut data = vec![0u8; 3];
     let mut pool = BufferPool::default();
 
-    assert!(matches!(
+    assert_matches!(
       apply_blur_rgba_bytes(&mut data, 1, 1, 4.0, BlurType::Filter, &mut pool),
       Err(Error::InvalidRgbaBufferLength {
         actual: 3,
         expected: 4
       })
-    ));
+    );
   }
 
   #[test]

--- a/takumi/src/resources/image.rs
+++ b/takumi/src/resources/image.rs
@@ -530,7 +530,7 @@ pub enum ImageResourceError {
 
 #[cfg(test)]
 mod tests {
-  use std::borrow::Cow;
+  use std::{assert_matches, borrow::Cow};
 
   use image::Rgba;
   use tiny_skia::PremultipliedColorU8;
@@ -775,14 +775,14 @@ mod tests {
 
     assert_eq!(width, 4);
     assert_eq!(height, 4);
-    assert!(matches!(algo, ImageScalingAlgorithm::Pixelated));
+    assert_matches!(algo, ImageScalingAlgorithm::Pixelated);
     Ok(())
   }
 
   #[test]
   fn gif_source_from_decoded_rejects_empty_frames() {
     let result = GifSource::from_decoded(DecodedGif { frames: Vec::new() });
-    assert!(matches!(result, Err(ImageResourceError::InvalidGif)));
+    assert_matches!(result, Err(ImageResourceError::InvalidGif));
   }
 
   #[test]

--- a/takumi/tests/font_tests.rs
+++ b/takumi/tests/font_tests.rs
@@ -1,4 +1,5 @@
 use std::{
+  assert_matches,
   fs::File,
   io::Read,
   path::{Path, PathBuf},
@@ -79,7 +80,7 @@ fn test_invalid_format_detection() {
   let result = context
     .font_context
     .load_and_store(FontResource::new(invalid_data));
-  assert!(matches!(result, Err(FontError::UnsupportedFormat)));
+  assert_matches!(result, Err(FontError::UnsupportedFormat));
 }
 
 #[test]
@@ -91,7 +92,7 @@ fn test_empty_data() {
   let result = context
     .font_context
     .load_and_store(FontResource::new(empty_data));
-  assert!(matches!(result, Err(FontError::UnsupportedFormat)));
+  assert_matches!(result, Err(FontError::UnsupportedFormat));
 }
 
 #[test]
@@ -103,5 +104,5 @@ fn test_too_short_data() {
   let result = context
     .font_context
     .load_and_store(FontResource::new(short_data));
-  assert!(matches!(result, Err(FontError::UnsupportedFormat)));
+  assert_matches!(result, Err(FontError::UnsupportedFormat));
 }


### PR DESCRIPTION
Replace `assert!(matches!(…))` test assertions with the now-stable `assert_matches!` macro (Rust 1.96.0) for clearer mismatch diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion patterns across the codebase for better code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->