### PR TITLE
ci: work around bun exit hang in wasm tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,8 +629,34 @@ jobs:
         run: bun install --frozen-lockfile --filter ./takumi-wasm
 
       - name: Test WASM
+        if: runner.os != 'Windows'
         working-directory: takumi-wasm
         run: bun test
+
+      # bun does not exit after the wasm tests finish on Windows (x64): the
+      # process hangs at teardown. Run the tests, then kill the stuck process
+      # and read pass/fail from bun's printed summary.
+      - name: Test WASM (Windows)
+        if: runner.os == 'Windows'
+        working-directory: takumi-wasm
+        shell: pwsh
+        run: |
+          $p = Start-Process bun -ArgumentList 'test' -PassThru -NoNewWindow `
+            -WorkingDirectory (Get-Location).Path `
+            -RedirectStandardOutput out.log -RedirectStandardError err.log
+          $exited = $p.WaitForExit(120000)
+          $log = (Get-Content out.log, err.log -Raw -ErrorAction SilentlyContinue) -join "`n"
+          Write-Host $log
+          if ($exited) { exit $p.ExitCode }
+          $log = $log -replace "`e\[[0-9;]*m", ""
+          # Tests completed but the process never exits; force-terminate and
+          # derive the result from bun's summary so failures are not masked.
+          $p.Kill($true)
+          if ($log -notmatch 'Ran \d+ test') { Write-Error 'wasm tests did not complete'; exit 1 }
+          if ($log -match '(?m)^\s*(\d+)\s+fail' -and [int]$Matches[1] -gt 0) {
+            Write-Error 'wasm tests failed'; exit 1
+          }
+          Write-Host 'wasm tests passed (process force-terminated after bun exit hang)'
 
   preview-packages:
     name: Publish PR preview packages


### PR DESCRIPTION
## Problem

`Test @takumi-rs/wasm for x86_64-pc-windows-msvc` hangs forever. The tests all pass (arm64 Windows and every other platform run the same portable wasm and go green), but bun does not exit after the run completes on Windows x64 — the process hangs at teardown, so the job never finishes. This is a bun runtime bug, not a takumi one; wasm has no threads.

## Fix

Keep `bun test` as-is on non-Windows. On Windows, run the tests as a child process and, if it does not exit within 120s, force-terminate it and read the result from bun's printed summary:

- bun exits on its own (e.g. arm64 Windows) → use its real exit code.
- bun hangs (x64 Windows) → kill the tree, then fail unless the run completed (`Ran N tests`) with zero failures.

Failures are not masked: a missing completion marker or a non-zero `fail` count exits 1.

## Note

Separate from #765 (which fixes the `@takumi-rs/core` teardown crash — a real rayon bug). This one is purely the bun test-runner exit hang.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test suite reliability on Windows environments by improving test execution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->