### PR TITLE
NAPI: fix Windows crash at process exit

### DIFF
--- a/.changeset/fix-windows-teardown-crash.md
+++ b/.changeset/fix-windows-teardown-crash.md
@@ -1,0 +1,5 @@
+---
+"@takumi-rs/core": patch
+---
+
+Join rayon's worker threads on N-API teardown to fix a Windows crash (`0xC0000005`) when Node exits after rendering (#763)

--- a/takumi-napi-core/src/encode_frames_task.rs
+++ b/takumi-napi-core/src/encode_frames_task.rs
@@ -68,100 +68,102 @@ impl Task for EncodeFramesTask {
   type JsValue = Buffer;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    const ENCODED_BYTES_PER_PIXEL_ESTIMATE: usize = 1;
-    const FRAME_OVERHEAD_BYTES: usize = 128;
-    const MAX_PREALLOC: usize = 4 * 1024 * 1024;
+    crate::pool::install(move || {
+      const ENCODED_BYTES_PER_PIXEL_ESTIMATE: usize = 1;
+      const FRAME_OVERHEAD_BYTES: usize = 128;
+      const MAX_PREALLOC: usize = 4 * 1024 * 1024;
 
-    let Some(frames) = self.frames.take() else {
-      unreachable!()
-    };
-    let initialized_images = self
-      .fetched_resources
-      .iter()
-      .map(|(key, value)| {
-        Ok((
-          key.clone(),
-          LoadedImageSource::from_bytes(value).map_err(map_error)?,
-        ))
-      })
-      .collect::<Result<HashMap<_, _>, _>>()?;
-    let state = self
-      .state
-      .read()
-      .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
+      let Some(frames) = self.frames.take() else {
+        unreachable!()
+      };
+      let initialized_images = self
+        .fetched_resources
+        .iter()
+        .map(|(key, value)| {
+          Ok((
+            key.clone(),
+            LoadedImageSource::from_bytes(value).map_err(map_error)?,
+          ))
+        })
+        .collect::<Result<HashMap<_, _>, _>>()?;
+      let state = self
+        .state
+        .read()
+        .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
 
-    let viewport = self.viewport;
-    let draw_debug_border = self.draw_debug_border;
-    let stylesheet = parse_stylesheet(self.stylesheets.clone(), Vec::new())?;
-    let frames = frames
-      .into_par_iter()
-      .map(|(node, duration_ms)| {
-        Ok(AnimationFrame::new(
-          render(
-            takumi::rendering::RenderOptions::builder()
-              .viewport(viewport)
-              .fetched_resources(initialized_images.clone())
-              .stylesheet(stylesheet.clone())
-              .node(node)
-              .global(&state.global)
-              .draw_debug_border(draw_debug_border)
-              .build(),
-          )
-          .map_err(map_error)?,
-          duration_ms,
-        ))
-      })
-      .collect::<Result<Vec<_>, _>>()?;
+      let viewport = self.viewport;
+      let draw_debug_border = self.draw_debug_border;
+      let stylesheet = parse_stylesheet(self.stylesheets.clone(), Vec::new())?;
+      let frames = frames
+        .into_par_iter()
+        .map(|(node, duration_ms)| {
+          Ok(AnimationFrame::new(
+            render(
+              takumi::rendering::RenderOptions::builder()
+                .viewport(viewport)
+                .fetched_resources(initialized_images.clone())
+                .stylesheet(stylesheet.clone())
+                .node(node)
+                .global(&state.global)
+                .draw_debug_border(draw_debug_border)
+                .build(),
+            )
+            .map_err(map_error)?,
+            duration_ms,
+          ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let estimated_capacity = if let Some(first) = frames.first() {
-      let width = first.image.width() as usize;
-      let height = first.image.height() as usize;
-      let per_frame_estimate = width
-        .saturating_mul(height)
-        .saturating_mul(ENCODED_BYTES_PER_PIXEL_ESTIMATE)
-        .saturating_add(FRAME_OVERHEAD_BYTES);
-      per_frame_estimate
-        .saturating_mul(frames.len())
-        .saturating_add(44)
-        .min(MAX_PREALLOC)
-    } else {
-      0
-    };
-    let mut buffer = Vec::with_capacity(estimated_capacity);
+      let estimated_capacity = if let Some(first) = frames.first() {
+        let width = first.image.width() as usize;
+        let height = first.image.height() as usize;
+        let per_frame_estimate = width
+          .saturating_mul(height)
+          .saturating_mul(ENCODED_BYTES_PER_PIXEL_ESTIMATE)
+          .saturating_add(FRAME_OVERHEAD_BYTES);
+        per_frame_estimate
+          .saturating_mul(frames.len())
+          .saturating_add(44)
+          .min(MAX_PREALLOC)
+      } else {
+        0
+      };
+      let mut buffer = Vec::with_capacity(estimated_capacity);
 
-    if let Some(quality) = self.quality
-      && quality > 100
-    {
-      return Err(Error::from_reason(format!(
-        "Invalid WebP quality {quality}; expected a value in 0..=100"
-      )));
-    }
+      if let Some(quality) = self.quality
+        && quality > 100
+      {
+        return Err(Error::from_reason(format!(
+          "Invalid WebP quality {quality}; expected a value in 0..=100"
+        )));
+      }
 
-    match self.format {
-      AnimationOutputFormat::WebP => {
-        let mut options = AnimatedWebpOptions::default();
-        if let Some(quality) = self.quality {
-          options.quality = quality;
+      match self.format {
+        AnimationOutputFormat::WebP => {
+          let mut options = AnimatedWebpOptions::default();
+          if let Some(quality) = self.quality {
+            options.quality = quality;
+          }
+
+          encode_animated_webp(Cow::Owned(frames), &mut buffer, options)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
         }
-
-        encode_animated_webp(Cow::Owned(frames), &mut buffer, options)
+        AnimationOutputFormat::Apng => {
+          encode_animated_png(&frames, &mut buffer, AnimatedPngOptions::default())
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        }
+        AnimationOutputFormat::Gif => {
+          encode_animated_gif(
+            Cow::Owned(frames),
+            &mut buffer,
+            AnimatedGifOptions::default(),
+          )
           .map_err(|e| Error::from_reason(e.to_string()))?;
+        }
       }
-      AnimationOutputFormat::Apng => {
-        encode_animated_png(&frames, &mut buffer, AnimatedPngOptions::default())
-          .map_err(|e| Error::from_reason(e.to_string()))?;
-      }
-      AnimationOutputFormat::Gif => {
-        encode_animated_gif(
-          Cow::Owned(frames),
-          &mut buffer,
-          AnimatedGifOptions::default(),
-        )
-        .map_err(|e| Error::from_reason(e.to_string()))?;
-      }
-    }
 
-    Ok(buffer)
+      Ok(buffer)
+    })
   }
 
   fn resolve(&mut self, mut env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/takumi-napi-core/src/lib.rs
+++ b/takumi-napi-core/src/lib.rs
@@ -6,6 +6,7 @@
 mod encode_frames_task;
 mod load_font_task;
 mod measure_task;
+mod pool;
 mod put_persistent_image_task;
 mod render_animation_task;
 mod render_task;

--- a/takumi-napi-core/src/load_font_task.rs
+++ b/takumi-napi-core/src/load_font_task.rs
@@ -21,12 +21,14 @@ impl Task for LoadFontTask {
 
     let mut loaded_count = 0;
 
-    let resources = self
-      .buffers
-      .par_iter()
-      .with_min_len(2)
-      .map(|(font, buffer): &(FontInput, Buffer)| resolve_font_resource(font, buffer.as_ref()))
-      .collect::<Result<Vec<_>>>()?;
+    let resources = crate::pool::install(|| {
+      self
+        .buffers
+        .par_iter()
+        .with_min_len(2)
+        .map(|(font, buffer): &(FontInput, Buffer)| resolve_font_resource(font, buffer.as_ref()))
+        .collect::<Result<Vec<_>>>()
+    })?;
 
     let mut state = self
       .state

--- a/takumi-napi-core/src/pool.rs
+++ b/takumi-napi-core/src/pool.rs
@@ -6,7 +6,6 @@
 //! [`JoinHandle`]s and joins them from an env cleanup hook, so none are alive
 //! when the process exits. All parallel work runs through [`install`].
 
-use std::cell::Cell;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{Builder, JoinHandle};
 
@@ -22,8 +21,10 @@ static SHARED: OnceLock<Mutex<Shared>> = OnceLock::new();
 
 /// Builds an owned pool whose worker `JoinHandle`s are retained for joining.
 fn build() -> Shared {
-  let handles = Mutex::new(Vec::new());
+  let mut handles = Vec::new();
 
+  // `spawn_handler` is `FnMut` and called synchronously during `build`, so the
+  // handles can be collected without interior mutability.
   let pool = ThreadPoolBuilder::new()
     .spawn_handler(|thread| {
       let mut builder = Builder::new();
@@ -33,20 +34,14 @@ fn build() -> Shared {
       if let Some(size) = thread.stack_size() {
         builder = builder.stack_size(size);
       }
-      let handle = builder.spawn(|| thread.run())?;
-      if let Ok(mut handles) = handles.lock() {
-        handles.push(handle);
-      }
+      handles.push(builder.spawn(|| thread.run())?);
       Ok(())
     })
     .build()
     .ok()
     .map(Arc::new);
 
-  Shared {
-    pool,
-    handles: handles.into_inner().unwrap_or_default(),
-  }
+  Shared { pool, handles }
 }
 
 /// Returns a clone of the current pool, rebuilding it if a previous N-API
@@ -87,15 +82,11 @@ fn shutdown() {
   }
 }
 
-thread_local! {
-  static CLEANUP_REGISTERED: Cell<bool> = const { Cell::new(false) };
-}
-
-/// Registers [`shutdown`] as an env cleanup hook once per N-API environment.
+/// Joins the pool when the calling N-API environment tears down.
+///
+/// Registered per `Renderer`, not deduplicated: [`shutdown`] is idempotent, and
+/// registering on every environment that builds a pool is what keeps a pool
+/// rebuilt by one environment from outliving another's teardown.
 pub(crate) fn register_cleanup(env: &Env) {
-  CLEANUP_REGISTERED.with(|registered| {
-    if !registered.replace(true) {
-      let _ = env.add_env_cleanup_hook((), |_| shutdown());
-    }
-  });
+  let _ = env.add_env_cleanup_hook((), |_| shutdown());
 }

--- a/takumi-napi-core/src/pool.rs
+++ b/takumi-napi-core/src/pool.rs
@@ -1,0 +1,101 @@
+//! An owned rayon thread pool that is joined on N-API teardown.
+//!
+//! rayon's global pool spawns detached daemon workers and never joins them. On
+//! Windows, `ExitProcess` force-terminates them mid-flight during process exit,
+//! faulting with `0xC0000005` (#763). This pool keeps its workers'
+//! [`JoinHandle`]s and joins them from an env cleanup hook, so none are alive
+//! when the process exits. All parallel work runs through [`install`].
+
+use std::cell::Cell;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::{Builder, JoinHandle};
+
+use napi::Env;
+use rayon::{ThreadPool, ThreadPoolBuilder};
+
+struct Shared {
+  pool: Option<Arc<ThreadPool>>,
+  handles: Vec<JoinHandle<()>>,
+}
+
+static SHARED: OnceLock<Mutex<Shared>> = OnceLock::new();
+
+/// Builds an owned pool whose worker `JoinHandle`s are retained for joining.
+fn build() -> Shared {
+  let handles = Mutex::new(Vec::new());
+
+  let pool = ThreadPoolBuilder::new()
+    .spawn_handler(|thread| {
+      let mut builder = Builder::new();
+      if let Some(name) = thread.name() {
+        builder = builder.name(name.to_owned());
+      }
+      if let Some(size) = thread.stack_size() {
+        builder = builder.stack_size(size);
+      }
+      let handle = builder.spawn(|| thread.run())?;
+      if let Ok(mut handles) = handles.lock() {
+        handles.push(handle);
+      }
+      Ok(())
+    })
+    .build()
+    .ok()
+    .map(Arc::new);
+
+  Shared {
+    pool,
+    handles: handles.into_inner().unwrap_or_default(),
+  }
+}
+
+/// Returns a clone of the current pool, rebuilding it if a previous N-API
+/// environment shut it down on its own teardown.
+fn pool() -> Option<Arc<ThreadPool>> {
+  let cell = SHARED.get_or_init(|| Mutex::new(build()));
+  let mut shared = cell.lock().ok()?;
+  if shared.pool.is_none() {
+    *shared = build();
+  }
+  shared.pool.clone()
+}
+
+/// Runs `op` with all nested rayon work dispatched to the owned pool.
+pub(crate) fn install<OP, R>(op: OP) -> R
+where
+  OP: FnOnce() -> R + Send,
+  R: Send,
+{
+  match pool() {
+    Some(pool) => pool.install(op),
+    None => op(),
+  }
+}
+
+/// Joins the pool's workers so none outlive the N-API environment.
+fn shutdown() {
+  let Some(cell) = SHARED.get() else { return };
+  let handles = {
+    let Ok(mut shared) = cell.lock() else { return };
+    // Drop our pool reference so `terminate()` signals the workers; with no
+    // work in flight at teardown this is the last reference.
+    shared.pool.take();
+    std::mem::take(&mut shared.handles)
+  };
+  for handle in handles {
+    let _ = handle.join();
+  }
+}
+
+thread_local! {
+  static CLEANUP_REGISTERED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Registers [`shutdown`] as an env cleanup hook once per N-API environment.
+pub(crate) fn register_cleanup(env: &Env) {
+  CLEANUP_REGISTERED.with(|registered| {
+    if !registered.replace(true) {
+      let _ = env.add_env_cleanup_hook((), |_| shutdown());
+    }
+  });
+}

--- a/takumi-napi-core/src/render_animation_task.rs
+++ b/takumi-napi-core/src/render_animation_task.rs
@@ -99,79 +99,81 @@ impl Task for RenderAnimationTask {
   type JsValue = Buffer;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    let Some(scenes) = self.scenes.take() else {
-      unreachable!()
-    };
-    let initialized_images = self
-      .fetched_resources
-      .iter()
-      .map(|(key, value)| {
-        Ok((
-          key.clone(),
-          LoadedImageSource::from_bytes(value).map_err(map_error)?,
-        ))
-      })
-      .collect::<Result<HashMap<_, _>, _>>()?;
-    let state = self
-      .state
-      .read()
-      .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
-    let stylesheet = parse_stylesheet(take(&mut self.stylesheets), Vec::new())?;
-    let scene_options = scenes
-      .into_iter()
-      .map(|(node, duration_ms)| {
-        SequentialScene::builder()
-          .duration_ms(duration_ms)
-          .options(
-            RenderOptions::builder()
-              .viewport(self.viewport)
-              .fetched_resources(initialized_images.clone())
-              .stylesheet(stylesheet.clone())
-              .node(node)
-              .global(&state.global)
-              .draw_debug_border(self.draw_debug_border)
-              .build(),
-          )
-          .build()
-      })
-      .collect::<Vec<_>>();
-    let frames = render_sequence_animation(&scene_options, self.fps).map_err(map_error)?;
+    crate::pool::install(move || {
+      let Some(scenes) = self.scenes.take() else {
+        unreachable!()
+      };
+      let initialized_images = self
+        .fetched_resources
+        .iter()
+        .map(|(key, value)| {
+          Ok((
+            key.clone(),
+            LoadedImageSource::from_bytes(value).map_err(map_error)?,
+          ))
+        })
+        .collect::<Result<HashMap<_, _>, _>>()?;
+      let state = self
+        .state
+        .read()
+        .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
+      let stylesheet = parse_stylesheet(take(&mut self.stylesheets), Vec::new())?;
+      let scene_options = scenes
+        .into_iter()
+        .map(|(node, duration_ms)| {
+          SequentialScene::builder()
+            .duration_ms(duration_ms)
+            .options(
+              RenderOptions::builder()
+                .viewport(self.viewport)
+                .fetched_resources(initialized_images.clone())
+                .stylesheet(stylesheet.clone())
+                .node(node)
+                .global(&state.global)
+                .draw_debug_border(self.draw_debug_border)
+                .build(),
+            )
+            .build()
+        })
+        .collect::<Vec<_>>();
+      let frames = render_sequence_animation(&scene_options, self.fps).map_err(map_error)?;
 
-    if let Some(quality) = self.quality
-      && quality > 100
-    {
-      return Err(Error::from_reason(format!(
-        "Invalid WebP quality {quality}; expected a value in 0..=100"
-      )));
-    }
+      if let Some(quality) = self.quality
+        && quality > 100
+      {
+        return Err(Error::from_reason(format!(
+          "Invalid WebP quality {quality}; expected a value in 0..=100"
+        )));
+      }
 
-    let mut buffer = Vec::new();
+      let mut buffer = Vec::new();
 
-    match self.format {
-      AnimationOutputFormat::WebP => {
-        let mut options = AnimatedWebpOptions::default();
-        if let Some(quality) = self.quality {
-          options.quality = quality;
+      match self.format {
+        AnimationOutputFormat::WebP => {
+          let mut options = AnimatedWebpOptions::default();
+          if let Some(quality) = self.quality {
+            options.quality = quality;
+          }
+
+          encode_animated_webp(Cow::Owned(frames), &mut buffer, options)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
         }
-
-        encode_animated_webp(Cow::Owned(frames), &mut buffer, options)
+        AnimationOutputFormat::Apng => {
+          encode_animated_png(&frames, &mut buffer, AnimatedPngOptions::default())
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        }
+        AnimationOutputFormat::Gif => {
+          encode_animated_gif(
+            Cow::Owned(frames),
+            &mut buffer,
+            AnimatedGifOptions::default(),
+          )
           .map_err(|e| Error::from_reason(e.to_string()))?;
+        }
       }
-      AnimationOutputFormat::Apng => {
-        encode_animated_png(&frames, &mut buffer, AnimatedPngOptions::default())
-          .map_err(|e| Error::from_reason(e.to_string()))?;
-      }
-      AnimationOutputFormat::Gif => {
-        encode_animated_gif(
-          Cow::Owned(frames),
-          &mut buffer,
-          AnimatedGifOptions::default(),
-        )
-        .map_err(|e| Error::from_reason(e.to_string()))?;
-      }
-    }
 
-    Ok(buffer)
+      Ok(buffer)
+    })
   }
 
   fn resolve(&mut self, mut env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/takumi-napi-core/src/renderer.rs
+++ b/takumi-napi-core/src/renderer.rs
@@ -296,6 +296,8 @@ impl Renderer {
   /// Creates a new Renderer instance.
   #[napi(constructor)]
   pub fn new(env: Env, options: Option<ConstructRendererOptions>) -> Result<Self> {
+    crate::pool::register_cleanup(&env);
+
     let options = options.unwrap_or_default();
 
     let load_default_fonts = options
@@ -305,19 +307,21 @@ impl Renderer {
     let mut global = GlobalContext::default();
 
     if load_default_fonts {
-      let default_fonts_resources = EMBEDDED_FONTS
-        .par_iter()
-        .map(|(font, name, generic)| {
-          FontResource::new(*font)
-            .override_info(FontInfoOverride {
-              family_name: Some(*name),
-              ..Default::default()
-            })
-            .generic_family(*generic)
-            .into_resolved()
-            .map_err(|e| Error::from_reason(format!("Failed to load default font: {e}")))
-        })
-        .collect::<Result<Vec<_>>>()?;
+      let default_fonts_resources = crate::pool::install(|| {
+        EMBEDDED_FONTS
+          .par_iter()
+          .map(|(font, name, generic)| {
+            FontResource::new(*font)
+              .override_info(FontInfoOverride {
+                family_name: Some(*name),
+                ..Default::default()
+              })
+              .generic_family(*generic)
+              .into_resolved()
+              .map_err(|e| Error::from_reason(format!("Failed to load default font: {e}")))
+          })
+          .collect::<Result<Vec<_>>>()
+      })?;
 
       for resource in default_fonts_resources {
         global
@@ -337,11 +341,13 @@ impl Renderer {
         .map(|font| parse_font_input(env, font))
         .collect::<Result<Vec<_>>>()?;
 
-      let custom_fonts_resources = buffers
-        .par_iter()
-        .with_min_len(2)
-        .map(|(font, buffer): &(FontInput, Buffer)| resolve_font_resource(font, buffer.as_ref()))
-        .collect::<Result<Vec<_>>>()?;
+      let custom_fonts_resources = crate::pool::install(|| {
+        buffers
+          .par_iter()
+          .with_min_len(2)
+          .map(|(font, buffer): &(FontInput, Buffer)| resolve_font_resource(font, buffer.as_ref()))
+          .collect::<Result<Vec<_>>>()
+      })?;
 
       let mut state = renderer
         .state


### PR DESCRIPTION
## Problem

`@takumi-rs/core` crashes node at process exit on Windows with `0xC0000005` (ACCESS_VIOLATION). Users hit it at the end of `nuxt generate`: every route renders, every OG image is byte-for-byte correct, "Generated public" prints, then node dies at teardown with a non-zero code. That breaks npm `post*` hooks and fails the build in CI. Reported in #763.

## Root cause

rayon's global pool spawns detached daemon workers and never joins them: its default spawn handler drops the `JoinHandle`, and `terminate()` only signals. On Windows, `ExitProcess` force-terminates those threads mid-flight during teardown, which faults. In the OG-image path the only rayon use is font loading in `Renderer::new`.

The 1.8.0 bisect in #763 points at the `panic=immediate-abort` build flags, but those only shift timing. The stable build crashes too once enough rayon threads are alive. Thread count is the trigger: a 4-core runner at the default count does not reproduce it, the reporter's many-core machine does, and `RAYON_NUM_THREADS=128` makes it deterministic.

## Fix

`takumi-napi-core/src/pool.rs` owns a rayon `ThreadPool`, keeps its workers' `JoinHandle`s, routes all parallel work through `pool::install`, and joins the workers from an N-API env cleanup hook so none outlive the environment. The rayon sites (font loading, `load_font`, the two animation encoders) now run inside the owned pool. `render` and `measure` use no rayon and are untouched.

## Validation

Built the addon two ways and ran the reporter's exact `nuxt generate` repro on one Windows runner, interleaved at `RAYON_NUM_THREADS=128`:

| build | teardown crashes |
|---|---|
| master (unpatched) | 6 / 12 |
| this PR | 0 / 12 |

Same runner, same load. Earlier runs also crashed the default-flag stable build, confirming the build flags are not the cause.

## Notes

- The `encode_frames_task.rs` and `render_animation_task.rs` diffs are mostly reindentation from wrapping `compute` in `pool::install`; review with whitespace ignored.
- This likely also fixes the Windows `bun test` hang at exit, which has the same cause (rayon workers alive at exit; node force-kills them and crashes, bun joins them and hangs).

Closes #763.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical Windows crash (0xC0000005) occurring when Node exits after rendering.
  * Reduced intermittent rendering failures on shutdown.

* **Chores**
  * Improved thread management and cleanup during shutdown.
  * Rendering and font-loading now run via a managed worker pool for more reliable resource handling and stable shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->