### PR TITLE
Crate: support `safe`/`unsafe` box-alignment keywords (taffy 0.11)

### DIFF
--- a/.changeset/safe-alignment-keywords.md
+++ b/.changeset/safe-alignment-keywords.md
@@ -1,0 +1,6 @@
+---
+"takumi-css": patch
+"takumi": patch
+---
+
+Support `safe`/`unsafe` overflow keywords on `align-items` and `justify-content` (taffy 0.11)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -260,9 +260,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1308,9 +1308,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
+checksum = "ad513ff22558f1830b595ea6eb4091da48145d09a222ce157e781896f78be0b9"
 dependencies = [
  "bitflags",
  "ctor",
@@ -1419,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+checksum = "1f5bcdf71abd3a50d00b49c1c2c75251cb3c913777d6139cd37dabc093a5e400"
 dependencies = [
  "libloading",
 ]
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
+checksum = "dfde4e2f8595f222ceaae1fb16b4963952e9b33e358869dc4cd6316b0e0790cd"
 dependencies = [
  "arrayvec",
  "grid",
@@ -2545,18 +2545,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2577,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2590,18 +2590,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ version = "1.15"
 features = ["serde"]
 
 [workspace.dependencies.taffy]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = [
   "flexbox",

--- a/takumi-css/src/style/properties/mod.rs
+++ b/takumi-css/src/style/properties/mod.rs
@@ -106,7 +106,9 @@ pub use text_shadow::*;
 pub use text_stroke::*;
 pub use text_wrap::*;
 pub use traits::*;
-pub(crate) use traits::{declare_enum_from_css_impl, impl_from_taffy_enum};
+pub(crate) use traits::{
+  declare_box_alignment_enum_impl, declare_enum_from_css_impl, impl_from_taffy_enum,
+};
 pub use transform::*;
 pub use vertical_align::*;
 pub use white_space::*;
@@ -718,20 +720,34 @@ pub enum JustifyContent {
   /// last item on the end line, and the space between items is twice the space
   /// between the start/end items and the container edges.
   SpaceAround,
+  /// `safe start`: like `Start`, falling back to start-edge alignment on overflow.
+  SafeStart,
+  /// `safe end`: like `End`, falling back to start-edge alignment on overflow.
+  SafeEnd,
+  /// `safe flex-start`: like `FlexStart`, falling back to start-edge alignment on overflow.
+  SafeFlexStart,
+  /// `safe flex-end`: like `FlexEnd`, falling back to start-edge alignment on overflow.
+  SafeFlexEnd,
+  /// `safe center`: like `Center`, falling back to start-edge alignment on overflow.
+  SafeCenter,
 }
 
-declare_enum_from_css_impl!(
+declare_box_alignment_enum_impl!(
   JustifyContent,
-  "normal" => JustifyContent::Normal,
-  "start" => JustifyContent::Start,
-  "end" => JustifyContent::End,
-  "flex-start" => JustifyContent::FlexStart,
-  "flex-end" => JustifyContent::FlexEnd,
-  "center" => JustifyContent::Center,
-  "stretch" => JustifyContent::Stretch,
-  "space-between" => JustifyContent::SpaceBetween,
-  "space-around" => JustifyContent::SpaceAround,
-  "space-evenly" => JustifyContent::SpaceEvenly
+  safe {
+    "start" => Start / SafeStart,
+    "end" => End / SafeEnd,
+    "flex-start" => FlexStart / SafeFlexStart,
+    "flex-end" => FlexEnd / SafeFlexEnd,
+    "center" => Center / SafeCenter,
+  },
+  plain {
+    "normal" => Normal,
+    "stretch" => Stretch,
+    "space-between" => SpaceBetween,
+    "space-around" => SpaceAround,
+    "space-evenly" => SpaceEvenly,
+  }
 );
 
 impl TailwindPropertyParser for JustifyContent {
@@ -749,15 +765,20 @@ impl From<JustifyContent> for Option<taffy::JustifyContent> {
   fn from(value: JustifyContent) -> Self {
     match value {
       JustifyContent::Normal => None,
-      JustifyContent::Start => Some(taffy::JustifyContent::Start),
-      JustifyContent::End => Some(taffy::JustifyContent::End),
-      JustifyContent::FlexStart => Some(taffy::JustifyContent::FlexStart),
-      JustifyContent::FlexEnd => Some(taffy::JustifyContent::FlexEnd),
-      JustifyContent::Center => Some(taffy::JustifyContent::Center),
-      JustifyContent::Stretch => Some(taffy::JustifyContent::Stretch),
-      JustifyContent::SpaceBetween => Some(taffy::JustifyContent::SpaceBetween),
-      JustifyContent::SpaceAround => Some(taffy::JustifyContent::SpaceAround),
-      JustifyContent::SpaceEvenly => Some(taffy::JustifyContent::SpaceEvenly),
+      JustifyContent::Start => Some(taffy::JustifyContent::START),
+      JustifyContent::End => Some(taffy::JustifyContent::END),
+      JustifyContent::FlexStart => Some(taffy::JustifyContent::FLEX_START),
+      JustifyContent::FlexEnd => Some(taffy::JustifyContent::FLEX_END),
+      JustifyContent::Center => Some(taffy::JustifyContent::CENTER),
+      JustifyContent::Stretch => Some(taffy::JustifyContent::STRETCH),
+      JustifyContent::SpaceBetween => Some(taffy::JustifyContent::SPACE_BETWEEN),
+      JustifyContent::SpaceAround => Some(taffy::JustifyContent::SPACE_AROUND),
+      JustifyContent::SpaceEvenly => Some(taffy::JustifyContent::SPACE_EVENLY),
+      JustifyContent::SafeStart => Some(taffy::JustifyContent::SAFE_START),
+      JustifyContent::SafeEnd => Some(taffy::JustifyContent::SAFE_END),
+      JustifyContent::SafeFlexStart => Some(taffy::JustifyContent::SAFE_FLEX_START),
+      JustifyContent::SafeFlexEnd => Some(taffy::JustifyContent::SAFE_FLEX_END),
+      JustifyContent::SafeCenter => Some(taffy::JustifyContent::SAFE_CENTER),
     }
   }
 }
@@ -871,18 +892,32 @@ pub enum AlignItems {
   Baseline,
   /// Items are stretched to fill the container in the cross axis
   Stretch,
+  /// `safe start`: like `Start`, falling back to start-edge alignment on overflow.
+  SafeStart,
+  /// `safe end`: like `End`, falling back to start-edge alignment on overflow.
+  SafeEnd,
+  /// `safe flex-start`: like `FlexStart`, falling back to start-edge alignment on overflow.
+  SafeFlexStart,
+  /// `safe flex-end`: like `FlexEnd`, falling back to start-edge alignment on overflow.
+  SafeFlexEnd,
+  /// `safe center`: like `Center`, falling back to start-edge alignment on overflow.
+  SafeCenter,
 }
 
-declare_enum_from_css_impl!(
+declare_box_alignment_enum_impl!(
   AlignItems,
-  "normal" => AlignItems::Normal,
-  "start" => AlignItems::Start,
-  "end" => AlignItems::End,
-  "flex-start" => AlignItems::FlexStart,
-  "flex-end" => AlignItems::FlexEnd,
-  "center" => AlignItems::Center,
-  "baseline" => AlignItems::Baseline,
-  "stretch" => AlignItems::Stretch
+  safe {
+    "start" => Start / SafeStart,
+    "end" => End / SafeEnd,
+    "flex-start" => FlexStart / SafeFlexStart,
+    "flex-end" => FlexEnd / SafeFlexEnd,
+    "center" => Center / SafeCenter,
+  },
+  plain {
+    "normal" => Normal,
+    "baseline" => Baseline,
+    "stretch" => Stretch,
+  }
 );
 
 impl TailwindPropertyParser for AlignItems {
@@ -895,13 +930,18 @@ impl From<AlignItems> for Option<taffy::AlignItems> {
   fn from(value: AlignItems) -> Self {
     match value {
       AlignItems::Normal => None,
-      AlignItems::Start => Some(taffy::AlignItems::Start),
-      AlignItems::End => Some(taffy::AlignItems::End),
-      AlignItems::FlexStart => Some(taffy::AlignItems::FlexStart),
-      AlignItems::FlexEnd => Some(taffy::AlignItems::FlexEnd),
-      AlignItems::Center => Some(taffy::AlignItems::Center),
-      AlignItems::Baseline => Some(taffy::AlignItems::Baseline),
-      AlignItems::Stretch => Some(taffy::AlignItems::Stretch),
+      AlignItems::Start => Some(taffy::AlignItems::START),
+      AlignItems::End => Some(taffy::AlignItems::END),
+      AlignItems::FlexStart => Some(taffy::AlignItems::FLEX_START),
+      AlignItems::FlexEnd => Some(taffy::AlignItems::FLEX_END),
+      AlignItems::Center => Some(taffy::AlignItems::CENTER),
+      AlignItems::Baseline => Some(taffy::AlignItems::BASELINE),
+      AlignItems::Stretch => Some(taffy::AlignItems::STRETCH),
+      AlignItems::SafeStart => Some(taffy::AlignItems::SAFE_START),
+      AlignItems::SafeEnd => Some(taffy::AlignItems::SAFE_END),
+      AlignItems::SafeFlexStart => Some(taffy::AlignItems::SAFE_FLEX_START),
+      AlignItems::SafeFlexEnd => Some(taffy::AlignItems::SAFE_FLEX_END),
+      AlignItems::SafeCenter => Some(taffy::AlignItems::SAFE_CENTER),
     }
   }
 }

--- a/takumi-css/src/style/properties/traits.rs
+++ b/takumi-css/src/style/properties/traits.rs
@@ -697,3 +697,64 @@ macro_rules! declare_enum_from_css_impl {
 }
 
 pub(crate) use declare_enum_from_css_impl;
+
+/// Declares a box-alignment enum parser that accepts the optional `safe`/`unsafe`
+/// overflow-position prefix on its positional keywords.
+macro_rules! declare_box_alignment_enum_impl {
+  (
+    $enum_type:ty,
+    safe { $($safe_css:literal => $base_variant:ident / $safe_variant:ident),+ $(,)? },
+    plain { $($plain_css:literal => $plain_variant:ident),* $(,)? }
+  ) => {
+    impl crate::style::MakeComputed for $enum_type {}
+
+    impl<'i> crate::style::FromCss<'i> for $enum_type {
+      const VALID_TOKENS: &'static [crate::style::CssToken] = &[
+        $(crate::style::CssToken::Keyword($plain_css),)*
+        $(crate::style::CssToken::Keyword($safe_css),)*
+        crate::style::CssToken::Keyword("safe"),
+        crate::style::CssToken::Keyword("unsafe"),
+      ];
+
+      fn from_css(input: &mut cssparser::Parser<'i, '_>) -> crate::style::ParseResult<'i, Self> {
+        let mut safe = false;
+
+        loop {
+          let location = input.current_source_location();
+          let token = input.next()?;
+
+          let cssparser::Token::Ident(ident) = token else {
+            return Err($crate::style::unexpected_token!(location, token));
+          };
+
+          cssparser::match_ignore_ascii_case! {&ident,
+            "safe" => safe = true,
+            "unsafe" => safe = false,
+            $($safe_css => return Ok(if safe { Self::$safe_variant } else { Self::$base_variant }),)*
+            $($plain_css => return if safe {
+              Err($crate::style::unexpected_token!(location, token))
+            } else {
+              Ok(Self::$plain_variant)
+            },)*
+            _ => return Err($crate::style::unexpected_token!(location, token)),
+          }
+        }
+      }
+    }
+
+    impl crate::style::properties::ToCss for $enum_type {
+      fn to_css<W: std::fmt::Write>(&self, dest: &mut W) -> std::fmt::Result {
+        match self {
+          $(Self::$plain_variant => dest.write_str($plain_css),)*
+          $(Self::$base_variant => dest.write_str($safe_css),)*
+          $(Self::$safe_variant => {
+            dest.write_str("safe ")?;
+            dest.write_str($safe_css)
+          })*
+        }
+      }
+    }
+  };
+}
+
+pub(crate) use declare_box_alignment_enum_impl;

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -362,6 +362,53 @@ fn parse_style_declaration_expands_place_self() {
 }
 
 #[test]
+fn parse_align_items_safe_keywords() {
+  assert_eq!(
+    parse_declarations("align-items", "safe center")
+      .iter()
+      .collect::<Vec<_>>(),
+    vec![&StyleDeclaration::align_items(AlignItems::SafeCenter)]
+  );
+  assert_eq!(
+    parse_declarations("align-items", "unsafe flex-end")
+      .iter()
+      .collect::<Vec<_>>(),
+    vec![&StyleDeclaration::align_items(AlignItems::FlexEnd)]
+  );
+  assert!(parse_declarations_is_err("align-items", "safe stretch"));
+  assert!(parse_declarations_is_err("align-items", "safe"));
+}
+
+#[test]
+fn parse_justify_content_safe_keywords() {
+  assert_eq!(
+    parse_declarations("justify-content", "safe flex-start")
+      .iter()
+      .collect::<Vec<_>>(),
+    vec![&StyleDeclaration::justify_content(
+      JustifyContent::SafeFlexStart
+    )]
+  );
+  assert!(parse_declarations_is_err(
+    "justify-content",
+    "safe space-between"
+  ));
+}
+
+#[test]
+fn parse_place_items_safe_keywords() {
+  assert_eq!(
+    parse_declarations("place-items", "safe start safe end")
+      .iter()
+      .collect::<Vec<_>>(),
+    vec![
+      &StyleDeclaration::align_items(AlignItems::SafeStart),
+      &StyleDeclaration::justify_items(AlignItems::SafeEnd),
+    ]
+  );
+}
+
+#[test]
 fn parse_style_declaration_expands_grid_row_shorthand() {
   let declarations = parse_declarations("grid-row", "span 2 / 5");
 

--- a/takumi-napi-core/tests/deserialize-error.test.ts
+++ b/takumi-napi-core/tests/deserialize-error.test.ts
@@ -54,7 +54,7 @@ test("report deserialize error for justifyContent with wrong type", () => {
       ),
     "justifyContent",
     "integer `123`",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'stretch', 'space-between', 'space-around' or 'space-evenly'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'stretch', 'space-between', 'space-around', 'space-evenly', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -77,7 +77,7 @@ test("report deserialize error for justifyContent with invalid string value", ()
     "justifyContent",
     "star",
     "star",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'stretch', 'space-between', 'space-around' or 'space-evenly'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'stretch', 'space-between', 'space-around', 'space-evenly', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -192,7 +192,7 @@ test("report deserialize error for alignItems property with invalid type", () =>
       ),
     "alignItems",
     "sequence",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'baseline' or 'stretch'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'baseline', 'stretch', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -215,7 +215,7 @@ test("report deserialize error for alignItems property with invalid string value
     "alignItems",
     "invalid",
     "invalid",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'baseline' or 'stretch'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'baseline', 'stretch', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 

--- a/takumi-wasm/tests/deserialize-error.test.ts
+++ b/takumi-wasm/tests/deserialize-error.test.ts
@@ -54,7 +54,7 @@ test("report deserialize error for justifyContent with wrong type", () => {
       ),
     "justifyContent",
     "integer `123`",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'stretch', 'space-between', 'space-around' or 'space-evenly'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'stretch', 'space-between', 'space-around', 'space-evenly', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -76,7 +76,7 @@ test("report deserialize error for justifyContent with invalid string value", ()
     "justifyContent",
     "star",
     "star",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'stretch', 'space-between', 'space-around' or 'space-evenly'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'stretch', 'space-between', 'space-around', 'space-evenly', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -188,7 +188,7 @@ test("report deserialize error for alignItems property with invalid type", () =>
       ),
     "alignItems",
     "sequence",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'baseline' or 'stretch'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'baseline', 'stretch', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -210,7 +210,7 @@ test("report deserialize error for alignItems property with invalid string value
     "alignItems",
     "invalid",
     "invalid",
-    "a value of 'normal', 'start', 'end', 'flex-start', 'flex-end', 'center', 'baseline' or 'stretch'; also accepts 'initial', 'unset' or 'inherit'.",
+    "a value of 'normal', 'baseline', 'stretch', 'start', 'end', 'flex-start', 'flex-end', 'center', 'safe' or 'unsafe'; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 

--- a/takumi/src/layout/tree.rs
+++ b/takumi/src/layout/tree.rs
@@ -1816,7 +1816,7 @@ impl<'g> RenderNode<'g> {
         {
           node.style.display = TaffyDisplay::Flex;
           node.style.flex_direction = taffy::FlexDirection::Row;
-          node.style.justify_content = Some(taffy::JustifyContent::Start);
+          node.style.justify_content = Some(taffy::JustifyContent::START);
         }
 
         tree.compute_layout(Size {


### PR DESCRIPTION
Bump taffy `0.10` → `0.11` and adopt its new overflow-position (`safe` / `unsafe`) alignment keywords.

## Changes
- **deps**: taffy `0.10` → `0.11`. taffy's `AlignItems` / `AlignContent` are now structs (`{ keyword, safety }`) with associated consts, so the `From` bridges remap `::Start` → `::START`, etc.
- **takumi-css**: `align-items` and `justify-content` (and the shorthands/aliases that reuse them — `align-self`, `justify-items`, `justify-self`, `align-content`, `place-*`) now parse the optional `safe` / `unsafe` overflow-position prefix:
  ```css
  align-items: safe center;
  justify-content: unsafe flex-end;
  place-items: safe start safe end;
  ```
  `safe`/`unsafe` are accepted only on the positional keywords (`start`, `end`, `flex-start`, `flex-end`, `center`) per CSS Box Alignment §4.3; pairing with `stretch`/`baseline`/`space-*` is rejected. `unsafe` resolves to the plain (default) variant. New `Safe*` enum variants map to taffy's `SAFE_*` consts and round-trip through `to_css` as `safe <keyword>`.

## Tests
Added parser coverage for `align-items`, `justify-content`, and the `place-items` shorthand (valid safe/unsafe forms + rejected combinations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for `safe` / `unsafe` keywords on align-items and justify-content for safer alignment handling.
* **Bug Fixes**
  * Minor alignment measurement tweak improving flex layout behavior.
* **Tests**
  * Added parsing tests for `safe` usage and invalid combos; updated deserialization error messages to list `safe`/`unsafe`.
* **Chores**
  * Workspace dependency bumped to pick up the new alignment support; release metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->