### PR TITLE
Default border and outline width to medium

### DIFF
--- a/.changeset/border-width-default-medium.md
+++ b/.changeset/border-width-default-medium.md
@@ -1,0 +1,6 @@
+---
+"takumi-css": patch
+"takumi": patch
+---
+
+Default an omitted `border-width` / `outline-width` to `medium` (~3px) instead of `0`, so `border: solid red` and `outline: solid` paint a visible line as CSS specifies. Borders with no visible style (`border: none`, color-only, empty) keep width `0`.

--- a/takumi-css/src/style/properties/border.rs
+++ b/takumi-css/src/style/properties/border.rs
@@ -6,6 +6,13 @@ use crate::style::{
   SizingContext, properties::Length,
 };
 
+/// CSS initial value for `border-width` / `outline-width` keyword `medium`.
+///
+/// Per CSS, an omitted width on a visible border/outline resolves to `medium`,
+/// which user agents render as roughly `3px` (not `0`). See
+/// <https://drafts.csswg.org/css-backgrounds-3/#border-width>.
+const MEDIUM_BORDER_WIDTH_PX: f32 = 3.0;
+
 /// Parsed `border` value.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[non_exhaustive]
@@ -50,9 +57,23 @@ impl<'i> FromCss<'i> for Border {
       ));
     }
 
+    let style = style.unwrap_or_default();
+
+    // When the width token is omitted, CSS resolves it to `medium` (~3px) for a
+    // visible border/outline, so `border: solid red` and `outline: solid` paint
+    // a line. With no visible style (`border: none`, color-only, or empty) the
+    // width stays `0`, keeping `Border::default()` unchanged.
+    let width = width.unwrap_or_else(|| {
+      if style.is_rendered() {
+        Length::Px(MEDIUM_BORDER_WIDTH_PX)
+      } else {
+        Length::default()
+      }
+    });
+
     Ok(Border {
-      width: width.unwrap_or_default(),
-      style: style.unwrap_or_default(),
+      width,
+      style,
       color: color.unwrap_or_default(),
     })
   }
@@ -100,12 +121,28 @@ mod tests {
 
   #[test]
   fn test_parse_border_style_only() {
+    // `border: solid` with no width resolves to the CSS initial `medium` (~3px),
+    // not `0`, so a visible border is painted.
     assert_eq!(
       Border::from_str("solid"),
       Ok(Border {
-        width: Length::default(),
+        width: Length::Px(MEDIUM_BORDER_WIDTH_PX),
         style: BorderStyle::Solid,
         color: ColorInput::CurrentColor,
+      })
+    );
+  }
+
+  #[test]
+  fn test_parse_border_style_and_color_defaults_medium_width() {
+    // Regression for #728: `border: solid red` previously resolved width to `0`
+    // and rendered nothing. It must default to `medium` (~3px).
+    assert_eq!(
+      Border::from_str("solid red"),
+      Ok(Border {
+        width: Length::Px(MEDIUM_BORDER_WIDTH_PX),
+        style: BorderStyle::Solid,
+        color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
     );
   }

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -472,11 +472,13 @@ fn parse_style_declaration_expands_border_side_shorthands() {
     ]
   );
 
+  // A style-only side shorthand defaults its width to `medium` (~3px), matching
+  // the CSS initial value so the border is painted (#728).
   let border_left = parse_declarations("border-left", "solid #00ff00");
   assert_eq!(
     border_left.iter().collect::<Vec<_>>(),
     vec![
-      &StyleDeclaration::border_left_width(Length::default()),
+      &StyleDeclaration::border_left_width(Length::Px(3.0)),
       &StyleDeclaration::border_left_style(BorderStyle::Solid),
       &StyleDeclaration::border_left_color(ColorInput::Value(Color([0, 255, 0, 255]))),
     ]


### PR DESCRIPTION
## Summary

When the width token is omitted from the `border` shorthand, `Border::from_css`
in `takumi-css/src/style/properties/border.rs` fell back to
`width.unwrap_or_default()`, and `Length::default()` is `Px(0.0)`. As a result
`border: solid red` and `outline: solid` resolved to a zero width and painted
nothing.

This changes the omitted-width fallback to the CSS initial value `medium`
(~`3px`) when a visible border style is present (`style.is_rendered()`), while
keeping width `0` when no visible style is declared (`border: none`, color-only,
or empty). Because the `outline` shorthand parses through `Border` as well, this
one change fixes both `border` and `outline`.

`Border::default()` is unchanged, so elements with no border declared still
reserve zero width and there is no rendering regression.

## Why this matters

CSS specifies the initial value of `border-width` / `outline-width` as `medium`,
not `0` (https://drafts.csswg.org/css-backgrounds-3/#border-width). The previous
behavior silently dropped any border or outline declared without an explicit
width, which is the first CSS-conformance item called out in the v2 audit
(https://github.com/kane50613/takumi/issues/728).

## Testing

- Added `test_parse_border_style_and_color_defaults_medium_width` (the
  `border: solid red` case from the issue) and updated
  `test_parse_border_style_only` plus the `border-left` style-only assertion in
  `stylesheets_tests.rs` to expect `Px(3.0)`.
- Existing tests for explicit widths, `border: none`, empty, and color-only
  declarations are unchanged and still pass.
- `cargo test -p takumi-css` passes (all tests green).
- Added a changeset (`patch`) for `takumi-css` / `takumi`.

This PR addresses the border / outline-width item from the audit.

Closes #728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated border and outline width behavior to default to `medium` (~3px) when omitted but a visible style is applied (e.g., `border: solid`), aligning with CSS standard behavior. Non-rendered borders retain zero width defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->