### PR TITLE
Docs: add Copy Markdown button to doc pages

### DIFF
--- a/docs/src/pages/_api/llms.mdx/docs/[...slugs].ts
+++ b/docs/src/pages/_api/llms.mdx/docs/[...slugs].ts
@@ -1,0 +1,22 @@
+import type { ApiContext } from "waku/router";
+import { getLLMText } from "~/lib/get-llm-text";
+import { source } from "~/source";
+
+export async function GET(_: Request, { params }: ApiContext<"/llms.mdx/docs/[...slugs]">) {
+  const page = source.getPage(params.slugs ?? []);
+
+  if (!page) {
+    return new Response(undefined, { status: 404 });
+  }
+
+  return new Response(await getLLMText(page), {
+    headers: { "Content-Type": "text/markdown" },
+  });
+}
+
+export async function getConfig() {
+  return {
+    render: "static" as const,
+    staticPaths: source.getPages().map((page) => page.slugs ?? []),
+  };
+}

--- a/docs/src/pages/docs/[...slugs].tsx
+++ b/docs/src/pages/docs/[...slugs].tsx
@@ -4,6 +4,7 @@ import { Card, Cards } from "fumadocs-ui/components/card";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import defaultMdxComponents, { createRelativeLink } from "fumadocs-ui/mdx";
+import { MarkdownCopyButton, ViewOptionsPopover } from "fumadocs-ui/layouts/docs/page";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import { ArrowBigRight, BookOpen, FileCode2, Hand, Shovel, ToyBrick, Wrench } from "lucide-react";
 import type { PageProps } from "waku/router";
@@ -49,6 +50,8 @@ export default function Page({ slugs = [] }: PageProps<"/docs/[...slugs]">) {
   const MDX = page.data.body;
   const title = `${page.data.title} — Takumi`;
   const og = ["https://takumi.kane.tw/og", "docs", ...slugs, "image.webp"].join("/");
+  const markdownUrl = `/llms.mdx${page.url}`;
+  const githubUrl = `https://github.com/kane50613/takumi/blob/master/docs/content/docs/${page.path}`;
   const tree = source.getPageTree() as PageTreeRoot;
 
   return (
@@ -68,6 +71,10 @@ export default function Page({ slugs = [] }: PageProps<"/docs/[...slugs]">) {
       <Seo title={title} description={page.data.description} path={page.url} image={og} />
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="flex flex-row items-center gap-2 border-b pb-6">
+        <MarkdownCopyButton markdownUrl={markdownUrl} />
+        <ViewOptionsPopover markdownUrl={markdownUrl} githubUrl={githubUrl} />
+      </div>
       <DocsBody>
         <MDX
           components={{


### PR DESCRIPTION
Adds a fumadocs-style "Copy Markdown" button and an "Open" view-options dropdown to every documentation page, mirroring how [fumadocs](https://github.com/fuma-nama/fumadocs) ships it.

## What

- **Copy Markdown button** — copies the page's processed markdown to the clipboard.
- **Open dropdown** — View as Markdown, Open in GitHub, and Open in ChatGPT/Claude/Cursor/Scira (fumadocs' stock `ViewOptionsPopover`).

## How

- New per-page markdown route `docs/src/pages/_api/llms.mdx/docs/[...slugs].ts` serving each page's `getLLMText(page)` output with `Content-Type: text/markdown`, statically generated alongside the existing `/llms.txt` family. (Waku can't put `.md` on a catch-all segment, so the route follows fumadocs' own `/llms.mdx/...` URL shape.)
- Wires fumadocs-ui's built-in `MarkdownCopyButton` + `ViewOptionsPopover` into `docs/src/pages/docs/[...slugs].tsx` between the description and body, with `markdownUrl` pointing at the new route and `githubUrl` at the source file.

No custom components — both buttons are exported by `fumadocs-ui/layouts/docs/page`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown copy functionality and view options controls to documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->