### PR TITLE
Crate: fix SVG `background`/`mask` images with only a `viewBox` to scale to the box

### DIFF
--- a/.changeset/svg-viewbox-intrinsic-size.md
+++ b/.changeset/svg-viewbox-intrinsic-size.md
@@ -1,0 +1,5 @@
+---
+"takumi": patch
+---
+
+Fix `background-image`/`mask-image` SVGs with only a `viewBox` to scale to the box (Chrome-matching) instead of tiling

--- a/.changeset/svg-viewbox-intrinsic-size.md
+++ b/.changeset/svg-viewbox-intrinsic-size.md
@@ -2,4 +2,4 @@
 "takumi": patch
 ---
 
-Fix `background-image`/`mask-image` SVGs with only a `viewBox` to scale to the box (Chrome-matching) instead of tiling
+Fix `background-image`/`mask-image` SVGs with only a `viewBox` to scale to the box

--- a/takumi/src/layout/style/properties/background_size.rs
+++ b/takumi/src/layout/style/properties/background_size.rs
@@ -17,11 +17,61 @@ pub(crate) enum AutoBackgroundAxis {
   Height,
 }
 
+/// Intrinsic sizing of an image, per CSS Images Level 3 §5.3. `width`/`height`
+/// are set only where the image has an intrinsic dimension on that axis (a
+/// non-percentage SVG `width`/`height`); a `viewBox`-only SVG has `ratio` alone.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) struct IntrinsicSizing {
+  pub(crate) width: Option<f32>,
+  pub(crate) height: Option<f32>,
+  pub(crate) ratio: Option<f32>,
+}
+
+impl IntrinsicSizing {
+  pub(crate) fn from_dimensions(width: f32, height: f32) -> Self {
+    Self {
+      width: Some(width),
+      height: Some(height),
+      ratio: (height != 0.0).then_some(width / height),
+    }
+  }
+
+  /// §5.3 default sizing algorithm with `area` as the default object size
+  /// (Blink's `ConcreteObjectSize`).
+  fn concrete_size(self, area_width: f32, area_height: f32) -> (u32, u32) {
+    let round = |width: f32, height: f32| (width.round() as u32, height.round() as u32);
+
+    match (self.width, self.height) {
+      (Some(width), Some(height)) => round(width, height),
+      (Some(width), None) => match self.ratio {
+        Some(ratio) if ratio != 0.0 => round(width, width / ratio),
+        _ => round(width, area_height),
+      },
+      (None, Some(height)) => match self.ratio {
+        Some(ratio) => round(height * ratio, height),
+        None => round(area_width, height),
+      },
+      (None, None) => match self.ratio {
+        // Contain the intrinsic ratio within the default object size.
+        Some(ratio) if ratio != 0.0 => {
+          let solution_width = area_height * ratio;
+          if solution_width <= area_width {
+            round(solution_width, area_height)
+          } else {
+            round(area_width, area_width / ratio)
+          }
+        }
+        _ => round(area_width, area_height),
+      },
+    }
+  }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ResolvedBackgroundSize {
   pub(crate) width: u32,
   pub(crate) height: u32,
-  pub(crate) intrinsic_size: Option<(f32, f32)>,
+  pub(crate) intrinsic_ratio: Option<f32>,
   pub(crate) auto_axis: Option<AutoBackgroundAxis>,
 }
 
@@ -146,7 +196,7 @@ impl BackgroundSize {
     self,
     area: Size<u32>,
     sizing: &Sizing,
-    intrinsic_size: Option<(f32, f32)>,
+    intrinsic: IntrinsicSizing,
   ) -> ResolvedBackgroundSize {
     match self {
       BackgroundSize::Explicit { width, height } => {
@@ -154,18 +204,18 @@ impl BackgroundSize {
           return ResolvedBackgroundSize {
             width: width.to_px(sizing, area.width as f32).max(0.0) as u32,
             height: height.to_px(sizing, area.height as f32).max(0.0) as u32,
-            intrinsic_size: None,
+            intrinsic_ratio: None,
             auto_axis: None,
           };
         }
 
         let (resolved_width, resolved_height) =
-          resolve_auto_background_size(width, height, area, sizing, intrinsic_size);
+          resolve_auto_background_size(width, height, area, sizing, intrinsic);
 
         ResolvedBackgroundSize {
           width: resolved_width,
           height: resolved_height,
-          intrinsic_size,
+          intrinsic_ratio: intrinsic.ratio,
           auto_axis: match (width == Length::Auto, height == Length::Auto) {
             (true, false) => Some(AutoBackgroundAxis::Width),
             (false, true) => Some(AutoBackgroundAxis::Height),
@@ -173,63 +223,24 @@ impl BackgroundSize {
           },
         }
       }
-      BackgroundSize::Cover => {
-        let Some((intrinsic_width, intrinsic_height)) = intrinsic_size else {
+      // cover/contain scale the intrinsic ratio to the area; with no ratio the
+      // area is filled (§5.3).
+      BackgroundSize::Cover | BackgroundSize::Contain => {
+        let Some(ratio) = intrinsic.ratio.filter(|ratio| *ratio > 0.0) else {
           return ResolvedBackgroundSize {
-            width: 0,
-            height: 0,
-            intrinsic_size: None,
+            width: area.width,
+            height: area.height,
+            intrinsic_ratio: intrinsic.ratio,
             auto_axis: None,
           };
         };
 
-        if intrinsic_width == 0.0 || intrinsic_height == 0.0 {
-          return ResolvedBackgroundSize {
-            width: 0,
-            height: 0,
-            intrinsic_size: Some((intrinsic_width, intrinsic_height)),
-            auto_axis: None,
-          };
-        }
-
-        let scale_x = area.width as f32 / intrinsic_width;
-        let scale_y = area.height as f32 / intrinsic_height;
-        let scale = scale_x.max(scale_y);
+        let (width, height) = fit_ratio_to_area(ratio, area, matches!(self, BackgroundSize::Cover));
 
         ResolvedBackgroundSize {
-          width: (intrinsic_width * scale).round() as u32,
-          height: (intrinsic_height * scale).round() as u32,
-          intrinsic_size: Some((intrinsic_width, intrinsic_height)),
-          auto_axis: None,
-        }
-      }
-      BackgroundSize::Contain => {
-        let Some((intrinsic_width, intrinsic_height)) = intrinsic_size else {
-          return ResolvedBackgroundSize {
-            width: 0,
-            height: 0,
-            intrinsic_size: None,
-            auto_axis: None,
-          };
-        };
-
-        if intrinsic_width == 0.0 || intrinsic_height == 0.0 {
-          return ResolvedBackgroundSize {
-            width: 0,
-            height: 0,
-            intrinsic_size: Some((intrinsic_width, intrinsic_height)),
-            auto_axis: None,
-          };
-        }
-
-        let scale_x = area.width as f32 / intrinsic_width;
-        let scale_y = area.height as f32 / intrinsic_height;
-        let scale = scale_x.min(scale_y);
-
-        ResolvedBackgroundSize {
-          width: (intrinsic_width * scale).round() as u32,
-          height: (intrinsic_height * scale).round() as u32,
-          intrinsic_size: Some((intrinsic_width, intrinsic_height)),
+          width,
+          height,
+          intrinsic_ratio: Some(ratio),
           auto_axis: None,
         }
       }
@@ -237,53 +248,52 @@ impl BackgroundSize {
   }
 }
 
+/// Scale a rectangle of the given aspect ratio (`width / height`) to cover or
+/// contain `area`, returning rounded device-pixel dimensions.
+fn fit_ratio_to_area(ratio: f32, area: Size<u32>, cover: bool) -> (u32, u32) {
+  let area_width = area.width as f32;
+  let area_height = area.height as f32;
+  let width_at_area_height = area_height * ratio;
+
+  let (width, height) = if (width_at_area_height >= area_width) == cover {
+    (width_at_area_height, area_height)
+  } else {
+    (area_width, area_width / ratio)
+  };
+
+  (width.round() as u32, height.round() as u32)
+}
+
 fn resolve_auto_background_size(
   width: Length,
   height: Length,
   area: Size<u32>,
   sizing: &Sizing,
-  intrinsic_size: Option<(f32, f32)>,
+  intrinsic: IntrinsicSizing,
 ) -> (u32, u32) {
+  let area_width = area.width as f32;
+  let area_height = area.height as f32;
+
   match (width == Length::Auto, height == Length::Auto) {
-    (true, true) => {
-      let Some((intrinsic_width, intrinsic_height)) = intrinsic_size else {
-        return (area.width, area.height);
-      };
-
-      (
-        intrinsic_width.round() as u32,
-        intrinsic_height.round() as u32,
-      )
-    }
+    (true, true) => intrinsic.concrete_size(area_width, area_height),
+    // One axis definite: the auto axis follows the ratio, else that axis'
+    // intrinsic dimension, else the area (§5.3).
     (true, false) => {
-      let fixed_height = height.to_px(sizing, area.height as f32).max(0.0);
-      let Some((intrinsic_width, intrinsic_height)) = intrinsic_size else {
-        return (area.width, fixed_height as u32);
+      let fixed_height = height.to_px(sizing, area_height).max(0.0);
+      let resolved_width = match intrinsic.ratio {
+        Some(ratio) => fixed_height * ratio,
+        None => intrinsic.width.unwrap_or(area_width),
       };
-      if intrinsic_width == 0.0 || intrinsic_height == 0.0 {
-        return (0, 0);
-      }
-
-      let scale_factor = fixed_height / intrinsic_height;
-      (
-        (intrinsic_width * scale_factor).round() as u32,
-        fixed_height as u32,
-      )
+      (resolved_width.round() as u32, fixed_height.round() as u32)
     }
     (false, true) => {
-      let fixed_width = width.to_px(sizing, area.width as f32).max(0.0);
-      let Some((intrinsic_width, intrinsic_height)) = intrinsic_size else {
-        return (fixed_width as u32, area.height);
+      let fixed_width = width.to_px(sizing, area_width).max(0.0);
+      let resolved_height = match intrinsic.ratio {
+        Some(ratio) if ratio != 0.0 => fixed_width / ratio,
+        Some(_) => 0.0,
+        None => intrinsic.height.unwrap_or(area_height),
       };
-      if intrinsic_width == 0.0 || intrinsic_height == 0.0 {
-        return (0, 0);
-      }
-
-      let scale_factor = fixed_width / intrinsic_width;
-      (
-        fixed_width as u32,
-        (intrinsic_height * scale_factor).round() as u32,
-      )
+      (fixed_width.round() as u32, resolved_height.round() as u32)
     }
     (false, false) => (0, 0),
   }
@@ -416,5 +426,48 @@ mod tests {
   #[test]
   fn errors_on_invalid_first_layer() {
     assert!(BackgroundSizes::from_str("nope").is_err());
+  }
+
+  // `auto auto` (the default `background-size`/`mask-size`) sizing, per the CSS
+  // Images Level 3 §5.3 default sizing algorithm.
+
+  #[test]
+  fn auto_size_uses_intrinsic_dimensions_when_present() {
+    let intrinsic = IntrinsicSizing::from_dimensions(102.0, 38.0);
+    assert_eq!(intrinsic.concrete_size(1200.0, 630.0), (102, 38));
+  }
+
+  #[test]
+  fn auto_size_contains_ratio_only_image_within_area() {
+    // viewBox-only: contained within the area, not sized to the viewBox (which
+    // would tile under the default `repeat`).
+    let intrinsic = IntrinsicSizing {
+      width: None,
+      height: None,
+      ratio: Some(1.0),
+    };
+    assert_eq!(intrinsic.concrete_size(400.0, 400.0), (400, 400));
+    assert_eq!(intrinsic.concrete_size(1200.0, 630.0), (630, 630));
+  }
+
+  #[test]
+  fn auto_size_fills_area_without_intrinsic_information() {
+    // No dimensions and no ratio (e.g. a gradient): fill the positioning area.
+    assert_eq!(
+      IntrinsicSizing::default().concrete_size(1200.0, 630.0),
+      (1200, 630)
+    );
+  }
+
+  #[test]
+  fn contain_and_cover_scale_ratio_to_area() {
+    let area = Size {
+      width: 800,
+      height: 400,
+    };
+    // A 1:1 ratio: `contain` is the largest square fitting the area, `cover`
+    // the smallest square covering it.
+    assert_eq!(fit_ratio_to_area(1.0, area, false), (400, 400));
+    assert_eq!(fit_ratio_to_area(1.0, area, true), (800, 800));
   }
 }

--- a/takumi/src/rendering/background_drawing.rs
+++ b/takumi/src/rendering/background_drawing.rs
@@ -86,16 +86,16 @@ fn rasterize_tile(tile: BackgroundTile, buffer_pool: &mut BufferPool) -> Result<
   Ok(BackgroundTile::Pixmap(Arc::new(pixmap)))
 }
 
-fn resolve_intrinsic_size(image: &BackgroundImage, context: &RenderContext) -> Option<(f32, f32)> {
+fn resolve_intrinsic_size(image: &BackgroundImage, context: &RenderContext) -> IntrinsicSizing {
   let BackgroundImage::Url(url) = image else {
-    return None;
+    return IntrinsicSizing::default();
   };
 
   let Ok(source) = resolve_image(url, context) else {
-    return None;
+    return IntrinsicSizing::default();
   };
 
-  Some(source.size(&context.sizing))
+  source.intrinsic_sizing(&context.sizing)
 }
 
 pub(crate) fn rasterize_layers(
@@ -411,17 +411,17 @@ fn resolve_axis_tiles(
 
 fn resolve_auto_axis_from_intrinsic(
   auto_axis: AutoBackgroundAxis,
-  intrinsic_size: Option<(f32, f32)>,
+  intrinsic_ratio: Option<f32>,
   fixed_size: u32,
 ) -> Option<u32> {
-  let (intrinsic_width, intrinsic_height) = intrinsic_size?;
-  if intrinsic_width == 0.0 || intrinsic_height == 0.0 {
+  let ratio = intrinsic_ratio?;
+  if ratio == 0.0 {
     return Some(0);
   }
 
   let resolved = match auto_axis {
-    AutoBackgroundAxis::Width => fixed_size as f32 * (intrinsic_width / intrinsic_height),
-    AutoBackgroundAxis::Height => fixed_size as f32 * (intrinsic_height / intrinsic_width),
+    AutoBackgroundAxis::Width => fixed_size as f32 * ratio,
+    AutoBackgroundAxis::Height => fixed_size as f32 / ratio,
   };
 
   Some(resolved.round() as u32)
@@ -561,7 +561,7 @@ pub(crate) fn resolve_layer_tiles(
       let tile_w = if style.repeat.1 == BackgroundRepeatStyle::Round {
         resolve_auto_axis_from_intrinsic(
           AutoBackgroundAxis::Width,
-          resolved_size.intrinsic_size,
+          resolved_size.intrinsic_ratio,
           tile_h,
         )
         .unwrap_or(resolved_size.width)
@@ -590,7 +590,7 @@ pub(crate) fn resolve_layer_tiles(
       let tile_h = if style.repeat.0 == BackgroundRepeatStyle::Round {
         resolve_auto_axis_from_intrinsic(
           AutoBackgroundAxis::Height,
-          resolved_size.intrinsic_size,
+          resolved_size.intrinsic_ratio,
           tile_w,
         )
         .unwrap_or(resolved_size.height)

--- a/takumi/src/resources/image.rs
+++ b/takumi/src/resources/image.rs
@@ -15,7 +15,7 @@ use image::RgbaImage;
 use tiny_skia::Pixmap;
 
 use crate::{
-  layout::style::{Color, ImageScalingAlgorithm},
+  layout::style::{Color, ImageScalingAlgorithm, IntrinsicSizing},
   rendering::{Sizing, premultiplied_pixmap_from_rgba},
   resources::image_decoder::{DecodedGif, DecodedImage, decode_image},
 };
@@ -47,7 +47,19 @@ pub struct SvgSource {
   uses_current_color: bool,
   /// Parsed SVG tree used for size and initial metadata.
   pub(crate) tree: Arc<resvg::usvg::Tree>,
+  /// Intrinsic dimensions (non-percentage `width`/`height`) and `viewBox`
+  /// aspect ratio, for CSS `background-size`/`mask-size` resolution.
+  intrinsic: SvgIntrinsic,
   raster_cache: Arc<SvgRasterCache>,
+}
+
+/// Intrinsic width/height (in SVG user units) and aspect ratio of an SVG root.
+#[cfg(feature = "svg")]
+#[derive(Debug, Clone, Copy, Default)]
+struct SvgIntrinsic {
+  width: Option<f32>,
+  height: Option<f32>,
+  ratio: Option<f32>,
 }
 
 /// A decoded GIF image with frame timing metadata.
@@ -290,16 +302,26 @@ impl FromStr for SvgSource {
   type Err = ImageResourceError;
 
   fn from_str(src: &str) -> Result<Self, Self::Err> {
-    use resvg::usvg::Tree;
+    use resvg::usvg::{Error, Options, Tree};
+    use roxmltree::{Document, ParsingOptions};
 
-    let sanitized_svg = strip_unsupported_svg_text_nodes(src);
-    let tree = Tree::from_str(&sanitized_svg, &Default::default())
-      .map_err(ImageResourceError::SvgParseError)?;
+    // One parse, shared with usvg via `from_xmltree` (what `from_str` does
+    // internally). No text stripping: usvg drops `<text>`/`<tspan>` with its
+    // `text` feature off.
+    let options = ParsingOptions {
+      allow_dtd: true,
+      ..Default::default()
+    };
+    let document = Document::parse_with_options(src, options).map_err(Error::ParsingFailed)?;
+
+    let tree = Tree::from_xmltree(&document, &Options::default())?;
+    let intrinsic = svg_intrinsic_sizing(document.root_element(), tree.size());
 
     Ok(SvgSource {
-      uses_current_color: sanitized_svg.contains("currentColor"),
-      source: Arc::from(sanitized_svg),
+      uses_current_color: src.contains("currentColor"),
+      source: Arc::from(src),
       tree: Arc::new(tree),
+      intrinsic,
       raster_cache: Arc::default(),
     })
   }
@@ -421,6 +443,27 @@ impl ImageSource {
     let dpr = sizing.viewport.device_pixel_ratio;
     (width * dpr, height * dpr)
   }
+
+  /// Intrinsic sizing for `background-size`/`mask-size` (§5.3). Bitmaps and GIFs
+  /// have both dimensions; an SVG may have only a `viewBox` ratio.
+  pub(crate) fn intrinsic_sizing(&self, sizing: &Sizing) -> IntrinsicSizing {
+    let dpr = sizing.viewport.device_pixel_ratio;
+    match self {
+      #[cfg(feature = "svg")]
+      ImageSource::Svg(svg) => IntrinsicSizing {
+        width: svg.intrinsic.width.map(|width| width * dpr),
+        height: svg.intrinsic.height.map(|height| height * dpr),
+        ratio: svg.intrinsic.ratio,
+      },
+      ImageSource::Bitmap(bitmap) => {
+        IntrinsicSizing::from_dimensions(bitmap.width() as f32 * dpr, bitmap.height() as f32 * dpr)
+      }
+      ImageSource::Gif(gif) => {
+        let frame = &gif.frames[0].pixmap;
+        IntrinsicSizing::from_dimensions(frame.width() as f32 * dpr, frame.height() as f32 * dpr)
+      }
+    }
+  }
 }
 
 /// Check if the string looks like an SVG image.
@@ -428,66 +471,44 @@ pub(crate) fn is_svg_like(src: &str) -> bool {
   src.contains("<svg") && src.contains("xmlns")
 }
 
+/// SVG root intrinsic sizing per <https://www.w3.org/TR/SVG/coords.html#IntrinsicSizing>:
+/// a non-percentage `width`/`height` is an intrinsic dimension, the `viewBox`
+/// gives the ratio. Absolute px come from `resolved_size` (usvg's parsed size)
+/// to avoid reimplementing SVG length units.
 #[cfg(feature = "svg")]
-fn strip_unsupported_svg_text_nodes(src: &str) -> String {
-  use std::ops::Range;
-
-  use roxmltree::{Document, Node};
-
-  fn merge_ranges(mut ranges: Vec<Range<usize>>) -> Vec<Range<usize>> {
-    ranges.sort_by_key(|range| (range.start, range.end));
-
-    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
-    for range in ranges {
-      if let Some(last) = merged.last_mut()
-        && range.start <= last.end
-      {
-        last.end = last.end.max(range.end);
-      } else {
-        merged.push(range);
-      }
-    }
-
-    merged
-  }
-
-  let Ok(document) = Document::parse(src) else {
-    return src.to_owned();
+fn svg_intrinsic_sizing(root: roxmltree::Node, resolved_size: resvg::usvg::Size) -> SvgIntrinsic {
+  let is_absolute = |name| {
+    root
+      .attribute(name)
+      .map(str::trim)
+      .is_some_and(|value| !value.is_empty() && !value.ends_with('%'))
   };
 
-  let ranges = document
-    .descendants()
-    .filter(Node::is_element)
-    .filter_map(|node| {
-      let name = node.tag_name().name();
-      if name == "text" || name == "tspan" {
-        Some(node.range())
-      } else {
-        None
-      }
-    })
-    .collect::<Vec<_>>();
+  let width = is_absolute("width").then(|| resolved_size.width());
+  let height = is_absolute("height").then(|| resolved_size.height());
 
-  if ranges.is_empty() {
-    return src.to_owned();
+  let ratio = match (width, height) {
+    (Some(width), Some(height)) if width != 0.0 && height != 0.0 => Some(width / height),
+    _ => root.attribute("viewBox").and_then(parse_viewbox_ratio),
+  };
+
+  SvgIntrinsic {
+    width,
+    height,
+    ratio,
   }
+}
 
-  let merged_ranges = merge_ranges(ranges);
-  let mut stripped = String::with_capacity(src.len());
-  let mut cursor = 0;
-
-  for range in merged_ranges {
-    if range.start > cursor {
-      stripped.push_str(&src[cursor..range.start]);
-    }
-    cursor = cursor.max(range.end);
-  }
-
-  if cursor < src.len() {
-    stripped.push_str(&src[cursor..]);
-  }
-
-  stripped
+/// Parse the aspect ratio (`width / height`) from a `viewBox` (`min-x min-y
+/// width height`).
+#[cfg(feature = "svg")]
+fn parse_viewbox_ratio(view_box: &str) -> Option<f32> {
+  let mut numbers = view_box
+    .split([' ', ',', '\t', '\n', '\r'])
+    .filter(|part| !part.is_empty());
+  let width: f32 = numbers.nth(2)?.parse().ok()?;
+  let height: f32 = numbers.next()?.parse().ok()?;
+  (width > 0.0 && height > 0.0).then_some(width / height)
 }
 
 /// Represents the state of an image in the rendering system.
@@ -537,6 +558,44 @@ mod tests {
 
   use super::*;
   use crate::resources::image_decoder::DecodedGifFrame;
+
+  /// `width`/`height` attributes give intrinsic dimensions; a `viewBox` alone
+  /// gives only an aspect ratio (per the SVG/CSS intrinsic sizing rules).
+  #[cfg(feature = "svg")]
+  #[test]
+  fn svg_intrinsic_distinguishes_viewbox_from_dimensions() {
+    fn intrinsic(svg: String) -> SvgIntrinsic {
+      let Ok(source) = svg.parse::<SvgSource>() else {
+        unreachable!("valid svg");
+      };
+      source.intrinsic
+    }
+    let ns = r#"xmlns="http://www.w3.org/2000/svg""#;
+
+    // viewBox only: aspect ratio, no intrinsic dimensions.
+    let only = intrinsic(format!(r#"<svg {ns} viewBox="0 0 128 128"/>"#));
+    assert_eq!(
+      (only.width, only.height, only.ratio),
+      (None, None, Some(1.0))
+    );
+
+    // Absolute width/height: intrinsic dimensions.
+    let sized = intrinsic(format!(r#"<svg {ns} width="102" height="38"/>"#));
+    let ratio = Some(102.0 / 38.0);
+    assert_eq!(
+      (sized.width, sized.height, sized.ratio),
+      (Some(102.0), Some(38.0), ratio)
+    );
+
+    // Percentage width/height are not intrinsic; the ratio comes from the viewBox.
+    let percentage = intrinsic(format!(
+      r#"<svg {ns} width="100%" height="100%" viewBox="0 0 16 8"/>"#
+    ));
+    assert_eq!(
+      (percentage.width, percentage.height, percentage.ratio),
+      (None, None, Some(2.0))
+    );
+  }
 
   fn premul_at(image: &RenderedImage<'_>, x: u32, y: u32) -> PremultipliedColorU8 {
     match image {
@@ -704,18 +763,37 @@ mod tests {
     Ok(())
   }
 
+  /// usvg drops `<text>`/`<tspan>` (text feature off), so we no longer strip
+  /// them: the SVG renders identically with and without the text nodes.
   #[cfg(feature = "svg")]
   #[test]
-  fn parse_svg_str_strips_text_and_tspan_nodes() -> Result<(), ImageResourceError> {
-    let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><rect x="0" y="0" width="20" height="20" fill="#ff0000"/><text x="2" y="10">hello <tspan>world</tspan></text><g><tspan>orphan</tspan></g></svg>"##;
-    let image: ImageSource = SvgSource::from_str(svg)?.into();
-    let ImageSource::Svg(svg) = image else {
-      return Ok(());
-    };
+  fn svg_text_nodes_are_ignored_not_stripped() -> Result<(), ImageResourceError> {
+    fn rendered_data(svg: &str) -> Result<Vec<u8>, ImageResourceError> {
+      let image: ImageSource = SvgSource::from_str(svg)?.into();
+      let rendered =
+        image.render_for_layout(8, 8, ImageScalingAlgorithm::Auto, 0, Color::black())?;
+      let RenderedImage::Rasterized(pixmap) = rendered else {
+        unreachable!("svg renders to a rasterized pixmap");
+      };
+      Ok(pixmap.data().to_vec())
+    }
 
-    assert!(svg.source.contains("<rect"));
-    assert!(!svg.source.contains("<text"));
-    assert!(!svg.source.contains("<tspan"));
+    let with_text = r##"<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="#ff0000"/><text x="1" y="5">hi <tspan>there</tspan></text></svg>"##;
+    let without_text = r##"<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="#ff0000"/></svg>"##;
+
+    assert_eq!(rendered_data(with_text)?, rendered_data(without_text)?);
+    Ok(())
+  }
+
+  /// `<text>` inside `clipPath` and `foreignObject` must not break parsing.
+  #[cfg(feature = "svg")]
+  #[test]
+  fn svg_with_unsupported_nodes_still_parses() -> Result<(), ImageResourceError> {
+    let clip_path_text = r##"<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><clipPath id="c"><text>x</text></clipPath><rect width="8" height="8" fill="#ff0000" clip-path="url(#c)"/></svg>"##;
+    let foreign_object = r##"<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><foreignObject width="8" height="8"><div xmlns="http://www.w3.org/1999/xhtml">x</div></foreignObject><rect width="8" height="8" fill="#ff0000"/></svg>"##;
+
+    SvgSource::from_str(clip_path_text)?;
+    SvgSource::from_str(foreign_object)?;
     Ok(())
   }
 


### PR DESCRIPTION
## Problem

`<div tw="size-100 mask-[url('…/logo.svg')] bg-[red]">` rendered the mask as a **tiled grid** of tiny shapes; Chrome scales it to fill the box (one shape).

`logo.svg` declares only `viewBox="0 0 128 128"` — no `width`/`height`. Per the SVG/CSS intrinsic sizing rules, such an SVG has an intrinsic **aspect ratio** but **no intrinsic dimensions**. takumi instead took usvg's `tree.size()` (which falls back to the viewBox, `128×128`) as the intrinsic dimensions. With the default `mask-size: auto` that produced a fixed `128×128` tile, and the default `mask-repeat: repeat` then tiled it across the box.

The same bug affects `background-image`. It surfaced now because #743 made `mask-[url(…)]` parse at all.

## Fix

Resolve image intrinsic sizing through the CSS Images Level 3 §5.3 default sizing algorithm, distinguishing intrinsic *dimensions* from an intrinsic *ratio* — mirroring Blink (`ConcreteObjectSize` / `UnscaledNaturalSizingInfo`) and Servo (`NaturalSizes` / `svg_kind_size`):

- New `IntrinsicSizing { width: Option<f32>, height: Option<f32>, ratio: Option<f32> }`. Bitmaps/GIFs fill all three; an SVG only contributes a dimension where its `width`/`height` attribute is a **non-percentage** length, and otherwise just the `viewBox` ratio.
- `BackgroundSize::resolve` runs the §5.3 algorithm: `auto auto` with a ratio-only image is *contained* within the positioning area instead of sized to the viewBox; `cover`/`contain` are driven by the ratio.

No new public API — `IntrinsicSizing` and the new accessors are `pub(crate)`.

## SVG parsing consolidation

While here, the SVG load path was reworked from **three XML walks to one**. `SvgSource::from_str` previously: (1) roxmltree-parsed to strip `<text>`/`<tspan>`, (2) usvg-parsed the stripped string, (3) roxmltree-parsed *again* for intrinsic attrs, (4) string-scanned for `currentColor`.

Now it parses **once** with `roxmltree::Document::parse_with_options(src, { allow_dtd: true })` and hands that same `Document` to `usvg::Tree::from_xmltree` (which is exactly what `from_str` does internally), reading intrinsic sizing off the same parse.

The string-level text stripping is **gone**: usvg ignores `<text>`/`<tspan>` when its `text` feature is off (`converter.rs` `EId::Text` arm is empty), which it is in this build — verified empirically across plain/`currentColor`/`clipPath`/`foreignObject` cases. Matching usvg's `allow_dtd` also fixes a latent bug where the old strip's `parse()` silently no-op'd on SVGs with a DTD. Net: −39 lines in `image.rs`.

## Behaviour

- A `viewBox`-only SVG now scales to the box (Chrome-matching) instead of tiling.
- Images with real intrinsic dimensions (every existing fixture, e.g. `luma.svg`) are unchanged — `cover`/`contain` reduce to the previous math, so **0 rendered (`.webp`) fixtures changed**.
- `cover`/`contain` on an image with *no* intrinsic ratio (e.g. a gradient) now fills the area per §5.3, where it previously rendered nothing. No fixture exercises this.

## Tests

- `background_size`: unit tests for the §5.3 cases — intrinsic dimensions used verbatim, ratio-only contained within the area, no-intrinsic fills the area, `cover`/`contain` ratio scaling.
- `image`: a `viewBox`-only SVG resolves to ratio-without-dimensions; absolute `width`/`height` give dimensions; percentages do not. An SVG with `<text>`/`<tspan>` renders identically to the same SVG without them (text ignored, not stripped); `clipPath`/`foreignObject` SVGs still parse.
- Full lib suite (629) + all fixtures (198, no `.webp` diffs) + clippy + fmt pass.

## Known gap (out of scope)

The `<img>` replaced-element path (`node/image.rs`) carries the same latent ratio-only handling; left as a follow-up.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background/mask SVGs that only had a viewBox now size correctly (scale to the containing area) and behave properly for `auto`, `cover`, `contain`, and `round` cases.
* **New Features**
  * SVGs now expose CSS intrinsic sizing so background/mask sizing uses SVG intrinsic info (including viewBox-derived aspect ratios).
* **Tests**
  * Added tests for viewBox-only SVGs, ratio-only sizing, and rounding/fit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->