### PR TITLE
Crate: move clip-path mask rasterization to rendering

### DIFF
--- a/takumi/src/layout/style/properties/clip_path.rs
+++ b/takumi/src/layout/style/properties/clip_path.rs
@@ -2,17 +2,10 @@ use std::fmt;
 
 use crate::layout::style::{ToCss, properties::write_css_string, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
-use taffy::{AbsoluteAxis, Point, Rect, Size};
 
-use crate::{
-  layout::style::{
-    Axis, BorderStyle, Color, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-    ImageScalingAlgorithm, Length, MakeComputed, ParseResult, Sides, SizingContext, SpacePair,
-  },
-  rendering::{
-    BorderProperties, BufferPool, Fill, PathBuilder, PathData, Placement, RenderContext,
-    render_mask,
-  },
+use crate::layout::style::{
+  CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult, Sides,
+  SizingContext, SpacePair,
 };
 
 /// Represents the fill rule used for determining the interior of shapes.
@@ -26,15 +19,6 @@ pub enum FillRule {
   NonZero,
   /// Counts the total number of crossings - if even, the point is outside
   EvenOdd,
-}
-
-impl From<FillRule> for Fill {
-  fn from(value: FillRule) -> Self {
-    match value {
-      FillRule::EvenOdd => Fill::EvenOdd,
-      FillRule::NonZero => Fill::NonZero,
-    }
-  }
 }
 
 /// Represents radius values for circle() and ellipse() functions.
@@ -169,19 +153,6 @@ impl MakeComputed for BasicShape {
   }
 }
 
-fn resolve_radius(
-  radius: ShapeRadius,
-  distance: Size<f32>,
-  sizing: &SizingContext,
-  full: f32,
-) -> f32 {
-  match radius {
-    ShapeRadius::ClosestSide => distance.width.min(distance.height),
-    ShapeRadius::FarthestSide => distance.width.max(distance.height),
-    ShapeRadius::Length(length) => length.to_px(sizing, full),
-  }
-}
-
 impl BasicShape {
   pub(crate) fn fill_rule(&self) -> Option<FillRule> {
     match self {
@@ -189,113 +160,6 @@ impl BasicShape {
       BasicShape::Path(shape) => shape.fill_rule,
       _ => None,
     }
-  }
-
-  pub(crate) fn render_mask(
-    &self,
-    context: &RenderContext,
-    size: Size<f32>,
-    buffer_pool: &mut BufferPool,
-  ) -> (Vec<u8>, Placement) {
-    let mut paths = Vec::new();
-
-    match self {
-      BasicShape::Inset(shape) => {
-        let inset: Rect<f32> = shape
-          .inset
-          .map_axis(|value, axis| {
-            value.to_px(
-              &context.sizing,
-              match axis {
-                Axis::Horizontal => size.width,
-                Axis::Vertical => size.height,
-              },
-            )
-          })
-          .into();
-
-        let border = BorderProperties {
-          width: Rect::zero(),
-          color: Rect {
-            top: Color::transparent(),
-            right: Color::transparent(),
-            bottom: Color::transparent(),
-            left: Color::transparent(),
-          },
-          radius: shape
-            .border_radius
-            .map(|radius| {
-              Sides(
-                radius
-                  .0
-                  .map(|corner| SpacePair::from_single(corner.to_px(&context.sizing, size.width))),
-              )
-            })
-            .unwrap_or_default(),
-          image_rendering: ImageScalingAlgorithm::Auto,
-          style: Rect {
-            top: BorderStyle::Solid,
-            right: BorderStyle::Solid,
-            bottom: BorderStyle::Solid,
-            left: BorderStyle::Solid,
-          },
-        };
-
-        border.append_mask_commands(
-          &mut paths,
-          Size {
-            width: size.width - inset.grid_axis_sum(AbsoluteAxis::Horizontal),
-            height: size.height - inset.grid_axis_sum(AbsoluteAxis::Vertical),
-          },
-          Point {
-            x: inset.left,
-            y: inset.top,
-          },
-        );
-      }
-      BasicShape::Ellipse(shape) => {
-        let distance = Size {
-          width: shape.position.0.x.to_px(&context.sizing, size.width),
-          height: shape.position.0.y.to_px(&context.sizing, size.height),
-        };
-
-        paths.add_ellipse(
-          (distance.width, distance.height),
-          resolve_radius(shape.radius_x, distance, &context.sizing, size.width),
-          resolve_radius(shape.radius_y, distance, &context.sizing, size.height),
-        );
-      }
-      BasicShape::Polygon(shape) => {
-        if !shape.coordinates.is_empty() {
-          // Start the path at the first coordinate
-          let first = &shape.coordinates[0];
-          let first_x = first.x.to_px(&context.sizing, size.width);
-          let first_y = first.y.to_px(&context.sizing, size.height);
-
-          paths.move_to((first_x, first_y));
-
-          // Add lines to each subsequent coordinate
-          for coord in &shape.coordinates[1..] {
-            let x = coord.x.to_px(&context.sizing, size.width);
-            let y = coord.y.to_px(&context.sizing, size.height);
-            paths.line_to((x, y));
-          }
-
-          // Close the path to complete the polygon
-          paths.close();
-        }
-      }
-      BasicShape::Path(shape) => {
-        paths.extend(shape.path.as_ref().commands());
-      }
-    }
-
-    render_mask(
-      &paths,
-      Some(context.transform),
-      Some(Fill::from(self.fill_rule().unwrap_or(context.style.clip_rule)).into()),
-      buffer_pool,
-    )
   }
 }
 

--- a/takumi/src/rendering/canvas/mask.rs
+++ b/takumi/src/rendering/canvas/mask.rs
@@ -1,4 +1,4 @@
-use taffy::{Layout, Point, Size};
+use taffy::{AbsoluteAxis, Layout, Point, Rect, Size};
 use tiny_skia::{
   FillRule as TinyFillRule, IntSize, Mask as TinyMask, PathBuilder as TinyPathBuilder,
   Rect as TinyRect, Transform as TinyTransform,
@@ -6,9 +6,13 @@ use tiny_skia::{
 
 use crate::{
   Result,
-  layout::style::{Affine, ComputedStyle, Overflow},
+  layout::style::{
+    Affine, Axis, BasicShape, BorderStyle, Color, ComputedStyle, FillRule, ImageScalingAlgorithm,
+    Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
+  },
   rendering::{
-    BorderProperties, Command, Placement, RenderContext, Style, build_path,
+    BorderProperties, Command, Fill, PathBuilder, PathData, Placement, RenderContext, Style,
+    build_path,
     canvas::{BufferPool, mask_index_from_coord},
     create_mask, fast_div_255, transformed_rect_extents,
   },
@@ -52,7 +56,7 @@ pub(crate) fn prepare_node_mask(
   buffer_pool: &mut BufferPool,
 ) -> Result<NodeMaskAction> {
   if let Some(clip_path) = &style.clip_path {
-    let (mask, placement) = clip_path.render_mask(context, layout.size, buffer_pool);
+    let (mask, placement) = render_clip_shape_mask(clip_path, context, layout.size, buffer_pool);
     let end_x = placement.left + placement.width as i32;
     let end_y = placement.top + placement.height as i32;
 
@@ -548,6 +552,132 @@ fn transformed_mask_point(
     && original_point.y >= from.y
     && original_point.y < to.y;
   is_contained.then_some(original_point)
+}
+
+impl From<FillRule> for Fill {
+  fn from(value: FillRule) -> Self {
+    match value {
+      FillRule::EvenOdd => Fill::EvenOdd,
+      FillRule::NonZero => Fill::NonZero,
+    }
+  }
+}
+
+fn resolve_radius(
+  radius: ShapeRadius,
+  distance: Size<f32>,
+  sizing: &SizingContext,
+  full: f32,
+) -> f32 {
+  match radius {
+    ShapeRadius::ClosestSide => distance.width.min(distance.height),
+    ShapeRadius::FarthestSide => distance.width.max(distance.height),
+    ShapeRadius::Length(length) => length.to_px(sizing, full),
+  }
+}
+
+pub(crate) fn render_clip_shape_mask(
+  shape: &BasicShape,
+  context: &RenderContext,
+  size: Size<f32>,
+  buffer_pool: &mut BufferPool,
+) -> (Vec<u8>, Placement) {
+  let mut paths = Vec::new();
+
+  match shape {
+    BasicShape::Inset(shape) => {
+      let inset: Rect<f32> = shape
+        .inset
+        .map_axis(|value, axis| {
+          value.to_px(
+            &context.sizing,
+            match axis {
+              Axis::Horizontal => size.width,
+              Axis::Vertical => size.height,
+            },
+          )
+        })
+        .into();
+
+      let border = BorderProperties {
+        width: Rect::zero(),
+        color: Rect {
+          top: Color::transparent(),
+          right: Color::transparent(),
+          bottom: Color::transparent(),
+          left: Color::transparent(),
+        },
+        radius: shape
+          .border_radius
+          .map(|radius| {
+            Sides(
+              radius
+                .0
+                .map(|corner| SpacePair::from_single(corner.to_px(&context.sizing, size.width))),
+            )
+          })
+          .unwrap_or_default(),
+        image_rendering: ImageScalingAlgorithm::Auto,
+        style: Rect {
+          top: BorderStyle::Solid,
+          right: BorderStyle::Solid,
+          bottom: BorderStyle::Solid,
+          left: BorderStyle::Solid,
+        },
+      };
+
+      border.append_mask_commands(
+        &mut paths,
+        Size {
+          width: size.width - inset.grid_axis_sum(AbsoluteAxis::Horizontal),
+          height: size.height - inset.grid_axis_sum(AbsoluteAxis::Vertical),
+        },
+        Point {
+          x: inset.left,
+          y: inset.top,
+        },
+      );
+    }
+    BasicShape::Ellipse(shape) => {
+      let distance = Size {
+        width: shape.position.0.x.to_px(&context.sizing, size.width),
+        height: shape.position.0.y.to_px(&context.sizing, size.height),
+      };
+
+      paths.add_ellipse(
+        (distance.width, distance.height),
+        resolve_radius(shape.radius_x, distance, &context.sizing, size.width),
+        resolve_radius(shape.radius_y, distance, &context.sizing, size.height),
+      );
+    }
+    BasicShape::Polygon(shape) => {
+      if !shape.coordinates.is_empty() {
+        let first = &shape.coordinates[0];
+        let first_x = first.x.to_px(&context.sizing, size.width);
+        let first_y = first.y.to_px(&context.sizing, size.height);
+
+        paths.move_to((first_x, first_y));
+
+        for coord in &shape.coordinates[1..] {
+          let x = coord.x.to_px(&context.sizing, size.width);
+          let y = coord.y.to_px(&context.sizing, size.height);
+          paths.line_to((x, y));
+        }
+
+        paths.close();
+      }
+    }
+    BasicShape::Path(shape) => {
+      paths.extend(shape.path.as_ref().commands());
+    }
+  }
+
+  render_mask(
+    &paths,
+    Some(context.transform),
+    Some(Fill::from(shape.fill_rule().unwrap_or(context.style.clip_rule)).into()),
+    buffer_pool,
+  )
 }
 
 pub(crate) fn render_mask(


### PR DESCRIPTION
Stacked on #748. `BasicShape::render_mask` builds paths and calls the rendering `render_mask` — genuine rasterization. Moves it to `rendering::canvas::mask` as `render_clip_shape_mask` (with `resolve_radius` + `From<FillRule> for Fill`). Shape value types + `FromCss`/`ToCss` stay in `style`, which no longer depends on `rendering` for clip-path. No behavior change.