### PR TITLE
Crate: fix Tailwind border rendering from `tw` (per-side color + width style)

### DIFF
--- a/.changeset/border-width-implies-solid.md
+++ b/.changeset/border-width-implies-solid.md
@@ -1,0 +1,5 @@
+---
+"takumi-css": patch
+---
+
+Fix Tailwind per-side border colors and border-width rendering

--- a/.changeset/border-width-implies-solid.md
+++ b/.changeset/border-width-implies-solid.md
@@ -1,5 +1,6 @@
 ---
 "takumi-css": patch
+"takumi": patch
 ---
 
 Fix Tailwind per-side border colors and border-width rendering

--- a/takumi-css/src/style/tw/builder.rs
+++ b/takumi-css/src/style/tw/builder.rs
@@ -204,6 +204,45 @@ impl TailwindDeclarationBuilder {
       StyleDeclaration::grid_row_end,
     );
 
+    type BorderSide = (LonghandId, LonghandId, fn(BorderStyle) -> StyleDeclaration);
+    let sides: [BorderSide; 4] = [
+      (
+        LonghandId::BorderTopWidth,
+        LonghandId::BorderTopStyle,
+        StyleDeclaration::border_top_style,
+      ),
+      (
+        LonghandId::BorderRightWidth,
+        LonghandId::BorderRightStyle,
+        StyleDeclaration::border_right_style,
+      ),
+      (
+        LonghandId::BorderBottomWidth,
+        LonghandId::BorderBottomStyle,
+        StyleDeclaration::border_bottom_style,
+      ),
+      (
+        LonghandId::BorderLeftWidth,
+        LonghandId::BorderLeftStyle,
+        StyleDeclaration::border_left_style,
+      ),
+    ];
+    for (width_id, style_id, style_decl) in sides {
+      let has_width = self
+        .declarations
+        .iter()
+        .any(|d| d.longhand_id() == width_id);
+      let has_style = self
+        .declarations
+        .iter()
+        .any(|d| d.longhand_id() == style_id);
+      if has_width && !has_style {
+        self
+          .declarations
+          .push(style_decl(BorderStyle::Solid), false);
+      }
+    }
+
     self.declarations
   }
 }

--- a/takumi-css/src/style/tw/map.rs
+++ b/takumi-css/src/style/tw/map.rs
@@ -135,12 +135,30 @@ pub static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
     PropertyParser::BorderStyle(TailwindProperty::BorderStyle),
     PropertyParser::BorderWidth(TailwindProperty::BorderWidth),
   ],
-  "border-t" => &[PropertyParser::BorderWidth(TailwindProperty::BorderTopWidth)],
-  "border-r" => &[PropertyParser::BorderWidth(TailwindProperty::BorderRightWidth)],
-  "border-b" => &[PropertyParser::BorderWidth(TailwindProperty::BorderBottomWidth)],
-  "border-l" => &[PropertyParser::BorderWidth(TailwindProperty::BorderLeftWidth)],
-  "border-x" => &[PropertyParser::BorderWidth(TailwindProperty::BorderXWidth)],
-  "border-y" => &[PropertyParser::BorderWidth(TailwindProperty::BorderYWidth)],
+  "border-t" => &[
+    PropertyParser::ColorCurrent(TailwindProperty::BorderTopColor),
+    PropertyParser::BorderWidth(TailwindProperty::BorderTopWidth),
+  ],
+  "border-r" => &[
+    PropertyParser::ColorCurrent(TailwindProperty::BorderRightColor),
+    PropertyParser::BorderWidth(TailwindProperty::BorderRightWidth),
+  ],
+  "border-b" => &[
+    PropertyParser::ColorCurrent(TailwindProperty::BorderBottomColor),
+    PropertyParser::BorderWidth(TailwindProperty::BorderBottomWidth),
+  ],
+  "border-l" => &[
+    PropertyParser::ColorCurrent(TailwindProperty::BorderLeftColor),
+    PropertyParser::BorderWidth(TailwindProperty::BorderLeftWidth),
+  ],
+  "border-x" => &[
+    PropertyParser::ColorCurrent(TailwindProperty::BorderXColor),
+    PropertyParser::BorderWidth(TailwindProperty::BorderXWidth),
+  ],
+  "border-y" => &[
+    PropertyParser::ColorCurrent(TailwindProperty::BorderYColor),
+    PropertyParser::BorderWidth(TailwindProperty::BorderYWidth),
+  ],
   "outline" => &[
     PropertyParser::ColorCurrent(TailwindProperty::OutlineColor),
     PropertyParser::BorderStyle(TailwindProperty::OutlineStyle),

--- a/takumi-css/src/style/tw/mod.rs
+++ b/takumi-css/src/style/tw/mod.rs
@@ -392,6 +392,18 @@ pub enum TailwindProperty {
   BorderXWidth(TwBorderWidth),
   /// `border-block-width` property.
   BorderYWidth(TwBorderWidth),
+  /// `border-top-color` property.
+  BorderTopColor(ColorInput),
+  /// `border-right-color` property.
+  BorderRightColor(ColorInput),
+  /// `border-bottom-color` property.
+  BorderBottomColor(ColorInput),
+  /// `border-left-color` property.
+  BorderLeftColor(ColorInput),
+  /// `border-inline-color` property.
+  BorderXColor(ColorInput),
+  /// `border-block-color` property.
+  BorderYColor(ColorInput),
   /// Tailwind `outline` utility (`outline-width: 1px; outline-style: solid`).
   OutlineDefault,
   /// `outline-width` property.
@@ -936,11 +948,7 @@ impl TailwindProperty {
           border_top_width(Length::Px(1.0)),
           border_right_width(Length::Px(1.0)),
           border_bottom_width(Length::Px(1.0)),
-          border_left_width(Length::Px(1.0)),
-          border_top_style(BorderStyle::Solid),
-          border_right_style(BorderStyle::Solid),
-          border_bottom_style(BorderStyle::Solid),
-          border_left_style(BorderStyle::Solid)
+          border_left_width(Length::Px(1.0))
         );
       }
       TailwindProperty::BorderWidth(tw_border_width) => {
@@ -1012,6 +1020,34 @@ impl TailwindProperty {
           important,
           border_top_width(tw_border_width.0),
           border_bottom_width(tw_border_width.0)
+        );
+      }
+      TailwindProperty::BorderTopColor(color_input) => {
+        push_decl!(builder, important, border_top_color(color_input))
+      }
+      TailwindProperty::BorderRightColor(color_input) => {
+        push_decl!(builder, important, border_right_color(color_input))
+      }
+      TailwindProperty::BorderBottomColor(color_input) => {
+        push_decl!(builder, important, border_bottom_color(color_input))
+      }
+      TailwindProperty::BorderLeftColor(color_input) => {
+        push_decl!(builder, important, border_left_color(color_input))
+      }
+      TailwindProperty::BorderXColor(color_input) => {
+        push_decl!(
+          builder,
+          important,
+          border_left_color(color_input),
+          border_right_color(color_input)
+        );
+      }
+      TailwindProperty::BorderYColor(color_input) => {
+        push_decl!(
+          builder,
+          important,
+          border_top_color(color_input),
+          border_bottom_color(color_input)
         );
       }
       TailwindProperty::OutlineDefault => {

--- a/takumi-css/src/style/tw/tests.rs
+++ b/takumi-css/src/style/tw/tests.rs
@@ -1021,3 +1021,45 @@ fn test_gradient_stop_position_is_used_in_apply() {
     vec![Length::Percentage(10.0), Length::Percentage(80.0)]
   );
 }
+
+#[test]
+fn test_border_width_implies_solid_and_per_side_color() {
+  let viewport = Viewport::new((100, 100));
+  let computed = |tw: &str| {
+    Style::from(
+      TailwindValues::from_str(tw)
+        .expect("tailwind values should parse")
+        .into_declaration_block(viewport),
+    )
+    .inherit(&ComputedStyle::default())
+  };
+
+  let top = computed("border-t-8");
+  assert_eq!(top.border_top_width, Length::Px(8.0));
+  assert_eq!(top.border_top_style, BorderStyle::Solid);
+  assert_eq!(top.border_bottom_style, BorderStyle::None);
+
+  let all = computed("border-4");
+  assert_eq!(all.border_top_style, BorderStyle::Solid);
+  assert_eq!(all.border_right_style, BorderStyle::Solid);
+  assert_eq!(all.border_bottom_style, BorderStyle::Solid);
+  assert_eq!(all.border_left_style, BorderStyle::Solid);
+
+  let dashed = computed("border-2 border-dashed");
+  assert_eq!(dashed.border_top_style, BorderStyle::Dashed);
+
+  assert_eq!(
+    TailwindProperty::parse("border-t-blue-500"),
+    Some(TailwindProperty::BorderTopColor(ColorInput::Value(Color(
+      [43, 127, 255, 255]
+    ))))
+  );
+
+  let bar = computed("border-t-8 border-t-blue-500");
+  assert_eq!(bar.border_top_width, Length::Px(8.0));
+  assert_eq!(bar.border_top_style, BorderStyle::Solid);
+  assert_eq!(
+    bar.border_top_color,
+    ColorInput::Value(Color([43, 127, 255, 255]))
+  );
+}


### PR DESCRIPTION
## Bugs
Tailwind borders set via `tw` didn't render (surfaced by the playground Takumi-vs-Browser view: `border-t-8 border-t-blue-500` bar + `border-4 border-slate-700` ring). Two causes:

1. **Per-side border color not parsed.** `map.rs` gave `border-t/r/b/l/x/y` only a `BorderWidth` parser, so `border-t-blue-500` failed to parse and was dropped.
2. **Width utilities set no style.** Tailwind's preflight sets `border: 0 solid` on every element; Takumi has none, so `border-2`/`border-t-8` left `border-style` at the default `none`, and the renderer paints a side only when `is_side_visible = style.is_rendered() && width > 0`.

## Fix
- Add per-side border color: `BorderTopColor`/`Right`/`Bottom`/`Left`/`X`/`Y` variants, apply arms, `ColorCurrent` parsers (color tried before width).
- Width utilities stay width-only; the builder's `finish()` fills `border-style: solid` for any side given a width but no explicit style (preflight emulation in one place, so `border-dashed border-2` stays dashed regardless of order).

## Tests
`test_border_width_implies_solid_and_per_side_color`: `border-t-8` → solid+8px; `border-4` → all solid; `border-2 border-dashed` → dashed; `border-t-blue-500` → `BorderTopColor(blue)`; `border-t-8 border-t-blue-500` → 8px solid blue top. `takumi-css` suite (472) green, clippy clean; no golden fixtures use these utilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed border width and color rendering in Tailwind utilities to correctly handle per-side configurations.

* **New Features**
  * Added support for setting border colors on individual sides (top, right, bottom, left) and on directional axes (x, y).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->