### PR TITLE
Crate: reject percentage for shadow blur/spread radii and honor `max_height` in pretty reflow

### DIFF
--- a/takumi-base/src/shadow.rs
+++ b/takumi-base/src/shadow.rs
@@ -28,8 +28,8 @@ impl SizedShadow {
     Self {
       offset_x: shadow.offset_x.to_px(sizing, size.width),
       offset_y: shadow.offset_y.to_px(sizing, size.height),
-      blur_radius: shadow.blur_radius.to_px(sizing, size.width),
-      spread_radius: shadow.spread_radius.to_px(sizing, size.width),
+      blur_radius: shadow.blur_radius.to_px(sizing, 1.0),
+      spread_radius: shadow.spread_radius.to_px(sizing, 1.0),
       color: shadow.color.resolve(current_color),
     }
   }
@@ -44,7 +44,7 @@ impl SizedShadow {
     Self {
       offset_x: shadow.offset_x.to_px(sizing, size.width),
       offset_y: shadow.offset_y.to_px(sizing, size.height),
-      blur_radius: shadow.blur_radius.to_px(sizing, size.width),
+      blur_radius: shadow.blur_radius.to_px(sizing, 1.0),
       // Text shadows do not support spread radius; set to 0.
       spread_radius: 0.0,
       color: shadow.color.resolve(current_color),

--- a/takumi-base/src/text_processing.rs
+++ b/takumi-base/src/text_processing.rs
@@ -286,7 +286,7 @@ pub fn make_pretty_text(
   break_lines(
     inline_layout,
     adjusted_width,
-    None,
+    max_height,
     line_height_hint,
     text_wrap_mode,
     spans,

--- a/takumi-css/src/style/properties/box_shadow.rs
+++ b/takumi-css/src/style/properties/box_shadow.rs
@@ -44,6 +44,17 @@ impl<'i> FromCss<'i> for BoxShadows {
   const VALID_TOKENS: &'static [CssToken] = BoxShadow::VALID_TOKENS;
 }
 
+/// Parses a `<length>` rejecting percentages, which are invalid for shadow blur/spread radii.
+fn parse_non_percentage_length<'i>(
+  input: &mut Parser<'i, '_>,
+) -> ParseResult<'i, LengthDefaultsToZero> {
+  let length = Length::from_css(input)?;
+  if matches!(length, Length::Percentage(_)) {
+    return Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid));
+  }
+  Ok(length)
+}
+
 pub(super) fn parse_offsets_blur<'i>(
   input: &mut Parser<'i, '_>,
 ) -> ParseResult<
@@ -56,7 +67,9 @@ pub(super) fn parse_offsets_blur<'i>(
 > {
   let horizontal = Length::from_css(input)?;
   let vertical = Length::from_css(input)?;
-  let blur = input.try_parse(Length::from_css).unwrap_or(Length::zero());
+  let blur = input
+    .try_parse(parse_non_percentage_length)
+    .unwrap_or(Length::zero());
   Ok((horizontal, vertical, blur))
 }
 
@@ -93,7 +106,9 @@ impl<'i> FromCss<'i> for BoxShadow {
       if lengths.is_none() {
         let value = input.try_parse::<_, _, ParseError<Cow<'i, str>>>(|input| {
           let (horizontal, vertical, blur) = parse_offsets_blur(input)?;
-          let spread = input.try_parse(Length::from_css).unwrap_or(Length::zero());
+          let spread = input
+            .try_parse(parse_non_percentage_length)
+            .unwrap_or(Length::zero());
           Ok((horizontal, vertical, blur, spread))
         });
 
@@ -352,6 +367,31 @@ mod tests {
   fn test_parse_box_shadow_invalid() {
     assert!(BoxShadow::from_str("2px").is_err());
     assert!(BoxShadow::from_str("").is_err());
+  }
+
+  #[test]
+  fn test_box_shadow_rejects_percentage_radii() {
+    // Percentages are not valid <length> for blur/spread; loose parsing ignores
+    // the trailing token rather than capturing it as a Percentage length.
+    assert_eq!(
+      BoxShadow::from_str("2px 4px 50%"),
+      Ok(BoxShadow {
+        offset_x: Px(2.0),
+        offset_y: Px(4.0),
+        color: transparent(),
+        ..Default::default()
+      })
+    );
+    assert_eq!(
+      BoxShadow::from_str("2px 4px 6px 50%"),
+      Ok(BoxShadow {
+        offset_x: Px(2.0),
+        offset_y: Px(4.0),
+        blur_radius: Px(6.0),
+        color: transparent(),
+        ..Default::default()
+      })
+    );
   }
 
   #[test]


### PR DESCRIPTION
Addresses CodeRabbit review on #781. Stacked on #789 (rename); GitHub will retarget to `v2` once #789 merges.

**#2 `max_height` (correctness)** — `make_pretty_text` ran its 90%-width trial reflow with `max_height = None`, so an accepted orphan-fix layout ignored the height constraint that the fallback path honors. Now passes `max_height` (`text_processing.rs`).

**#1 shadow blur/spread % (CSS-correctness)** — blur/spread are `<length>`; `%` is invalid. Parser now rejects `%` for blur/spread (loose parsing ignores the trailing token rather than capturing a `Percentage`), and the resolver passes a `1.0` basis instead of `size.width` (consistent with `takumi-raster`). Not `unreachable!()` — `BoxShadow`'s public builder can still construct a `Percentage`, so the resolve path stays panic-free.

**#3 (skipped)** — `pixmap_ref_from_buffer` returning `None` means zero-dim/empty buffer; skipping draws nothing = transparent, same outcome as the suggested fallback. No change.

Added a unit test locking in % rejection. Golden fixtures (if affected by #2) regenerate on CI.