### PR TITLE
JS: don't load default fonts in managed renderer when custom fonts are provided

### DIFF
--- a/.changeset/font-default-shadow.md
+++ b/.changeset/font-default-shadow.md
@@ -1,0 +1,5 @@
+---
+"takumi-js": patch
+---
+
+Disable default fonts in the managed renderer when custom fonts are provided, matching the renderer constructor behavior.

--- a/.changeset/wasm-state-lock.md
+++ b/.changeset/wasm-state-lock.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/wasm": patch
+---
+
+Hold renderer state behind a lock so all methods take `&self`, preventing a panic from permanently breaking the wasm-bindgen borrow flag.

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -3,7 +3,11 @@ import type * as wasm from "@takumi-rs/wasm";
 import { extractEmojis, type EmojiType } from "@takumi-rs/helpers/emoji";
 import { extractResourceUrls, fetchResources } from "@takumi-rs/helpers";
 import { fromJsx, type FromJsxOptions } from "@takumi-rs/helpers/jsx";
-import { loadRendererResources, type ManagedRendererOptions } from "./renderer";
+import {
+  loadRendererResources,
+  type ManagedRendererOptions,
+  shouldLoadDefaultFonts,
+} from "./renderer";
 import { getImports } from "./import";
 import type { ReactNode } from "react";
 import type { FetchResourcesOptions, Node, ReactElementLike } from "@takumi-rs/helpers";
@@ -83,7 +87,7 @@ export async function render(element: RenderInput, options?: RenderOptions) {
   const renderer = isExternalRenderer
     ? options.renderer
     : (globalRenderer ??= new imports.Renderer({
-        loadDefaultFonts: options?.loadDefaultFonts,
+        loadDefaultFonts: shouldLoadDefaultFonts(options),
       }));
 
   if (!isExternalRenderer) {

--- a/takumi-js/src/renderer.ts
+++ b/takumi-js/src/renderer.ts
@@ -5,8 +5,8 @@ import type { RenderOptionsWithoutRenderer } from "./render";
 export type ManagedRendererOptions = {
   fonts?: napi.FontLoader[];
   /**
-   * Only supported by the native `@takumi-rs/core` renderer.
-   * This option is ignored when using the WASM renderer.
+   * Whether to load the embedded default fonts.
+   * Defaults to `false` when `fonts` are provided.
    */
   loadDefaultFonts?: boolean;
   persistentImages?: napi.ImageSourceLoader[];
@@ -15,6 +15,17 @@ export type ManagedRendererOptions = {
    */
   module?: wasm.InitInput | Promise<wasm.InitInput> | { default: wasm.InitInput };
 };
+
+/**
+ * Mirrors the renderer constructor behavior: when custom fonts are provided,
+ * default fonts are disabled so they can't shadow user fonts through generic
+ * family resolution (e.g. `sans-serif` resolving to the embedded font).
+ */
+export function shouldLoadDefaultFonts(
+  options: RenderOptionsWithoutRenderer | undefined,
+): boolean | undefined {
+  return options?.loadDefaultFonts ?? (options?.fonts?.length ? false : undefined);
+}
 
 export async function loadRendererResources(
   renderer: napi.Renderer | wasm.Renderer,

--- a/takumi-js/tests/renderer.test.ts
+++ b/takumi-js/tests/renderer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { shouldLoadDefaultFonts } from "../src/renderer";
+
+const font = { name: "Geist", data: new Uint8Array(), weight: 400 };
+
+describe("shouldLoadDefaultFonts", () => {
+  test("defers to the renderer default when no fonts are provided", () => {
+    expect(shouldLoadDefaultFonts(undefined)).toBeUndefined();
+    expect(shouldLoadDefaultFonts({})).toBeUndefined();
+    expect(shouldLoadDefaultFonts({ fonts: [] })).toBeUndefined();
+  });
+
+  test("disables default fonts when custom fonts are provided", () => {
+    expect(shouldLoadDefaultFonts({ fonts: [font] })).toBe(false);
+  });
+
+  test("respects an explicit loadDefaultFonts option", () => {
+    expect(shouldLoadDefaultFonts({ fonts: [font], loadDefaultFonts: true })).toBe(true);
+    expect(shouldLoadDefaultFonts({ loadDefaultFonts: false })).toBe(false);
+  });
+});

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -4,7 +4,11 @@ use crate::{helper::map_error, model::*};
 use base64::{Engine, prelude::BASE64_STANDARD};
 use parley::{FontWeight, GenericFamily, fontique::FontInfoOverride};
 use serde_wasm_bindgen::{from_value, to_value};
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{
+  borrow::Cow,
+  collections::HashMap,
+  sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
 use takumi::{
   GlobalContext,
   layout::{
@@ -28,10 +32,88 @@ const EMBEDDED_FONTS: &[(&[u8], &str, GenericFamily)] = &[(
 )];
 
 /// The main renderer for Takumi image rendering engine.
+///
+/// State lives behind a lock and every method takes `&self`, mirroring the
+/// napi bindings: a panic mid-call can't leave the wasm-bindgen borrow flag
+/// permanently set, which would otherwise fail all subsequent calls.
 #[wasm_bindgen]
 #[derive(Default)]
 pub struct Renderer {
-  pub(crate) context: GlobalContext,
+  state: RwLock<GlobalContext>,
+}
+
+fn load_default_fonts(context: &mut GlobalContext) -> Result<(), js_sys::Error> {
+  for (font, family_name, generic_family) in EMBEDDED_FONTS {
+    let resource = FontResource::new((*font).to_vec())
+      .override_info(FontInfoOverride {
+        family_name: Some(*family_name),
+        ..Default::default()
+      })
+      .generic_family(*generic_family)
+      .into_resolved()
+      .map_err(|error| js_sys::Error::new(&format!("Failed to load default font: {error}")))?;
+
+    context
+      .font_context
+      .load_and_store(resource)
+      .map_err(map_error)?;
+  }
+
+  Ok(())
+}
+
+fn load_font_internal(context: &mut GlobalContext, font: Font) -> Result<(), js_sys::Error> {
+  match font {
+    Font::Buffer(buffer) => {
+      context
+        .font_context
+        .load_and_store(FontResource::new(buffer.into_vec()))
+        .map_err(map_error)?;
+    }
+    Font::Object(details) => {
+      context
+        .font_context
+        .load_and_store(FontResource::new(details.data.into_vec()).override_info(
+          FontInfoOverride {
+            family_name: details.name.as_deref(),
+            style: details.style.map(Into::into),
+            weight: details.weight.map(|weight| FontWeight::new(weight as f32)),
+            axes: None,
+            width: None,
+          },
+        ))
+        .map_err(map_error)?;
+    }
+  }
+  Ok(())
+}
+
+fn put_persistent_image_internal(
+  context: &mut GlobalContext,
+  data: &ImageSource,
+) -> Result<(), js_sys::Error> {
+  let image = LoadedImageSource::from_bytes(&data.data).map_err(map_error)?;
+  context
+    .persistent_image_store
+    .insert(data.src.to_string(), image);
+
+  Ok(())
+}
+
+impl Renderer {
+  fn read_state(&self) -> Result<RwLockReadGuard<'_, GlobalContext>, js_sys::Error> {
+    self
+      .state
+      .try_read()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))
+  }
+
+  fn write_state(&self) -> Result<RwLockWriteGuard<'_, GlobalContext>, js_sys::Error> {
+    self
+      .state
+      .try_write()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))
+  }
 }
 
 #[wasm_bindgen]
@@ -107,29 +189,6 @@ impl Renderer {
     Ok(buffer)
   }
 
-  fn load_default_fonts(&mut self) -> Result<(), js_sys::Error> {
-    for (font, family_name, generic_family) in EMBEDDED_FONTS {
-      self
-        .context
-        .font_context
-        .load_and_store(
-          FontResource::new((*font).to_vec())
-            .override_info(FontInfoOverride {
-              family_name: Some(*family_name),
-              ..Default::default()
-            })
-            .generic_family(*generic_family)
-            .into_resolved()
-            .map_err(|error| {
-              js_sys::Error::new(&format!("Failed to load default font: {error}"))
-            })?,
-        )
-        .map_err(map_error)?;
-    }
-
-    Ok(())
-  }
-
   /// Creates a new Renderer instance.
   #[wasm_bindgen(constructor)]
   pub fn new(options: Option<ConstructRendererOptionsType>) -> Result<Renderer, js_sys::Error> {
@@ -138,88 +197,54 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let mut renderer = Self::default();
+    let mut context = GlobalContext::default();
 
-    let load_default_fonts = options
+    let should_load_default_fonts = options
       .load_default_fonts
       .unwrap_or_else(|| options.fonts.is_none());
 
-    if load_default_fonts {
-      renderer.load_default_fonts()?;
+    if should_load_default_fonts {
+      load_default_fonts(&mut context)?;
     }
 
     if let Some(fonts) = options.fonts {
       for font in fonts {
-        renderer.load_font_internal(font)?;
+        load_font_internal(&mut context, font)?;
       }
     }
 
     if let Some(images) = options.persistent_images {
       for image in images {
-        renderer.put_persistent_image_internal(&image)?;
+        put_persistent_image_internal(&mut context, &image)?;
       }
     }
 
-    Ok(renderer)
-  }
-
-  fn load_font_internal(&mut self, font: Font) -> Result<(), js_sys::Error> {
-    match font {
-      Font::Buffer(buffer) => {
-        self
-          .context
-          .font_context
-          .load_and_store(FontResource::new(buffer.into_vec()))
-          .map_err(map_error)?;
-      }
-      Font::Object(details) => {
-        self
-          .context
-          .font_context
-          .load_and_store(FontResource::new(details.data.into_vec()).override_info(
-            FontInfoOverride {
-              family_name: details.name.as_deref(),
-              style: details.style.map(Into::into),
-              weight: details.weight.map(|weight| FontWeight::new(weight as f32)),
-              axes: None,
-              width: None,
-            },
-          ))
-          .map_err(map_error)?;
-      }
-    }
-    Ok(())
+    Ok(Renderer {
+      state: RwLock::new(context),
+    })
   }
 
   /// Loads a font into the renderer.
   #[wasm_bindgen(js_name = loadFont)]
-  pub fn load_font(&mut self, font: FontType) -> Result<(), js_sys::Error> {
+  pub fn load_font(&self, font: FontType) -> Result<(), js_sys::Error> {
     let input: Font = from_value(font.into()).map_err(map_error)?;
-    self.load_font_internal(input)
-  }
-
-  /// Puts a persistent image into the renderer's internal store (internal version without JS conversion).
-  fn put_persistent_image_internal(&mut self, data: &ImageSource) -> Result<(), js_sys::Error> {
-    let image = LoadedImageSource::from_bytes(&data.data).map_err(map_error)?;
-    self
-      .context
-      .persistent_image_store
-      .insert(data.src.to_string(), image);
-
-    Ok(())
+    let mut state = self.write_state()?;
+    load_font_internal(&mut state, input)
   }
 
   /// Puts a persistent image into the renderer's internal store.
   #[wasm_bindgen(js_name = putPersistentImage)]
-  pub fn put_persistent_image(&mut self, data: ImageSourceType) -> Result<(), js_sys::Error> {
+  pub fn put_persistent_image(&self, data: ImageSourceType) -> Result<(), js_sys::Error> {
     let data: ImageSource = from_value(data.into()).map_err(map_error)?;
-    self.put_persistent_image_internal(&data)
+    let mut state = self.write_state()?;
+    put_persistent_image_internal(&mut state, &data)
   }
 
   /// Clears the renderer's internal image store.
   #[wasm_bindgen(js_name = clearImageStore)]
-  pub fn clear_image_store(&mut self) {
-    self.context.persistent_image_store.clear();
+  pub fn clear_image_store(&self) -> Result<(), js_sys::Error> {
+    self.write_state()?.persistent_image_store.clear();
+    Ok(())
   }
 
   /// Renders a node tree into an image buffer.
@@ -235,10 +260,16 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    self.render_internal(node, options)
+    let state = self.read_state()?;
+    self.render_internal(&state, node, options)
   }
 
-  fn render_internal(&self, node: Node, options: RenderOptions) -> Result<Vec<u8>, JsValue> {
+  fn render_internal(
+    &self,
+    context: &GlobalContext,
+    node: Node,
+    options: RenderOptions,
+  ) -> Result<Vec<u8>, JsValue> {
     let fetched_resources = self.fetch_resources_map(options.fetched_resources.as_deref())?;
     let dithering = options.dithering.unwrap_or_default();
     let stylesheet =
@@ -258,7 +289,7 @@ impl Renderer {
       .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
       .dithering(dithering)
       .node(node)
-      .global(&self.context)
+      .global(context)
       .build();
 
     let image = render(render_options).map_err(map_error)?;
@@ -299,6 +330,7 @@ impl Renderer {
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
 
+    let state = self.read_state()?;
     let render_options = takumi::rendering::RenderOptions::builder()
       .viewport(
         Viewport::new((options.width, options.height)).with_device_pixel_ratio(
@@ -312,7 +344,7 @@ impl Renderer {
       .stylesheet(stylesheet)
       .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
       .node(node)
-      .global(&self.context)
+      .global(&state)
       .build();
 
     let layout = measure_layout(render_options).map_err(map_error)?;
@@ -340,7 +372,8 @@ impl Renderer {
       ));
     }
 
-    let buffer = self.render_internal(node, options)?;
+    let state = self.read_state()?;
+    let buffer = self.render_internal(&state, node, options)?;
 
     let mut data_uri = String::new();
 
@@ -381,6 +414,7 @@ impl Renderer {
       .with_device_pixel_ratio(device_pixel_ratio.unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO));
     let draw_debug_border = draw_debug_border.unwrap_or_default();
     let stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
+    let state = self.read_state()?;
     let scene_options = scenes
       .into_iter()
       .map(|scene| {
@@ -392,7 +426,7 @@ impl Renderer {
               .fetched_resources(fetched_resources.clone())
               .stylesheet(stylesheet.clone())
               .node(scene.node)
-              .global(&self.context)
+              .global(&state)
               .draw_debug_border(draw_debug_border)
               .build(),
           )
@@ -420,6 +454,7 @@ impl Renderer {
         .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
     );
     let stylesheet = StyleSheet::parse_owned_list_loosy(options.stylesheets.unwrap_or_default());
+    let state = self.read_state()?;
     let rendered_frames = frames
       .into_iter()
       .map(|frame| -> Result<AnimationFrame, JsValue> {
@@ -427,7 +462,7 @@ impl Renderer {
           .viewport(viewport)
           .fetched_resources(fetched_resources.clone())
           .node(frame.node)
-          .global(&self.context)
+          .global(&state)
           .draw_debug_border(options.draw_debug_border.unwrap_or_default())
           .stylesheet(stylesheet.clone())
           .build();


### PR DESCRIPTION
## Problem

The managed renderer in `takumi-js` constructs the global renderer without passing the font decision, so the constructor loads embedded defaults, which are registered to generic families and shadow user fonts loaded afterwards via `loadFonts`. Text without an explicit matching `fontFamily` renders with the embedded default — visible on WASM (Manrope), masked on napi (defaults are Geist).

## Fix

- `takumi-js`: when the managed render options include custom fonts, default `loadDefaultFonts` to `false`, matching the constructor semantics ("if `fonts` are provided, this will be `false` by default"). Explicit `loadDefaultFonts` is respected.
- `@takumi-rs/wasm`: hold renderer state behind a lock and take `&self` in all methods, mirroring the napi bindings — a panic mid-call can no longer leave the wasm-bindgen borrow flag permanently set (the rare Workers failure where every later call throws `recursive use of an object`). Lock acquisition uses `try_read`/`try_write` and reports a graceful error instead of hanging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could permanently break subsequent renderer calls.

* **New Features**
  * Default fonts are now automatically disabled when custom fonts are provided, ensuring consistent behavior across renderer implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->