### PR TITLE
Docs: fix llms.mdx static-generation path collision

### DIFF
--- a/docs/src/pages/_api/llms.mdx/docs/[...slugs].ts
+++ b/docs/src/pages/_api/llms.mdx/docs/[...slugs].ts
@@ -3,7 +3,8 @@ import { getLLMText } from "~/lib/get-llm-text";
 import { source } from "~/source";
 
 export async function GET(_: Request, { params }: ApiContext<"/llms.mdx/docs/[...slugs]">) {
-  const page = source.getPage(params.slugs ?? []);
+  const path = (params.slugs ?? []).join("/");
+  const page = source.getPages().find((candidate) => candidate.path === path);
 
   if (!page) {
     return new Response(undefined, { status: 404 });
@@ -17,6 +18,6 @@ export async function GET(_: Request, { params }: ApiContext<"/llms.mdx/docs/[..
 export async function getConfig() {
   return {
     render: "static" as const,
-    staticPaths: source.getPages().map((page) => page.slugs ?? []),
+    staticPaths: source.getPages().map((page) => page.path.split("/")),
   };
 }

--- a/docs/src/pages/docs/[...slugs].tsx
+++ b/docs/src/pages/docs/[...slugs].tsx
@@ -50,7 +50,7 @@ export default function Page({ slugs = [] }: PageProps<"/docs/[...slugs]">) {
   const MDX = page.data.body;
   const title = `${page.data.title} — Takumi`;
   const og = ["https://takumi.kane.tw/og", "docs", ...slugs, "image.webp"].join("/");
-  const markdownUrl = `/llms.mdx${page.url}`;
+  const markdownUrl = `/llms.mdx/docs/${page.path}`;
   const githubUrl = `https://github.com/kane50613/takumi/blob/master/docs/content/docs/${page.path}`;
   const tree = source.getPageTree() as PageTreeRoot;
 


### PR DESCRIPTION
## Problem

The `Deploy docs` build fails at static generation:

```
[Error: EISDIR: illegal operation on a directory, open 'docs/dist/public/llms.mdx/docs']
```

The `/llms.mdx/docs/[...slugs]` catch-all route (added in #778) writes **extensionless** markdown files. The index page (`/docs`, empty slugs) renders to the bare file `llms.mdx/docs`, while child pages like `/docs/architecture` require `llms.mdx/docs/` to be a **directory** — the same name can't be both, so the second write fails with `EISDIR`.

## Fix

Key the route off `page.path` (which keeps the `.mdx` extension and the literal `index.mdx` leaf) instead of `page.slugs`. Every generated file now ends in `.mdx`, so no path is a prefix of another:

- `/llms.mdx/docs/index.mdx`
- `/llms.mdx/docs/architecture.mdx`
- `/llms.mdx/docs/integration/nextjs.mdx`

The `GET` handler resolves the page by matching `page.path`, and the Copy-Markdown button URL is updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated path resolution logic for API routing to improve consistency.
  * Improved URL construction for documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->