### PR TITLE
Run cargo-rdme in lefthook pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,3 +6,7 @@ pre-commit:
 
     - run: cargo fmt --all
       stage_fixed: true
+
+    - root: takumi/
+      run: cargo rdme --force
+      stage_fixed: true


### PR DESCRIPTION
Adds a cargo-rdme pre-commit job so `takumi/README.md` stays in sync with the `lib.rs` doc comment, preventing the CI "README.md is up to date" check from failing on doc edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hook configuration to enhance the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->