### PR TITLE
Crate: move `SizingContext` into `layout::style`

### DIFF
--- a/takumi/src/layout/style/animation.rs
+++ b/takumi/src/layout/style/animation.rs
@@ -15,7 +15,7 @@ use crate::{
       *,
     },
   },
-  rendering::{RenderContext, Sizing},
+  rendering::RenderContext,
 };
 
 #[derive(Debug, Clone, Deserialize, PartialEq, TypedBuilder)]
@@ -586,7 +586,7 @@ impl<const DEFAULT_AUTO: bool> Animatable for Length<DEFAULT_AUTO> {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     _current_color: Color,
   ) {
     *self = interpolate_length(*from, *to, progress)
@@ -633,7 +633,7 @@ fn interpolate_length<const DEFAULT_AUTO: bool>(
 
 fn resolve_length_with_sizing<const DEFAULT_AUTO: bool>(
   value: Length<DEFAULT_AUTO>,
-  sizing: &Sizing,
+  sizing: &SizingContext,
 ) -> Option<f32> {
   if matches!(value, Length::Auto) {
     return None;
@@ -652,13 +652,13 @@ mod tests {
   use taffy::Size;
 
   use crate::{
+    layout::style::SizingContext,
     layout::style::animation::{sample_animation_progress, tailwind_animation_keyframes},
     layout::{Viewport, style::*},
-    rendering::Sizing,
   };
 
-  fn sizing() -> Sizing {
-    Sizing {
+  fn sizing() -> SizingContext {
+    SizingContext {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
       font_size: 16.0,

--- a/takumi/src/layout/style/mod.rs
+++ b/takumi/src/layout/style/mod.rs
@@ -2,6 +2,7 @@ mod animation;
 pub(crate) mod matching;
 mod properties;
 mod selector;
+mod sizing;
 mod stylesheets;
 pub(crate) mod tw;
 
@@ -16,6 +17,7 @@ use serde::{
   Deserialize,
   de::{self, DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor},
 };
+pub(crate) use sizing::SizingContext;
 pub use stylesheets::*;
 
 #[derive(Clone, Copy)]

--- a/takumi/src/layout/style/properties/aspect_ratio.rs
+++ b/takumi/src/layout/style/properties/aspect_ratio.rs
@@ -2,11 +2,11 @@ use cssparser::Parser;
 use std::fmt;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, lerp,
     tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -28,7 +28,7 @@ impl Animatable for AspectRatio {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     *self = match (*from, *to) {

--- a/takumi/src/layout/style/properties/background.rs
+++ b/takumi/src/layout/style/properties/background.rs
@@ -3,7 +3,6 @@ use cssparser::Parser;
 use typed_builder::TypedBuilder;
 
 use crate::layout::style::*;
-use crate::rendering::Sizing;
 
 /// Parsed `background` shorthand value.
 #[derive(Debug, Clone, Default, PartialEq, TypedBuilder)]
@@ -27,7 +26,7 @@ pub struct Background {
 }
 
 impl MakeComputed for Background {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.image.make_computed(sizing);
     self.position.make_computed(sizing);
     self.size.make_computed(sizing);

--- a/takumi/src/layout/style/properties/background_image.rs
+++ b/takumi/src/layout/style/properties/background_image.rs
@@ -6,9 +6,9 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::layout::style::{
   Animatable, ConicGradient, CssDescriptorKind, CssToken, FromCss, LinearGradient,
-  ListInterpolationStrategy, MakeComputed, ParseResult, RadialGradient, tw::TailwindPropertyParser,
+  ListInterpolationStrategy, MakeComputed, ParseResult, RadialGradient, SizingContext,
+  tw::TailwindPropertyParser,
 };
-use crate::rendering::Sizing;
 
 /// Background image variants supported by Takumi.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -28,7 +28,7 @@ pub enum BackgroundImage {
 }
 
 impl MakeComputed for BackgroundImage {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       BackgroundImage::Linear(gradient) => gradient.make_computed(sizing),
       BackgroundImage::Radial(gradient) => gradient.make_computed(sizing),

--- a/takumi/src/layout/style/properties/background_position.rs
+++ b/takumi/src/layout/style/properties/background_position.rs
@@ -4,11 +4,11 @@ use std::fmt;
 use taffy::{Point, Size};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
     MakeComputed, ParseResult, SpacePair, tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 /// Horizontal keywords for `background-position`.
@@ -48,7 +48,7 @@ pub enum PositionComponent {
 }
 
 impl MakeComputed for PositionComponent {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Self::Length(length) = self {
       length.make_computed(sizing);
     }
@@ -61,7 +61,7 @@ impl Animatable for PositionComponent {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     let mut length = Length::from(*from);
@@ -112,7 +112,7 @@ pub type ObjectPosition = BackgroundPosition<false>;
 pub type TransformOrigin = BackgroundPosition<false>;
 
 impl<const DEFAULT_TOP_LEFT: bool> MakeComputed for BackgroundPosition<DEFAULT_TOP_LEFT> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.0.make_computed(sizing);
   }
 }
@@ -127,7 +127,7 @@ impl<const DEFAULT_TOP_LEFT: bool> Animatable for BackgroundPosition<DEFAULT_TOP
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     let mut value = from.0;
@@ -137,7 +137,7 @@ impl<const DEFAULT_TOP_LEFT: bool> Animatable for BackgroundPosition<DEFAULT_TOP
 }
 
 impl<const DEFAULT_TOP_LEFT: bool> BackgroundPosition<DEFAULT_TOP_LEFT> {
-  pub(crate) fn to_point(self, sizing: &Sizing, border_box: Size<f32>) -> Point<f32> {
+  pub(crate) fn to_point(self, sizing: &SizingContext, border_box: Size<f32>) -> Point<f32> {
     Point {
       x: Length::from(self.0.x).to_px(sizing, border_box.width),
       y: Length::from(self.0.y).to_px(sizing, border_box.height),

--- a/takumi/src/layout/style/properties/background_size.rs
+++ b/takumi/src/layout/style/properties/background_size.rs
@@ -4,11 +4,11 @@ use std::fmt;
 use taffy::Size;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
     MakeComputed, ParseResult, tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -142,7 +142,7 @@ impl<'i> FromCss<'i> for BackgroundSize {
 }
 
 impl MakeComputed for BackgroundSize {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Self::Explicit { width, height } = self {
       width.make_computed(sizing);
       height.make_computed(sizing);
@@ -160,7 +160,7 @@ impl Animatable for BackgroundSize {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = match (*from, *to) {
@@ -195,7 +195,7 @@ impl BackgroundSize {
   pub(crate) fn resolve(
     self,
     area: Size<u32>,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     intrinsic: IntrinsicSizing,
   ) -> ResolvedBackgroundSize {
     match self {
@@ -268,7 +268,7 @@ fn resolve_auto_background_size(
   width: Length,
   height: Length,
   area: Size<u32>,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   intrinsic: IntrinsicSizing,
 ) -> (u32, u32) {
   let area_width = area.width as f32;

--- a/takumi/src/layout/style/properties/border.rs
+++ b/takumi/src/layout/style/properties/border.rs
@@ -2,11 +2,11 @@ use crate::layout::style::unexpected_token;
 use cssparser::Parser;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     BorderStyle, ColorInput, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult,
     properties::Length,
   },
-  rendering::Sizing,
 };
 
 /// Parsed `border` value.
@@ -68,7 +68,7 @@ impl<'i> FromCss<'i> for Border {
 }
 
 impl MakeComputed for Border {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.width.make_computed(sizing);
   }
 }

--- a/takumi/src/layout/style/properties/box_shadow.rs
+++ b/takumi/src/layout/style/properties/box_shadow.rs
@@ -4,11 +4,11 @@ use cssparser::{BasicParseErrorKind, ParseError, Parser};
 use typed_builder::TypedBuilder;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, Length, LengthDefaultsToZero,
     ListInterpolationStrategy, MakeComputed, ParseResult, ToCss, next_is_comma,
   },
-  rendering::Sizing,
 };
 
 /// Represents a box shadow with all its properties.
@@ -131,7 +131,7 @@ impl crate::layout::style::tw::TailwindPropertyParser for BoxShadow {
 }
 
 impl MakeComputed for BoxShadow {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.offset_x.make_computed(sizing);
     self.offset_y.make_computed(sizing);
     self.blur_radius.make_computed(sizing);
@@ -160,7 +160,7 @@ impl Animatable for BoxShadow {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     if from.inset != to.inset {

--- a/takumi/src/layout/style/properties/clip_path.rs
+++ b/takumi/src/layout/style/properties/clip_path.rs
@@ -7,10 +7,10 @@ use taffy::{AbsoluteAxis, Point, Rect, Size};
 use crate::{
   layout::style::{
     Axis, BorderStyle, Color, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-    ImageScalingAlgorithm, Length, MakeComputed, ParseResult, Sides, SpacePair,
+    ImageScalingAlgorithm, Length, MakeComputed, ParseResult, Sides, SizingContext, SpacePair,
   },
   rendering::{
-    BorderProperties, BufferPool, Fill, PathBuilder, PathData, Placement, RenderContext, Sizing,
+    BorderProperties, BufferPool, Fill, PathBuilder, PathData, Placement, RenderContext,
     render_mask,
   },
 };
@@ -51,7 +51,7 @@ pub enum ShapeRadius {
 }
 
 impl MakeComputed for ShapeRadius {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let ShapeRadius::Length(length) = self {
       length.make_computed(sizing);
     }
@@ -64,7 +64,7 @@ impl MakeComputed for ShapeRadius {
 pub struct ShapePosition(pub SpacePair<Length>);
 
 impl MakeComputed for ShapePosition {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.0.make_computed(sizing);
   }
 }
@@ -89,7 +89,7 @@ pub struct InsetShape {
 }
 
 impl MakeComputed for InsetShape {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.inset.make_computed(sizing);
     self.border_radius.make_computed(sizing);
   }
@@ -108,7 +108,7 @@ pub struct EllipseShape {
 }
 
 impl MakeComputed for EllipseShape {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.radius_x.make_computed(sizing);
     self.radius_y.make_computed(sizing);
     self.position.make_computed(sizing);
@@ -129,7 +129,7 @@ pub struct PolygonShape {
 }
 
 impl MakeComputed for PolygonShape {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.coordinates.make_computed(sizing);
   }
 }
@@ -159,7 +159,7 @@ pub enum BasicShape {
 }
 
 impl MakeComputed for BasicShape {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       BasicShape::Inset(shape) => shape.make_computed(sizing),
       BasicShape::Ellipse(shape) => shape.make_computed(sizing),
@@ -169,7 +169,12 @@ impl MakeComputed for BasicShape {
   }
 }
 
-fn resolve_radius(radius: ShapeRadius, distance: Size<f32>, sizing: &Sizing, full: f32) -> f32 {
+fn resolve_radius(
+  radius: ShapeRadius,
+  distance: Size<f32>,
+  sizing: &SizingContext,
+  full: f32,
+) -> f32 {
   match radius {
     ShapeRadius::ClosestSide => distance.width.min(distance.height),
     ShapeRadius::FarthestSide => distance.width.max(distance.height),

--- a/takumi/src/layout/style/properties/color.rs
+++ b/takumi/src/layout/style/properties/color.rs
@@ -13,10 +13,10 @@ use tiny_skia::{ColorU8, PremultipliedColorU8};
 use crate::{
   layout::style::{
     Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-    MakeComputed, ParseResult, PercentageNumber,
+    MakeComputed, ParseResult, PercentageNumber, SizingContext,
     properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
   },
-  rendering::{Sizing, fast_div_255},
+  rendering::fast_div_255,
 };
 
 fn is_cylindrical_color_space(color_space: ColorSpaceTag) -> bool {
@@ -189,7 +189,7 @@ impl<const DEFAULT_CURRENT_COLOR: bool> Animatable for ColorInput<DEFAULT_CURREN
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     current_color: CurrentColor,
   ) {
     *self = match (from, to) {

--- a/takumi/src/layout/style/properties/conic_gradient.rs
+++ b/takumi/src/layout/style/properties/conic_gradient.rs
@@ -12,9 +12,9 @@ use crate::{
   layout::style::{
     Angle, BackgroundPosition, ColorInput, ColorInterpolationMethod, CssDescriptorKind, CssToken,
     FromCss, GradientStop, Length, MakeComputed, ObjectPosition, ParseResult, ResolvedGradientStop,
-    StopPosition, ToCss, unexpected_token,
+    SizingContext, StopPosition, ToCss, unexpected_token,
   },
-  rendering::{RenderContext, Sizing},
+  rendering::RenderContext,
 };
 
 const LUT_INDEX_BOUNDARY_EPSILON: f32 = 0.001;
@@ -41,7 +41,7 @@ pub struct ConicGradient {
 }
 
 impl MakeComputed for ConicGradient {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.center.make_computed(sizing);
     self.stops.make_computed(sizing);
   }

--- a/takumi/src/layout/style/properties/content.rs
+++ b/takumi/src/layout/style/properties/content.rs
@@ -42,7 +42,7 @@ pub struct AttrRef {
 }
 
 impl MakeComputed for ContentValue {
-  fn make_computed(&mut self, sizing: &crate::rendering::Sizing) {
+  fn make_computed(&mut self, sizing: &crate::layout::style::SizingContext) {
     if let ContentValue::Items(items) = self {
       for item in items.iter_mut() {
         if let ContentItem::Image(image) = item {

--- a/takumi/src/layout/style/properties/filter.rs
+++ b/takumi/src/layout/style/properties/filter.rs
@@ -11,12 +11,12 @@ use crate::{
   Result,
   layout::style::{
     Affine, Angle, Animatable, Color, CssDescriptorKind, CssToken, FromCss, Length,
-    ListInterpolationStrategy, MakeComputed, ParseResult, PercentageNumber, TextShadow,
-    tw::TailwindPropertyParser,
+    ListInterpolationStrategy, MakeComputed, ParseResult, PercentageNumber, SizingContext,
+    TextShadow, tw::TailwindPropertyParser,
   },
   rendering::{
     BlurFormat, BlurType, BorderProperties, BufferPool, Canvas, Placement, RenderContext,
-    SizedShadow, Sizing, apply_blur, apply_blur_rgba_bytes, fast_div_255, render_mask,
+    SizedShadow, apply_blur, apply_blur_rgba_bytes, fast_div_255, render_mask,
   },
 };
 
@@ -90,7 +90,7 @@ pub enum Filter {
 pub type Filters = Vec<Filter>;
 
 impl MakeComputed for Filter {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       Filter::Blur(length) => length.make_computed(sizing),
       Filter::DropShadow(shadow) => shadow.make_computed(sizing),
@@ -129,7 +129,7 @@ impl Animatable for Filter {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = match (*from, *to) {
@@ -493,7 +493,7 @@ fn mask_bounds(mask: &[u8], width: u32, height: u32) -> Option<Placement> {
   find_nonzero_bounds(mask, width, height, |alpha| *alpha)
 }
 
-fn backdrop_filter_padding(filters: &[Filter], sizing: &Sizing) -> i32 {
+fn backdrop_filter_padding(filters: &[Filter], sizing: &SizingContext) -> i32 {
   filters
     .iter()
     .filter_map(|filter| match filter {
@@ -550,7 +550,7 @@ fn composite_backdrop_with_mask(
 
 pub(crate) fn apply_filters_to_pixmap<'f, F: Iterator<Item = &'f Filter>>(
   pixmap: &mut PixmapMut<'_>,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   current_color: Color,
   buffer_pool: &mut BufferPool,
   filters: F,
@@ -1024,7 +1024,7 @@ mod tests {
     ];
 
     let viewport = Viewport::new((100, 100));
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport,
       container_size: Size::NONE,
       font_size: 16.0,

--- a/takumi/src/layout/style/properties/flex.rs
+++ b/takumi/src/layout/style/properties/flex.rs
@@ -2,11 +2,11 @@ use crate::layout::style::unexpected_token;
 use cssparser::{Parser, match_ignore_ascii_case};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     AspectRatio, CssSyntaxKind, CssToken, FlexDirection, FlexWrap, FromCss, Length, MakeComputed,
     ParseResult, tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -185,7 +185,7 @@ impl<'i> FromCss<'i> for Flex {
 }
 
 impl MakeComputed for Flex {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.basis.make_computed(sizing);
   }
 }

--- a/takumi/src/layout/style/properties/flex_grow.rs
+++ b/takumi/src/layout/style/properties/flex_grow.rs
@@ -2,10 +2,9 @@ use cssparser::Parser;
 use std::fmt;
 
 use crate::layout::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, lerp,
-  tw::TailwindPropertyParser,
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
+  ToCss, lerp, tw::TailwindPropertyParser,
 };
-use crate::rendering::Sizing;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// Represents a flex grow value.
@@ -19,7 +18,7 @@ impl Animatable for FlexGrow {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     self.0 = lerp(from.0, to.0, progress);

--- a/takumi/src/layout/style/properties/font_size.rs
+++ b/takumi/src/layout/style/properties/font_size.rs
@@ -4,10 +4,10 @@ use crate::layout::style::{ToCss, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
   },
-  rendering::Sizing,
 };
 
 /// Absolute `font-size` keywords.
@@ -93,7 +93,7 @@ pub enum FontSize {
 }
 
 impl FontSize {
-  pub(crate) fn to_px(self, sizing: &Sizing, inherited_font_size: f32) -> f32 {
+  pub(crate) fn to_px(self, sizing: &SizingContext, inherited_font_size: f32) -> f32 {
     match self {
       Self::Keyword(keyword) => keyword.to_length().to_px(sizing, inherited_font_size),
       Self::Length(length) => length.to_px(sizing, inherited_font_size),
@@ -141,7 +141,7 @@ impl<'i> FromCss<'i> for FontSize {
 }
 
 impl MakeComputed for FontSize {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Self::Length(length) = self {
       length.make_computed(sizing);
     }
@@ -154,7 +154,7 @@ impl Animatable for FontSize {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     let from_length = match *from {
@@ -204,8 +204,8 @@ mod tests {
 
   use super::*;
   use crate::{
+    layout::style::SizingContext,
     layout::{style::CalcArena, viewport::Viewport},
-    rendering::Sizing,
   };
 
   #[test]
@@ -218,7 +218,7 @@ mod tests {
 
   #[test]
   fn resolves_medium_keyword_to_default_font_size() {
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
@@ -237,7 +237,7 @@ mod tests {
 
     let viewport = Viewport::new((1200, 630)).with_device_pixel_ratio(2.0);
     let root_font_size_device_px = DEFAULT_FONT_SIZE * viewport.device_pixel_ratio;
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport,
       container_size: Size::NONE,
       font_size: root_font_size_device_px,

--- a/takumi/src/layout/style/properties/font_stretch.rs
+++ b/takumi/src/layout/style/properties/font_stretch.rs
@@ -5,10 +5,9 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::FontWidth;
 
 use crate::layout::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, lerp,
-  tw::TailwindPropertyParser,
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
+  lerp, tw::TailwindPropertyParser,
 };
-use crate::rendering::Sizing;
 
 /// Controls the width/stretch of text rendering.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -22,7 +21,7 @@ impl Animatable for FontStretch {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     *self = FontStretch::from_percentage(lerp(from.percentage(), to.percentage(), progress));

--- a/takumi/src/layout/style/properties/font_weight.rs
+++ b/takumi/src/layout/style/properties/font_weight.rs
@@ -5,10 +5,9 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::style::FontWeight as ParleyFontWeight;
 
 use crate::layout::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, lerp,
-  tw::TailwindPropertyParser,
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
+  lerp, tw::TailwindPropertyParser,
 };
-use crate::rendering::Sizing;
 
 /// Represents font weight value.
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -22,7 +21,7 @@ impl Animatable for FontWeight {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     *self = FontWeight::from(lerp(from.value(), to.value(), progress));

--- a/takumi/src/layout/style/properties/grid/grid_length.rs
+++ b/takumi/src/layout/style/properties/grid/grid_length.rs
@@ -2,8 +2,8 @@ use cssparser::{Parser, Token};
 use taffy::CompactLength;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{CssToken, FromCss, Length, MakeComputed, ParseResult, ToCss, unexpected_token},
-  rendering::Sizing,
 };
 
 /// Represents a fraction of the available space
@@ -26,7 +26,7 @@ pub enum GridLength {
 
 impl GridLength {
   /// Converts the grid track size to a compact length representation.
-  pub(crate) fn to_compact_length(self, sizing: &Sizing) -> CompactLength {
+  pub(crate) fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
     match self {
       GridLength::Fr(fr) => CompactLength::fr(fr),
       GridLength::Unit(unit) => unit.to_compact_length(sizing),
@@ -59,7 +59,7 @@ impl<'i> FromCss<'i> for GridLength {
 }
 
 impl MakeComputed for GridLength {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let GridLength::Unit(unit) = self {
       unit.make_computed(sizing);
     }

--- a/takumi/src/layout/style/properties/grid/grid_line.rs
+++ b/takumi/src/layout/style/properties/grid/grid_line.rs
@@ -2,9 +2,8 @@ use cssparser::Parser;
 
 use crate::layout::style::{
   CssSyntaxKind, CssToken, FromCss, GridPlacementKeyword, GridPlacementSpan, MakeComputed,
-  ParseResult, tw::TailwindPropertyParser,
+  ParseResult, SizingContext, tw::TailwindPropertyParser,
 };
-use crate::rendering::Sizing;
 
 use crate::layout::style::GridPlacement;
 
@@ -19,7 +18,7 @@ pub struct GridLine {
 }
 
 impl MakeComputed for GridLine {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.start.make_computed(sizing);
     self.end.make_computed(sizing);
   }

--- a/takumi/src/layout/style/properties/grid/grid_min_max_size.rs
+++ b/takumi/src/layout/style/properties/grid/grid_min_max_size.rs
@@ -1,10 +1,10 @@
 use cssparser::Parser;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     CssDescriptorKind, CssToken, FromCss, GridLength, MakeComputed, ParseResult, ToCss,
   },
-  rendering::Sizing,
 };
 
 /// Represents a grid minmax()
@@ -32,7 +32,7 @@ impl<'i> FromCss<'i> for GridMinMaxSize {
 }
 
 impl MakeComputed for GridMinMaxSize {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.min.make_computed(sizing);
     self.max.make_computed(sizing);
   }

--- a/takumi/src/layout/style/properties/grid/grid_repeat_track.rs
+++ b/takumi/src/layout/style/properties/grid/grid_repeat_track.rs
@@ -1,9 +1,8 @@
 use cssparser::Parser;
 
 use crate::layout::style::{
-  CssSyntaxKind, CssToken, FromCss, GridTrackSize, MakeComputed, ParseResult, ToCss,
+  CssSyntaxKind, CssToken, FromCss, GridTrackSize, MakeComputed, ParseResult, SizingContext, ToCss,
 };
-use crate::rendering::Sizing;
 
 /// Represents a grid repeat track
 #[derive(Debug, Clone, PartialEq)]
@@ -19,7 +18,7 @@ pub struct GridRepeatTrack {
 }
 
 impl MakeComputed for GridRepeatTrack {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.size.make_computed(sizing);
   }
 }

--- a/takumi/src/layout/style/properties/grid/grid_template_component.rs
+++ b/takumi/src/layout/style/properties/grid/grid_template_component.rs
@@ -4,9 +4,8 @@ use cssparser::Parser;
 
 use crate::layout::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, GridRepeatTrack, GridRepetitionCount,
-  GridTrackSize, MakeComputed, ParseResult, ToCss,
+  GridTrackSize, MakeComputed, ParseResult, SizingContext, ToCss,
 };
-use crate::rendering::Sizing;
 
 /// A transparent wrapper around a list of `GridTemplateComponent`.
 ///
@@ -17,7 +16,7 @@ pub type GridTemplateComponents = Vec<GridTemplateComponent>;
 pub(crate) trait GridTemplateComponentsExt {
   fn collect_components_and_names(
     &self,
-    sizing: &Sizing,
+    sizing: &SizingContext,
   ) -> (Vec<taffy::GridTemplateComponent<String>>, Vec<Vec<String>>);
 }
 
@@ -35,7 +34,7 @@ pub enum GridTemplateComponent {
 }
 
 impl MakeComputed for GridTemplateComponent {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       GridTemplateComponent::Single(size) => size.make_computed(sizing),
       GridTemplateComponent::Repeat(_, tracks) => {
@@ -150,7 +149,7 @@ impl<'i> FromCss<'i> for GridTemplateComponents {
 impl GridTemplateComponentsExt for [GridTemplateComponent] {
   fn collect_components_and_names(
     &self,
-    sizing: &Sizing,
+    sizing: &SizingContext,
   ) -> (Vec<taffy::GridTemplateComponent<String>>, Vec<Vec<String>>) {
     let mut track_components = Vec::new();
     let mut line_name_sets = Vec::new();

--- a/takumi/src/layout/style/properties/grid/grid_track_size.rs
+++ b/takumi/src/layout/style/properties/grid/grid_track_size.rs
@@ -4,11 +4,11 @@ use cssparser::{Parser, match_ignore_ascii_case};
 use taffy::{MaxTrackSizingFunction, MinTrackSizingFunction, TrackSizingFunction};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, GridLength, GridMinMaxSize, Length,
     MakeComputed, ParseResult, ToCss, tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 /// A list of `GridTrackSize`
@@ -45,7 +45,7 @@ impl From<GridLength> for GridTrackSize {
 
 impl GridTrackSize {
   /// Converts the grid track size to a non-repeated track sizing function.
-  pub(crate) fn to_min_max(self, sizing: &Sizing) -> TrackSizingFunction {
+  pub(crate) fn to_min_max(self, sizing: &SizingContext) -> TrackSizingFunction {
     match self {
       // SAFETY: The compact length is a valid track sizing function.
       Self::Fixed(size) => unsafe {
@@ -100,7 +100,7 @@ impl<'i> FromCss<'i> for GridTrackSize {
 }
 
 impl MakeComputed for GridTrackSize {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       GridTrackSize::MinMax(min_max) => min_max.make_computed(sizing),
       GridTrackSize::Fixed(length) => length.make_computed(sizing),

--- a/takumi/src/layout/style/properties/length.rs
+++ b/takumi/src/layout/style/properties/length.rs
@@ -5,11 +5,11 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use taffy::{CompactLength, Dimension, LengthPercentage, LengthPercentageAuto};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     AspectRatio, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult,
     tw::{TW_VAR_SPACING, TailwindPropertyParser},
   },
-  rendering::Sizing,
 };
 
 const ONE_CM_IN_PX: f32 = 96.0 / 2.54;
@@ -346,7 +346,7 @@ impl CalcFormula {
     }
   }
 
-  pub(crate) fn resolve(self, sizing: &Sizing) -> CalcLinear {
+  pub(crate) fn resolve(self, sizing: &SizingContext) -> CalcLinear {
     let viewport_width = sizing.viewport.size.width.unwrap_or_default() as f32;
     let viewport_height = sizing.viewport.size.height.unwrap_or_default() as f32;
     let viewport_min = viewport_width.min(viewport_height);
@@ -899,7 +899,7 @@ impl<'i, const DEFAULT_AUTO: bool> FromCss<'i> for Length<DEFAULT_AUTO> {
 }
 
 impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
-  fn to_px_pre_dpr(self, sizing: &Sizing, percentage_full_px: f32) -> f32 {
+  fn to_px_pre_dpr(self, sizing: &SizingContext, percentage_full_px: f32) -> f32 {
     match self {
       Length::Auto => 0.0,
       Length::Px(value) => value,
@@ -947,7 +947,7 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
     }
   }
 
-  pub(crate) fn to_compact_length(self, sizing: &Sizing) -> CompactLength {
+  pub(crate) fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
     match self {
       Length::Auto => CompactLength::auto(),
       Length::Percentage(value) => CompactLength::percent(value / 100.0),
@@ -1007,7 +1007,7 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
     }
   }
 
-  pub(crate) fn resolve_to_length_percentage(self, sizing: &Sizing) -> LengthPercentage {
+  pub(crate) fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
     let compact_length = self.to_compact_length(sizing);
 
     if compact_length.is_auto() {
@@ -1017,7 +1017,7 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
     unsafe { LengthPercentage::from_raw(compact_length) }
   }
 
-  pub(crate) fn to_px(self, sizing: &Sizing, percentage_full_px: f32) -> f32 {
+  pub(crate) fn to_px(self, sizing: &SizingContext, percentage_full_px: f32) -> f32 {
     let value = self.to_px_pre_dpr(sizing, percentage_full_px);
 
     let value = if matches!(
@@ -1046,17 +1046,20 @@ impl<const DEFAULT_AUTO: bool> Length<DEFAULT_AUTO> {
     clamp_px_for_integer_cast(value)
   }
 
-  pub(crate) fn resolve_to_length_percentage_auto(self, sizing: &Sizing) -> LengthPercentageAuto {
+  pub(crate) fn resolve_to_length_percentage_auto(
+    self,
+    sizing: &SizingContext,
+  ) -> LengthPercentageAuto {
     unsafe { LengthPercentageAuto::from_raw(self.to_compact_length(sizing)) }
   }
 
-  pub(crate) fn resolve_to_dimension(self, sizing: &Sizing) -> Dimension {
+  pub(crate) fn resolve_to_dimension(self, sizing: &SizingContext) -> Dimension {
     self.resolve_to_length_percentage_auto(sizing).into()
   }
 }
 
 impl<const DEFAULT_AUTO: bool> MakeComputed for Length<DEFAULT_AUTO> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Self::Em(em) = *self {
       let dpr = sizing.viewport.device_pixel_ratio;
       let font_size = if dpr > 0.0 {
@@ -1114,8 +1117,8 @@ mod tests {
   use super::*;
   use crate::layout::Viewport;
 
-  fn sizing() -> Sizing {
-    Sizing {
+  fn sizing() -> SizingContext {
+    SizingContext {
       viewport: Viewport {
         size: (200, 100).into(),
         font_size: 16.0,
@@ -1262,7 +1265,7 @@ mod tests {
     assert_near(px, 64.0);
   }
 
-  fn descendant_sizing() -> Sizing {
+  fn descendant_sizing() -> SizingContext {
     let mut sizing = sizing();
     sizing.root_font_size = Some(32.0);
     sizing

--- a/takumi/src/layout/style/properties/line_height.rs
+++ b/takumi/src/layout/style/properties/line_height.rs
@@ -1,11 +1,11 @@
 use cssparser::{Parser, match_ignore_ascii_case};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult, ToCss,
     parse_calc_number_expression, tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 /// Represents a line height value.
@@ -85,7 +85,7 @@ impl LineHeight {
     matches!(self, Self::Normal | Self::Unitless(_))
   }
 
-  pub(crate) fn into_parley(self, sizing: &Sizing) -> parley::LineHeight {
+  pub(crate) fn into_parley(self, sizing: &SizingContext) -> parley::LineHeight {
     match self {
       Self::Normal => parley::LineHeight::MetricsRelative(1.0),
       Self::Length(length) => parley::LineHeight::Absolute(length.to_px(sizing, sizing.font_size)),
@@ -93,7 +93,7 @@ impl LineHeight {
     }
   }
 
-  pub(crate) fn to_px(self, sizing: &Sizing, normal_basis: f32) -> f32 {
+  pub(crate) fn to_px(self, sizing: &SizingContext, normal_basis: f32) -> f32 {
     match self {
       Self::Normal => normal_basis,
       Self::Unitless(value) => value * sizing.font_size,
@@ -103,7 +103,7 @@ impl LineHeight {
 }
 
 impl MakeComputed for LineHeight {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       Self::Length(Length::Percentage(value)) => {
         let dpr = sizing.viewport.device_pixel_ratio;

--- a/takumi/src/layout/style/properties/linear_gradient.rs
+++ b/takumi/src/layout/style/properties/linear_gradient.rs
@@ -13,10 +13,10 @@ use super::gradient_utils::{
 };
 use crate::layout::style::{
   Animatable, Color, ColorInterpolationMethod, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-  Length, MakeComputed, ParseResult, ToCss, declare_enum_from_css_impl, properties::ColorInput,
-  tw::TailwindPropertyParser, unexpected_token,
+  Length, MakeComputed, ParseResult, SizingContext, ToCss, declare_enum_from_css_impl,
+  properties::ColorInput, tw::TailwindPropertyParser, unexpected_token,
 };
-use crate::rendering::{RenderContext, Sizing};
+use crate::rendering::RenderContext;
 
 /// Represents a linear gradient.
 #[derive(Debug, Clone, PartialEq, TypedBuilder)]
@@ -37,7 +37,7 @@ pub struct LinearGradient {
 }
 
 impl MakeComputed for LinearGradient {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.stops.make_computed(sizing);
   }
 }
@@ -361,7 +361,7 @@ impl GradientOverlayTile for LinearGradientTile {
 pub struct StopPosition(pub Length);
 
 impl MakeComputed for StopPosition {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.0.make_computed(sizing);
   }
 }
@@ -382,7 +382,7 @@ pub enum GradientStop {
 }
 
 impl MakeComputed for GradientStop {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     match self {
       GradientStop::ColorHint { hint, .. } => hint.make_computed(sizing),
       GradientStop::Hint(hint) => hint.make_computed(sizing),
@@ -515,7 +515,7 @@ impl Animatable for Angle {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     let from_degrees = **from;
@@ -912,8 +912,8 @@ mod tests {
   };
 
   use super::*;
-  fn sizing() -> Sizing {
-    Sizing {
+  fn sizing() -> SizingContext {
+    SizingContext {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
       font_size: 16.0,

--- a/takumi/src/layout/style/properties/mod.rs
+++ b/takumi/src/layout/style/properties/mod.rs
@@ -117,8 +117,8 @@ use std::borrow::Cow;
 use std::fmt;
 
 use crate::{
-  layout::style::tw::TailwindPropertyParser,
-  rendering::{Join, Sizing},
+  layout::style::{SizingContext, tw::TailwindPropertyParser},
+  rendering::Join,
 };
 
 /// Parser result type alias for CSS property parsers.
@@ -422,7 +422,7 @@ impl<'i> FromCss<'i> for String {
 /// Converts a parsed/inherited value into a computed value for the current node context.
 pub(crate) trait MakeComputed {
   /// Default no-op for types that do not need computed-value normalization.
-  fn make_computed(&mut self, _sizing: &Sizing) {}
+  fn make_computed(&mut self, _sizing: &SizingContext) {}
 }
 
 pub(crate) trait Animatable: Sized + Clone {
@@ -431,7 +431,7 @@ pub(crate) trait Animatable: Sized + Clone {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     *self = if progress >= 1.0 {
@@ -465,7 +465,7 @@ pub(crate) enum ListInterpolationStrategy {
 }
 
 impl<T: MakeComputed> MakeComputed for Option<T> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Some(value) = self.as_mut() {
       value.make_computed(sizing);
     }
@@ -473,7 +473,7 @@ impl<T: MakeComputed> MakeComputed for Option<T> {
 }
 
 impl<T: MakeComputed> MakeComputed for Box<[T]> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     for value in self.iter_mut() {
       value.make_computed(sizing);
     }
@@ -481,7 +481,7 @@ impl<T: MakeComputed> MakeComputed for Box<[T]> {
 }
 
 impl<T: MakeComputed> MakeComputed for Vec<T> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     for value in self.iter_mut() {
       value.make_computed(sizing);
     }
@@ -501,7 +501,7 @@ impl<T: Animatable + Clone> Animatable for Option<T> {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = match (from, to) {
@@ -557,7 +557,7 @@ impl<T: Animatable + Clone> Animatable for Box<[T]> {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = interpolate_list(
@@ -592,7 +592,7 @@ impl<T: Animatable + Clone> Animatable for Vec<T> {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = interpolate_list(from, to, progress, sizing, current_color, |values| values)
@@ -610,7 +610,7 @@ fn interpolate_list<T: Animatable + Clone, C: AsRef<[T]>, O>(
   from: &C,
   to: &C,
   progress: f32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   current_color: Color,
   build: impl FnOnce(Vec<T>) -> O,
 ) -> Option<O> {
@@ -650,7 +650,7 @@ fn interpolate_pairwise_list<T: Animatable + Clone>(
   to: &[T],
   output_len: usize,
   progress: f32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   current_color: Color,
 ) -> Vec<T> {
   (0..output_len)
@@ -668,7 +668,7 @@ fn interpolate_neutral_padded_list<T: Animatable + Clone>(
   from: &[T],
   to: &[T],
   progress: f32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   current_color: Color,
 ) -> Option<Vec<T>> {
   let output_len = from.len().max(to.len());
@@ -714,7 +714,7 @@ impl<T: Animatable + Copy> Animatable for SpacePair<T> {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     self
@@ -732,7 +732,7 @@ impl<T: Animatable + Copy> Animatable for Sides<T> {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     for (index, value) in self.0.iter_mut().enumerate() {
@@ -1021,7 +1021,7 @@ impl From<f32> for BorderRadius {
 }
 
 impl MakeComputed for BorderRadius {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.0.make_computed(sizing);
   }
 }
@@ -1032,7 +1032,7 @@ impl Animatable for BorderRadius {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     self

--- a/takumi/src/layout/style/properties/percentage_number.rs
+++ b/takumi/src/layout/style/properties/percentage_number.rs
@@ -7,11 +7,10 @@ use std::{
 use cssparser::{Parser, Token};
 
 use crate::layout::style::{
-  Animatable, Color, MakeComputed, lerp,
+  Animatable, Color, MakeComputed, SizingContext, lerp,
   properties::{FromCss, ParseResult},
   tw::TailwindPropertyParser,
 };
-use crate::rendering::Sizing;
 
 use crate::layout::style::{CssSyntaxKind, CssToken};
 
@@ -27,7 +26,7 @@ impl Animatable for PercentageNumber {
     from: &Self,
     to: &Self,
     progress: f32,
-    _sizing: &Sizing,
+    _sizing: &SizingContext,
     _current_color: Color,
   ) {
     *self = Self(lerp(from.0, to.0, progress));

--- a/takumi/src/layout/style/properties/radial_gradient.rs
+++ b/takumi/src/layout/style/properties/radial_gradient.rs
@@ -11,9 +11,9 @@ use crate::{
   layout::style::{
     ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop, GradientStops,
     Length, LengthDefaultsToZero, MakeComputed, ObjectPosition, ParseResult, ResolvedGradientStop,
-    ToCss, declare_enum_from_css_impl, unexpected_token,
+    SizingContext, ToCss, declare_enum_from_css_impl, unexpected_token,
   },
-  rendering::{RenderContext, Sizing},
+  rendering::RenderContext,
 };
 
 /// Represents a radial gradient.
@@ -41,7 +41,7 @@ pub struct RadialGradient {
 }
 
 impl MakeComputed for RadialGradient {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.center.make_computed(sizing);
     self.stops.make_computed(sizing);
   }

--- a/takumi/src/layout/style/properties/sides.rs
+++ b/takumi/src/layout/style/properties/sides.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use taffy::Rect;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     CssExpectedMessage, CssToken, FromCss, Length, MakeComputed, ParseResult, ToCss,
   },
-  rendering::Sizing,
 };
 
 /// Represents the values for the four sides of a box (top, right, bottom, left).
@@ -95,7 +95,7 @@ impl<T: Copy> From<T> for Sides<T> {
 }
 
 impl<T: Copy + MakeComputed> MakeComputed for Sides<T> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     for value in &mut self.0 {
       value.make_computed(sizing);
     }

--- a/takumi/src/layout/style/properties/space_pair.rs
+++ b/takumi/src/layout/style/properties/space_pair.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use taffy::{Point, Size};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     CssExpectedMessage, CssToken, FromCss, LengthDefaultsToZero, MakeComputed, Overflow,
     ParseResult, ToCss,
   },
-  rendering::Sizing,
 };
 
 /// A pair of values for horizontal and vertical axes.
@@ -55,7 +55,7 @@ impl<T: Copy> SpacePair<T> {
 }
 
 impl<T: Copy + MakeComputed> MakeComputed for SpacePair<T> {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.x.make_computed(sizing);
     self.y.make_computed(sizing);
   }
@@ -80,7 +80,7 @@ impl SpacePair<Overflow> {
 pub type BorderRadiusPair = SpacePair<LengthDefaultsToZero>;
 
 impl BorderRadiusPair {
-  pub(crate) fn to_px(self, sizing: &Sizing, border_box: Size<f32>) -> SpacePair<f32> {
+  pub(crate) fn to_px(self, sizing: &SizingContext, border_box: Size<f32>) -> SpacePair<f32> {
     SpacePair::from_pair(
       self.x.to_px(sizing, border_box.width).max(0.0),
       self.y.to_px(sizing, border_box.height).max(0.0),

--- a/takumi/src/layout/style/properties/text_decoration.rs
+++ b/takumi/src/layout/style/properties/text_decoration.rs
@@ -6,11 +6,11 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
     declare_enum_from_css_impl, properties::ColorInput, tw::TailwindPropertyParser,
   },
-  rendering::Sizing,
 };
 
 bitflags! {
@@ -88,7 +88,7 @@ impl Default for TextDecorationThickness {
 }
 
 impl MakeComputed for TextDecorationThickness {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Self::Length(length) = self {
       length.make_computed(sizing);
     }
@@ -101,7 +101,7 @@ impl Animatable for TextDecorationThickness {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = match (*from, *to) {
@@ -221,7 +221,7 @@ pub struct TextDecoration {
 }
 
 impl MakeComputed for TextDecoration {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.color.make_computed(sizing);
     self.thickness.make_computed(sizing);
   }

--- a/takumi/src/layout/style/properties/text_indent.rs
+++ b/takumi/src/layout/style/properties/text_indent.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, CssSyntaxKind, CssToken, FromCss, LengthDefaultsToZero, MakeComputed,
     ParseResult, ToCss, unexpected_token,
   },
-  rendering::Sizing,
 };
 
 /// Controls indentation of the first line, or hanging/each-line variants.
@@ -44,7 +44,7 @@ impl TextIndent {
     self
   }
 
-  pub(crate) fn resolve_px(self, sizing: &Sizing, line_width: f32) -> f32 {
+  pub(crate) fn resolve_px(self, sizing: &SizingContext, line_width: f32) -> f32 {
     self.amount.to_px(sizing, line_width)
   }
 }
@@ -57,7 +57,7 @@ impl Animatable for TextIndent {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     self

--- a/takumi/src/layout/style/properties/text_shadow.rs
+++ b/takumi/src/layout/style/properties/text_shadow.rs
@@ -4,11 +4,11 @@ use cssparser::{BasicParseErrorKind, ParseError, Parser};
 use typed_builder::TypedBuilder;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, Length, LengthDefaultsToZero,
     ListInterpolationStrategy, MakeComputed, ParseResult, ToCss, next_is_comma,
   },
-  rendering::Sizing,
 };
 
 /// Represents a text shadow with all its properties.
@@ -107,7 +107,7 @@ impl crate::layout::style::tw::TailwindPropertyParser for TextShadow {
 }
 
 impl MakeComputed for TextShadow {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.offset_x.make_computed(sizing);
     self.offset_y.make_computed(sizing);
     self.blur_radius.make_computed(sizing);
@@ -133,7 +133,7 @@ impl Animatable for TextShadow {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     self.offset_x.interpolate(

--- a/takumi/src/layout/style/properties/text_stroke.rs
+++ b/takumi/src/layout/style/properties/text_stroke.rs
@@ -1,10 +1,10 @@
 use cssparser::Parser;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     ColorInput, CssSyntaxKind, CssToken, FromCss, LengthDefaultsToZero, MakeComputed, ParseResult,
   },
-  rendering::Sizing,
 };
 
 /// Parsed `text-stroke` value.
@@ -36,7 +36,7 @@ impl<'i> FromCss<'i> for TextStroke {
 }
 
 impl MakeComputed for TextStroke {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     self.width.make_computed(sizing);
   }
 }

--- a/takumi/src/layout/style/properties/transform.rs
+++ b/takumi/src/layout/style/properties/transform.rs
@@ -9,11 +9,11 @@ use taffy::{Point, Size};
 use tiny_skia::Transform as TinyTransform;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{
     Angle, Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
     MakeComputed, ParseResult, PercentageNumber, lerp,
   },
-  rendering::Sizing,
 };
 
 const DEFAULT_SCALE: f32 = 1.0;
@@ -35,7 +35,7 @@ pub enum Transform {
 }
 
 impl MakeComputed for Transform {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Transform::Translate(x, y) = self {
       x.make_computed(sizing);
       y.make_computed(sizing);
@@ -63,7 +63,7 @@ impl Animatable for Transform {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     *self = match (*from, *to) {
@@ -324,7 +324,7 @@ impl Affine {
   /// When applied to point p: translate * rotate * p, rotate is applied first.
   pub(crate) fn from_transforms<'a, I: Iterator<Item = &'a Transform>>(
     transforms: I,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     border_box: Size<f32>,
   ) -> Affine {
     let mut instance = Affine::IDENTITY;
@@ -386,7 +386,7 @@ impl<'i> FromCss<'i> for Transforms {
 }
 
 impl MakeComputed for Transforms {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     for transform in self.0.iter_mut() {
       transform.make_computed(sizing);
     }
@@ -403,7 +403,7 @@ impl Animatable for Transforms {
     from: &Self,
     to: &Self,
     progress: f32,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
   ) {
     self

--- a/takumi/src/layout/style/properties/vertical_align.rs
+++ b/takumi/src/layout/style/properties/vertical_align.rs
@@ -4,8 +4,8 @@ use cssparser::{Parser, match_ignore_ascii_case};
 use parley::LineMetrics;
 
 use crate::{
+  layout::style::SizingContext,
   layout::style::{ToCss, tw::TailwindPropertyParser, *},
-  rendering::Sizing,
 };
 
 /// Keyword values for the CSS `vertical-align` property.
@@ -114,7 +114,7 @@ impl<'i> FromCss<'i> for VerticalAlign {
 impl VerticalAlign {
   pub(crate) fn resolve(
     self,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     font_size: f32,
     line_height: LineHeight,
   ) -> ResolvedVerticalAlign {
@@ -155,7 +155,7 @@ impl VerticalAlign {
 }
 
 impl MakeComputed for VerticalAlign {
-  fn make_computed(&mut self, sizing: &Sizing) {
+  fn make_computed(&mut self, sizing: &SizingContext) {
     if let Self::Length(length) = self {
       length.make_computed(sizing);
     }
@@ -237,8 +237,8 @@ mod tests {
 
   use super::*;
 
-  fn sizing() -> Sizing {
-    Sizing {
+  fn sizing() -> SizingContext {
+    SizingContext {
       viewport: Viewport {
         size: (200, 100).into(),
         font_size: 16.0,

--- a/takumi/src/layout/style/selector.rs
+++ b/takumi/src/layout/style/selector.rs
@@ -15,13 +15,13 @@ use taffy::Size;
 use crate::{
   error::StyleSheetParseError,
   keyframes::parse_keyframe_prelude,
+  layout::style::SizingContext,
   layout::{
     Viewport,
     style::{
       CalcArena, FromCss, KeyframeRule, KeyframesRule, LengthDefaultsToZero, StyleDeclarationBlock,
     },
   },
-  rendering::Sizing,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -576,7 +576,7 @@ pub(crate) struct MediaQueryList {
 }
 
 impl MediaFeature {
-  fn matches(&self, viewport: Viewport, sizing: &Sizing) -> bool {
+  fn matches(&self, viewport: Viewport, sizing: &SizingContext) -> bool {
     match self {
       Self::Width(comparison, value) => viewport.size.width.is_some_and(|width| {
         compare_media_feature(*comparison, width as f32, value.to_px(sizing, width as f32))
@@ -603,7 +603,7 @@ impl MediaFeature {
 }
 
 impl MediaQuery {
-  fn matches(&self, viewport: Viewport, sizing: &Sizing) -> bool {
+  fn matches(&self, viewport: Viewport, sizing: &SizingContext) -> bool {
     let media_type_matches = match &self.media_type {
       MediaType::All | MediaType::Screen => true,
       MediaType::Unsupported(_) => false,
@@ -629,7 +629,7 @@ impl MediaQueryList {
       return true;
     }
 
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport,
       container_size: Size::NONE,
       font_size: viewport.font_size,

--- a/takumi/src/layout/style/sizing.rs
+++ b/takumi/src/layout/style/sizing.rs
@@ -1,0 +1,54 @@
+use std::rc::Rc;
+
+use taffy::Size;
+
+use crate::layout::Viewport;
+use crate::layout::style::CalcArena;
+
+/// The sizing context used for length value resolving.
+#[derive(Clone)]
+pub(crate) struct SizingContext {
+  /// The viewport for the image renderer.
+  pub(crate) viewport: Viewport,
+  /// The nearest query container size (content box) in device pixels.
+  pub(crate) container_size: Size<Option<f32>>,
+  /// The font size in pixels.
+  pub(crate) font_size: f32,
+  /// Computed `font-size` of the root element in device pixels. `None` before
+  /// the root has been resolved; readers should fall back to `viewport.font_size`.
+  /// https://www.w3.org/TR/css-values-4/#rem
+  pub(crate) root_font_size: Option<f32>,
+  /// Pixel basis for the `lh` unit.
+  pub(crate) line_height: f32,
+  /// Pixel basis for the `rlh` unit; `None` before root is resolved.
+  pub(crate) root_line_height: Option<f32>,
+  /// The calc arena shared by the current layout tree.
+  pub(crate) calc_arena: Rc<CalcArena>,
+}
+
+impl SizingContext {
+  /// Device-pixel basis for the `rem` unit.
+  pub(crate) fn rem_basis(&self) -> f32 {
+    self
+      .root_font_size
+      .unwrap_or(self.viewport.font_size * self.viewport.device_pixel_ratio)
+  }
+
+  pub(crate) fn root_line_height_basis(&self) -> f32 {
+    self.root_line_height.unwrap_or(self.line_height)
+  }
+
+  pub(crate) fn query_container_width(&self) -> f32 {
+    self
+      .container_size
+      .width
+      .unwrap_or(self.viewport.size.width.unwrap_or_default() as f32)
+  }
+
+  pub(crate) fn query_container_height(&self) -> f32 {
+    self
+      .container_size
+      .height
+      .unwrap_or(self.viewport.size.height.unwrap_or_default() as f32)
+  }
+}

--- a/takumi/src/layout/style/stylesheets.rs
+++ b/takumi/src/layout/style/stylesheets.rs
@@ -13,9 +13,9 @@ use crate::{
   error::StyleDeclarationBlockParseError,
   layout::{
     inline::InlineBrush,
-    style::{CssInput, CssValueSeed, properties::*},
+    style::{CssInput, CssValueSeed, SizingContext, properties::*},
   },
-  rendering::{RenderContext, SizedShadow, Sizing},
+  rendering::{RenderContext, SizedShadow},
 };
 use cssparser::RuleBodyParser;
 #[path = "stylesheets_helpers.rs"]
@@ -46,7 +46,7 @@ struct DeferredDeclaration {
 #[derive(Clone, Copy)]
 struct InterpolationContext<'a> {
   progress: f32,
-  sizing: &'a Sizing,
+  sizing: &'a SizingContext,
   current_color: Color,
 }
 
@@ -608,7 +608,7 @@ macro_rules! define_style {
           }
         }
 
-        pub(crate) fn make_computed_values(&mut self, sizing: &Sizing) {
+        pub(crate) fn make_computed_values(&mut self, sizing: &SizingContext) {
           $(self.$longhand.make_computed(sizing);)*
         }
 
@@ -618,7 +618,7 @@ macro_rules! define_style {
           to: &Self,
           animated_properties: &PropertyMask,
           progress: f32,
-          sizing: &Sizing,
+          sizing: &SizingContext,
           current_color: Color,
         ) {
           let interpolation_context = InterpolationContext {
@@ -1633,7 +1633,7 @@ pub(crate) struct SizedFontStyle<'s> {
   pub text_stroke_color: Color,
   pub text_decoration_color: Color,
   pub text_decoration_thickness: SizedTextDecorationThickness,
-  pub sizing: Sizing,
+  pub sizing: SizingContext,
 }
 
 impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
@@ -1697,7 +1697,7 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
 
 impl ComputedStyle {
   /// Normalize inheritable text-related values to computed values for this node.
-  pub(crate) fn make_computed(&mut self, sizing: &Sizing) {
+  pub(crate) fn make_computed(&mut self, sizing: &SizingContext) {
     // `font-size` computed value is already resolved in `sizing.font_size`.
     // Keep it as css-px in style to avoid re-resolving descendant inheritance.
     let dpr = sizing.viewport.device_pixel_ratio;
@@ -1731,7 +1731,7 @@ impl ComputedStyle {
   pub(crate) fn creates_stacking_context(
     &self,
     border_box: Size<f32>,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     is_flex_or_grid_item: bool,
   ) -> bool {
     self.isolation == Isolation::Isolate
@@ -1754,7 +1754,11 @@ impl ComputedStyle {
       })
   }
 
-  pub(crate) fn has_non_identity_transform(&self, border_box: Size<f32>, sizing: &Sizing) -> bool {
+  pub(crate) fn has_non_identity_transform(
+    &self,
+    border_box: Size<f32>,
+    sizing: &SizingContext,
+  ) -> bool {
     let transform_origin = self.transform_origin;
     let origin = transform_origin.to_point(sizing, border_box);
 
@@ -1836,7 +1840,7 @@ impl ComputedStyle {
   #[inline]
   fn grid_template(
     components: &Option<GridTemplateComponents>,
-    sizing: &Sizing,
+    sizing: &SizingContext,
   ) -> (Vec<taffy::GridTemplateComponent<String>>, Vec<Vec<String>>) {
     components.as_deref().map_or_else(
       || (Vec::new(), vec![Vec::new()]),
@@ -1865,7 +1869,10 @@ impl ComputedStyle {
   }
 
   #[inline]
-  fn resolved_text_decoration_thickness(&self, sizing: &Sizing) -> SizedTextDecorationThickness {
+  fn resolved_text_decoration_thickness(
+    &self,
+    sizing: &SizingContext,
+  ) -> SizedTextDecorationThickness {
     match self.text_decoration_thickness {
       TextDecorationThickness::Length(Length::Auto) | TextDecorationThickness::FromFont => {
         SizedTextDecorationThickness::FromFont
@@ -1912,7 +1919,7 @@ impl ComputedStyle {
     }
   }
 
-  pub(crate) fn to_taffy_style(&self, sizing: &Sizing) -> taffy::Style {
+  pub(crate) fn to_taffy_style(&self, sizing: &SizingContext) -> taffy::Style {
     // Convert grid templates and associated line names
     let (grid_template_columns, grid_template_column_names) =
       Self::grid_template(&self.grid_template_columns, sizing);
@@ -2086,11 +2093,11 @@ mod tests {
     CssWideKeyword, LonghandId, PropertyId, PropertyMask, ShorthandId, StyleDeclarationBlock,
   };
   use crate::{
+    layout::style::SizingContext,
     layout::{
       Viewport,
       style::{ComputedStyle, Style, StyleDeclaration, properties::*},
     },
-    rendering::Sizing,
   };
 
   fn style_with(declarations: impl IntoIterator<Item = StyleDeclaration>) -> Style {
@@ -2679,7 +2686,7 @@ mod tests {
   #[test]
   fn test_creates_stacking_context_from_z_index_scope() {
     let mut style = ComputedStyle::default();
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
@@ -2712,7 +2719,7 @@ mod tests {
   #[test]
   fn test_non_identity_transform_detection() {
     let mut style = ComputedStyle::default();
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
@@ -2738,7 +2745,7 @@ mod tests {
   #[test]
   fn test_transform_creates_stacking_context_without_offscreen_compositing() {
     let mut style = ComputedStyle::default();
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
@@ -2786,7 +2793,7 @@ mod tests {
     ])
     .inherit(&ComputedStyle::default());
 
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,
@@ -2809,7 +2816,7 @@ mod tests {
       StyleDeclaration::line_height(LineHeight::Length(Length::Em(1.5))),
     ])
     .inherit(&ComputedStyle::default());
-    parent.make_computed(&Sizing {
+    parent.make_computed(&SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 32.0,
@@ -2820,7 +2827,7 @@ mod tests {
     });
 
     let inherited_child = Style::default().inherit(&parent);
-    let inherited_child_sizing = Sizing {
+    let inherited_child_sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 32.0,
@@ -2836,7 +2843,7 @@ mod tests {
 
     let child_with_own_font_size =
       style_with([StyleDeclaration::font_size(Length::Px(10.0).into())]).inherit(&parent);
-    let child_sizing = Sizing {
+    let child_sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 10.0,
@@ -3063,7 +3070,7 @@ mod tests {
       [("border-radius", "calc(infinity * 1px)")],
       &ComputedStyle::default(),
     );
-    let sizing = Sizing {
+    let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,

--- a/takumi/src/layout/style/tw/mod.rs
+++ b/takumi/src/layout/style/tw/mod.rs
@@ -2261,7 +2261,7 @@ mod tests {
       "hidden",
       "block",
       "inline",
-      // Sizing
+      // SizingContext
       "w-4",
       "h-8",
       "size-12",

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -22,13 +22,13 @@ use crate::{
     style::{
       Affine, BackgroundImage, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem,
       ContentValue, Display, Filters, Float, Isolation, LineHeight, Overflow, PercentageNumber,
-      Position, Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode,
+      Position, SizingContext, Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode,
       apply_stylesheet_animations,
       matching::{MatchedDeclarationsView, NodeMatchedDeclarations, match_stylesheets_view},
     },
   },
   rendering::{
-    Canvas, RenderContext, Sizing,
+    Canvas, RenderContext,
     inline_drawing::{InlineLayoutDrawData, draw_inline_box, draw_inline_layout},
   },
 };
@@ -260,7 +260,7 @@ fn registered_custom_property_parent_style(
 fn pseudo_computed_style<'g>(
   parent_context: &RenderContext<'g>,
   pseudo_matched: &MatchedDeclarationsView<'_>,
-) -> (ComputedStyle, Sizing, Color) {
+) -> (ComputedStyle, SizingContext, Color) {
   let style_layers = build_style_layers(
     NodeStyleLayers::default(),
     pseudo_matched,
@@ -280,7 +280,7 @@ fn pseudo_computed_style<'g>(
   let line_height = style
     .line_height
     .to_px(&parent_context.sizing, normal_basis);
-  let sizing = Sizing {
+  let sizing = SizingContext {
     font_size,
     root_font_size: Some(parent_context.sizing.root_font_size.unwrap_or(font_size)),
     line_height,
@@ -1217,7 +1217,7 @@ impl<'g> RenderNode<'g> {
       node: &mut Node,
       node_index: usize,
       matched_declarations: &[NodeMatchedDeclarations<'_>],
-    ) -> (ComputedStyle, Sizing, Color) {
+    ) -> (ComputedStyle, SizingContext, Color) {
       let default_matched = MatchedDeclarationsView::default();
       let matched = matched_declarations
         .get(node_index)
@@ -1238,7 +1238,7 @@ impl<'g> RenderNode<'g> {
       let parent_root_font_size = parent_context.sizing.root_font_size;
       let parent_root_line_height = parent_context.sizing.root_line_height;
 
-      let mut child_sizing_for_final: Option<Sizing> = None;
+      let mut child_sizing_for_final: Option<SizingContext> = None;
       if !style.animation_name.is_empty() {
         let font_size = style
           .font_size
@@ -1247,7 +1247,7 @@ impl<'g> RenderNode<'g> {
         let line_height = style
           .line_height
           .to_px(&parent_context.sizing, normal_basis);
-        let child_sizing = Sizing {
+        let child_sizing = SizingContext {
           font_size,
           root_font_size: parent_root_font_size,
           line_height,
@@ -1277,7 +1277,7 @@ impl<'g> RenderNode<'g> {
       let line_height = style
         .line_height
         .to_px(&parent_context.sizing, normal_basis);
-      let sizing = Sizing {
+      let sizing = SizingContext {
         font_size,
         root_font_size: Some(parent_root_font_size.unwrap_or(font_size)),
         line_height,

--- a/takumi/src/rendering/background_drawing.rs
+++ b/takumi/src/rendering/background_drawing.rs
@@ -12,7 +12,7 @@ use crate::{
   layout::{node::resolve_image, style::*},
   rendering::{
     BorderProperties, BufferPool, OverlayOptions, PaintSource, RenderContext, SamplingFootprint,
-    Sizing, fast_div_255, interpolate_with_footprint, overlay_gradient_tile, overlay_image,
+    fast_div_255, interpolate_with_footprint, overlay_gradient_tile, overlay_image,
     overlay_linear_gradient_tile, overlay_radial_gradient_tile,
   },
   resources::image::ImageSource,
@@ -378,7 +378,7 @@ fn resolve_axis_tiles(
   pos: BackgroundPosition,
   tile_size: u32,
   area_size: u32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   is_x: bool,
 ) -> (SmallVec<[i32; 1]>, u32) {
   match repeat {
@@ -430,7 +430,7 @@ fn resolve_auto_axis_from_intrinsic(
 pub(crate) fn resolve_length_to_position_component(
   length: Length,
   available: i32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
 ) -> i32 {
   match length {
     Length::Auto => available / 2,
@@ -448,7 +448,7 @@ pub(crate) fn resolve_position_component_x(
   comp: BackgroundPosition,
   tile_w: u32,
   area_w: u32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
 ) -> i32 {
   let available = calculate_available_space(area_w, tile_w);
   match comp.0.x {
@@ -466,7 +466,7 @@ pub(crate) fn resolve_position_component_y(
   comp: BackgroundPosition,
   tile_h: u32,
   area_h: u32,
-  sizing: &Sizing,
+  sizing: &SizingContext,
 ) -> i32 {
   let available = calculate_available_space(area_h, tile_h);
   match comp.0.y {
@@ -863,6 +863,7 @@ mod tests {
 
   use super::{resolve_position_component_x, resolve_position_component_y};
   use crate::{
+    layout::style::SizingContext,
     layout::{
       Viewport,
       style::{
@@ -870,12 +871,11 @@ mod tests {
         PositionKeywordY, SpacePair,
       },
     },
-    rendering::Sizing,
   };
 
-  fn test_sizing() -> Sizing {
+  fn test_sizing() -> SizingContext {
     let viewport = Viewport::new((100, 100));
-    Sizing {
+    SizingContext {
       viewport,
       container_size: Size::NONE,
       font_size: viewport.font_size,

--- a/takumi/src/rendering/components/shadow.rs
+++ b/takumi/src/rendering/components/shadow.rs
@@ -3,10 +3,12 @@ use tiny_skia::{IntSize, Pixmap};
 
 use crate::{
   Error, Result,
-  layout::style::{Affine, BlendMode, BoxShadow, Color, ImageScalingAlgorithm, Sides, TextShadow},
+  layout::style::{
+    Affine, BlendMode, BoxShadow, Color, ImageScalingAlgorithm, Sides, SizingContext, TextShadow,
+  },
   rendering::{
     BlurFormat, BlurType, BorderProperties, BufferPool, Canvas, Command, Fill, Placement,
-    SamplingOptions, Sizing, Style, apply_blur, attenuate_alpha_by_mask, fast_div_255, render_mask,
+    SamplingOptions, Style, apply_blur, attenuate_alpha_by_mask, fast_div_255, render_mask,
   },
 };
 
@@ -29,7 +31,7 @@ impl SizedShadow {
   /// Creates a new [`SizedShadow`] from a [`BoxShadow`].
   pub fn from_box_shadow(
     shadow: BoxShadow,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
     size: Size<f32>,
   ) -> Self {
@@ -45,7 +47,7 @@ impl SizedShadow {
   /// Creates a new `SizedShadow` from a `TextShadow`.
   pub fn from_text_shadow(
     shadow: TextShadow,
-    sizing: &Sizing,
+    sizing: &SizingContext,
     current_color: Color,
     size: Size<f32>,
   ) -> Self {

--- a/takumi/src/rendering/image_drawing.rs
+++ b/takumi/src/rendering/image_drawing.rs
@@ -3,8 +3,10 @@ use taffy::{Layout, Point, Size};
 use crate::layout::style::BlendMode;
 use crate::{
   Result,
-  layout::style::{Affine, ObjectFit, PositionComponent, PositionKeywordX, PositionKeywordY},
-  rendering::{BorderProperties, Canvas, RenderContext, SamplingOptions, Sizing},
+  layout::style::{
+    Affine, ObjectFit, PositionComponent, PositionKeywordX, PositionKeywordY, SizingContext,
+  },
+  rendering::{BorderProperties, Canvas, RenderContext, SamplingOptions},
   resources::image::{ImageSource, RenderedImage},
 };
 
@@ -15,7 +17,7 @@ pub(crate) struct PreparedImage<'a> {
 
 fn resolve_object_position_axis(
   component: PositionComponent,
-  sizing: &Sizing,
+  sizing: &SizingContext,
   available_space: f32,
 ) -> f32 {
   match component {
@@ -328,16 +330,16 @@ mod tests {
 
   use super::resolve_object_position_axis;
   use crate::{
+    layout::style::SizingContext,
     layout::{
       Viewport,
       style::{CalcArena, Length, PositionComponent, PositionKeywordX},
     },
-    rendering::Sizing,
   };
   use taffy::Size;
 
-  fn sizing() -> Sizing {
-    Sizing {
+  fn sizing() -> SizingContext {
+    SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
       font_size: 16.0,

--- a/takumi/src/rendering/mod.rs
+++ b/takumi/src/rendering/mod.rs
@@ -44,58 +44,10 @@ use crate::{
   GlobalContext,
   layout::{
     Viewport,
-    style::{Affine, CalcArena, Color, ComputedStyle, StyleSheet},
+    style::{Affine, CalcArena, Color, ComputedStyle, SizingContext, StyleSheet},
   },
   resources::image::ImageSource,
 };
-
-/// The sizing context used for length value resolving.
-#[derive(Clone)]
-pub(crate) struct Sizing {
-  /// The viewport for the image renderer.
-  pub(crate) viewport: Viewport,
-  /// The nearest query container size (content box) in device pixels.
-  pub(crate) container_size: Size<Option<f32>>,
-  /// The font size in pixels.
-  pub(crate) font_size: f32,
-  /// Computed `font-size` of the root element in device pixels. `None` before
-  /// the root has been resolved; readers should fall back to `viewport.font_size`.
-  /// https://www.w3.org/TR/css-values-4/#rem
-  pub(crate) root_font_size: Option<f32>,
-  /// Pixel basis for the `lh` unit.
-  pub(crate) line_height: f32,
-  /// Pixel basis for the `rlh` unit; `None` before root is resolved.
-  pub(crate) root_line_height: Option<f32>,
-  /// The calc arena shared by the current layout tree.
-  pub(crate) calc_arena: Rc<CalcArena>,
-}
-
-impl Sizing {
-  /// Device-pixel basis for the `rem` unit.
-  pub(crate) fn rem_basis(&self) -> f32 {
-    self
-      .root_font_size
-      .unwrap_or(self.viewport.font_size * self.viewport.device_pixel_ratio)
-  }
-
-  pub(crate) fn root_line_height_basis(&self) -> f32 {
-    self.root_line_height.unwrap_or(self.line_height)
-  }
-
-  pub(crate) fn query_container_width(&self) -> f32 {
-    self
-      .container_size
-      .width
-      .unwrap_or(self.viewport.size.width.unwrap_or_default() as f32)
-  }
-
-  pub(crate) fn query_container_height(&self) -> f32 {
-    self
-      .container_size
-      .height
-      .unwrap_or(self.viewport.size.height.unwrap_or_default() as f32)
-  }
-}
 
 /// The context for the internal rendering. You should not construct this directly.
 #[derive(Clone)]
@@ -105,7 +57,7 @@ pub(crate) struct RenderContext<'g> {
   /// The scale factor for the image renderer.
   pub(crate) transform: Affine,
   /// The sizing context.
-  pub(crate) sizing: Sizing,
+  pub(crate) sizing: SizingContext,
   /// What the `currentColor` value is resolved to.
   pub(crate) current_color: Color,
   /// The style after inheritance.
@@ -130,7 +82,7 @@ impl<'g> RenderContext<'g> {
   ) -> Self {
     Self {
       global,
-      sizing: Sizing {
+      sizing: SizingContext {
         viewport,
         container_size: Size::NONE,
         font_size: viewport.font_size,
@@ -158,7 +110,7 @@ impl<'g> RenderContext<'g> {
   pub(crate) fn from_parent(
     parent: &Self,
     style: ComputedStyle,
-    sizing: Sizing,
+    sizing: SizingContext,
     current_color: Color,
   ) -> Self {
     Self {

--- a/takumi/src/rendering/stacking_context.rs
+++ b/takumi/src/rendering/stacking_context.rs
@@ -14,15 +14,15 @@ use crate::{
   layout::{
     inline::{collect_inline_items, create_inline_layout, resolve_inline_max_height},
     style::{
-      Affine, BackgroundImage, BlendMode, Color, ComputedStyle, Display, Filter, SpacePair,
-      apply_backdrop_filter, apply_filters_to_pixmap,
+      Affine, BackgroundImage, BlendMode, Color, ComputedStyle, Display, Filter, SizingContext,
+      SpacePair, apply_backdrop_filter, apply_filters_to_pixmap,
     },
     tree::{LayoutResults, OrderedChild, RenderNode},
   },
   rendering::{
     BlurType, BorderProperties, Canvas, CanvasSubcanvas, CanvasViewport, NodeMaskAction, Placement,
-    Sizing, blend_pixel, draw_debug_border, get_node_mut_by_path, prepare_node_mask,
-    scale_text_fit_x, transformed_rect_extents,
+    blend_pixel, draw_debug_border, get_node_mut_by_path, prepare_node_mask, scale_text_fit_x,
+    transformed_rect_extents,
   },
 };
 
@@ -113,7 +113,7 @@ pub(crate) fn apply_transform(
   transform: &mut Affine,
   style: &ComputedStyle,
   border_box: Size<f32>,
-  sizing: &Sizing,
+  sizing: &SizingContext,
 ) {
   let origin = style.transform_origin.to_point(sizing, border_box);
 
@@ -778,7 +778,7 @@ fn finish_node_render<'g>(
   Ok(())
 }
 
-fn filter_padding(filters: &[Filter], sizing: &Sizing, transform: Affine) -> i32 {
+fn filter_padding(filters: &[Filter], sizing: &SizingContext, transform: Affine) -> i32 {
   let transform_scale = affine_max_scale(transform);
   filters
     .iter()

--- a/takumi/src/resources/image.rs
+++ b/takumi/src/resources/image.rs
@@ -15,8 +15,8 @@ use image::RgbaImage;
 use tiny_skia::Pixmap;
 
 use crate::{
-  layout::style::{Color, ImageScalingAlgorithm, IntrinsicSizing},
-  rendering::{Sizing, premultiplied_pixmap_from_rgba},
+  layout::style::{Color, ImageScalingAlgorithm, IntrinsicSizing, SizingContext},
+  rendering::premultiplied_pixmap_from_rgba,
   resources::image_decoder::{DecodedGif, DecodedImage, decode_image},
 };
 use thiserror::Error;
@@ -429,7 +429,7 @@ impl ImageSource {
   }
 
   /// Get the image size in device pixels for the current sizing context.
-  pub(crate) fn size(&self, sizing: &Sizing) -> (f32, f32) {
+  pub(crate) fn size(&self, sizing: &SizingContext) -> (f32, f32) {
     let (width, height) = match self {
       #[cfg(feature = "svg")]
       ImageSource::Svg(svg) => (svg.tree.size().width(), svg.tree.size().height()),
@@ -446,7 +446,7 @@ impl ImageSource {
 
   /// Intrinsic sizing for `background-size`/`mask-size` (§5.3). Bitmaps and GIFs
   /// have both dimensions; an SVG may have only a `viewBox` ratio.
-  pub(crate) fn intrinsic_sizing(&self, sizing: &Sizing) -> IntrinsicSizing {
+  pub(crate) fn intrinsic_sizing(&self, sizing: &SizingContext) -> IntrinsicSizing {
     let dpr = sizing.viewport.device_pixel_ratio;
     match self {
       #[cfg(feature = "svg")]


### PR DESCRIPTION
Relocates the length-resolution context (renamed `Sizing` → `SizingContext`) from `rendering` into `layout::style`.

It only depends on style types (`CalcArena`, `Viewport`), so this removes the `style → rendering` import cycle — a prerequisite for extracting the CSS layer into its own crate (`takumi-css`) where the cold CSS parser can be size-optimized independently. Pure move + rename — no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal layout sizing infrastructure to improve code maintainability and separation of concerns across styling, animation, and rendering systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->