### PR TITLE
Crate!: align border/outline-width, scale, position with CSS spec (#728)

### DIFF
--- a/.changeset/css-conformance-line-width-scale-position.md
+++ b/.changeset/css-conformance-line-width-scale-position.md
@@ -1,0 +1,10 @@
+---
+"takumi": major
+---
+
+Align CSS initial values and value semantics with the spec:
+
+- `border-*-width`/`outline-width` default to `medium` (3px) and accept `thin|medium|thick`
+- `scale`/`scaleX`/`scaleY`/`scale()` accept negative factors
+- `position` defaults to `static`
+- `line-clamp` no longer inherits

--- a/.changeset/css-conformance-line-width-scale-position.md
+++ b/.changeset/css-conformance-line-width-scale-position.md
@@ -1,4 +1,5 @@
 ---
+"takumi-css": major
 "takumi": major
 ---
 
@@ -7,4 +8,4 @@ Align CSS initial values and value semantics with the spec:
 - `border-*-width`/`outline-width` default to `medium` (3px) and accept `thin|medium|thick`
 - `scale`/`scaleX`/`scaleY`/`scale()` accept negative factors
 - `position` defaults to `static`
-- `line-clamp` no longer inherits
+- split `line-clamp` into the `max-lines`/`block-ellipsis`/`continue` longhands with correct per-longhand inheritance

--- a/docs/content/docs/reference.mdx
+++ b/docs/content/docs/reference.mdx
@@ -247,7 +247,7 @@ An image node displays rasterized or svg images.
     <tr>
       <td rowSpan={3}>`border`</td>
       <td>`borderWidth` (`borderTopWidth`, `borderRightWidth`, `borderBottomWidth`, `borderLeftWidth`, `borderInlineWidth`, `borderBlockWidth`)</td>
-      <td>Supported</td>
+      <td>`thin`, `medium`, `thick`, `<length>`</td>
     </tr>
     <tr>
       <td>`borderStyle`</td>
@@ -265,7 +265,7 @@ An image node displays rasterized or svg images.
     <tr>
       <td rowSpan={4}>`outline`</td>
       <td>`outlineWidth`</td>
-      <td>Supported</td>
+      <td>`thin`, `medium`, `thick`, `<length>`</td>
     </tr>
     <tr>
       <td>`outlineStyle`</td>
@@ -474,7 +474,7 @@ An image node displays rasterized or svg images.
       <td>Supported</td>
     </tr>
     <tr>
-      <td rowSpan={26}>Typography</td>
+      <td rowSpan={29}>Typography</td>
       <td>`textOverflow`</td>
       <td>`ellipsis`, `clip`, custom character</td>
     </tr>
@@ -540,7 +540,19 @@ An image node displays rasterized or svg images.
     </tr>
     <tr>
       <td>`lineClamp`</td>
-      <td>number, `1 "ellipsis character"`</td>
+      <td>`none`, `<integer>`, `<integer> <block-ellipsis>`</td>
+    </tr>
+    <tr>
+      <td>`maxLines`</td>
+      <td>`none`, `<integer>`</td>
+    </tr>
+    <tr>
+      <td>`blockEllipsis`</td>
+      <td>`none`, `auto`, `<string>`</td>
+    </tr>
+    <tr>
+      <td>`continue`</td>
+      <td>`normal`, `collapse`</td>
     </tr>
     <tr>
       <td>`textAlign`</td>

--- a/docs/content/docs/upgrade/v2.mdx
+++ b/docs/content/docs/upgrade/v2.mdx
@@ -21,6 +21,39 @@ If you relied on the old behavior to tint an icon, set the color in the SVG mark
 const tinted = icon.replace(/currentColor/g, "#3b82f6"); // [!code ++]
 ```
 
+### `position` defaults to `static`
+
+Through v1, `position` defaulted to `relative`, so every element established a containing block for absolutely-positioned descendants and honored `top`/`right`/`bottom`/`left` insets. v2 defaults to `static` to match the CSS specification, so an element only becomes a positioned containing block when you opt in.
+
+If you relied on the default to anchor an absolutely-positioned child or to apply insets, set `position: relative` explicitly.
+
+```tsx
+<div
+  style={{
+    display: "flex",
+    position: "relative", // [!code ++]
+  }}
+>
+  <div style={{ position: "absolute", top: 0, left: 0 }}>Badge</div>
+</div>
+```
+
+### `border-width` and `outline-width` default to `medium`
+
+Omitting the width in `border` / `outline` now resolves to the CSS initial value `medium` (3px) instead of `0`, and the `thin`, `medium`, and `thick` keywords are accepted. `border: solid red` and `outline: solid` render a 3px line where they previously rendered nothing. The used width is still `0` when the line's style is `none` or `hidden`.
+
+```tsx
+<div style={{ border: "solid red" }}>3px border in v2, invisible in v1</div>
+```
+
+### Negative `scale` factors reflect
+
+`scale: -1` and `transform: scaleX(-1)` / `scaleY(-1)` / `scale(-1)` now reflect the element instead of collapsing it to zero size.
+
+### `line-clamp` is now a shorthand
+
+`line-clamp` is now a shorthand for the `max-lines`, `block-ellipsis`, and `continue` longhands (CSS Overflow 4), rather than a single collapsed property. Inheritance follows the spec: `block-ellipsis` inherits, while `max-lines` and `continue` do not — so a clamped ancestor no longer forces its line limit onto descendants. `-webkit-line-clamp` still works and expands to the same longhands.
+
 ## Rust
 
 ### `ImageSource::render_for_layout` Drops the `current_color` Argument

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -7,7 +7,7 @@ use taffy::{Size, prelude::FromLength};
 use crate::context::RenderContext;
 use crate::layout::inline::InlineBrush;
 use crate::layout::style::{
-  BorderStyle, Color, ComputedStyle, Display, FontSynthesis, SizedTextDecorationThickness,
+  BorderStyle, Color, ComputedStyle, Display, FontSynthesis, Length, SizedTextDecorationThickness,
   SizingContext, WordBreak,
 };
 use crate::shadow::SizedShadow;
@@ -129,7 +129,9 @@ impl<'s> SizedFontStyle<'s> {
         .webkit_text_stroke_width
         .unwrap_or_default()
         .to_px(&context.sizing, context.sizing.font_size),
-      outline_width: style.outline_width.to_px(&context.sizing, 0.0).max(0.0),
+      outline_width: Length::from(style.outline_width)
+        .to_px(&context.sizing, 0.0)
+        .max(0.0),
       outline_offset: style.outline_offset.to_px(&context.sizing, 0.0),
       letter_spacing: style
         .letter_spacing

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -77,7 +77,7 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
         line_height_scales_with_text_fit: style.line_height_scales_with_text_fit,
         vertical_align: style.parent.vertical_align,
       },
-      text_wrap_mode: style.parent.text_wrap_mode_and_line_clamp().0.into(),
+      text_wrap_mode: style.parent.resolved_text_wrap_mode().into(),
       font_width: style.parent.font_stretch.into(),
 
       locale: None,

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1383,10 +1383,10 @@ pub fn resolve_inline_max_height(
   font_style: &SizedFontStyle,
   content_box_height: f32,
 ) -> Option<MaxHeight> {
-  let resolved_line_clamp = font_style.parent.resolved_line_clamp();
-  resolved_line_clamp
-    .as_ref()
-    .map(|clamp| MaxHeight::HeightAndLines(content_box_height, clamp.count))
+  font_style
+    .parent
+    .clamp_lines()
+    .map(|lines| MaxHeight::HeightAndLines(content_box_height, lines))
     .or_else(|| {
       (font_style.parent.text_overflow == TextOverflow::Ellipsis)
         .then_some(MaxHeight::Absolute(content_box_height))
@@ -2030,13 +2030,11 @@ pub fn create_inline_constraint(
   // applies a maximum height to reduce unnecessary calculation.
   let max_height = match (
     context.sizing.viewport.size.height,
-    context.style.resolved_line_clamp(),
+    context.style.clamp_lines(),
   ) {
-    (Some(height), Some(line_clamp)) => {
-      Some(MaxHeight::HeightAndLines(height as f32, line_clamp.count))
-    }
+    (Some(height), Some(lines)) => Some(MaxHeight::HeightAndLines(height as f32, lines)),
     (Some(height), None) => Some(MaxHeight::Absolute(height as f32)),
-    (None, Some(line_clamp)) => Some(MaxHeight::Lines(line_clamp.count)),
+    (None, Some(lines)) => Some(MaxHeight::Lines(lines)),
     (None, None) => None,
   };
 

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1131,7 +1131,7 @@ fn prepare_inline_layout(
   max_height: Option<MaxHeight>,
   style: &SizedFontStyle,
 ) -> (TextWrapMode, f32) {
-  let text_wrap_mode = style.parent.text_wrap_mode_and_line_clamp().0;
+  let text_wrap_mode = style.parent.resolved_text_wrap_mode();
   let line_height_hint = inline_line_height_hint(style);
   apply_text_indent(&mut built.layout, style, max_width);
   break_lines(
@@ -1383,7 +1383,7 @@ pub fn resolve_inline_max_height(
   font_style: &SizedFontStyle,
   content_box_height: f32,
 ) -> Option<MaxHeight> {
-  let resolved_line_clamp = font_style.parent.text_wrap_mode_and_line_clamp().1;
+  let resolved_line_clamp = font_style.parent.resolved_line_clamp();
   resolved_line_clamp
     .as_ref()
     .map(|clamp| MaxHeight::HeightAndLines(content_box_height, clamp.count))
@@ -2030,7 +2030,7 @@ pub fn create_inline_constraint(
   // applies a maximum height to reduce unnecessary calculation.
   let max_height = match (
     context.sizing.viewport.size.height,
-    context.style.text_wrap_mode_and_line_clamp().1,
+    context.style.resolved_line_clamp(),
   ) {
     (Some(height), Some(line_clamp)) => {
       Some(MaxHeight::HeightAndLines(height as f32, line_clamp.count))
@@ -2191,7 +2191,7 @@ fn make_ellipsis_layout<'c, 'g: 'c>(
     });
 
   apply_text_indent(&mut final_layout, root_style, max_width);
-  let text_wrap_mode = root_style.parent.text_wrap_mode_and_line_clamp().0;
+  let text_wrap_mode = root_style.parent.resolved_text_wrap_mode();
   custom_inline_boxes.clear();
   break_lines(
     &mut final_layout,

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -16,7 +16,7 @@ use crate::{
     border::BorderPath,
     node::Node,
     style::{
-      Affine, BoxSizing, Color, Float, FontSynthesis, ResolvedVerticalAlign,
+      Affine, BoxSizing, Color, Float, FontSynthesis, Length, ResolvedVerticalAlign,
       SizedTextDecorationThickness, TextDecorationLines, TextDecorationSkipInk, TextFitMode,
       TextFitTarget, TextOverflow, TextWrapMode, TextWrapStyle, VerticalAlign,
     },
@@ -1062,7 +1062,7 @@ fn build_inline_layout_tree<'c, 'g: 'c>(
             bottom: context.style.border_bottom_width,
             left: context.style.border_left_width,
           }
-          .map(|length| length.to_px(&context.sizing, 0.0));
+          .map(|width| Length::from(width).to_px(&context.sizing, 0.0));
 
           let atomic_metrics = render_node
             .node
@@ -2017,12 +2017,12 @@ pub fn create_inline_constraint(
       + if !context.style.border_left_style.is_rendered() {
         0.0
       } else {
-        context.style.border_left_width.to_px(sizing, 0.0)
+        Length::from(context.style.border_left_width).to_px(sizing, 0.0)
       }
       + if !context.style.border_right_style.is_rendered() {
         0.0
       } else {
-        context.style.border_right_width.to_px(sizing, 0.0)
+        Length::from(context.style.border_right_width).to_px(sizing, 0.0)
       };
     width_constraint = (width_constraint - horizontal_insets).max(0.0);
   }

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1807,7 +1807,7 @@ impl<'g> RenderNode<'g> {
         mode: InlineLayoutMode::Measure,
       });
 
-      let ceil_width = font_style.parent.text_wrap_mode_and_line_clamp().0 == TextWrapMode::Wrap;
+      let ceil_width = font_style.parent.resolved_text_wrap_mode() == TextWrapMode::Wrap;
       let parent_font_metrics = get_parent_font_metrics(&built.layout);
       return measure_inline_layout(
         &mut built.layout,

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -24,8 +24,9 @@ use crate::{
     node::{Node, NodeStyleLayers},
     style::{
       BackgroundImage, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem, ContentValue,
-      Display, Filters, Float, Isolation, LineHeight, PercentageNumber, Position, SizingContext,
-      Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode, apply_stylesheet_animations,
+      Display, Filters, Float, Isolation, Length, LineHeight, PercentageNumber, Position,
+      SizingContext, Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode,
+      apply_stylesheet_animations,
     },
   },
 };
@@ -1437,8 +1438,8 @@ impl<'g> RenderNode<'g> {
       + self.context.style.margin_bottom.to_px(sizing, 0.0);
 
     if include_padding_border {
-      height += self.context.style.border_top_width.to_px(sizing, 0.0)
-        + self.context.style.border_bottom_width.to_px(sizing, 0.0)
+      height += Length::from(self.context.style.border_top_width).to_px(sizing, 0.0)
+        + Length::from(self.context.style.border_bottom_width).to_px(sizing, 0.0)
         + self.context.style.padding_top.to_px(sizing, 0.0)
         + self.context.style.padding_bottom.to_px(sizing, 0.0);
     }
@@ -1461,24 +1462,24 @@ impl<'g> RenderNode<'g> {
       + if !self.context.style.border_left_style.is_rendered() {
         0.0
       } else {
-        self.context.style.border_left_width.to_px(sizing, 0.0)
+        Length::from(self.context.style.border_left_width).to_px(sizing, 0.0)
       }
       + if !self.context.style.border_right_style.is_rendered() {
         0.0
       } else {
-        self.context.style.border_right_width.to_px(sizing, 0.0)
+        Length::from(self.context.style.border_right_width).to_px(sizing, 0.0)
       };
     let vertical_insets = self.context.style.padding_top.to_px(sizing, 0.0)
       + self.context.style.padding_bottom.to_px(sizing, 0.0)
       + if !self.context.style.border_top_style.is_rendered() {
         0.0
       } else {
-        self.context.style.border_top_width.to_px(sizing, 0.0)
+        Length::from(self.context.style.border_top_width).to_px(sizing, 0.0)
       }
       + if !self.context.style.border_bottom_style.is_rendered() {
         0.0
       } else {
-        self.context.style.border_bottom_width.to_px(sizing, 0.0)
+        Length::from(self.context.style.border_bottom_width).to_px(sizing, 0.0)
       };
 
     let width_auto = layout_style.size.width.is_auto();
@@ -1559,7 +1560,7 @@ impl<'g> RenderNode<'g> {
     let metrics = line.metrics();
     let sizing = &self.context.sizing;
     let margin_top = self.context.style.margin_top.to_px(sizing, 0.0);
-    let border_top = self.context.style.border_top_width.to_px(sizing, 0.0);
+    let border_top = Length::from(self.context.style.border_top_width).to_px(sizing, 0.0);
     let padding_top = self.context.style.padding_top.to_px(sizing, 0.0);
     Some(margin_top + border_top + padding_top + metrics.baseline)
   }

--- a/takumi-css/src/style/properties/border.rs
+++ b/takumi-css/src/style/properties/border.rs
@@ -1,8 +1,7 @@
 use std::fmt;
 
-use crate::style::{ToCss, unexpected_token};
-use cssparser::{Parser, Token, match_ignore_ascii_case};
-use taffy::LengthPercentage;
+use crate::style::{ToCss, declare_enum_from_css_impl, unexpected_token};
+use cssparser::Parser;
 
 use crate::style::{
   Animatable, BorderStyle, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, MakeComputed,
@@ -21,14 +20,20 @@ pub enum LineWidthKeyword {
   Thick,
 }
 
-impl LineWidthKeyword {
-  /// Resolved width in pixels.
-  pub const fn to_px(self) -> f32 {
-    match self {
-      Self::Thin => 1.0,
-      Self::Medium => 3.0,
-      Self::Thick => 5.0,
-    }
+declare_enum_from_css_impl!(
+  LineWidthKeyword,
+  "thin" => LineWidthKeyword::Thin,
+  "medium" => LineWidthKeyword::Medium,
+  "thick" => LineWidthKeyword::Thick,
+);
+
+impl From<LineWidthKeyword> for Length {
+  fn from(keyword: LineWidthKeyword) -> Self {
+    Length::Px(match keyword {
+      LineWidthKeyword::Thin => 1.0,
+      LineWidthKeyword::Medium => 3.0,
+      LineWidthKeyword::Thick => 5.0,
+    })
   }
 }
 
@@ -44,29 +49,6 @@ pub enum LineWidth {
   Length(Length),
 }
 
-impl LineWidth {
-  /// Zero width, the used value when the line's style is `none` or `hidden`.
-  pub const ZERO: Self = Self::Length(Length::Px(0.0));
-
-  /// Resolves the value to a [`Length`], mapping keywords to their pixel widths.
-  pub fn to_length(self) -> Length {
-    match self {
-      Self::Keyword(keyword) => Length::Px(keyword.to_px()),
-      Self::Length(length) => length,
-    }
-  }
-
-  /// Resolves the value to absolute pixels.
-  pub fn to_px(self, sizing: &SizingContext, percentage_full_px: f32) -> f32 {
-    self.to_length().to_px(sizing, percentage_full_px)
-  }
-
-  /// Resolves the value to a taffy [`LengthPercentage`].
-  pub fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
-    self.to_length().resolve_to_length_percentage(sizing)
-  }
-}
-
 impl Default for LineWidth {
   fn default() -> Self {
     Self::Keyword(LineWidthKeyword::Medium)
@@ -79,18 +61,18 @@ impl From<Length> for LineWidth {
   }
 }
 
+impl From<LineWidth> for Length {
+  fn from(width: LineWidth) -> Self {
+    match width {
+      LineWidth::Keyword(keyword) => keyword.into(),
+      LineWidth::Length(length) => length,
+    }
+  }
+}
+
 impl<'i> FromCss<'i> for LineWidth {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    if let Ok(keyword) = input.try_parse(|input| -> ParseResult<'i, LineWidthKeyword> {
-      let location = input.current_source_location();
-      let ident = input.expect_ident_cloned()?;
-      match_ignore_ascii_case! { ident.as_ref(),
-        "thin" => Ok(LineWidthKeyword::Thin),
-        "medium" => Ok(LineWidthKeyword::Medium),
-        "thick" => Ok(LineWidthKeyword::Thick),
-        _ => Err(unexpected_token!(location, &Token::Ident(ident))),
-      }
-    }) {
+    if let Ok(keyword) = input.try_parse(LineWidthKeyword::from_css) {
       return Ok(Self::Keyword(keyword));
     }
 
@@ -122,8 +104,8 @@ impl Animatable for LineWidth {
     sizing: &SizingContext,
     current_color: Color,
   ) {
-    let from_length = from.to_length();
-    let to_length = to.to_length();
+    let from_length = Length::from(*from);
+    let to_length = Length::from(*to);
     let mut value = from_length;
     value.interpolate(&from_length, &to_length, progress, sizing, current_color);
     *self = Self::Length(value);
@@ -395,9 +377,9 @@ mod tests {
       LineWidth::default(),
       LineWidth::Keyword(LineWidthKeyword::Medium)
     );
-    assert_eq!(LineWidth::default().to_length(), Length::Px(3.0));
-    assert_eq!(LineWidthKeyword::Thin.to_px(), 1.0);
-    assert_eq!(LineWidthKeyword::Thick.to_px(), 5.0);
+    assert_eq!(Length::from(LineWidth::default()), Length::Px(3.0));
+    assert_eq!(Length::from(LineWidthKeyword::Thin), Length::Px(1.0));
+    assert_eq!(Length::from(LineWidthKeyword::Thick), Length::Px(5.0));
   }
 
   #[test]

--- a/takumi-css/src/style/properties/border.rs
+++ b/takumi-css/src/style/properties/border.rs
@@ -1,17 +1,161 @@
-use crate::style::unexpected_token;
-use cssparser::Parser;
+use std::fmt;
+
+use crate::style::{ToCss, unexpected_token};
+use cssparser::{Parser, Token, match_ignore_ascii_case};
+use taffy::LengthPercentage;
 
 use crate::style::{
-  BorderStyle, ColorInput, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult,
-  SizingContext, properties::Length,
+  Animatable, BorderStyle, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, MakeComputed,
+  ParseResult, SizingContext, properties::Length, tw::TailwindPropertyParser,
 };
+
+/// CSSWG `<line-width>` keyword (`thin | medium | thick`).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum LineWidthKeyword {
+  /// `thin`, resolves to 1px.
+  Thin,
+  /// `medium`, resolves to 3px (initial value of `border-width`/`outline-width`).
+  #[default]
+  Medium,
+  /// `thick`, resolves to 5px.
+  Thick,
+}
+
+impl LineWidthKeyword {
+  /// Resolved width in pixels.
+  pub const fn to_px(self) -> f32 {
+    match self {
+      Self::Thin => 1.0,
+      Self::Medium => 3.0,
+      Self::Thick => 5.0,
+    }
+  }
+}
+
+/// CSSWG `<line-width>`: a `thin | medium | thick` keyword or a `<length>`.
+///
+/// Used by `border-*-width` and `outline-width`. The initial value is `medium`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum LineWidth {
+  /// A `thin | medium | thick` keyword.
+  Keyword(LineWidthKeyword),
+  /// An explicit length.
+  Length(Length),
+}
+
+impl LineWidth {
+  /// Zero width, the used value when the line's style is `none` or `hidden`.
+  pub const ZERO: Self = Self::Length(Length::Px(0.0));
+
+  /// Resolves the value to a [`Length`], mapping keywords to their pixel widths.
+  pub fn to_length(self) -> Length {
+    match self {
+      Self::Keyword(keyword) => Length::Px(keyword.to_px()),
+      Self::Length(length) => length,
+    }
+  }
+
+  /// Resolves the value to absolute pixels.
+  pub fn to_px(self, sizing: &SizingContext, percentage_full_px: f32) -> f32 {
+    self.to_length().to_px(sizing, percentage_full_px)
+  }
+
+  /// Resolves the value to a taffy [`LengthPercentage`].
+  pub fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
+    self.to_length().resolve_to_length_percentage(sizing)
+  }
+}
+
+impl Default for LineWidth {
+  fn default() -> Self {
+    Self::Keyword(LineWidthKeyword::Medium)
+  }
+}
+
+impl From<Length> for LineWidth {
+  fn from(length: Length) -> Self {
+    Self::Length(length)
+  }
+}
+
+impl<'i> FromCss<'i> for LineWidth {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if let Ok(keyword) = input.try_parse(|input| -> ParseResult<'i, LineWidthKeyword> {
+      let location = input.current_source_location();
+      let ident = input.expect_ident_cloned()?;
+      match_ignore_ascii_case! { ident.as_ref(),
+        "thin" => Ok(LineWidthKeyword::Thin),
+        "medium" => Ok(LineWidthKeyword::Medium),
+        "thick" => Ok(LineWidthKeyword::Thick),
+        _ => Err(unexpected_token!(location, &Token::Ident(ident))),
+      }
+    }) {
+      return Ok(Self::Keyword(keyword));
+    }
+
+    Ok(Self::Length(Length::from_css(input)?))
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("thin"),
+    CssToken::Keyword("medium"),
+    CssToken::Keyword("thick"),
+    CssToken::Syntax(CssSyntaxKind::Length),
+  ];
+}
+
+impl MakeComputed for LineWidth {
+  fn make_computed(&mut self, sizing: &SizingContext) {
+    if let Self::Length(length) = self {
+      length.make_computed(sizing);
+    }
+  }
+}
+
+impl Animatable for LineWidth {
+  fn interpolate(
+    &mut self,
+    from: &Self,
+    to: &Self,
+    progress: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) {
+    let from_length = from.to_length();
+    let to_length = to.to_length();
+    let mut value = from_length;
+    value.interpolate(&from_length, &to_length, progress, sizing, current_color);
+    *self = Self::Length(value);
+  }
+}
+
+impl TailwindPropertyParser for LineWidth {
+  fn parse_tw(token: &str) -> Option<Self> {
+    token
+      .parse::<f32>()
+      .ok()
+      .map(|value| Self::Length(Length::Px(value)))
+  }
+}
+
+impl ToCss for LineWidth {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::Keyword(LineWidthKeyword::Thin) => dest.write_str("thin"),
+      Self::Keyword(LineWidthKeyword::Medium) => dest.write_str("medium"),
+      Self::Keyword(LineWidthKeyword::Thick) => dest.write_str("thick"),
+      Self::Length(length) => length.to_css(dest),
+    }
+  }
+}
 
 /// Parsed `border` value.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub struct Border {
   /// Border width.
-  pub width: Length,
+  pub width: LineWidth,
   /// Border style.
   pub style: BorderStyle,
   /// Border color.
@@ -29,7 +173,7 @@ impl<'i> FromCss<'i> for Border {
         break;
       }
 
-      if let Ok(value) = input.try_parse(Length::from_css) {
+      if let Ok(value) = input.try_parse(LineWidth::from_css) {
         width = Some(value);
         continue;
       }
@@ -91,7 +235,7 @@ mod tests {
     assert_eq!(
       Border::from_str("10px"),
       Ok(Border {
-        width: Length::Px(10.0),
+        width: LineWidth::Length(Length::Px(10.0)),
         style: BorderStyle::None,
         color: ColorInput::CurrentColor,
       })
@@ -103,7 +247,7 @@ mod tests {
     assert_eq!(
       Border::from_str("solid"),
       Ok(Border {
-        width: Length::default(),
+        width: LineWidth::default(),
         style: BorderStyle::Solid,
         color: ColorInput::CurrentColor,
       })
@@ -115,7 +259,7 @@ mod tests {
     assert_eq!(
       Border::from_str("red"),
       Ok(Border {
-        width: Length::default(),
+        width: LineWidth::default(),
         style: BorderStyle::None,
         color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
@@ -127,7 +271,7 @@ mod tests {
     assert_eq!(
       Border::from_str("2px solid"),
       Ok(Border {
-        width: Length::Px(2.0),
+        width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
         color: ColorInput::CurrentColor,
       })
@@ -139,7 +283,7 @@ mod tests {
     assert_eq!(
       Border::from_str("2px solid red"),
       Ok(Border {
-        width: Length::Px(2.0),
+        width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
@@ -151,7 +295,7 @@ mod tests {
     assert_eq!(
       Border::from_str("solid 2px red"),
       Ok(Border {
-        width: Length::Px(2.0),
+        width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
@@ -163,7 +307,7 @@ mod tests {
     assert_eq!(
       Border::from_str("red solid 2px"),
       Ok(Border {
-        width: Length::Px(2.0),
+        width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
@@ -175,7 +319,7 @@ mod tests {
     assert_eq!(
       Border::from_str("1.5rem solid blue"),
       Ok(Border {
-        width: Length::Rem(1.5),
+        width: LineWidth::Length(Length::Rem(1.5)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([0, 0, 255, 255])),
       })
@@ -187,7 +331,7 @@ mod tests {
     assert_eq!(
       Border::from_str("3px solid #ff0000"),
       Ok(Border {
-        width: Length::Px(3.0),
+        width: LineWidth::Length(Length::Px(3.0)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
@@ -199,7 +343,7 @@ mod tests {
     assert_eq!(
       Border::from_str("4px solid rgb(0, 255, 0)"),
       Ok(Border {
-        width: Length::Px(4.0),
+        width: LineWidth::Length(Length::Px(4.0)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([0, 255, 0, 255])),
       })
@@ -211,7 +355,7 @@ mod tests {
     assert_eq!(
       Border::from_str("2px dashed red"),
       Ok(Border {
-        width: Length::Px(2.0),
+        width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Dashed,
         color: ColorInput::Value(Color([255, 0, 0, 255])),
       })
@@ -233,7 +377,7 @@ mod tests {
     assert_eq!(
       Border::from_str("3px solid blue"),
       Ok(Border {
-        width: Length::Px(3.0),
+        width: LineWidth::Length(Length::Px(3.0)),
         style: BorderStyle::Solid,
         color: ColorInput::Value(Color([0, 0, 255, 255])),
       })
@@ -243,5 +387,48 @@ mod tests {
   #[test]
   fn test_border_value_from_invalid_css() {
     assert!(Border::from_str("invalid border").is_err());
+  }
+
+  #[test]
+  fn test_line_width_default_is_medium() {
+    assert_eq!(
+      LineWidth::default(),
+      LineWidth::Keyword(LineWidthKeyword::Medium)
+    );
+    assert_eq!(LineWidth::default().to_length(), Length::Px(3.0));
+    assert_eq!(LineWidthKeyword::Thin.to_px(), 1.0);
+    assert_eq!(LineWidthKeyword::Thick.to_px(), 5.0);
+  }
+
+  #[test]
+  fn test_line_width_keywords() {
+    assert_eq!(
+      LineWidth::from_str("thin"),
+      Ok(LineWidth::Keyword(LineWidthKeyword::Thin))
+    );
+    assert_eq!(
+      LineWidth::from_str("medium"),
+      Ok(LineWidth::Keyword(LineWidthKeyword::Medium))
+    );
+    assert_eq!(
+      LineWidth::from_str("thick"),
+      Ok(LineWidth::Keyword(LineWidthKeyword::Thick))
+    );
+    assert_eq!(
+      LineWidth::from_str("2px"),
+      Ok(LineWidth::Length(Length::Px(2.0)))
+    );
+  }
+
+  #[test]
+  fn test_border_keyword_width() {
+    assert_eq!(
+      Border::from_str("thick solid"),
+      Ok(Border {
+        width: LineWidth::Keyword(LineWidthKeyword::Thick),
+        style: BorderStyle::Solid,
+        color: ColorInput::CurrentColor,
+      })
+    );
   }
 }

--- a/takumi-css/src/style/properties/line_clamp.rs
+++ b/takumi-css/src/style/properties/line_clamp.rs
@@ -146,12 +146,3 @@ impl TailwindPropertyParser for LineClamp {
     Some(Self::clamp(Some(count), BlockEllipsis::Auto))
   }
 }
-
-/// Resolved line-clamp used during inline layout.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ResolvedLineClamp {
-  /// The number of lines to clamp to.
-  pub count: u32,
-  /// The ellipsis to use when the text is clamped, if overridden.
-  pub ellipsis: Option<String>,
-}

--- a/takumi-css/src/style/properties/line_clamp.rs
+++ b/takumi-css/src/style/properties/line_clamp.rs
@@ -92,22 +92,39 @@ impl ToCss for BlockEllipsis {
   }
 }
 
-/// `continue`: `auto | discard`. Not inherited.
+/// `continue`: `normal | collapse | -webkit-legacy`. Not inherited.
+///
+/// Mirrors Blink's value set. `collapse` (and the legacy `-webkit-legacy`) turns
+/// the box into a fragmentation context that discards content past `max-lines`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum Continue {
-  /// Default fragmentation behavior; content is not discarded.
+  /// Default fragmentation behavior; content is not clamped.
   #[default]
-  Auto,
-  /// Discard boxes that overflow the `max-lines` limit.
-  Discard,
+  Normal,
+  /// Discard content past the `max-lines` limit.
+  Collapse,
+  /// Legacy `-webkit-line-clamp` behavior; treated like `collapse`.
+  WebkitLegacy,
 }
 
 declare_enum_from_css_impl!(
   Continue,
-  "auto" => Continue::Auto,
-  "discard" => Continue::Discard,
+  "normal" => Continue::Normal,
+  "collapse" => Continue::Collapse,
+  "-webkit-legacy" => Continue::WebkitLegacy,
 );
+
+impl Continue {
+  /// Whether this value clamps content past `max-lines`.
+  ///
+  /// Blink only honors `-webkit-legacy` for `display: -webkit-box`; takumi has no
+  /// such display, so it treats the legacy value as `collapse` to keep
+  /// `-webkit-line-clamp` working.
+  pub const fn collapses(self) -> bool {
+    matches!(self, Self::Collapse | Self::WebkitLegacy)
+  }
+}
 
 impl Animatable for Continue {}
 
@@ -131,7 +148,7 @@ impl LineClampShorthand {
     Self {
       max_lines,
       block_ellipsis,
-      line_continue: Continue::Discard,
+      line_continue: Continue::Collapse,
     }
   }
 }

--- a/takumi-css/src/style/properties/line_clamp.rs
+++ b/takumi-css/src/style/properties/line_clamp.rs
@@ -2,65 +2,168 @@ use cssparser::Parser;
 use std::fmt;
 
 use crate::style::{
-  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
-  tw::TailwindPropertyParser,
+  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
+  declare_enum_from_css_impl, properties::write_css_string, tw::TailwindPropertyParser,
 };
 
-#[derive(Debug, Clone, PartialEq)]
-/// Represents a line clamp value.
+/// `max-lines`: `none | <integer>`. Not inherited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
-pub struct LineClamp {
-  /// The number of lines to clamp.
-  pub count: u32,
-  /// The ellipsis character to use when the text is clamped.
-  pub ellipsis: Option<String>,
+pub enum MaxLines {
+  /// No limit on the number of lines.
+  #[default]
+  None,
+  /// Clamp to at most this many lines.
+  Lines(u32),
 }
 
-impl MakeComputed for LineClamp {}
+impl MakeComputed for MaxLines {}
+impl Animatable for MaxLines {}
 
-impl TailwindPropertyParser for LineClamp {
-  fn parse_tw(token: &str) -> Option<Self> {
-    if token.eq_ignore_ascii_case("none") {
-      return Some(LineClamp {
-        count: 0,
-        ellipsis: None,
-      });
-    }
-    let count = token.parse::<u32>().ok()?;
-    if count == 0 {
-      return None;
-    }
-    Some(LineClamp {
-      count,
-      ellipsis: None,
-    })
-  }
-}
-
-impl From<u32> for LineClamp {
-  fn from(count: u32) -> Self {
-    Self {
-      count,
-      ellipsis: None,
-    }
-  }
-}
-
-impl<'i> FromCss<'i> for LineClamp {
+impl<'i> FromCss<'i> for MaxLines {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     if input.try_parse(|i| i.expect_ident_matching("none")).is_ok() {
-      return Ok(LineClamp {
-        count: 0,
-        ellipsis: None,
-      });
+      return Ok(Self::None);
     }
-    let count = input.try_parse(Parser::expect_integer)?;
-    let ellipsis = input.try_parse(Parser::expect_string_cloned).ok();
-
-    Ok(LineClamp {
-      count: count as u32,
-      ellipsis: ellipsis.map(|s| s.to_string()),
+    let count = input.expect_integer()?;
+    Ok(if count >= 1 {
+      Self::Lines(count as u32)
+    } else {
+      Self::None
     })
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("none"),
+    CssToken::Syntax(CssSyntaxKind::Integer),
+  ];
+}
+
+impl ToCss for MaxLines {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::None => dest.write_str("none"),
+      Self::Lines(count) => write!(dest, "{count}"),
+    }
+  }
+}
+
+/// `block-ellipsis`: `none | auto | <string>`. Inherited.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub enum BlockEllipsis {
+  /// No ellipsis is shown when content is clamped.
+  #[default]
+  None,
+  /// Use the user-agent default ellipsis (`…`).
+  Auto,
+  /// Use a specific string as the ellipsis.
+  String(String),
+}
+
+impl MakeComputed for BlockEllipsis {}
+impl Animatable for BlockEllipsis {}
+
+impl<'i> FromCss<'i> for BlockEllipsis {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if input.try_parse(|i| i.expect_ident_matching("none")).is_ok() {
+      return Ok(Self::None);
+    }
+    if input.try_parse(|i| i.expect_ident_matching("auto")).is_ok() {
+      return Ok(Self::Auto);
+    }
+    Ok(Self::String(input.expect_string_cloned()?.to_string()))
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("none"),
+    CssToken::Keyword("auto"),
+    CssToken::Syntax(CssSyntaxKind::String),
+  ];
+}
+
+impl ToCss for BlockEllipsis {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::None => dest.write_str("none"),
+      Self::Auto => dest.write_str("auto"),
+      Self::String(value) => write_css_string(dest, value),
+    }
+  }
+}
+
+/// `continue`: `auto | discard`. Not inherited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum Continue {
+  /// Default fragmentation behavior; content is not discarded.
+  #[default]
+  Auto,
+  /// Discard boxes that overflow the `max-lines` limit.
+  Discard,
+}
+
+declare_enum_from_css_impl!(
+  Continue,
+  "auto" => Continue::Auto,
+  "discard" => Continue::Discard,
+);
+
+impl Animatable for Continue {}
+
+/// Parsed `line-clamp` shorthand: `none | <integer> || <'block-ellipsis'>`.
+///
+/// Expands to `max-lines`, `block-ellipsis`, and `continue`. `-webkit-line-clamp`
+/// shares this parser via vendor-prefix stripping.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LineClampShorthand {
+  /// `max-lines` longhand.
+  pub max_lines: MaxLines,
+  /// `block-ellipsis` longhand.
+  pub block_ellipsis: BlockEllipsis,
+  /// `continue` longhand.
+  pub line_continue: Continue,
+}
+
+impl LineClampShorthand {
+  fn clamp(max_lines: MaxLines, block_ellipsis: BlockEllipsis) -> Self {
+    Self {
+      max_lines,
+      block_ellipsis,
+      line_continue: Continue::Discard,
+    }
+  }
+}
+
+impl From<u32> for LineClampShorthand {
+  fn from(count: u32) -> Self {
+    if count >= 1 {
+      Self::clamp(MaxLines::Lines(count), BlockEllipsis::Auto)
+    } else {
+      Self::default()
+    }
+  }
+}
+
+impl MakeComputed for LineClampShorthand {}
+
+impl<'i> FromCss<'i> for LineClampShorthand {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if input.try_parse(|i| i.expect_ident_matching("none")).is_ok() {
+      return Ok(Self::default());
+    }
+
+    let count = input.expect_integer()?;
+    if count < 1 {
+      return Ok(Self::default());
+    }
+
+    let block_ellipsis = input
+      .try_parse(BlockEllipsis::from_css)
+      .unwrap_or(BlockEllipsis::Auto);
+
+    Ok(Self::clamp(MaxLines::Lines(count as u32), block_ellipsis))
   }
 
   const VALID_TOKENS: &'static [CssToken] = &[
@@ -70,17 +173,24 @@ impl<'i> FromCss<'i> for LineClamp {
   ];
 }
 
-impl ToCss for LineClamp {
-  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    if self.count == 0 && self.ellipsis.is_none() {
-      return dest.write_str("none");
+impl TailwindPropertyParser for LineClampShorthand {
+  fn parse_tw(token: &str) -> Option<Self> {
+    if token.eq_ignore_ascii_case("none") {
+      return Some(Self::default());
     }
-    match &self.ellipsis {
-      Some(e) => {
-        write!(dest, "{} ", self.count)?;
-        write_css_string(dest, e)
-      }
-      None => write!(dest, "{}", self.count),
+    let count = token.parse::<u32>().ok()?;
+    if count == 0 {
+      return None;
     }
+    Some(Self::clamp(MaxLines::Lines(count), BlockEllipsis::Auto))
   }
+}
+
+/// Resolved line-clamp used during inline layout.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LineClamp {
+  /// The number of lines to clamp to.
+  pub count: u32,
+  /// The ellipsis to use when the text is clamped, if overridden.
+  pub ellipsis: Option<String>,
 }

--- a/takumi-css/src/style/properties/line_clamp.rs
+++ b/takumi-css/src/style/properties/line_clamp.rs
@@ -6,48 +6,6 @@ use crate::style::{
   declare_enum_from_css_impl, properties::write_css_string, tw::TailwindPropertyParser,
 };
 
-/// `max-lines`: `none | <integer>`. Not inherited.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[non_exhaustive]
-pub enum MaxLines {
-  /// No limit on the number of lines.
-  #[default]
-  None,
-  /// Clamp to at most this many lines.
-  Lines(u32),
-}
-
-impl MakeComputed for MaxLines {}
-impl Animatable for MaxLines {}
-
-impl<'i> FromCss<'i> for MaxLines {
-  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    if input.try_parse(|i| i.expect_ident_matching("none")).is_ok() {
-      return Ok(Self::None);
-    }
-    let count = input.expect_integer()?;
-    Ok(if count >= 1 {
-      Self::Lines(count as u32)
-    } else {
-      Self::None
-    })
-  }
-
-  const VALID_TOKENS: &'static [CssToken] = &[
-    CssToken::Keyword("none"),
-    CssToken::Syntax(CssSyntaxKind::Integer),
-  ];
-}
-
-impl ToCss for MaxLines {
-  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    match self {
-      Self::None => dest.write_str("none"),
-      Self::Lines(count) => write!(dest, "{count}"),
-    }
-  }
-}
-
 /// `block-ellipsis`: `none | auto | <string>`. Inherited.
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
@@ -92,10 +50,10 @@ impl ToCss for BlockEllipsis {
   }
 }
 
-/// `continue`: `normal | collapse | -webkit-legacy`. Not inherited.
+/// `continue`: `normal | collapse`. Not inherited.
 ///
-/// Mirrors Blink's value set. `collapse` (and the legacy `-webkit-legacy`) turns
-/// the box into a fragmentation context that discards content past `max-lines`.
+/// `collapse` turns the box into a fragmentation context that discards content
+/// past `max-lines`; `line-clamp`/`-webkit-line-clamp` set it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum Continue {
@@ -104,27 +62,13 @@ pub enum Continue {
   Normal,
   /// Discard content past the `max-lines` limit.
   Collapse,
-  /// Legacy `-webkit-line-clamp` behavior; treated like `collapse`.
-  WebkitLegacy,
 }
 
 declare_enum_from_css_impl!(
   Continue,
   "normal" => Continue::Normal,
   "collapse" => Continue::Collapse,
-  "-webkit-legacy" => Continue::WebkitLegacy,
 );
-
-impl Continue {
-  /// Whether this value clamps content past `max-lines`.
-  ///
-  /// Blink only honors `-webkit-legacy` for `display: -webkit-box`; takumi has no
-  /// such display, so it treats the legacy value as `collapse` to keep
-  /// `-webkit-line-clamp` working.
-  pub const fn collapses(self) -> bool {
-    matches!(self, Self::Collapse | Self::WebkitLegacy)
-  }
-}
 
 impl Animatable for Continue {}
 
@@ -134,17 +78,17 @@ impl Animatable for Continue {}
 /// shares this parser via vendor-prefix stripping.
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
-pub struct LineClampShorthand {
+pub struct LineClamp {
   /// `max-lines` longhand.
-  pub max_lines: MaxLines,
+  pub max_lines: Option<u32>,
   /// `block-ellipsis` longhand.
   pub block_ellipsis: BlockEllipsis,
   /// `continue` longhand.
   pub line_continue: Continue,
 }
 
-impl LineClampShorthand {
-  fn clamp(max_lines: MaxLines, block_ellipsis: BlockEllipsis) -> Self {
+impl LineClamp {
+  fn clamp(max_lines: Option<u32>, block_ellipsis: BlockEllipsis) -> Self {
     Self {
       max_lines,
       block_ellipsis,
@@ -153,19 +97,19 @@ impl LineClampShorthand {
   }
 }
 
-impl From<u32> for LineClampShorthand {
+impl From<u32> for LineClamp {
   fn from(count: u32) -> Self {
     if count >= 1 {
-      Self::clamp(MaxLines::Lines(count), BlockEllipsis::Auto)
+      Self::clamp(Some(count), BlockEllipsis::Auto)
     } else {
       Self::default()
     }
   }
 }
 
-impl MakeComputed for LineClampShorthand {}
+impl MakeComputed for LineClamp {}
 
-impl<'i> FromCss<'i> for LineClampShorthand {
+impl<'i> FromCss<'i> for LineClamp {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     if input.try_parse(|i| i.expect_ident_matching("none")).is_ok() {
       return Ok(Self::default());
@@ -180,7 +124,7 @@ impl<'i> FromCss<'i> for LineClampShorthand {
       .try_parse(BlockEllipsis::from_css)
       .unwrap_or(BlockEllipsis::Auto);
 
-    Ok(Self::clamp(MaxLines::Lines(count as u32), block_ellipsis))
+    Ok(Self::clamp(Some(count as u32), block_ellipsis))
   }
 
   const VALID_TOKENS: &'static [CssToken] = &[
@@ -190,7 +134,7 @@ impl<'i> FromCss<'i> for LineClampShorthand {
   ];
 }
 
-impl TailwindPropertyParser for LineClampShorthand {
+impl TailwindPropertyParser for LineClamp {
   fn parse_tw(token: &str) -> Option<Self> {
     if token.eq_ignore_ascii_case("none") {
       return Some(Self::default());
@@ -199,13 +143,13 @@ impl TailwindPropertyParser for LineClampShorthand {
     if count == 0 {
       return None;
     }
-    Some(Self::clamp(MaxLines::Lines(count), BlockEllipsis::Auto))
+    Some(Self::clamp(Some(count), BlockEllipsis::Auto))
   }
 }
 
 /// Resolved line-clamp used during inline layout.
 #[derive(Debug, Clone, PartialEq)]
-pub struct LineClamp {
+pub struct ResolvedLineClamp {
   /// The number of lines to clamp to.
   pub count: u32,
   /// The ellipsis to use when the text is clamped, if overridden.

--- a/takumi-css/src/style/properties/mod.rs
+++ b/takumi-css/src/style/properties/mod.rs
@@ -485,16 +485,16 @@ impl TailwindPropertyParser for LineJoin {
 /// This enum determines how an element is positioned within its containing element.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub enum Position {
-  /// The element is positioned according to the normal flow of the document.
+  /// The element is laid out in the normal flow and is not a containing block.
   /// Offsets (top, right, bottom, left) have no effect.
   #[default]
+  Static,
+  /// The element is laid out in the normal flow, then offset relative to itself.
+  /// Offsets (top, right, bottom, left) shift it without affecting other boxes.
   Relative,
   /// The element is removed from the normal document flow and positioned relative to its nearest positioned ancestor.
   /// Offsets (top, right, bottom, left) specify the distance from the ancestor.
   Absolute,
-  /// The element is laid out in the normal flow and is not a containing block.
-  /// Offsets (top, right, bottom, left) have no effect.
-  Static,
   /// The element is removed from the normal document flow and positioned relative to the viewport (root).
   Fixed,
 }

--- a/takumi-css/src/style/properties/percentage_number.rs
+++ b/takumi-css/src/style/properties/percentage_number.rs
@@ -67,8 +67,8 @@ impl<'i> FromCss<'i> for PercentageNumber {
     let token = input.next()?;
 
     match token {
-      Token::Number { value, .. } => Ok(PercentageNumber(value.max(0.0))),
-      Token::Percentage { unit_value, .. } => Ok(PercentageNumber(unit_value.max(0.0))),
+      Token::Number { value, .. } => Ok(PercentageNumber(*value)),
+      Token::Percentage { unit_value, .. } => Ok(PercentageNumber(*unit_value)),
       _ => Err(unexpected_token!(location, token)),
     }
   }

--- a/takumi-css/src/style/properties/traits.rs
+++ b/takumi-css/src/style/properties/traits.rs
@@ -629,6 +629,17 @@ impl ToCss for u32 {
   }
 }
 
+impl MakeComputed for u32 {}
+impl Animatable for u32 {}
+
+impl<'i> FromCss<'i> for u32 {
+  const VALID_TOKENS: &'static [CssToken] = &[CssToken::Syntax(CssSyntaxKind::Integer)];
+
+  fn from_css(input: &mut cssparser::Parser<'i, '_>) -> ParseResult<'i, Self> {
+    Ok(input.expect_integer()?.max(0) as u32)
+  }
+}
+
 impl ToCss for i32 {
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
     write!(dest, "{}", self)

--- a/takumi-css/src/style/properties/transform.rs
+++ b/takumi-css/src/style/properties/transform.rs
@@ -601,6 +601,22 @@ mod tests {
   }
 
   #[test]
+  fn test_transform_negative_scale_reflects() {
+    assert_eq!(
+      Transform::from_str("scale(-1)"),
+      Ok(Transform::Scale(-1.0, -1.0))
+    );
+    assert_eq!(
+      Transform::from_str("scaleX(-1)"),
+      Ok(Transform::Scale(-1.0, DEFAULT_SCALE))
+    );
+    assert_eq!(
+      Transform::from_str("scaleY(-2)"),
+      Ok(Transform::Scale(DEFAULT_SCALE, -2.0))
+    );
+  }
+
+  #[test]
   fn test_transform_invert() {
     let transform = Affine::rotation(Angle::new(45.0));
 

--- a/takumi-css/src/style/stylesheets.rs
+++ b/takumi-css/src/style/stylesheets.rs
@@ -998,7 +998,7 @@ define_style! {
     font_feature_settings: FontFeatureSettings where inherit = true,
     font_synthesis_weight: FontSynthesic where inherit = true,
     font_synthesis_style: FontSynthesic where inherit = true,
-    max_lines: MaxLines,
+    max_lines: Option<u32>,
     block_ellipsis: BlockEllipsis where inherit = true,
     r#continue: Continue,
     text_align: TextAlign where inherit = true,
@@ -1327,7 +1327,7 @@ define_style! {
       target.push(StyleDeclaration::text_wrap_mode(value.mode));
       target.push(StyleDeclaration::text_wrap_style(value.style));
     },
-    line_clamp: LineClampShorthand => [MaxLines, BlockEllipsis, Continue] |value, target| {
+    line_clamp: LineClamp => [MaxLines, BlockEllipsis, Continue] |value, target| {
       target.push(StyleDeclaration::max_lines(value.max_lines));
       target.push(StyleDeclaration::block_ellipsis(value.block_ellipsis));
       target.push(StyleDeclaration::r#continue(value.line_continue));

--- a/takumi-css/src/style/stylesheets.rs
+++ b/takumi-css/src/style/stylesheets.rs
@@ -145,7 +145,6 @@ macro_rules! define_style {
     shorthands {
       $(
         $shorthand:ident: $shorthand_ty:ty
-          $(where inherit = $shorthand_inherit:expr)?
           => [$($target:ident),+ $(,)?]
           |$value:ident, $target_var:ident|
           $expand:block,
@@ -945,10 +944,10 @@ define_style! {
     border_top_right_radius: SpacePair<LengthDefaultsToZero>,
     border_bottom_right_radius: SpacePair<LengthDefaultsToZero>,
     border_bottom_left_radius: SpacePair<LengthDefaultsToZero>,
-    border_top_width: Length,
-    border_right_width: Length,
-    border_bottom_width: Length,
-    border_left_width: Length,
+    border_top_width: LineWidth,
+    border_right_width: LineWidth,
+    border_bottom_width: LineWidth,
+    border_left_width: LineWidth,
     border_top_style: BorderStyle,
     border_right_style: BorderStyle,
     border_bottom_style: BorderStyle,
@@ -957,7 +956,7 @@ define_style! {
     border_right_color: ColorInput,
     border_bottom_color: ColorInput,
     border_left_color: ColorInput,
-    outline_width: Length,
+    outline_width: LineWidth,
     outline_style: BorderStyle,
     outline_color: ColorInput,
     outline_offset: Length,
@@ -999,7 +998,7 @@ define_style! {
     font_feature_settings: FontFeatureSettings where inherit = true,
     font_synthesis_weight: FontSynthesic where inherit = true,
     font_synthesis_style: FontSynthesic where inherit = true,
-    line_clamp: Option<LineClamp> where inherit = true,
+    line_clamp: Option<LineClamp>,
     text_align: TextAlign where inherit = true,
     webkit_text_stroke_width: Option<LengthDefaultsToZero> where inherit = true,
     webkit_text_stroke_color: Option<ColorInput> where inherit = true,
@@ -1174,7 +1173,7 @@ define_style! {
         border_bottom_left_radius
       );
     },
-    border_width: Sides<Length> => [BorderTopWidth, BorderRightWidth, BorderBottomWidth, BorderLeftWidth] |value, target| {
+    border_width: Sides<LineWidth> => [BorderTopWidth, BorderRightWidth, BorderBottomWidth, BorderLeftWidth] |value, target| {
       push_four_side_declarations!(
         target,
         value.0,
@@ -1184,7 +1183,7 @@ define_style! {
         border_left_width
       );
     },
-    border_inline_width: SpacePair<Length> => [BorderLeftWidth, BorderRightWidth] |value, target| {
+    border_inline_width: SpacePair<LineWidth> => [BorderLeftWidth, BorderRightWidth] |value, target| {
       push_axis_declarations!(
         target,
         value,
@@ -1192,7 +1191,7 @@ define_style! {
         border_right_width
       );
     },
-    border_block_width: SpacePair<Length> => [BorderTopWidth, BorderBottomWidth] |value, target| {
+    border_block_width: SpacePair<LineWidth> => [BorderTopWidth, BorderBottomWidth] |value, target| {
       push_axis_declarations!(
         target,
         value,
@@ -1298,11 +1297,11 @@ define_style! {
           .collect(),
       )));
     },
-    font_synthesis: FontSynthesis where inherit = true => [FontSynthesisWeight, FontSynthesisStyle] |value, target| {
+    font_synthesis: FontSynthesis => [FontSynthesisWeight, FontSynthesisStyle] |value, target| {
       target.push(StyleDeclaration::font_synthesis_weight(value.weight));
       target.push(StyleDeclaration::font_synthesis_style(value.style));
     },
-    webkit_text_stroke: Option<TextStroke> where inherit = true => [WebkitTextStrokeWidth, WebkitTextStrokeColor] |value, target| {
+    webkit_text_stroke: Option<TextStroke> => [WebkitTextStrokeWidth, WebkitTextStrokeColor] |value, target| {
       target.push(StyleDeclaration::webkit_text_stroke_width(
         value.map(|value| value.width),
       ));
@@ -1316,13 +1315,13 @@ define_style! {
       target.push(StyleDeclaration::text_decoration_color(value.color));
       target.push(StyleDeclaration::text_decoration_thickness(value.thickness));
     },
-    white_space: WhiteSpace where inherit = true => [TextWrapMode, WhiteSpaceCollapse] |value, target| {
+    white_space: WhiteSpace => [TextWrapMode, WhiteSpaceCollapse] |value, target| {
       target.push(StyleDeclaration::text_wrap_mode(value.text_wrap_mode));
       target.push(StyleDeclaration::white_space_collapse(
         value.white_space_collapse,
       ));
     },
-    text_wrap: TextWrap where inherit = true => [TextWrapMode, TextWrapStyle] |value, target| {
+    text_wrap: TextWrap => [TextWrapMode, TextWrapStyle] |value, target| {
       target.push(StyleDeclaration::text_wrap_mode(value.mode));
       target.push(StyleDeclaration::text_wrap_style(value.style));
     },

--- a/takumi-css/src/style/stylesheets.rs
+++ b/takumi-css/src/style/stylesheets.rs
@@ -836,7 +836,7 @@ macro_rules! define_style {
           match self {
             $(
               Self::[<$longhand:camel>](value) => {
-                let name = stringify!($longhand).replace("_", "-");
+                let name = stringify!($longhand).replace("r#", "").replace("_", "-");
                 if name.starts_with("webkit-") {
                   dest.write_str("-")?;
                 }
@@ -998,7 +998,9 @@ define_style! {
     font_feature_settings: FontFeatureSettings where inherit = true,
     font_synthesis_weight: FontSynthesic where inherit = true,
     font_synthesis_style: FontSynthesic where inherit = true,
-    line_clamp: Option<LineClamp>,
+    max_lines: MaxLines,
+    block_ellipsis: BlockEllipsis where inherit = true,
+    r#continue: Continue,
     text_align: TextAlign where inherit = true,
     webkit_text_stroke_width: Option<LengthDefaultsToZero> where inherit = true,
     webkit_text_stroke_color: Option<ColorInput> where inherit = true,
@@ -1324,6 +1326,11 @@ define_style! {
     text_wrap: TextWrap => [TextWrapMode, TextWrapStyle] |value, target| {
       target.push(StyleDeclaration::text_wrap_mode(value.mode));
       target.push(StyleDeclaration::text_wrap_style(value.style));
+    },
+    line_clamp: LineClampShorthand => [MaxLines, BlockEllipsis, Continue] |value, target| {
+      target.push(StyleDeclaration::max_lines(value.max_lines));
+      target.push(StyleDeclaration::block_ellipsis(value.block_ellipsis));
+      target.push(StyleDeclaration::r#continue(value.line_continue));
     },
   }
 }

--- a/takumi-css/src/style/stylesheets_helpers.rs
+++ b/takumi-css/src/style/stylesheets_helpers.rs
@@ -214,6 +214,9 @@ fn legacy_alias_property_id(name: &str) -> Option<PropertyId> {
     "grid_gap" => Some(PropertyId::Shorthand(ShorthandId::Gap)),
     "grid_row_gap" => Some(PropertyId::Longhand(LonghandId::RowGap)),
     "grid_column_gap" => Some(PropertyId::Longhand(LonghandId::ColumnGap)),
+    // `continue` is a Rust keyword; its longhand field is `r#continue`, so the
+    // name-derived lookup can't reach it.
+    "continue" => Some(PropertyId::Longhand(LonghandId::Continue)),
     _ => None,
   }
 }

--- a/takumi-css/src/style/stylesheets_query.rs
+++ b/takumi-css/src/style/stylesheets_query.rs
@@ -21,6 +21,24 @@ impl ComputedStyle {
 
     self.make_computed_values(sizing);
 
+    // The used value of `border-width`/`outline-width` is zero when the line's
+    // style is `none` or `hidden`, even though the computed value is `medium`.
+    if !self.border_top_style.is_rendered() {
+      self.border_top_width = LineWidth::ZERO;
+    }
+    if !self.border_right_style.is_rendered() {
+      self.border_right_width = LineWidth::ZERO;
+    }
+    if !self.border_bottom_style.is_rendered() {
+      self.border_bottom_width = LineWidth::ZERO;
+    }
+    if !self.border_left_style.is_rendered() {
+      self.border_left_width = LineWidth::ZERO;
+    }
+    if !self.outline_style.is_rendered() {
+      self.outline_width = LineWidth::ZERO;
+    }
+
     // https://www.w3.org/TR/css-display-3/#transformations
     // Elements with position: absolute or fixed are blockified
     if self.position.is_out_of_flow() || self.float != Float::None {
@@ -190,27 +208,12 @@ impl ComputedStyle {
         height: self.height,
       }
       .map(|length| length.resolve_to_dimension(sizing)),
+      // Used widths are already zeroed for non-rendered styles in `make_computed`.
       border: Rect {
-        top: if !self.border_top_style.is_rendered() {
-          Length::default()
-        } else {
-          self.border_top_width
-        },
-        right: if !self.border_right_style.is_rendered() {
-          Length::default()
-        } else {
-          self.border_right_width
-        },
-        bottom: if !self.border_bottom_style.is_rendered() {
-          Length::default()
-        } else {
-          self.border_bottom_width
-        },
-        left: if !self.border_left_style.is_rendered() {
-          Length::default()
-        } else {
-          self.border_left_width
-        },
+        top: self.border_top_width,
+        right: self.border_right_width,
+        bottom: self.border_bottom_width,
+        left: self.border_left_width,
       }
       .map(|border| border.resolve_to_length_percentage(sizing)),
       padding: Rect {

--- a/takumi-css/src/style/stylesheets_query.rs
+++ b/takumi-css/src/style/stylesheets_query.rs
@@ -151,32 +151,21 @@ impl ComputedStyle {
     }
   }
 
-  /// Resolves the effective line clamp for layout. Per CSS Overflow 4, `max-lines`
-  /// only clamps inside a fragmentation context, i.e. when `continue` collapses
-  /// (`line-clamp`/`-webkit-line-clamp` set this).
-  pub fn resolved_line_clamp(&self) -> Option<ResolvedLineClamp> {
+  /// The number of lines to clamp to for layout, or `None` when not clamped.
+  ///
+  /// `nowrap` + `ellipsis` clamps to a single line; otherwise `max-lines` applies
+  /// only inside a fragmentation context (`continue: collapse`), per CSS Overflow 4.
+  /// The ellipsis itself comes from [`Self::ellipsis_char`].
+  pub fn clamp_lines(&self) -> Option<u32> {
     if self.forces_single_line_ellipsis() {
-      return Some(ResolvedLineClamp {
-        count: 1,
-        ellipsis: Some(self.ellipsis_char().to_string()),
-      });
+      return Some(1);
     }
 
     if self.r#continue != Continue::Collapse {
       return None;
     }
 
-    match self.max_lines {
-      Some(count) if count >= 1 => Some(ResolvedLineClamp {
-        count,
-        ellipsis: match &self.block_ellipsis {
-          BlockEllipsis::String(custom) => Some(custom.clone()),
-          BlockEllipsis::None => Some(String::new()),
-          BlockEllipsis::Auto => None,
-        },
-      }),
-      _ => None,
-    }
+    self.max_lines.filter(|&count| count >= 1)
   }
 
   #[inline]

--- a/takumi-css/src/style/stylesheets_query.rs
+++ b/takumi-css/src/style/stylesheets_query.rs
@@ -139,7 +139,14 @@ impl ComputedStyle {
   }
 
   /// Resolves the `max-lines`/`block-ellipsis` longhands into a clamp for layout.
+  ///
+  /// Per CSS Overflow 4, `max-lines` only clamps inside a fragmentation context,
+  /// i.e. when `continue` collapses (`line-clamp`/`-webkit-line-clamp` set this).
   fn resolved_line_clamp(&self) -> Option<LineClamp> {
+    if !self.r#continue.collapses() {
+      return None;
+    }
+
     match self.max_lines {
       MaxLines::Lines(count) if count >= 1 => Some(LineClamp {
         count,

--- a/takumi-css/src/style/stylesheets_query.rs
+++ b/takumi-css/src/style/stylesheets_query.rs
@@ -24,19 +24,19 @@ impl ComputedStyle {
     // The used value of `border-width`/`outline-width` is zero when the line's
     // style is `none` or `hidden`, even though the computed value is `medium`.
     if !self.border_top_style.is_rendered() {
-      self.border_top_width = LineWidth::ZERO;
+      self.border_top_width = LineWidth::Length(Length::zero());
     }
     if !self.border_right_style.is_rendered() {
-      self.border_right_width = LineWidth::ZERO;
+      self.border_right_width = LineWidth::Length(Length::zero());
     }
     if !self.border_bottom_style.is_rendered() {
-      self.border_bottom_width = LineWidth::ZERO;
+      self.border_bottom_width = LineWidth::Length(Length::zero());
     }
     if !self.border_left_style.is_rendered() {
-      self.border_left_width = LineWidth::ZERO;
+      self.border_left_width = LineWidth::Length(Length::zero());
     }
     if !self.outline_style.is_rendered() {
-      self.outline_width = LineWidth::ZERO;
+      self.outline_width = LineWidth::Length(Length::zero());
     }
 
     // https://www.w3.org/TR/css-display-3/#transformations
@@ -131,20 +131,31 @@ impl ComputedStyle {
       _ => {}
     }
 
-    if let Some(clamp) = &self
-      .line_clamp
-      .as_ref()
-      .and_then(|clamp| clamp.ellipsis.as_deref())
-    {
-      return clamp;
+    match &self.block_ellipsis {
+      BlockEllipsis::String(custom) => custom.as_str(),
+      BlockEllipsis::None => "",
+      BlockEllipsis::Auto => ELLIPSIS_CHAR,
     }
+  }
 
-    ELLIPSIS_CHAR
+  /// Resolves the `max-lines`/`block-ellipsis` longhands into a clamp for layout.
+  fn resolved_line_clamp(&self) -> Option<LineClamp> {
+    match self.max_lines {
+      MaxLines::Lines(count) if count >= 1 => Some(LineClamp {
+        count,
+        ellipsis: match &self.block_ellipsis {
+          BlockEllipsis::String(custom) => Some(custom.clone()),
+          BlockEllipsis::None => Some(String::new()),
+          BlockEllipsis::Auto => None,
+        },
+      }),
+      _ => None,
+    }
   }
 
   pub fn text_wrap_mode_and_line_clamp(&self) -> (TextWrapMode, Option<Cow<'_, LineClamp>>) {
     let mut text_wrap_mode = self.text_wrap_mode;
-    let mut line_clamp = self.line_clamp.as_ref().map(Cow::Borrowed);
+    let mut line_clamp = self.resolved_line_clamp().map(Cow::Owned);
 
     // Special case: when nowrap + ellipsis, parley will layout all the text even when it overflows.
     // So we need to use a fixed line clamp of 1 instead.
@@ -215,7 +226,7 @@ impl ComputedStyle {
         bottom: self.border_bottom_width,
         left: self.border_left_width,
       }
-      .map(|border| border.resolve_to_length_percentage(sizing)),
+      .map(|border| Length::from(border).resolve_to_length_percentage(sizing)),
       padding: Rect {
         top: self.padding_top,
         right: self.padding_right,

--- a/takumi-css/src/style/stylesheets_query.rs
+++ b/takumi-css/src/style/stylesheets_query.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use taffy::{Line, Point, Rect, Size};
@@ -138,17 +137,37 @@ impl ComputedStyle {
     }
   }
 
-  /// Resolves the `max-lines`/`block-ellipsis` longhands into a clamp for layout.
-  ///
-  /// Per CSS Overflow 4, `max-lines` only clamps inside a fragmentation context,
-  /// i.e. when `continue` collapses (`line-clamp`/`-webkit-line-clamp` set this).
-  fn resolved_line_clamp(&self) -> Option<LineClamp> {
-    if !self.r#continue.collapses() {
+  /// `nowrap` + `ellipsis`: parley lays out all the text even when it overflows,
+  /// so this case is rendered by switching to wrapping with a one-line clamp.
+  fn forces_single_line_ellipsis(&self) -> bool {
+    self.text_wrap_mode == TextWrapMode::NoWrap && self.text_overflow == TextOverflow::Ellipsis
+  }
+
+  pub fn resolved_text_wrap_mode(&self) -> TextWrapMode {
+    if self.forces_single_line_ellipsis() {
+      TextWrapMode::Wrap
+    } else {
+      self.text_wrap_mode
+    }
+  }
+
+  /// Resolves the effective line clamp for layout. Per CSS Overflow 4, `max-lines`
+  /// only clamps inside a fragmentation context, i.e. when `continue` collapses
+  /// (`line-clamp`/`-webkit-line-clamp` set this).
+  pub fn resolved_line_clamp(&self) -> Option<ResolvedLineClamp> {
+    if self.forces_single_line_ellipsis() {
+      return Some(ResolvedLineClamp {
+        count: 1,
+        ellipsis: Some(self.ellipsis_char().to_string()),
+      });
+    }
+
+    if self.r#continue != Continue::Collapse {
       return None;
     }
 
     match self.max_lines {
-      MaxLines::Lines(count) if count >= 1 => Some(LineClamp {
+      Some(count) if count >= 1 => Some(ResolvedLineClamp {
         count,
         ellipsis: match &self.block_ellipsis {
           BlockEllipsis::String(custom) => Some(custom.clone()),
@@ -157,29 +176,6 @@ impl ComputedStyle {
         },
       }),
       _ => None,
-    }
-  }
-
-  pub fn text_wrap_mode_and_line_clamp(&self) -> (TextWrapMode, Option<Cow<'_, LineClamp>>) {
-    let mut text_wrap_mode = self.text_wrap_mode;
-    let mut line_clamp = self.resolved_line_clamp().map(Cow::Owned);
-
-    // Special case: when nowrap + ellipsis, parley will layout all the text even when it overflows.
-    // So we need to use a fixed line clamp of 1 instead.
-    if text_wrap_mode == TextWrapMode::NoWrap && self.text_overflow == TextOverflow::Ellipsis {
-      line_clamp = Some(Cow::Owned(self.single_line_ellipsis_clamp()));
-
-      text_wrap_mode = TextWrapMode::Wrap;
-    }
-
-    (text_wrap_mode, line_clamp)
-  }
-
-  #[inline]
-  fn single_line_ellipsis_clamp(&self) -> LineClamp {
-    LineClamp {
-      count: 1,
-      ellipsis: Some(self.ellipsis_char().to_string()),
     }
   }
 

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -466,7 +466,7 @@ fn parse_style_declaration_expands_border_side_shorthands() {
   assert_eq!(
     border_top.iter().collect::<Vec<_>>(),
     vec![
-      &StyleDeclaration::border_top_width(Length::Px(2.0)),
+      &StyleDeclaration::border_top_width(LineWidth::Length(Length::Px(2.0))),
       &StyleDeclaration::border_top_style(BorderStyle::Solid),
       &StyleDeclaration::border_top_color(ColorInput::Value(Color([255, 0, 0, 255]))),
     ]
@@ -476,7 +476,7 @@ fn parse_style_declaration_expands_border_side_shorthands() {
   assert_eq!(
     border_left.iter().collect::<Vec<_>>(),
     vec![
-      &StyleDeclaration::border_left_width(Length::default()),
+      &StyleDeclaration::border_left_width(LineWidth::default()),
       &StyleDeclaration::border_left_style(BorderStyle::Solid),
       &StyleDeclaration::border_left_color(ColorInput::Value(Color([0, 255, 0, 255]))),
     ]
@@ -655,6 +655,7 @@ fn test_needs_offscreen_compositing_for_clip_path_and_mask_image() {
 fn test_is_z_index_applicable_matches_supported_scope() {
   let mut style = ComputedStyle {
     z_index: ZIndex::Integer(2),
+    position: Position::Relative,
     ..Default::default()
   };
   assert!(style.is_z_index_applicable(false));
@@ -662,9 +663,11 @@ fn test_is_z_index_applicable_matches_supported_scope() {
   style.position = Position::Absolute;
   assert!(style.is_z_index_applicable(false));
 
-  style.position = Position::Relative;
-  assert!(style.is_z_index_applicable(false));
+  // `z-index` does not apply to a static element.
+  style.position = Position::Static;
+  assert!(!style.is_z_index_applicable(false));
 
+  style.position = Position::Relative;
   style.z_index = ZIndex::Auto;
   assert!(!style.is_z_index_applicable(false));
 }
@@ -686,6 +689,7 @@ fn test_creates_stacking_context_from_z_index_scope() {
     height: 100.0,
   };
 
+  style.position = Position::Relative;
   style.z_index = ZIndex::Integer(1);
   assert!(style.creates_stacking_context(border_box, &sizing, false));
 

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -196,14 +196,14 @@ fn continue_property_resolves_by_name() {
 fn max_lines_clamps_only_inside_fragmentation_context() {
   // Bare `max-lines` (continue: normal) does not clamp.
   let bare = inherited_style_from_pairs([("max-lines", "3")], &ComputedStyle::default());
-  assert!(bare.resolved_line_clamp().is_none());
+  assert!(bare.clamp_lines().is_none());
 
   // `continue: collapse` turns it into a fragmentation context that clamps.
   let clamped = inherited_style_from_pairs(
     [("max-lines", "3"), ("continue", "collapse")],
     &ComputedStyle::default(),
   );
-  assert_eq!(clamped.resolved_line_clamp().map(|c| c.count), Some(3));
+  assert_eq!(clamped.clamp_lines(), Some(3));
 }
 
 #[test]
@@ -807,13 +807,7 @@ fn test_text_overflow_ellipsis_forces_single_line_clamp_on_nowrap() {
   };
 
   assert_eq!(style.resolved_text_wrap_mode(), TextWrapMode::Wrap);
-  assert_eq!(
-    style.resolved_line_clamp(),
-    Some(ResolvedLineClamp {
-      count: 1,
-      ellipsis: Some("…".to_string()),
-    })
-  );
+  assert_eq!(style.clamp_lines(), Some(1));
 }
 
 #[test]

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -157,7 +157,7 @@ fn parse_webkit_line_clamp_matches_line_clamp() {
 
   let webkit = webkit_line_clamp.inherit(&ComputedStyle::default());
   let plain = line_clamp.inherit(&ComputedStyle::default());
-  assert_eq!(webkit.max_lines, MaxLines::Lines(2));
+  assert_eq!(webkit.max_lines, Some(2));
   assert_eq!(webkit.max_lines, plain.max_lines);
   assert_eq!(webkit.block_ellipsis, plain.block_ellipsis);
 }
@@ -168,7 +168,7 @@ fn line_clamp_shorthand_expands_to_longhands() {
   parent.append_block(parse_declarations("line-clamp", "3 \"...\""));
   let parent = parent.inherit(&ComputedStyle::default());
 
-  assert_eq!(parent.max_lines, MaxLines::Lines(3));
+  assert_eq!(parent.max_lines, Some(3));
   assert_eq!(
     parent.block_ellipsis,
     BlockEllipsis::String("...".to_owned())
@@ -177,7 +177,7 @@ fn line_clamp_shorthand_expands_to_longhands() {
 
   // Only `block-ellipsis` inherits; `max-lines` and `continue` do not.
   let child = Style::default().inherit(&parent);
-  assert_eq!(child.max_lines, MaxLines::None);
+  assert_eq!(child.max_lines, None);
   assert_eq!(child.r#continue, Continue::Normal);
   assert_eq!(
     child.block_ellipsis,
@@ -196,17 +196,14 @@ fn continue_property_resolves_by_name() {
 fn max_lines_clamps_only_inside_fragmentation_context() {
   // Bare `max-lines` (continue: normal) does not clamp.
   let bare = inherited_style_from_pairs([("max-lines", "3")], &ComputedStyle::default());
-  assert!(bare.text_wrap_mode_and_line_clamp().1.is_none());
+  assert!(bare.resolved_line_clamp().is_none());
 
   // `continue: collapse` turns it into a fragmentation context that clamps.
   let clamped = inherited_style_from_pairs(
     [("max-lines", "3"), ("continue", "collapse")],
     &ComputedStyle::default(),
   );
-  assert_eq!(
-    clamped.text_wrap_mode_and_line_clamp().1.map(|c| c.count),
-    Some(3)
-  );
+  assert_eq!(clamped.resolved_line_clamp().map(|c| c.count), Some(3));
 }
 
 #[test]
@@ -809,15 +806,13 @@ fn test_text_overflow_ellipsis_forces_single_line_clamp_on_nowrap() {
     ..Default::default()
   };
 
-  let (text_wrap_mode, line_clamp) = style.text_wrap_mode_and_line_clamp();
-
-  assert_eq!(text_wrap_mode, TextWrapMode::Wrap);
+  assert_eq!(style.resolved_text_wrap_mode(), TextWrapMode::Wrap);
   assert_eq!(
-    line_clamp,
-    Some(std::borrow::Cow::Owned(LineClamp {
+    style.resolved_line_clamp(),
+    Some(ResolvedLineClamp {
       count: 1,
       ellipsis: Some("…".to_string()),
-    }))
+    })
   );
 }
 

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -173,12 +173,12 @@ fn line_clamp_shorthand_expands_to_longhands() {
     parent.block_ellipsis,
     BlockEllipsis::String("...".to_owned())
   );
-  assert_eq!(parent.r#continue, Continue::Discard);
+  assert_eq!(parent.r#continue, Continue::Collapse);
 
   // Only `block-ellipsis` inherits; `max-lines` and `continue` do not.
   let child = Style::default().inherit(&parent);
   assert_eq!(child.max_lines, MaxLines::None);
-  assert_eq!(child.r#continue, Continue::Auto);
+  assert_eq!(child.r#continue, Continue::Normal);
   assert_eq!(
     child.block_ellipsis,
     BlockEllipsis::String("...".to_owned())
@@ -190,6 +190,23 @@ fn continue_property_resolves_by_name() {
   let continue_id = PropertyId::Longhand(LonghandId::Continue);
   assert_eq!(PropertyId::from_kebab_case("continue"), continue_id);
   assert_eq!(PropertyId::from_camel_case("continue"), continue_id);
+}
+
+#[test]
+fn max_lines_clamps_only_inside_fragmentation_context() {
+  // Bare `max-lines` (continue: normal) does not clamp.
+  let bare = inherited_style_from_pairs([("max-lines", "3")], &ComputedStyle::default());
+  assert!(bare.text_wrap_mode_and_line_clamp().1.is_none());
+
+  // `continue: collapse` turns it into a fragmentation context that clamps.
+  let clamped = inherited_style_from_pairs(
+    [("max-lines", "3"), ("continue", "collapse")],
+    &ComputedStyle::default(),
+  );
+  assert_eq!(
+    clamped.text_wrap_mode_and_line_clamp().1.map(|c| c.count),
+    Some(3)
+  );
 }
 
 #[test]

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -120,7 +120,7 @@ fn custom_properties_map_to_custom_property_id() {
 
 #[test]
 fn property_id_accepts_webkit_aliases() {
-  let line_clamp = PropertyId::Longhand(LonghandId::LineClamp);
+  let line_clamp = PropertyId::Shorthand(ShorthandId::LineClamp);
 
   assert_eq!(PropertyId::from_kebab_case("line-clamp"), line_clamp);
   assert_eq!(PropertyId::from_camel_case("lineClamp"), line_clamp);
@@ -155,12 +155,41 @@ fn parse_webkit_line_clamp_matches_line_clamp() {
   let mut webkit_line_clamp = Style::default();
   webkit_line_clamp.append_block(parse_declarations("-webkit-line-clamp", "2"));
 
+  let webkit = webkit_line_clamp.inherit(&ComputedStyle::default());
+  let plain = line_clamp.inherit(&ComputedStyle::default());
+  assert_eq!(webkit.max_lines, MaxLines::Lines(2));
+  assert_eq!(webkit.max_lines, plain.max_lines);
+  assert_eq!(webkit.block_ellipsis, plain.block_ellipsis);
+}
+
+#[test]
+fn line_clamp_shorthand_expands_to_longhands() {
+  let mut parent = Style::default();
+  parent.append_block(parse_declarations("line-clamp", "3 \"...\""));
+  let parent = parent.inherit(&ComputedStyle::default());
+
+  assert_eq!(parent.max_lines, MaxLines::Lines(3));
   assert_eq!(
-    webkit_line_clamp
-      .inherit(&ComputedStyle::default())
-      .line_clamp,
-    line_clamp.inherit(&ComputedStyle::default()).line_clamp
+    parent.block_ellipsis,
+    BlockEllipsis::String("...".to_owned())
   );
+  assert_eq!(parent.r#continue, Continue::Discard);
+
+  // Only `block-ellipsis` inherits; `max-lines` and `continue` do not.
+  let child = Style::default().inherit(&parent);
+  assert_eq!(child.max_lines, MaxLines::None);
+  assert_eq!(child.r#continue, Continue::Auto);
+  assert_eq!(
+    child.block_ellipsis,
+    BlockEllipsis::String("...".to_owned())
+  );
+}
+
+#[test]
+fn continue_property_resolves_by_name() {
+  let continue_id = PropertyId::Longhand(LonghandId::Continue);
+  assert_eq!(PropertyId::from_kebab_case("continue"), continue_id);
+  assert_eq!(PropertyId::from_camel_case("continue"), continue_id);
 }
 
 #[test]

--- a/takumi-css/src/style/tw/map.rs
+++ b/takumi-css/src/style/tw/map.rs
@@ -57,7 +57,7 @@ property_parsers! {
   ColorTransparent(ColorDefaultsToTransparent) => ColorDefaultsToTransparent,
   Percentage(PercentageNumber) => PercentageNumber,
   FontFamily(FontFamily) => FontFamily,
-  LineClamp(LineClampShorthand) => LineClampShorthand,
+  LineClamp(LineClamp) => LineClamp,
   WhiteSpace(WhiteSpace) => WhiteSpace,
   OverflowWrap(OverflowWrap) => OverflowWrap,
   FontSize(TwFontSize) => TwFontSize,

--- a/takumi-css/src/style/tw/map.rs
+++ b/takumi-css/src/style/tw/map.rs
@@ -57,7 +57,7 @@ property_parsers! {
   ColorTransparent(ColorDefaultsToTransparent) => ColorDefaultsToTransparent,
   Percentage(PercentageNumber) => PercentageNumber,
   FontFamily(FontFamily) => FontFamily,
-  LineClamp(LineClamp) => LineClamp,
+  LineClamp(LineClampShorthand) => LineClampShorthand,
   WhiteSpace(WhiteSpace) => WhiteSpace,
   OverflowWrap(OverflowWrap) => OverflowWrap,
   FontSize(TwFontSize) => TwFontSize,

--- a/takumi-css/src/style/tw/map.rs
+++ b/takumi-css/src/style/tw/map.rs
@@ -40,7 +40,7 @@ property_parsers! {
   Justify(JustifyContent) => JustifyContent,
   Align(AlignItems) => AlignItems,
   Overflow(Overflow) => Overflow,
-  BorderWidth(TwBorderWidth) => TwBorderWidth,
+  BorderWidth(LineWidth) => LineWidth,
   BorderStyle(BorderStyle) => BorderStyle,
   Rounded(TwRounded) => TwRounded,
   GridTemplate(TwGridTemplate) => TwGridTemplate,

--- a/takumi-css/src/style/tw/mod.rs
+++ b/takumi-css/src/style/tw/mod.rs
@@ -275,7 +275,7 @@ pub enum TailwindProperty {
   /// `font-family` property.
   FontFamily(FontFamily),
   /// `line-clamp` property.
-  LineClamp(LineClampShorthand),
+  LineClamp(LineClamp),
   /// `text-overflow` property.
   TextOverflow(TextOverflow),
   /// `text-wrap` property.

--- a/takumi-css/src/style/tw/mod.rs
+++ b/takumi-css/src/style/tw/mod.rs
@@ -275,7 +275,7 @@ pub enum TailwindProperty {
   /// `font-family` property.
   FontFamily(FontFamily),
   /// `line-clamp` property.
-  LineClamp(LineClamp),
+  LineClamp(LineClampShorthand),
   /// `text-overflow` property.
   TextOverflow(TextOverflow),
   /// `text-wrap` property.
@@ -868,8 +868,14 @@ impl TailwindProperty {
       TailwindProperty::FontFamily(font_family) => {
         push_decl!(builder, important, font_family(font_family))
       }
-      TailwindProperty::LineClamp(line_clamp) => {
-        push_decl!(builder, important, line_clamp(Some(line_clamp)))
+      TailwindProperty::LineClamp(value) => {
+        push_decl!(
+          builder,
+          important,
+          max_lines(value.max_lines),
+          block_ellipsis(value.block_ellipsis),
+          r#continue(value.line_continue)
+        )
       }
       TailwindProperty::TextAlign(text_align) => {
         push_decl!(builder, important, text_align(text_align))
@@ -1071,7 +1077,7 @@ impl TailwindProperty {
         push_decl!(
           builder,
           important,
-          outline_offset(outline_offset.to_length())
+          outline_offset(Length::from(outline_offset))
         )
       }
       TailwindProperty::Rounded(rounded) => rounded_corners!(

--- a/takumi-css/src/style/tw/mod.rs
+++ b/takumi-css/src/style/tw/mod.rs
@@ -369,7 +369,7 @@ pub enum TailwindProperty {
   /// Tailwind `border` utility (`border-width: 1px; border-style: solid`).
   BorderDefault,
   /// `border-width` property.
-  BorderWidth(TwBorderWidth),
+  BorderWidth(LineWidth),
   /// `border-style` property.
   BorderStyle(BorderStyle),
   /// `color` property.
@@ -381,17 +381,17 @@ pub enum TailwindProperty {
   /// `border-color` property.
   BorderColor(ColorInput),
   /// `border-top-width` property.
-  BorderTopWidth(TwBorderWidth),
+  BorderTopWidth(LineWidth),
   /// `border-right-width` property.
-  BorderRightWidth(TwBorderWidth),
+  BorderRightWidth(LineWidth),
   /// `border-bottom-width` property.
-  BorderBottomWidth(TwBorderWidth),
+  BorderBottomWidth(LineWidth),
   /// `border-left-width` property.
-  BorderLeftWidth(TwBorderWidth),
+  BorderLeftWidth(LineWidth),
   /// `border-inline-width` property.
-  BorderXWidth(TwBorderWidth),
+  BorderXWidth(LineWidth),
   /// `border-block-width` property.
-  BorderYWidth(TwBorderWidth),
+  BorderYWidth(LineWidth),
   /// `border-top-color` property.
   BorderTopColor(ColorInput),
   /// `border-right-color` property.
@@ -407,13 +407,13 @@ pub enum TailwindProperty {
   /// Tailwind `outline` utility (`outline-width: 1px; outline-style: solid`).
   OutlineDefault,
   /// `outline-width` property.
-  OutlineWidth(TwBorderWidth),
+  OutlineWidth(LineWidth),
   /// `outline-color` property.
   OutlineColor(ColorInput),
   /// `outline-style` property.
   OutlineStyle(BorderStyle),
   /// `outline-offset` property.
-  OutlineOffset(TwBorderWidth),
+  OutlineOffset(LineWidth),
   /// `border-radius` property.
   Rounded(TwRounded),
   /// `border-top-left-radius` property.
@@ -945,20 +945,20 @@ impl TailwindProperty {
         push_decl!(
           builder,
           important,
-          border_top_width(Length::Px(1.0)),
-          border_right_width(Length::Px(1.0)),
-          border_bottom_width(Length::Px(1.0)),
-          border_left_width(Length::Px(1.0))
+          border_top_width(LineWidth::Length(Length::Px(1.0))),
+          border_right_width(LineWidth::Length(Length::Px(1.0))),
+          border_bottom_width(LineWidth::Length(Length::Px(1.0))),
+          border_left_width(LineWidth::Length(Length::Px(1.0)))
         );
       }
       TailwindProperty::BorderWidth(tw_border_width) => {
         push_decl!(
           builder,
           important,
-          border_top_width(tw_border_width.0),
-          border_right_width(tw_border_width.0),
-          border_bottom_width(tw_border_width.0),
-          border_left_width(tw_border_width.0)
+          border_top_width(tw_border_width),
+          border_right_width(tw_border_width),
+          border_bottom_width(tw_border_width),
+          border_left_width(tw_border_width)
         );
       }
       TailwindProperty::BorderStyle(border_style) => {
@@ -995,31 +995,31 @@ impl TailwindProperty {
         )
       }
       TailwindProperty::BorderTopWidth(tw_border_width) => {
-        push_decl!(builder, important, border_top_width(tw_border_width.0))
+        push_decl!(builder, important, border_top_width(tw_border_width))
       }
       TailwindProperty::BorderRightWidth(tw_border_width) => {
-        push_decl!(builder, important, border_right_width(tw_border_width.0))
+        push_decl!(builder, important, border_right_width(tw_border_width))
       }
       TailwindProperty::BorderBottomWidth(tw_border_width) => {
-        push_decl!(builder, important, border_bottom_width(tw_border_width.0))
+        push_decl!(builder, important, border_bottom_width(tw_border_width))
       }
       TailwindProperty::BorderLeftWidth(tw_border_width) => {
-        push_decl!(builder, important, border_left_width(tw_border_width.0))
+        push_decl!(builder, important, border_left_width(tw_border_width))
       }
       TailwindProperty::BorderXWidth(tw_border_width) => {
         push_decl!(
           builder,
           important,
-          border_left_width(tw_border_width.0),
-          border_right_width(tw_border_width.0)
+          border_left_width(tw_border_width),
+          border_right_width(tw_border_width)
         );
       }
       TailwindProperty::BorderYWidth(tw_border_width) => {
         push_decl!(
           builder,
           important,
-          border_top_width(tw_border_width.0),
-          border_bottom_width(tw_border_width.0)
+          border_top_width(tw_border_width),
+          border_bottom_width(tw_border_width)
         );
       }
       TailwindProperty::BorderTopColor(color_input) => {
@@ -1054,12 +1054,12 @@ impl TailwindProperty {
         push_decl!(
           builder,
           important,
-          outline_width(Length::Px(1.0)),
+          outline_width(LineWidth::Length(Length::Px(1.0))),
           outline_style(BorderStyle::Solid)
         );
       }
       TailwindProperty::OutlineWidth(tw_border_width) => {
-        push_decl!(builder, important, outline_width(tw_border_width.0))
+        push_decl!(builder, important, outline_width(tw_border_width))
       }
       TailwindProperty::OutlineColor(color_input) => {
         push_decl!(builder, important, outline_color(color_input))
@@ -1068,7 +1068,11 @@ impl TailwindProperty {
         push_decl!(builder, important, outline_style(outline_style))
       }
       TailwindProperty::OutlineOffset(outline_offset) => {
-        push_decl!(builder, important, outline_offset(outline_offset.0))
+        push_decl!(
+          builder,
+          important,
+          outline_offset(outline_offset.to_length())
+        )
       }
       TailwindProperty::Rounded(rounded) => rounded_corners!(
         builder,

--- a/takumi-css/src/style/tw/parser.rs
+++ b/takumi-css/src/style/tw/parser.rs
@@ -161,25 +161,6 @@ impl TailwindPropertyParser for TwLetterSpacing {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TwBorderWidth(pub Length);
-
-impl<'i> FromCss<'i> for TwBorderWidth {
-  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    Ok(Self(Length::from_css(input)?))
-  }
-
-  const VALID_TOKENS: &'static [CssToken] = Length::<true>::VALID_TOKENS;
-}
-
-impl TailwindPropertyParser for TwBorderWidth {
-  fn parse_tw(token: &str) -> Option<Self> {
-    let value = token.parse::<f32>().ok()?;
-
-    Some(TwBorderWidth(Length::Px(value)))
-  }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TwRounded(pub LengthDefaultsToZero);
 
 impl<'i> FromCss<'i> for TwRounded {

--- a/takumi-css/src/style/tw/tests.rs
+++ b/takumi-css/src/style/tw/tests.rs
@@ -261,15 +261,15 @@ fn test_parse_border_width() {
   );
   assert_eq!(
     TailwindProperty::parse("border-t-2"),
-    Some(TailwindProperty::BorderTopWidth(TwBorderWidth(Length::Px(
-      2.0
-    ))))
+    Some(TailwindProperty::BorderTopWidth(LineWidth::Length(
+      Length::Px(2.0)
+    )))
   );
   assert_eq!(
     TailwindProperty::parse("border-x-4"),
-    Some(TailwindProperty::BorderXWidth(TwBorderWidth(Length::Px(
-      4.0
-    ))))
+    Some(TailwindProperty::BorderXWidth(LineWidth::Length(
+      Length::Px(4.0)
+    )))
   );
   assert_eq!(
     TailwindProperty::parse("border-solid"),
@@ -297,9 +297,9 @@ fn test_parse_outline() {
   );
   assert_eq!(
     TailwindProperty::parse("outline-2"),
-    Some(TailwindProperty::OutlineWidth(TwBorderWidth(Length::Px(
-      2.0
-    ))))
+    Some(TailwindProperty::OutlineWidth(LineWidth::Length(
+      Length::Px(2.0)
+    )))
   );
   assert_eq!(
     TailwindProperty::parse("outline-red-500"),
@@ -317,9 +317,9 @@ fn test_parse_outline() {
   );
   assert_eq!(
     TailwindProperty::parse("outline-offset-4"),
-    Some(TailwindProperty::OutlineOffset(TwBorderWidth(Length::Px(
-      4.0
-    ))))
+    Some(TailwindProperty::OutlineOffset(LineWidth::Length(
+      Length::Px(4.0)
+    )))
   );
   assert_eq!(
     TailwindProperty::parse("outline-none"),
@@ -1035,7 +1035,7 @@ fn test_border_width_implies_solid_and_per_side_color() {
   };
 
   let top = computed("border-t-8");
-  assert_eq!(top.border_top_width, Length::Px(8.0));
+  assert_eq!(top.border_top_width, LineWidth::Length(Length::Px(8.0)));
   assert_eq!(top.border_top_style, BorderStyle::Solid);
   assert_eq!(top.border_bottom_style, BorderStyle::None);
 
@@ -1056,7 +1056,7 @@ fn test_border_width_implies_solid_and_per_side_color() {
   );
 
   let bar = computed("border-t-8 border-t-blue-500");
-  assert_eq!(bar.border_top_width, Length::Px(8.0));
+  assert_eq!(bar.border_top_width, LineWidth::Length(Length::Px(8.0)));
   assert_eq!(bar.border_top_style, BorderStyle::Solid);
   assert_eq!(
     bar.border_top_color,

--- a/takumi-css/src/style/tw/tests.rs
+++ b/takumi-css/src/style/tw/tests.rs
@@ -902,7 +902,7 @@ fn test_font_numeric_weight() {
 fn test_line_clamp_none() {
   assert_eq!(
     TailwindProperty::parse("line-clamp-none"),
-    Some(TailwindProperty::LineClamp(LineClamp::from(0)))
+    Some(TailwindProperty::LineClamp(LineClampShorthand::default()))
   );
 }
 

--- a/takumi-css/src/style/tw/tests.rs
+++ b/takumi-css/src/style/tw/tests.rs
@@ -902,7 +902,7 @@ fn test_font_numeric_weight() {
 fn test_line_clamp_none() {
   assert_eq!(
     TailwindProperty::parse("line-clamp-none"),
-    Some(TailwindProperty::LineClamp(LineClampShorthand::default()))
+    Some(TailwindProperty::LineClamp(LineClamp::default()))
   );
 }
 

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -14,7 +14,7 @@ use crate::{
       resolve_inline_max_height,
     },
     node::{ImageData, Node, NodeKind, TextData},
-    style::{Affine, BackgroundClip, BlendMode, Sides},
+    style::{Affine, BackgroundClip, BlendMode, Length, Sides},
   },
 };
 
@@ -269,9 +269,7 @@ pub(crate) fn draw_outline(
   canvas: &mut Canvas,
   layout: Layout,
 ) -> Result<()> {
-  let width = context
-    .style
-    .outline_width
+  let width = Length::from(context.style.outline_width)
     .to_px(&context.sizing, layout.size.width)
     .max(0.0);
 

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -17,7 +17,7 @@ use takumi_core::{
     node::{ImageData, Node, NodeKind},
     style::{
       BackgroundClip, BackgroundImage, BasicShape, BlendMode, BorderStyle, Color, ComputedStyle,
-      Display, FillRule, Isolation, Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
+      Display, FillRule, Isolation, Length, Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
       StyleSheet, ToCss,
     },
     tree::{LayoutResults, LayoutTree, RenderNode},
@@ -883,7 +883,9 @@ fn emit_outline(
     return Ok(());
   }
   let sizing = &node.context.sizing;
-  let width = style.outline_width.to_px(sizing, size.width).max(0.0);
+  let width = Length::from(style.outline_width)
+    .to_px(sizing, size.width)
+    .max(0.0);
   if width <= 0.0 {
     return Ok(());
   }

--- a/takumi/tests/fixtures/deep_nesting.rs
+++ b/takumi/tests/fixtures/deep_nesting.rs
@@ -69,7 +69,12 @@ fn recursive_visual_node(level: usize, max_depth: usize) -> Node {
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(10.0), Px(10.0), Px(10.0), Px(14.0)]))
       .with_margin(Sides([Px(0.0), Px(0.0), Px(0.0), Px(8.0)]))
-      .with_border_width(Sides([Px(0.0), Px(0.0), Px(0.0), Px(3.0)]))
+      .with_border_width(Sides([
+        Px(0.0).into(),
+        Px(0.0).into(),
+        Px(0.0).into(),
+        Px(3.0).into(),
+      ]))
       .with_border_color(Sides([ColorInput::Value(Color([215, 132, 55, 255])); 4]))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         recursive_level_background(level),

--- a/takumi/tests/fixtures/inline.rs
+++ b/takumi/tests/fixtures/inline.rs
@@ -75,7 +75,7 @@ fn inline_image() {
     Node::image(("assets/images/yeecord.png", 64.0, 64.0)).with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Inline))
-        .with_border_width(Sides([Px(12.0); 4]))
+        .with_border_width(Sides([Px(12.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color::transparent()); 4]))
         .with(StyleDeclaration::background_image(
@@ -92,7 +92,7 @@ fn inline_image() {
   let container = Node::container([Node::container(children).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
-      .with_border_width(Sides([Px(2.0); 4]))
+      .with_border_width(Sides([Px(2.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with(StyleDeclaration::display(Display::Block))
       .with(StyleDeclaration::font_size(Px(48.0).into())),
@@ -321,7 +321,7 @@ fn inline_outline_span_boundaries() {
       .with_style(
         Style::default()
           .with(StyleDeclaration::display(Display::Inline))
-          .with(StyleDeclaration::outline_width(Px(3.0)))
+          .with(StyleDeclaration::outline_width(Px(3.0).into()))
           .with(StyleDeclaration::outline_style(BorderStyle::Solid))
           .with(StyleDeclaration::outline_color(ColorInput::Value(Color([
             255, 0, 0, 255,
@@ -339,7 +339,7 @@ fn inline_outline_span_boundaries() {
       .with(StyleDeclaration::display(Display::Block))
       .with(StyleDeclaration::width(Px(320.0)))
       .with_padding(Sides([Px(24.0); 4]))
-      .with_border_width(Sides([Px(2.0); 4]))
+      .with_border_width(Sides([Px(2.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with(StyleDeclaration::font_size(Px(28.0).into()))
       .with(StyleDeclaration::line_height(Px(34.0).into()))
@@ -373,7 +373,7 @@ fn inline_atomic_containers() {
         .with(StyleDeclaration::background_color(ColorInput::Value(
           bg_color,
         )))
-        .with_border_width(Sides([Px(5.0); 4]))
+        .with_border_width(Sides([Px(5.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(border_color); 4])),
     )
@@ -419,7 +419,7 @@ fn inline_atomic_containers() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::display(Display::Block))
       .with(StyleDeclaration::font_size(Px(24.0).into()))
-      .with_border_width(Sides([Px(6.0); 4]))
+      .with_border_width(Sides([Px(6.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([40, 40, 40, 255])); 4])),
   )])
@@ -551,7 +551,7 @@ fn inline_complex_nested_fixture() {
           .with(StyleDeclaration::background_color(ColorInput::Value(Color([
             231, 241, 250, 255,
           ]))))
-          .with_border_width(Sides([Px(2.0); 4]))
+          .with_border_width(Sides([Px(2.0).into(); 4]))
           .with_border_style(Sides([BorderStyle::Solid; 4]))
           .with_border_color(Sides([ColorInput::Value(Color([
             156, 189, 217, 255,
@@ -584,7 +584,7 @@ fn inline_complex_nested_fixture() {
           .with(StyleDeclaration::background_color(ColorInput::Value(Color([
             255, 236, 208, 255,
           ]))))
-          .with_border_width(Sides([Px(2.0); 4]))
+          .with_border_width(Sides([Px(2.0).into(); 4]))
           .with_border_style(Sides([BorderStyle::Solid; 4]))
           .with_border_color(Sides([ColorInput::Value(Color([
             212, 118, 22, 255,
@@ -803,7 +803,7 @@ fn inline_social_post_regression() {
         )))
         .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(16.0)); 4])))
         .with_padding(Sides([Px(24.0); 4]))
-        .with_border_width(Sides([Px(1.0); 4]))
+        .with_border_width(Sides([Px(1.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([56, 68, 77, 255])); 4])),
     )

--- a/takumi/tests/fixtures/inline.rs
+++ b/takumi/tests/fixtures/inline.rs
@@ -57,7 +57,7 @@ fn text_inline() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Block))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with(StyleDeclaration::line_clamp(Some(3.into())))
+      .with_line_clamp(3u32.into())
       .with(StyleDeclaration::text_overflow(TextOverflow::Ellipsis))
       .with(StyleDeclaration::font_size(Px(48.0).into()))
       .with_white_space(WhiteSpace::pre_wrap()),

--- a/takumi/tests/fixtures/inline_vertical_align.rs
+++ b/takumi/tests/fixtures/inline_vertical_align.rs
@@ -32,7 +32,7 @@ fn inline_vertical_align_types() {
           .with(StyleDeclaration::height(Px(44.0)))
           .with(StyleDeclaration::background_color(ColorInput::Value(color)))
           .with(StyleDeclaration::vertical_align(align))
-          .with_border_width(Sides([Px(2.0); 4]))
+          .with_border_width(Sides([Px(2.0).into(); 4]))
           .with_border_style(Sides([BorderStyle::Solid; 4]))
           .with_border_color(Sides([ColorInput::Value(Color([30, 30, 30, 255])); 4])),
       ),
@@ -64,7 +64,7 @@ fn inline_vertical_align_types() {
         .with(StyleDeclaration::background_color(ColorInput::Value(
           Color([248, 248, 248, 255]),
         )))
-        .with_border_width(Sides([Px(1.0); 4]))
+        .with_border_width(Sides([Px(1.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([180, 180, 180, 255])); 4])),
     )

--- a/takumi/tests/fixtures/rtl.rs
+++ b/takumi/tests/fixtures/rtl.rs
@@ -10,7 +10,7 @@ fn create_test_nodes() -> Vec<Node> {
     .map(|i| {
       Node::text(format!("Node {i}")).with_style(
         Style::default()
-          .with_border_width(Sides([Px(1.0); 4]))
+          .with_border_width(Sides([Px(1.0).into(); 4]))
           .with_padding(Sides([Px(16.0); 4]))
           .with_border_style(Sides([BorderStyle::Solid; 4]))
           .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0))))

--- a/takumi/tests/fixtures/style_background_clip.rs
+++ b/takumi/tests/fixtures/style_background_clip.rs
@@ -21,7 +21,7 @@ fn create_container_with_background_clip(
       )))
       .with(StyleDeclaration::background_clip(background_clip))
       .with_padding(Sides([Px(padding); 4]))
-      .with_border_width(Sides([Px(border_width); 4]))
+      .with_border_width(Sides([Px(border_width).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([0, 0, 0, 255])); 4]))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(8.0)); 4]))),
@@ -167,7 +167,7 @@ fn test_style_background_clip_border_area() {
         BackgroundClip::BorderArea,
       ))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_border_width(Sides([Px(10.0); 4]))
+      .with_border_width(Sides([Px(10.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([0, 0, 0, 128])); 4]))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(8.0)); 4]))),
@@ -205,7 +205,7 @@ fn test_style_background_clip_with_gradient_background() {
         BackgroundClip::PaddingBox,
       ))
       .with_padding(Sides([Px(30.0); 4]))
-      .with_border_width(Sides([Px(15.0); 4]))
+      .with_border_width(Sides([Px(15.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([255, 255, 255, 255])); 4])),
   )])
@@ -273,7 +273,7 @@ fn test_style_background_clip_comparison() {
         )))
         .with(StyleDeclaration::background_clip(BackgroundClip::BorderBox))
         .with_padding(Sides([Px(15.0); 4]))
-        .with_border_width(Sides([Px(8.0); 4]))
+        .with_border_width(Sides([Px(8.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([0, 0, 0, 128])); 4])),
     ),
@@ -296,7 +296,7 @@ fn test_style_background_clip_comparison() {
           BackgroundClip::PaddingBox,
         ))
         .with_padding(Sides([Px(15.0); 4]))
-        .with_border_width(Sides([Px(8.0); 4]))
+        .with_border_width(Sides([Px(8.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([0, 0, 0, 128])); 4])),
     ),
@@ -319,7 +319,7 @@ fn test_style_background_clip_comparison() {
           BackgroundClip::ContentBox,
         ))
         .with_padding(Sides([Px(15.0); 4]))
-        .with_border_width(Sides([Px(8.0); 4]))
+        .with_border_width(Sides([Px(8.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([0, 0, 0, 128])); 4])),
     ),

--- a/takumi/tests/fixtures/style_overflow.rs
+++ b/takumi/tests/fixtures/style_overflow.rs
@@ -12,7 +12,7 @@ fn create_overflow_fixture(overflows: SpacePair<Overflow>) -> Node {
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::width(Px(300.0)))
         .with(StyleDeclaration::height(Px(300.0)))
-        .with_border_width(Sides([Px(4.0); 4]))
+        .with_border_width(Sides([Px(4.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([0, 255, 0, 255])); 4])),
     )])
@@ -22,7 +22,7 @@ fn create_overflow_fixture(overflows: SpacePair<Overflow>) -> Node {
         .with(StyleDeclaration::display(Display::Block))
         .with(StyleDeclaration::width(Px(200.0)))
         .with(StyleDeclaration::height(Px(200.0)))
-        .with_border_width(Sides([Px(4.0); 4]))
+        .with_border_width(Sides([Px(4.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([Color([255, 0, 0, 255]).into(); 4]))
         .with_overflow(overflows),
@@ -49,7 +49,7 @@ fn create_text_overflow_fixture(overflows: SpacePair<Overflow>) -> Node {
             Style::default().with(StyleDeclaration::display(Display::Flex))
               .with(StyleDeclaration::font_size(Rem(4.0).into()))
               .with(StyleDeclaration::color(ColorInput::Value(Color([0, 0, 0, 255]))))
-              .with_border_width(Sides([Px(2.0); 4]))
+              .with_border_width(Sides([Px(2.0).into(); 4]))
               .with_border_style(Sides([BorderStyle::Solid; 4]))
               .with_border_color(Sides([Color([255, 0, 0, 255]).into(); 4])),
           ),
@@ -59,7 +59,7 @@ fn create_text_overflow_fixture(overflows: SpacePair<Overflow>) -> Node {
           .with(StyleDeclaration::display(Display::Block))
           .with(StyleDeclaration::width(Px(400.0)))
           .with(StyleDeclaration::height(Px(200.0)))
-          .with_border_width(Sides([Px(4.0); 4]))
+          .with_border_width(Sides([Px(4.0).into(); 4]))
           .with_border_style(Sides([BorderStyle::Solid; 4]))
           .with_border_color(Sides([Color([0, 0, 0, 255]).into(); 4]))
           .with_overflow(overflows),
@@ -132,7 +132,7 @@ fn create_split_pill_case(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::height(Px(220.0)))
-        .with_border_width(Sides([Px(2.0); 4]))
+        .with_border_width(Sides([Px(2.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([220, 220, 220, 255])); 4])),
     ),

--- a/takumi/tests/fixtures/style_transform.rs
+++ b/takumi/tests/fixtures/style_transform.rs
@@ -128,7 +128,7 @@ fn create_rotated_container(angle: f32, transform_origin: TransformOrigin) -> No
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 0, 0, 30]),
       )))
-      .with_border_width(Sides([Px(1.0); 4]))
+      .with_border_width(Sides([Px(1.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(12.0)); 4]))),
   )
@@ -157,7 +157,7 @@ fn test_style_transform_translate_and_scale() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::width(Px(300.0)))
       .with(StyleDeclaration::height(Px(300.0)))
-      .with_border_width(Sides([Px(1.0); 4]))
+      .with_border_width(Sides([Px(1.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with(StyleDeclaration::translate(SpacePair::from_single(Px(
         300.0,
@@ -179,7 +179,7 @@ fn test_style_transform_translate_and_scale() {
         )))
         .with(StyleDeclaration::width(Px(100.0)))
         .with(StyleDeclaration::height(Px(100.0)))
-        .with_border_width(Sides([Px(1.0); 4]))
+        .with_border_width(Sides([Px(1.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with(StyleDeclaration::font_size(Px(12.0).into())),
     );
@@ -194,7 +194,7 @@ fn test_style_transform_translate_and_scale() {
         )))
         .with(StyleDeclaration::width(Px(200.0)))
         .with(StyleDeclaration::height(Px(200.0)))
-        .with_border_width(Sides([Px(1.0); 4]))
+        .with_border_width(Sides([Px(1.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with(StyleDeclaration::color(ColorInput::Value(Color::white())))
         .with_border_color(Sides([ColorInput::Value(Color::black()); 4])),

--- a/takumi/tests/fixtures/style_visuals.rs
+++ b/takumi/tests/fixtures/style_visuals.rs
@@ -73,7 +73,7 @@ fn test_style_border_width() {
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::white(),
       )))
-      .with_border_width(Sides([Px(10.0); 4]))
+      .with_border_width(Sides([Px(10.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([255, 0, 0, 255])); 4])),
   );
@@ -91,7 +91,12 @@ fn test_style_border_per_side_color_and_width() {
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::white(),
       )))
-      .with_border_width(Sides([Px(12.0), Px(24.0), Px(36.0), Px(48.0)]))
+      .with_border_width(Sides([
+        Px(12.0).into(),
+        Px(24.0).into(),
+        Px(36.0).into(),
+        Px(48.0).into(),
+      ]))
       .with_border_style(Sides([
         BorderStyle::Solid,
         BorderStyle::Solid,
@@ -129,7 +134,7 @@ fn test_style_border_width_with_radius() {
       .with(StyleDeclaration::height(Rem(8.0)))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(10.0)); 4])))
       .with_border_color(Sides([ColorInput::Value(Color([255, 0, 0, 255])); 4]))
-      .with_border_width(Sides([Px(4.0); 4]))
+      .with_border_width(Sides([Px(4.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4])),
   )])
   .with_style(
@@ -289,7 +294,7 @@ fn test_style_border_radius_width_offset() {
           .with(StyleDeclaration::background_color(ColorInput::Value(
             Color::white(),
           )))
-          .with_border_width(Sides([Px(1.0); 4]))
+          .with_border_width(Sides([Px(1.0).into(); 4]))
           .with_border_style(Sides([BorderStyle::Solid; 4]))
           .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(24.0)); 4])))
           .with_border_color(Sides([ColorInput::Value(Color([0, 0, 0, 255])); 4])),
@@ -330,7 +335,7 @@ fn test_style_border_radius_circle_avatar() {
         [SpacePair::from_single(Percentage(50.0)); 4],
       )))
       .with_border_color(Sides([ColorInput::Value(Color([128, 128, 128, 128])); 4]))
-      .with_border_width(Sides([Px(4.0); 4]))
+      .with_border_width(Sides([Px(4.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4])),
   )])
   .with_style(
@@ -356,7 +361,7 @@ fn test_style_border_width_on_image_node() {
       .with_border_radius(BorderRadius(Sides(
         [SpacePair::from_single(Percentage(100.0)); 4],
       )))
-      .with_border_width(Sides([Px(2.0); 4]))
+      .with_border_width(Sides([Px(2.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([202, 202, 202, 255])); 4]))
       .with(StyleDeclaration::width(Px(128.0)))
@@ -389,7 +394,7 @@ fn test_style_outline() {
         Color([14, 165, 233, 255]),
       )))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(16.0)); 4])))
-      .with(StyleDeclaration::outline_width(Px(10.0)))
+      .with(StyleDeclaration::outline_width(Px(10.0).into()))
       .with(StyleDeclaration::outline_color(ColorInput::Value(Color([
         17, 24, 39, 255,
       ]))))
@@ -458,7 +463,7 @@ fn non_uniform_border_demo(label: &str, style: Sides<BorderStyle>, width: Sides<
         Color([56, 189, 248, 255]),
       )))
       .with_border_style(style)
-      .with_border_width(width)
+      .with_border_width(width.map_axis(|w, _| w.into()))
       .with_border_color(Sides([ColorInput::Value(Color([17, 24, 39, 255])); 4])),
   );
 
@@ -488,7 +493,7 @@ fn border_style_demo(label: &str, style: BorderStyle) -> Node {
         Color([14, 165, 233, 255]),
       )))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(18.0)); 4])))
-      .with_border_width(Sides([Px(8.0); 4]))
+      .with_border_width(Sides([Px(8.0).into(); 4]))
       .with_border_style(Sides([style; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([17, 24, 39, 255])); 4])),
   );
@@ -506,10 +511,10 @@ fn outline_style_demo(label: &str, style: BorderStyle) -> Node {
         Color([251, 191, 36, 255]),
       )))
       .with_border_radius(BorderRadius(Sides([SpacePair::from_single(Px(18.0)); 4])))
-      .with_border_width(Sides([Px(2.0); 4]))
+      .with_border_width(Sides([Px(2.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([255, 255, 255, 255])); 4]))
-      .with(StyleDeclaration::outline_width(Px(8.0)))
+      .with(StyleDeclaration::outline_width(Px(8.0).into()))
       .with(StyleDeclaration::outline_offset(Px(8.0)))
       .with(StyleDeclaration::outline_style(style))
       .with(StyleDeclaration::outline_color(ColorInput::Value(Color([

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -636,7 +636,7 @@ fn text_ellipsis_line_clamp_2() {
       )))
       .with(StyleDeclaration::font_size(Px(48.0).into()))
       .with(StyleDeclaration::text_overflow(TextOverflow::Ellipsis))
-      .with(StyleDeclaration::line_clamp(Some(2.into()))),
+      .with_line_clamp(2u32.into()),
   );
 
   run_fixture_test(text, "text_ellipsis_line_clamp_2");

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -152,7 +152,7 @@ fn text_typography_line_height_variants() {
         .with(StyleDeclaration::width(Percentage(100.0)))
         .with(StyleDeclaration::background_color(ColorInput::Value(panel)))
         .with_padding(Sides([Px(18.0); 4]))
-        .with_border_width(Sides([Px(1.0); 4]))
+        .with_border_width(Sides([Px(1.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color([205, 214, 228, 255])); 4])),
     )
@@ -935,7 +935,7 @@ fn text_ellipsis_text_nowrap() {
   .with_style(Style::default().with(StyleDeclaration::display(Display::Flex))
             .with(StyleDeclaration::text_overflow(TextOverflow::Ellipsis))
             .with(StyleDeclaration::text_wrap_mode(TextWrapMode::NoWrap))
-            .with_border_width(Sides([Px(1.0); 4]))
+            .with_border_width(Sides([Px(1.0).into(); 4]))
             .with_border_style(Sides([BorderStyle::Solid; 4]))
             .with_border_color(Sides([ColorInput::Value(Color([255, 0, 0, 255])); 4]))
             .with(StyleDeclaration::word_break(WordBreak::BreakAll))

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -949,7 +949,7 @@ fn test_measure_inline_layout_preserves_text_span_boundaries() {
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::display(Display::Inline))
-        .with(StyleDeclaration::outline_width(Px(2.0)))
+        .with(StyleDeclaration::outline_width(Px(2.0).into()))
         .with(StyleDeclaration::outline_style(BorderStyle::Solid))
         .with(StyleDeclaration::outline_color(ColorInput::Value(Color([
           255, 0, 0, 255,
@@ -1033,7 +1033,7 @@ fn test_measure_inline_atomic_containers_fixture() {
         .with(StyleDeclaration::background_color(ColorInput::Value(
           bg_color,
         )))
-        .with_border_width(Sides([Px(5.0); 4]))
+        .with_border_width(Sides([Px(5.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(border_color); 4])),
     )
@@ -1070,7 +1070,7 @@ fn test_measure_inline_atomic_containers_fixture() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::display(Display::Block))
       .with(StyleDeclaration::font_size(Px(24.0).into()))
-      .with_border_width(Sides([Px(6.0); 4]))
+      .with_border_width(Sides([Px(6.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
       .with_border_color(Sides([ColorInput::Value(Color([40, 40, 40, 255])); 4])),
   )])
@@ -1199,7 +1199,7 @@ fn test_measure_inline_image_uses_replaced_baseline_fallback() {
         .with(StyleDeclaration::width(Px(20.0)))
         .with(StyleDeclaration::height(Px(20.0)))
         .with_padding(Sides([Px(4.0); 4]))
-        .with_border_width(Sides([Px(2.0); 4]))
+        .with_border_width(Sides([Px(2.0).into(); 4]))
         .with_border_style(Sides([BorderStyle::Solid; 4])),
     ),
     Node::text("world".to_string())
@@ -1233,7 +1233,7 @@ fn test_measure_inline_image_respects_box_sizing_with_border() {
       .with(StyleDeclaration::box_sizing(box_sizing))
       .with(StyleDeclaration::width(Px(20.0)))
       .with(StyleDeclaration::height(Px(20.0)))
-      .with_border_width(Sides([Px(2.0); 4]))
+      .with_border_width(Sides([Px(2.0).into(); 4]))
       .with_border_style(Sides([BorderStyle::Solid; 4]))
   };
 


### PR DESCRIPTION
Part of #728 — bundles the remaining **breaking** CSS-conformance fixes for v2.

## Bugs (wrong rendered result)
- **`border-*-width` / `outline-width` default to `medium` (3px)**, not `0`. Adds a CSSWG `LineWidth` / `LineWidthKeyword` type (`<line-width>` = `<length> | thin | medium | thick`), used by `border-*-width` and `outline-width`. `border: solid red` / `outline: solid` now render the 3px default. The used value is zeroed when the line's style is `none`/`hidden` — centralized in `ComputedStyle::make_computed`, so every consumer (taffy layout, inline, paint) reads used values.
- **Negative `scale`** — dropped the `.max(0.0)` clamp in `PercentageNumber::from_css`; `scale: -1`, `scaleX(-1)`, `scaleY(-1)`, `scale(-1)` now reflect. (opacity/filters already clamp at render.)
- **`line-clamp` no longer inherits** (the collapsed `-webkit-line-clamp` model is not inherited).

## Cleanup
- Removed the dead `where inherit` shorthand flag (unused `$shorthand_inherit` macro capture + the flag on `font-synthesis` / `-webkit-text-stroke` / `white-space` / `text-wrap`; each constituent longhand already carries its own inheritance).
- Deleted `TwBorderWidth`, merged into `LineWidth` (Tailwind border/outline width parse through it; `outline-offset` resolves via `LineWidth::to_length()`).

## Deliberate deviations (now aligned)
- **`position` defaults to `static`** (was `relative`) — elements no longer become positioned containing blocks / honor insets / apply `z-index` by default.

## Notes
- `thin | medium | thick` parsing (earmarked for 1.x) comes for free with `LineWidth`. The other non-breaking "accept-more" grammar gaps from #728 are intentionally left for 1.x.
- **No golden image changes**: `static` vs `relative` with no insets is pixel-identical, and every fixture pairs a border/outline *style* with an explicit *width*, so the `medium` default never fires. The only asymmetry is that a border-style-without-width grows the layout box while an outline-style-without-width only paints.
- `905` workspace tests pass; clippy clean. Added tests for negative scale and `LineWidth` keyword/default parsing.