### PR TITLE
Crate: narrow gradient rasterization to `SizingContext`

### DIFF
--- a/takumi/src/layout/style/properties/conic_gradient.rs
+++ b/takumi/src/layout/style/properties/conic_gradient.rs
@@ -8,13 +8,10 @@ use super::gradient_utils::{
   GradientOverlayTile, adaptive_lut_size_with_visible_samples, build_color_lut_with_interpolation,
   resolve_stops_along_axis,
 };
-use crate::{
-  layout::style::{
-    Angle, BackgroundPosition, ColorInput, ColorInterpolationMethod, CssDescriptorKind, CssToken,
-    FromCss, GradientStop, Length, MakeComputed, ObjectPosition, ParseResult, ResolvedGradientStop,
-    SizingContext, StopPosition, ToCss, unexpected_token,
-  },
-  rendering::RenderContext,
+use crate::layout::style::{
+  Angle, BackgroundPosition, Color, ColorInput, ColorInterpolationMethod, CssDescriptorKind,
+  CssToken, FromCss, GradientStop, Length, MakeComputed, ObjectPosition, ParseResult,
+  ResolvedGradientStop, SizingContext, StopPosition, ToCss, unexpected_token,
 };
 
 const LUT_INDEX_BOUNDARY_EPSILON: f32 = 0.001;
@@ -149,14 +146,20 @@ impl ConicGradientTile {
   }
 
   /// Builds a drawing context from a conic gradient and a target viewport.
-  pub fn new(gradient: &ConicGradient, width: u32, height: u32, context: &RenderContext) -> Self {
-    let cx = Length::from(gradient.center.0.x).to_px(&context.sizing, width as f32);
-    let cy = Length::from(gradient.center.0.y).to_px(&context.sizing, height as f32);
+  pub fn new(
+    gradient: &ConicGradient,
+    width: u32,
+    height: u32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) -> Self {
+    let cx = Length::from(gradient.center.0.x).to_px(sizing, width as f32);
+    let cy = Length::from(gradient.center.0.y).to_px(sizing, height as f32);
 
     let start_rad = gradient.from_angle.to_radians().rem_euclid(TAU);
 
     // Resolve stop percentages against one full turn (360deg).
-    let resolved_stops = resolve_stops_along_axis(&gradient.stops, 360.0, context);
+    let resolved_stops = resolve_stops_along_axis(&gradient.stops, 360.0, sizing, current_color);
 
     let (repeating, repeat_start_deg, repeat_period_deg, lut_axis_length_deg, lut_resolved_stops) =
       if gradient.repeating
@@ -487,7 +490,6 @@ mod tests {
   use super::*;
   use crate::layout::Viewport;
   use crate::layout::style::{Color, Length, SpacePair, StopPosition};
-  use crate::{GlobalContext, rendering::RenderContext};
   #[test]
   fn test_parse_conic_gradient_basic() {
     let gradient = ConicGradient::from_str("conic-gradient(#ff0000, #0000ff)");
@@ -697,9 +699,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = ConicGradientTile::new(&gradient, 100, 100, &render_context);
+    let render_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = ConicGradientTile::new(&gradient, 100, 100, &render_context, Color::black());
 
     // Top center (50, 0) should be red (start of gradient)
     let color_top = tile.sample_pixel(50, 0).demultiply();
@@ -738,9 +739,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = ConicGradientTile::new(&gradient, 100, 100, &render_context);
+    let render_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = ConicGradientTile::new(&gradient, 100, 100, &render_context, Color::black());
 
     // Top-center should be red
     let top = tile.sample_pixel(50, 0).demultiply();
@@ -775,9 +775,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
-    let tile = ConicGradientTile::new(&gradient, 40, 40, &render_context);
+    let render_context = SizingContext::new_test(Viewport::new((40, 40)));
+    let tile = ConicGradientTile::new(&gradient, 40, 40, &render_context, Color::black());
 
     assert_eq!(
       [

--- a/takumi/src/layout/style/properties/gradient_utils.rs
+++ b/takumi/src/layout/style/properties/gradient_utils.rs
@@ -5,8 +5,9 @@ use smallvec::SmallVec;
 use taffy::Point;
 use tiny_skia::{ColorU8, PremultipliedColorU8};
 
-use crate::layout::style::{Color, GradientStop, ResolvedGradientStop, fast_div_255};
-use crate::rendering::RenderContext;
+use crate::layout::style::{
+  Color, GradientStop, ResolvedGradientStop, SizingContext, fast_div_255,
+};
 
 const MIN_GRADIENT_LUT_SIZE: usize = 2;
 const MAX_GRADIENT_LUT_SIZE: usize = 8193;
@@ -465,7 +466,8 @@ const UNDEFINED_POSITION: f32 = -1.0;
 pub(crate) fn resolve_stops_along_axis(
   stops: &[GradientStop],
   axis_size_px: f32,
-  context: &RenderContext,
+  sizing: &SizingContext,
+  current_color: Color,
 ) -> SmallVec<[ResolvedGradientStop; 4]> {
   let mut resolved: SmallVec<[ResolvedGradientStop; 4]> = SmallVec::new();
   let mut last_position = 0.0;
@@ -476,21 +478,18 @@ pub(crate) fn resolve_stops_along_axis(
         color,
         hint: Some(hint),
       } => {
-        let position = hint
-          .0
-          .to_px(&context.sizing, axis_size_px)
-          .max(last_position);
+        let position = hint.0.to_px(sizing, axis_size_px).max(last_position);
 
         last_position = position;
 
         resolved.push(ResolvedGradientStop {
-          color: color.resolve(context.current_color),
+          color: color.resolve(current_color),
           position,
         });
       }
       GradientStop::ColorHint { color, hint: None } => {
         resolved.push(ResolvedGradientStop {
-          color: color.resolve(context.current_color),
+          color: color.resolve(current_color),
           position: UNDEFINED_POSITION,
         });
       }
@@ -500,7 +499,7 @@ pub(crate) fn resolve_stops_along_axis(
         };
 
         let Some(after_color) = stops.get(i + 1).and_then(|stop| match stop {
-          GradientStop::ColorHint { color, hint: _ } => Some(color.resolve(context.current_color)),
+          GradientStop::ColorHint { color, hint: _ } => Some(color.resolve(current_color)),
           GradientStop::Hint(_) => None,
         }) else {
           continue;
@@ -508,10 +507,7 @@ pub(crate) fn resolve_stops_along_axis(
 
         let interpolated_color = interpolate_rgba(before.color, after_color, 0.5);
 
-        let position = hint
-          .0
-          .to_px(&context.sizing, axis_size_px)
-          .max(last_position);
+        let position = hint.0.to_px(sizing, axis_size_px).max(last_position);
 
         resolved.push(ResolvedGradientStop {
           color: interpolated_color,
@@ -592,11 +588,8 @@ mod tests {
   use taffy::Point;
 
   use crate::layout::Viewport;
+  use crate::layout::style::{BlendMode, Color, Length, StopPosition};
   use crate::rendering::blend_pixel;
-  use crate::{
-    GlobalContext,
-    layout::style::{BlendMode, Color, Length, StopPosition},
-  };
 
   use super::*;
 
@@ -712,15 +705,18 @@ mod tests {
       },
     ];
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
+    let render_context = SizingContext::new_test(Viewport::new((40, 40)));
 
-    let width = render_context.sizing.viewport.size.width;
+    let width = render_context.viewport.size.width;
 
     assert!(width.is_some());
 
-    let resolved =
-      resolve_stops_along_axis(&stops, width.unwrap_or_default() as f32, &render_context);
+    let resolved = resolve_stops_along_axis(
+      &stops,
+      width.unwrap_or_default() as f32,
+      &render_context,
+      Color::black(),
+    );
 
     assert_eq!(
       resolved[0],
@@ -764,18 +760,13 @@ mod tests {
       },
     ];
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
+    let render_context = SizingContext::new_test(Viewport::new((40, 40)));
 
     let resolved = resolve_stops_along_axis(
       &stops,
-      render_context
-        .sizing
-        .viewport
-        .size
-        .width
-        .unwrap_or_default() as f32,
+      render_context.viewport.size.width.unwrap_or_default() as f32,
       &render_context,
+      Color::black(),
     );
 
     assert_eq!(
@@ -787,22 +778,11 @@ mod tests {
         },
         ResolvedGradientStop {
           color: Color([0, 255, 0, 255]),
-          position: render_context
-            .sizing
-            .viewport
-            .size
-            .width
-            .unwrap_or_default() as f32
-            / 2.0,
+          position: render_context.viewport.size.width.unwrap_or_default() as f32 / 2.0,
         },
         ResolvedGradientStop {
           color: Color([0, 0, 255, 255]),
-          position: render_context
-            .sizing
-            .viewport
-            .size
-            .width
-            .unwrap_or_default() as f32,
+          position: render_context.viewport.size.width.unwrap_or_default() as f32,
         },
       ]
     );
@@ -822,18 +802,13 @@ mod tests {
       },
     ];
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
+    let render_context = SizingContext::new_test(Viewport::new((40, 40)));
 
     let resolved = resolve_stops_along_axis(
       &stops,
-      render_context
-        .sizing
-        .viewport
-        .size
-        .width
-        .unwrap_or_default() as f32,
+      render_context.viewport.size.width.unwrap_or_default() as f32,
       &render_context,
+      Color::black(),
     );
 
     assert_eq!(
@@ -849,13 +824,7 @@ mod tests {
       resolved[1],
       ResolvedGradientStop {
         color: interpolate_rgba(Color([255, 0, 0, 255]), Color([0, 0, 255, 255]), 0.5),
-        position: render_context
-          .sizing
-          .viewport
-          .size
-          .width
-          .unwrap_or_default() as f32
-          * 0.1,
+        position: render_context.viewport.size.width.unwrap_or_default() as f32 * 0.1,
       },
     );
 
@@ -863,12 +832,7 @@ mod tests {
       resolved[2],
       ResolvedGradientStop {
         color: Color([0, 0, 255, 255]),
-        position: render_context
-          .sizing
-          .viewport
-          .size
-          .width
-          .unwrap_or_default() as f32,
+        position: render_context.viewport.size.width.unwrap_or_default() as f32,
       },
     );
   }

--- a/takumi/src/layout/style/properties/linear_gradient.rs
+++ b/takumi/src/layout/style/properties/linear_gradient.rs
@@ -16,7 +16,6 @@ use crate::layout::style::{
   Length, MakeComputed, ParseResult, SizingContext, ToCss, declare_enum_from_css_impl,
   properties::ColorInput, tw::TailwindPropertyParser, unexpected_token,
 };
-use crate::rendering::RenderContext;
 
 /// Represents a linear gradient.
 #[derive(Debug, Clone, PartialEq, TypedBuilder)]
@@ -186,7 +185,13 @@ impl LinearGradientTile {
   }
 
   /// Builds a drawing context from a gradient and a target viewport.
-  pub fn new(gradient: &LinearGradient, width: u32, height: u32, context: &RenderContext) -> Self {
+  pub fn new(
+    gradient: &LinearGradient,
+    width: u32,
+    height: u32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) -> Self {
     let (dir_x, dir_y) = Self::direction_components(gradient, width, height);
     let axis_aligned_kind = Self::classify_axis_aligned(dir_x, dir_y);
 
@@ -196,7 +201,12 @@ impl LinearGradientTile {
     let axis_length = 2.0 * max_extent;
     let projection_bias = max_extent - cx * dir_x - cy * dir_y;
 
-    let resolved_stops = resolve_stops_along_axis(&gradient.stops, axis_length.max(1e-6), context);
+    let resolved_stops = resolve_stops_along_axis(
+      &gradient.stops,
+      axis_length.max(1e-6),
+      sizing,
+      current_color,
+    );
 
     let (repeating, repeat_start, repeat_period, lut_axis_length, lut_resolved_stops) = if gradient
       .repeating
@@ -906,10 +916,7 @@ mod tests {
   use taffy::Size;
   use tiny_skia::ColorU8;
 
-  use crate::{
-    GlobalContext,
-    layout::{Viewport, style::CalcArena},
-  };
+  use crate::layout::{Viewport, style::CalcArena};
 
   use super::*;
   fn sizing() -> SizingContext {
@@ -1415,9 +1422,8 @@ mod tests {
     };
 
     // Test at the top (should be red)
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context, Color::black());
 
     let color_top = tile.sample_pixel(50, 0).demultiply();
     assert_eq!(color_top, ColorU8::from_rgba(255, 0, 0, 255));
@@ -1451,10 +1457,9 @@ mod tests {
     };
 
     // Test at the left (should be red)
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
+    let dummy_context = SizingContext::new_test(Viewport::new((100, 100)));
 
-    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context);
+    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context, Color::black());
     let color_left = tile.sample_pixel(0, 50).demultiply();
     assert_eq!(color_left, ColorU8::from_rgba(255, 0, 0, 255));
 
@@ -1485,9 +1490,8 @@ mod tests {
       .into(),
     };
 
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((200, 100)));
-    let tile = LinearGradientTile::new(&gradient, 200, 100, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((200, 100)));
+    let tile = LinearGradientTile::new(&gradient, 200, 100, &dummy_context, Color::black());
 
     assert!((tile.dir_x - 0.4472136).abs() < 0.001);
     assert!((tile.dir_y - 0.8944272).abs() < 0.001);
@@ -1507,9 +1511,8 @@ mod tests {
     };
 
     // Should always return the same color
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context, Color::black());
     let color = tile.sample_pixel(50, 50).demultiply();
     assert_eq!(color, ColorU8::from_rgba(255, 0, 0, 255));
   }
@@ -1524,9 +1527,8 @@ mod tests {
     };
 
     // Should return transparent
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = LinearGradientTile::new(&gradient, 100, 100, &dummy_context, Color::black());
     let color = tile.sample_pixel(50, 50).demultiply();
     assert_eq!(color, ColorU8::from_rgba(0, 0, 0, 0));
   }
@@ -1556,9 +1558,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((40, 1)));
-    let tile = LinearGradientTile::new(&gradient, 40, 1, &render_context);
+    let render_context = SizingContext::new_test(Viewport::new((40, 1)));
+    let tile = LinearGradientTile::new(&gradient, 40, 1, &render_context, Color::black());
 
     assert_eq!(
       [
@@ -1581,9 +1582,8 @@ mod tests {
     let gradient =
       LinearGradient::from_str("linear-gradient(to right, grey 1px, transparent 1px)")?;
 
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
-    let tile = LinearGradientTile::new(&gradient, 40, 40, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((40, 40)));
+    let tile = LinearGradientTile::new(&gradient, 40, 40, &dummy_context, Color::black());
 
     // grey at 0,0
     let c0 = tile.sample_pixel(0, 0).demultiply();
@@ -1605,9 +1605,8 @@ mod tests {
     let gradient =
       LinearGradient::from_str("linear-gradient(to bottom, grey 1px, transparent 1px)")?;
 
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
-    let tile = LinearGradientTile::new(&gradient, 40, 40, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((40, 40)));
+    let tile = LinearGradientTile::new(&gradient, 40, 40, &dummy_context, Color::black());
 
     // color at top-left (0, 0) should be grey (1px hard stop)
     assert_eq!(
@@ -1675,13 +1674,13 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let ctx = RenderContext::new_test(&context, Viewport::new((200, 100)));
+    let ctx = SizingContext::new_test(Viewport::new((200, 100)));
 
     let resolved = resolve_stops_along_axis(
       &gradient.stops,
-      ctx.sizing.viewport.size.width.unwrap_or_default() as f32,
+      ctx.viewport.size.width.unwrap_or_default() as f32,
       &ctx,
+      Color::black(),
     );
     assert_eq!(resolved.len(), 3);
     assert!((resolved[0].position - 0.0).abs() < 1e-3);
@@ -1704,13 +1703,13 @@ mod tests {
         },
       ])
       .build();
-    let context = GlobalContext::default();
-    let ctx = RenderContext::new_test(&context, Viewport::new((200, 100)));
+    let ctx = SizingContext::new_test(Viewport::new((200, 100)));
 
     let resolved = resolve_stops_along_axis(
       &gradient.stops,
-      ctx.sizing.viewport.size.width.unwrap_or_default() as f32,
+      ctx.viewport.size.width.unwrap_or_default() as f32,
       &ctx,
+      Color::black(),
     );
     assert_eq!(resolved.len(), 2);
     assert!((resolved[0].position - 0.0).abs() < 1e-3);

--- a/takumi/src/layout/style/properties/radial_gradient.rs
+++ b/takumi/src/layout/style/properties/radial_gradient.rs
@@ -7,13 +7,10 @@ use super::gradient_utils::{
   GradientOverlayTile, adaptive_lut_size_with_visible_samples, build_color_lut_with_interpolation,
   resolve_stops_along_axis,
 };
-use crate::{
-  layout::style::{
-    ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop, GradientStops,
-    Length, LengthDefaultsToZero, MakeComputed, ObjectPosition, ParseResult, ResolvedGradientStop,
-    SizingContext, ToCss, declare_enum_from_css_impl, unexpected_token,
-  },
-  rendering::RenderContext,
+use crate::layout::style::{
+  Color, ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop,
+  GradientStops, Length, LengthDefaultsToZero, MakeComputed, ObjectPosition, ParseResult,
+  ResolvedGradientStop, SizingContext, ToCss, declare_enum_from_css_impl, unexpected_token,
 };
 
 /// Represents a radial gradient.
@@ -202,9 +199,15 @@ impl RadialGradientTile {
   }
 
   /// Builds a drawing context from a gradient and a target viewport.
-  pub fn new(gradient: &RadialGradient, width: u32, height: u32, context: &RenderContext) -> Self {
-    let cx = Length::from(gradient.center.0.x).to_px(&context.sizing, width as f32);
-    let cy = Length::from(gradient.center.0.y).to_px(&context.sizing, height as f32);
+  pub fn new(
+    gradient: &RadialGradient,
+    width: u32,
+    height: u32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) -> Self {
+    let cx = Length::from(gradient.center.0.x).to_px(sizing, width as f32);
+    let cy = Length::from(gradient.center.0.y).to_px(sizing, height as f32);
 
     // Distances to sides and corners
     let dx_left = cx;
@@ -214,8 +217,8 @@ impl RadialGradientTile {
 
     let (radius_x, radius_y) = match (gradient.shape, gradient.size) {
       (shape, RadialSize::Explicit { radius_x, radius_y }) => {
-        let resolved_radius_x = radius_x.to_px(&context.sizing, width as f32).max(0.0);
-        let resolved_radius_y = radius_y.to_px(&context.sizing, height as f32).max(0.0);
+        let resolved_radius_x = radius_x.to_px(sizing, width as f32).max(0.0);
+        let resolved_radius_y = radius_y.to_px(sizing, height as f32).max(0.0);
 
         match shape {
           RadialShape::Circle => {
@@ -289,7 +292,12 @@ impl RadialGradientTile {
     };
 
     let radius_scale = radius_x.max(radius_y);
-    let resolved_stops = resolve_stops_along_axis(&gradient.stops, radius_scale.max(1e-6), context);
+    let resolved_stops = resolve_stops_along_axis(
+      &gradient.stops,
+      radius_scale.max(1e-6),
+      sizing,
+      current_color,
+    );
 
     let (repeating, repeat_start, repeat_period, lut_axis_length, lut_resolved_stops) = if gradient
       .repeating
@@ -588,7 +596,6 @@ mod tests {
     BackgroundPosition, Color, Length, LengthDefaultsToZero, PositionComponent, PositionKeywordX,
     PositionKeywordY, SpacePair, StopPosition,
   };
-  use crate::{GlobalContext, rendering::RenderContext};
   #[test]
   fn test_parse_radial_gradient_basic() {
     let gradient = RadialGradient::from_str("radial-gradient(#ff0000, #0000ff)");
@@ -854,17 +861,12 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((200, 100)));
+    let render_context = SizingContext::new_test(Viewport::new((200, 100)));
     let resolved = resolve_stops_along_axis(
       &gradient.stops,
-      render_context
-        .sizing
-        .viewport
-        .size
-        .width
-        .unwrap_or_default() as f32,
+      render_context.viewport.size.width.unwrap_or_default() as f32,
       &render_context,
+      Color::black(),
     );
 
     assert_eq!(resolved.len(), 3);
@@ -891,17 +893,12 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((200, 100)));
+    let render_context = SizingContext::new_test(Viewport::new((200, 100)));
     let resolved = resolve_stops_along_axis(
       &gradient.stops,
-      render_context
-        .sizing
-        .viewport
-        .size
-        .width
-        .unwrap_or_default() as f32,
+      render_context.viewport.size.width.unwrap_or_default() as f32,
       &render_context,
+      Color::black(),
     );
 
     assert_eq!(resolved.len(), 3);
@@ -926,9 +923,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = RadialGradientTile::new(&gradient, 100, 100, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = RadialGradientTile::new(&gradient, 100, 100, &dummy_context, Color::black());
 
     // Center (50, 50) should be red
     let color_center = tile.sample_pixel(50, 50).demultiply();
@@ -968,9 +964,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let render_context = RenderContext::new_test(&context, Viewport::new((40, 40)));
-    let tile = RadialGradientTile::new(&gradient, 40, 40, &render_context);
+    let render_context = SizingContext::new_test(Viewport::new((40, 40)));
+    let tile = RadialGradientTile::new(&gradient, 40, 40, &render_context, Color::black());
 
     assert_eq!(
       [
@@ -1008,9 +1003,8 @@ mod tests {
       ])
       .build();
 
-    let context = GlobalContext::default();
-    let dummy_context = RenderContext::new_test(&context, Viewport::new((100, 100)));
-    let tile = RadialGradientTile::new(&gradient, 100, 100, &dummy_context);
+    let dummy_context = SizingContext::new_test(Viewport::new((100, 100)));
+    let tile = RadialGradientTile::new(&gradient, 100, 100, &dummy_context, Color::black());
 
     // dx_left=20, dx_right=80, dy_top=20, dy_bottom=80
     // f_rx = 80, f_ry = 80

--- a/takumi/src/layout/style/sizing.rs
+++ b/takumi/src/layout/style/sizing.rs
@@ -27,6 +27,19 @@ pub(crate) struct SizingContext {
 }
 
 impl SizingContext {
+  #[cfg(test)]
+  pub(crate) fn new_test(viewport: Viewport) -> Self {
+    Self {
+      viewport,
+      container_size: Size::NONE,
+      font_size: viewport.font_size,
+      root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
+      calc_arena: Rc::new(CalcArena::default()),
+    }
+  }
+
   /// Device-pixel basis for the `rem` unit.
   pub(crate) fn rem_basis(&self) -> f32 {
     self

--- a/takumi/src/rendering/background_drawing.rs
+++ b/takumi/src/rendering/background_drawing.rs
@@ -490,13 +490,25 @@ pub(crate) fn render_tile(
   Ok(match image {
     BackgroundImage::None => None,
     BackgroundImage::Linear(gradient) => Some(BackgroundTile::Linear(LinearGradientTile::new(
-      gradient, tile_w, tile_h, context,
+      gradient,
+      tile_w,
+      tile_h,
+      &context.sizing,
+      context.current_color,
     ))),
     BackgroundImage::Radial(gradient) => Some(BackgroundTile::Radial(RadialGradientTile::new(
-      gradient, tile_w, tile_h, context,
+      gradient,
+      tile_w,
+      tile_h,
+      &context.sizing,
+      context.current_color,
     ))),
     BackgroundImage::Conic(gradient) => Some(BackgroundTile::Conic(ConicGradientTile::new(
-      gradient, tile_w, tile_h, context,
+      gradient,
+      tile_w,
+      tile_h,
+      &context.sizing,
+      context.current_color,
     ))),
     BackgroundImage::Url(url) => {
       if let Ok(source) = resolve_image(url, context) {

--- a/takumi/src/rendering/canvas.rs
+++ b/takumi/src/rendering/canvas.rs
@@ -1782,7 +1782,13 @@ mod tests {
     };
     let global_context = GlobalContext::default();
     let render_context = RenderContext::new_test(&global_context, Viewport::new((32, 16)));
-    let tile = LinearGradientTile::new(&gradient, 32, 16, &render_context);
+    let tile = LinearGradientTile::new(
+      &gradient,
+      32,
+      16,
+      &render_context.sizing,
+      render_context.current_color,
+    );
     assert_gradient_overlay_matches_reference_with(
       &tile,
       Size {
@@ -1838,7 +1844,8 @@ mod tests {
         &gradient,
         tile_size.width,
         tile_size.height,
-        &render_context,
+        &render_context.sizing,
+        render_context.current_color,
       );
       assert_gradient_overlay_matches_reference_with(
         &tile,
@@ -1859,7 +1866,13 @@ mod tests {
 
     let global_context = GlobalContext::default();
     let render_context = RenderContext::new_test(&global_context, Viewport::new((32, 24)));
-    let tile = ConicGradientTile::new(&gradient, 32, 24, &render_context);
+    let tile = ConicGradientTile::new(
+      &gradient,
+      32,
+      24,
+      &render_context.sizing,
+      render_context.current_color,
+    );
     assert_gradient_overlay_matches_reference_with(
       &tile,
       Size {
@@ -1951,7 +1964,8 @@ mod tests {
         &gradient,
         tile_size.width,
         tile_size.height,
-        &render_context,
+        &render_context.sizing,
+        render_context.current_color,
       );
       assert_gradient_overlay_matches_reference_with(
         &tile,
@@ -2061,7 +2075,13 @@ mod tests {
 
     let global_context = GlobalContext::default();
     let render_context = RenderContext::new_test(&global_context, Viewport::new((48, 48)));
-    let tile = ConicGradientTile::new(&gradient, 48, 48, &render_context);
+    let tile = ConicGradientTile::new(
+      &gradient,
+      48,
+      48,
+      &render_context.sizing,
+      render_context.current_color,
+    );
     assert_gradient_overlay_matches_reference(
       &tile,
       Size {
@@ -2081,7 +2101,13 @@ mod tests {
     };
     let global_context = GlobalContext::default();
     let render_context = RenderContext::new_test(&global_context, Viewport::new((32, 24)));
-    let tile = RadialGradientTile::new(&gradient, 32, 24, &render_context);
+    let tile = RadialGradientTile::new(
+      &gradient,
+      32,
+      24,
+      &render_context.sizing,
+      render_context.current_color,
+    );
     assert_gradient_overlay_matches_reference(
       &tile,
       Size {


### PR DESCRIPTION
Stacked on #746.

The three `*GradientTile::new` constructors and `resolve_stops_along_axis` took a full `&RenderContext` but only read `sizing` + `current_color`. Pass those directly (`&SizingContext`, `Color`) so the gradient value modules no longer depend on `rendering` — cutting the bulk of the `style → rendering` cycle.

Adds `SizingContext::new_test` for tests. One overlay reference test still uses `blend_pixel`; it relocates with the hot overlay loop in a follow-up (that code belongs in `rendering`, not the soon-to-be size-optimized CSS crate). No behavior change.