### PR TITLE
Crate: move `fast_div_255` to `layout::style`

### DIFF
--- a/takumi/src/layout/style/math.rs
+++ b/takumi/src/layout/style/math.rs
@@ -1,0 +1,10 @@
+#[inline(always)]
+pub(crate) fn fast_div_255(v: u32) -> u8 {
+  fast_div_255_u32(v) as u8
+}
+
+/// Fast division by 255 by approximating `v / 255` using bitwise operations.
+#[inline(always)]
+pub(crate) fn fast_div_255_u32(v: u32) -> u32 {
+  ((v.wrapping_add(128).wrapping_add(v >> 8)) >> 8).min(255)
+}

--- a/takumi/src/layout/style/mod.rs
+++ b/takumi/src/layout/style/mod.rs
@@ -1,5 +1,6 @@
 mod animation;
 pub(crate) mod matching;
+mod math;
 mod properties;
 mod selector;
 mod sizing;
@@ -10,6 +11,7 @@ use std::{borrow::Cow, fmt::Formatter};
 
 pub(crate) use animation::apply_stylesheet_animations;
 pub use animation::{KeyframeRule, KeyframesRule};
+pub(crate) use math::{fast_div_255, fast_div_255_u32};
 pub(crate) use properties::unexpected_token;
 pub use properties::*;
 pub use selector::*;

--- a/takumi/src/layout/style/properties/color.rs
+++ b/takumi/src/layout/style/properties/color.rs
@@ -10,13 +10,10 @@ use cssparser::{
 use image::Rgba;
 use tiny_skia::{ColorU8, PremultipliedColorU8};
 
-use crate::{
-  layout::style::{
-    Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-    MakeComputed, ParseResult, PercentageNumber, SizingContext,
-    properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
-  },
-  rendering::fast_div_255,
+use crate::layout::style::{
+  Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
+  MakeComputed, ParseResult, PercentageNumber, SizingContext, fast_div_255,
+  properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
 };
 
 fn is_cylindrical_color_space(color_space: ColorSpaceTag) -> bool {

--- a/takumi/src/layout/style/properties/filter.rs
+++ b/takumi/src/layout/style/properties/filter.rs
@@ -12,11 +12,11 @@ use crate::{
   layout::style::{
     Affine, Angle, Animatable, Color, CssDescriptorKind, CssToken, FromCss, Length,
     ListInterpolationStrategy, MakeComputed, ParseResult, PercentageNumber, SizingContext,
-    TextShadow, tw::TailwindPropertyParser,
+    TextShadow, fast_div_255, tw::TailwindPropertyParser,
   },
   rendering::{
     BlurFormat, BlurType, BorderProperties, BufferPool, Canvas, Placement, RenderContext,
-    SizedShadow, apply_blur, apply_blur_rgba_bytes, fast_div_255, render_mask,
+    SizedShadow, apply_blur, apply_blur_rgba_bytes, render_mask,
   },
 };
 

--- a/takumi/src/layout/style/properties/gradient_utils.rs
+++ b/takumi/src/layout/style/properties/gradient_utils.rs
@@ -5,8 +5,8 @@ use smallvec::SmallVec;
 use taffy::Point;
 use tiny_skia::{ColorU8, PremultipliedColorU8};
 
-use crate::layout::style::{Color, GradientStop, ResolvedGradientStop};
-use crate::rendering::{RenderContext, fast_div_255};
+use crate::layout::style::{Color, GradientStop, ResolvedGradientStop, fast_div_255};
+use crate::rendering::RenderContext;
 
 const MIN_GRADIENT_LUT_SIZE: usize = 2;
 const MAX_GRADIENT_LUT_SIZE: usize = 8193;

--- a/takumi/src/rendering/mod.rs
+++ b/takumi/src/rendering/mod.rs
@@ -40,6 +40,7 @@ pub use render::*;
 pub(crate) use text_drawing::*;
 pub use write::*;
 
+pub(crate) use crate::layout::style::{fast_div_255, fast_div_255_u32};
 use crate::{
   GlobalContext,
   layout::{
@@ -125,17 +126,6 @@ impl<'g> RenderContext<'g> {
       stylesheet: parent.stylesheet.clone(),
     }
   }
-}
-
-#[inline(always)]
-pub(crate) fn fast_div_255(v: u32) -> u8 {
-  fast_div_255_u32(v) as u8
-}
-
-/// Fast division by 255 by approximating `v / 255` using bitwise operations.
-#[inline(always)]
-pub(crate) fn fast_div_255_u32(v: u32) -> u32 {
-  ((v.wrapping_add(128).wrapping_add(v >> 8)) >> 8).min(255)
 }
 
 pub(crate) fn text_fit_x_correction(


### PR DESCRIPTION
Stacked on #745.

`fast_div_255`/`fast_div_255_u32` are pure primitives needed by value-level colour math (`color-mix`), which must stay in `style`. Moves them into `layout::style` (`rendering` re-exports for its own use). Removes `color.rs`'s last `rendering` dependency.

First step of lifting the rasterization layer out of `style` (see plan in #745). Pure move — no behavior change.