### PR TITLE
Crate: skip painting zero-sized nodes instead of full-viewport isolation

### DIFF
--- a/.changeset/zero-size-opacity-isolation.md
+++ b/.changeset/zero-size-opacity-isolation.md
@@ -1,0 +1,5 @@
+---
+"takumi": patch
+---
+
+Skip painting zero-sized nodes instead of isolating them on a full-viewport offscreen canvas. Zero-sized nodes with `opacity` previously forced a full-canvas clear and composite each; a 1200x630 scene with a few such nodes rendered ~5x slower (much worse on WASM).

--- a/.changeset/zero-size-opacity-isolation.md
+++ b/.changeset/zero-size-opacity-isolation.md
@@ -2,4 +2,4 @@
 "takumi": patch
 ---
 
-Skip painting zero-sized nodes instead of isolating them on a full-viewport offscreen canvas. Zero-sized nodes with `opacity` previously forced a full-canvas clear and composite each; a 1200x630 scene with a few such nodes rendered ~5x slower (much worse on WASM).
+Skip painting zero-sized nodes instead of compositing them through a full-viewport offscreen canvas, fixing a severe slowdown for zero-sized nodes with `opacity`.

--- a/takumi/src/rendering/stacking_context.rs
+++ b/takumi/src/rendering/stacking_context.rs
@@ -1153,6 +1153,8 @@ fn compute_isolation_bounds(
 
 #[cfg(test)]
 mod tests {
+  use std::error::Error;
+
   use taffy::{Point, geometry::Size};
 
   use super::bounds_for_rect;
@@ -1162,15 +1164,17 @@ mod tests {
     rendering::{CanvasViewport, RenderOptions, render},
   };
 
-  fn render_json(json: &str) -> image::RgbaImage {
+  type TestResult = Result<(), Box<dyn Error>>;
+
+  fn render_json(json: &str) -> Result<image::RgbaImage, Box<dyn Error>> {
     let global = GlobalContext::default();
-    let node: Node = serde_json::from_str(json).unwrap();
+    let node: Node = serde_json::from_str(json)?;
     let options = RenderOptions::builder()
       .viewport(Viewport::new((100, 100)))
       .node(node)
       .global(&global)
       .build();
-    render(options).unwrap()
+    Ok(render(options)?)
   }
 
   #[test]
@@ -1181,8 +1185,7 @@ mod tests {
         height: 100.0,
       },
       Affine::translation(50.0, 50.0),
-    )
-    .expect("zero-sized rect should produce empty bounds, not unknown");
+    );
 
     let viewport = CanvasViewport {
       origin: Point { x: 0, y: 0 },
@@ -1191,11 +1194,15 @@ mod tests {
         height: 100,
       },
     };
-    assert!(!bounds.intersects_viewport(viewport));
+    assert!(
+      bounds.is_some_and(|bounds| !bounds.intersects_viewport(viewport)),
+      "zero-sized rect should produce empty bounds that intersect nothing, got {:?}",
+      bounds.map(|bounds| (bounds.left, bounds.top, bounds.right, bounds.bottom))
+    );
   }
 
   #[test]
-  fn zero_sized_opacity_node_does_not_change_output() {
+  fn zero_sized_opacity_node_does_not_change_output() -> TestResult {
     let bar = r##"{"type": "container", "style": {"width": "20px", "height": "50px", "backgroundColor": "#3b82f6", "opacity": 0.9}, "children": []}"##;
     let zero_bar = r##"{"type": "container", "style": {"width": "20px", "height": "0px", "backgroundColor": "#3b82f6", "opacity": 0.9}, "children": []}"##;
     let tree = |bars: &str| {
@@ -1204,14 +1211,15 @@ mod tests {
       )
     };
 
-    let with_zero = render_json(&tree(&format!("{bar}, {zero_bar}")));
-    let without_zero = render_json(&tree(bar));
+    let with_zero = render_json(&tree(&format!("{bar}, {zero_bar}")))?;
+    let without_zero = render_json(&tree(bar))?;
 
     assert_eq!(with_zero, without_zero);
+    Ok(())
   }
 
   #[test]
-  fn zero_sized_opacity_parent_still_paints_overflowing_child() {
+  fn zero_sized_opacity_parent_still_paints_overflowing_child() -> TestResult {
     let image = render_json(
       r##"{
         "type": "container",
@@ -1220,12 +1228,13 @@ mod tests {
           {"type": "container", "style": {"width": "50px", "height": "50px", "flexShrink": 0, "backgroundColor": "#ff0000"}, "children": []}
         ]
       }"##,
-    );
+    )?;
 
     let pixel = image.get_pixel(10, 10);
     assert!(
       pixel.0[0] > 0 && pixel.0[3] > 0,
       "overflowing child of zero-sized opacity parent must still paint, got {pixel:?}"
     );
+    Ok(())
   }
 }

--- a/takumi/src/rendering/stacking_context.rs
+++ b/takumi/src/rendering/stacking_context.rs
@@ -183,8 +183,12 @@ struct SceneBounds {
 }
 
 impl SceneBounds {
+  fn is_empty(self) -> bool {
+    self.left >= self.right || self.top >= self.bottom
+  }
+
   fn intersects_viewport(self, viewport: CanvasViewport) -> bool {
-    if self.left >= self.right || self.top >= self.bottom {
+    if self.is_empty() {
       return false;
     }
 
@@ -651,9 +655,7 @@ fn bounds_for_rect(size: Size<f32>, transform: Affine) -> Option<SceneBounds> {
   let right = (max_x.ceil() as i32).max(0) as usize;
   let bottom = (max_y.ceil() as i32).max(0) as usize;
 
-  // Degenerate rects yield empty bounds rather than None: None means
-  // "unknown" and forces full-viewport isolation, while empty bounds let
-  // zero-sized nodes be skipped entirely.
+  // Empty bounds mean "paints nothing"; None means "unknown" and forces full-viewport isolation.
   Some(SceneBounds {
     left,
     top,
@@ -664,6 +666,9 @@ fn bounds_for_rect(size: Size<f32>, transform: Affine) -> Option<SceneBounds> {
 
 fn merge_bounds(left: Option<SceneBounds>, right: Option<SceneBounds>) -> Option<SceneBounds> {
   match (left, right) {
+    // Empty bounds paint nothing and sit at clamped positions; don't let them expand the union.
+    (Some(left), Some(right)) if left.is_empty() => Some(right),
+    (Some(left), Some(right)) if right.is_empty() => Some(left),
     (Some(left), Some(right)) => Some(SceneBounds {
       left: left.left.min(right.left),
       top: left.top.min(right.top),
@@ -838,8 +843,7 @@ fn begin_node_render<'g>(
     return Ok(None);
   }
 
-  // For stacking context roots the hint holds the context's merged bounds;
-  // a zero-sized root may still have visible overflowing children.
+  // Prefer the context's merged bounds: a zero-sized root can still have visible overflowing children.
   if let Some(bounds) = isolation_bounds_hint.or(node_paint.paint_bounds)
     && !bounds.intersects_viewport(canvas.viewport())
   {
@@ -1157,7 +1161,7 @@ mod tests {
 
   use taffy::{Point, geometry::Size};
 
-  use super::bounds_for_rect;
+  use super::{SceneBounds, bounds_for_rect, merge_bounds};
   use crate::{
     GlobalContext,
     layout::{Viewport, node::Node, style::Affine},
@@ -1199,6 +1203,33 @@ mod tests {
       "zero-sized rect should produce empty bounds that intersect nothing, got {:?}",
       bounds.map(|bounds| (bounds.left, bounds.top, bounds.right, bounds.bottom))
     );
+  }
+
+  #[test]
+  fn merge_bounds_ignores_empty_bounds() {
+    let empty = SceneBounds {
+      left: 0,
+      top: 5,
+      right: 0,
+      bottom: 10,
+    };
+    let real = SceneBounds {
+      left: 1000,
+      top: 0,
+      right: 1200,
+      bottom: 50,
+    };
+
+    for (left, right) in [(empty, real), (real, empty)] {
+      let merged = merge_bounds(Some(left), Some(right));
+      assert!(
+        merged.is_some_and(
+          |bounds| (bounds.left, bounds.top, bounds.right, bounds.bottom)
+            == (real.left, real.top, real.right, real.bottom)
+        ),
+        "empty bounds must not expand the union"
+      );
+    }
   }
 
   #[test]

--- a/takumi/src/rendering/stacking_context.rs
+++ b/takumi/src/rendering/stacking_context.rs
@@ -184,6 +184,10 @@ struct SceneBounds {
 
 impl SceneBounds {
   fn intersects_viewport(self, viewport: CanvasViewport) -> bool {
+    if self.left >= self.right || self.top >= self.bottom {
+      return false;
+    }
+
     let viewport_left = viewport.origin.x as i32;
     let viewport_top = viewport.origin.y as i32;
     let viewport_right = viewport.right();
@@ -647,10 +651,9 @@ fn bounds_for_rect(size: Size<f32>, transform: Affine) -> Option<SceneBounds> {
   let right = (max_x.ceil() as i32).max(0) as usize;
   let bottom = (max_y.ceil() as i32).max(0) as usize;
 
-  if left >= right || top >= bottom {
-    return None;
-  }
-
+  // Degenerate rects yield empty bounds rather than None: None means
+  // "unknown" and forces full-viewport isolation, while empty bounds let
+  // zero-sized nodes be skipped entirely.
   Some(SceneBounds {
     left,
     top,
@@ -835,7 +838,9 @@ fn begin_node_render<'g>(
     return Ok(None);
   }
 
-  if let Some(bounds) = node_paint.paint_bounds
+  // For stacking context roots the hint holds the context's merged bounds;
+  // a zero-sized root may still have visible overflowing children.
+  if let Some(bounds) = isolation_bounds_hint.or(node_paint.paint_bounds)
     && !bounds.intersects_viewport(canvas.viewport())
   {
     return Ok(Some(DeferredNodeRender::SkipRendering));
@@ -1144,4 +1149,83 @@ fn compute_isolation_bounds(
   };
 
   placement.unwrap_or_else(|| full_viewport_placement(viewport))
+}
+
+#[cfg(test)]
+mod tests {
+  use taffy::{Point, geometry::Size};
+
+  use super::bounds_for_rect;
+  use crate::{
+    GlobalContext,
+    layout::{Viewport, node::Node, style::Affine},
+    rendering::{CanvasViewport, RenderOptions, render},
+  };
+
+  fn render_json(json: &str) -> image::RgbaImage {
+    let global = GlobalContext::default();
+    let node: Node = serde_json::from_str(json).unwrap();
+    let options = RenderOptions::builder()
+      .viewport(Viewport::new((100, 100)))
+      .node(node)
+      .global(&global)
+      .build();
+    render(options).unwrap()
+  }
+
+  #[test]
+  fn zero_sized_rect_bounds_are_empty_not_unknown() {
+    let bounds = bounds_for_rect(
+      Size {
+        width: 0.0,
+        height: 100.0,
+      },
+      Affine::translation(50.0, 50.0),
+    )
+    .expect("zero-sized rect should produce empty bounds, not unknown");
+
+    let viewport = CanvasViewport {
+      origin: Point { x: 0, y: 0 },
+      size: Size {
+        width: 100,
+        height: 100,
+      },
+    };
+    assert!(!bounds.intersects_viewport(viewport));
+  }
+
+  #[test]
+  fn zero_sized_opacity_node_does_not_change_output() {
+    let bar = r##"{"type": "container", "style": {"width": "20px", "height": "50px", "backgroundColor": "#3b82f6", "opacity": 0.9}, "children": []}"##;
+    let zero_bar = r##"{"type": "container", "style": {"width": "20px", "height": "0px", "backgroundColor": "#3b82f6", "opacity": 0.9}, "children": []}"##;
+    let tree = |bars: &str| {
+      format!(
+        r##"{{"type": "container", "style": {{"display": "flex", "alignItems": "flex-end", "width": "100%", "height": "100%", "backgroundColor": "#ffffff"}}, "children": [{bars}]}}"##
+      )
+    };
+
+    let with_zero = render_json(&tree(&format!("{bar}, {zero_bar}")));
+    let without_zero = render_json(&tree(bar));
+
+    assert_eq!(with_zero, without_zero);
+  }
+
+  #[test]
+  fn zero_sized_opacity_parent_still_paints_overflowing_child() {
+    let image = render_json(
+      r##"{
+        "type": "container",
+        "style": {"display": "flex", "width": "0px", "height": "0px", "opacity": 0.5},
+        "children": [
+          {"type": "container", "style": {"width": "50px", "height": "50px", "flexShrink": 0, "backgroundColor": "#ff0000"}, "children": []}
+        ]
+      }"##,
+    );
+
+    let pixel = image.get_pixel(10, 10);
+    assert!(
+      pixel.0[0] > 0 && pixel.0[3] > 0,
+      "overflowing child of zero-sized opacity parent must still paint, got {pixel:?}"
+    );
+  }
 }


### PR DESCRIPTION
## Problem

A zero-sized node that needs offscreen compositing (e.g. `opacity < 1`) was isolated on a **full-viewport** offscreen canvas. `bounds_for_rect` returned `None` for degenerate rects, and `None` means "unknown bounds" downstream, so `compute_isolation_bounds` fell back to `full_viewport_placement` — a full canvas clear + opacity composite per invisible node.

Found via image-bench: the analytics dashboard template generates bar heights of `20 + sin(i*0.5)*40 + random()*30` **%**, which goes negative for several of its 24 bars. Each zero-height bar with fractional opacity cost a full 1200x630 isolation pass (~5ms native, ~30ms WASM), pushing renders from ~6ms to 70–200ms on WASM depending on the random roll.

## Fix

- `bounds_for_rect` now returns degenerate empty bounds instead of `None`, so "empty" is distinguishable from "unknown"
- `SceneBounds::intersects_viewport` returns `false` for empty bounds, so zero-sized nodes skip painting (and isolation) via the existing viewport cull
- the cull in `begin_node_render` uses the stacking context's merged bounds (`isolation_bounds_hint.or(node_paint.paint_bounds)`) so a zero-sized context root with visible overflowing children still paints them

## Results

- Repro tree (analytics chart, fixed node tree, 1200x630 raw): native 19ms → 4ms
- Full analytics template on locally built `@takumi-rs/wasm` (PNG): ~105ms median → ~15–20ms median
- Output byte-identical to v1.8.0 on the same tree (raw pixel diff: 0 of 3,024,000 bytes)
- All 875 workspace tests pass, clippy clean; 3 new tests cover the bounds semantics, output equivalence, and the overflowing-child guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering performance by skipping unnecessary full-viewport isolation for zero-sized elements with opacity, reducing slowdowns in complex scenes and on WebAssembly.
  * Preserves correct painting of overflowing children: zero-sized parents with visible overflow still render their children as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->