### PR TITLE
CI: add least-privilege top-level permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"


### PR DESCRIPTION
Set a restrictive `contents: read` baseline for `GITHUB_TOKEN` at the workflow level, reducing the blast radius if any step is compromised.

Jobs that need more keep their existing job-level `permissions` blocks, which fully override the default:
- `release` — `contents: write`, `id-token: write`, `pull-requests: write`
- `deploy-docs` — `contents: read`, `pull-requests: write`

All other jobs only check out, build/test, and up/download same-run artifacts; `preview-packages` (pkg-pr-new) authenticates via its GitHub App and needs no token scopes. All work with `contents: read`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration security configuration to restrict GitHub token permissions to repository read access only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->