### PR TITLE
CI, WASM, NAPI: setup nightly std build

### DIFF
--- a/.changeset/cruel-months-feel.md
+++ b/.changeset/cruel-months-feel.md
@@ -1,0 +1,6 @@
+---
+"@takumi-rs/core": minor
+"@takumi-rs/wasm": minor
+---
+
+Built with nightly Rust toolchain with `panic=immediate-abort` to reduce binary size

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -5,6 +5,10 @@ inputs:
   binstall:
     description: Install cargo-binstall
     required: false
+  toolchain:
+    description: Rust toolchain to install
+    required: false
+    default: stable
   targets:
     description: Targets to install
     required: false
@@ -26,7 +30,7 @@ runs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: stable
+        toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,9 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
+          toolchain: nightly
           targets: ${{ matrix.settings.target }}
+          components: rust-src
           stage: build
 
       - name: Install cargo-zigbuild
@@ -225,6 +227,11 @@ jobs:
 
       - name: Build
         working-directory: takumi-napi-core
+        # build-std + panic=immediate-abort shrinks the binary (drops panic
+        # format machinery; Result-based errors are unaffected)
+        env:
+          CARGO_UNSTABLE_BUILD_STD: std,panic_abort
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zunstable-options -Cpanic=immediate-abort
         run: ${{ matrix.settings.build }} && bun build:js
 
       - name: Upload artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,9 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
+          toolchain: nightly
           targets: wasm32-unknown-unknown
+          components: rust-src
           stage: build
 
       - name: Install wasm-pack
@@ -551,6 +553,9 @@ jobs:
 
       - name: Build WASM
         working-directory: takumi-wasm
+        env:
+          CARGO_UNSTABLE_BUILD_STD: std,panic_abort
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zunstable-options -Cpanic=immediate-abort
         run: bun run build
 
       - name: Upload artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,8 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          # pinned: newer nightlies emit --fix-cortex-a53-843419 which zig rejects (cargo-zigbuild#451)
+          toolchain: nightly-2026-06-04
           targets: ${{ matrix.settings.target }}
           components: rust-src
           stage: build
@@ -545,7 +546,8 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          # pinned to match build-napi (see comment there)
+          toolchain: nightly-2026-06-04
           targets: wasm32-unknown-unknown
           components: rust-src
           stage: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,6 @@ jobs:
 
       - name: Build
         working-directory: takumi-napi-core
-        # build-std + panic=immediate-abort shrinks the binary (drops panic
-        # format machinery; Result-based errors are unaffected)
         env:
           CARGO_UNSTABLE_BUILD_STD: std,panic_abort
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zunstable-options -Cpanic=immediate-abort


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configurable Rust toolchain input for setup, replacing the previous fixed value.
  * CI build jobs for native N‑API and WASM now use the nightly Rust toolchain, include necessary Rust sources, and enable unstable build options to reduce binary size and enforce immediate panic abort.
  * Added a changeset documenting the release bump and nightly build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->