### PR TITLE
NAPI, WASM: add `renderSvg`

### DIFF
--- a/.changeset/render-svg-bindings.md
+++ b/.changeset/render-svg-bindings.md
@@ -1,0 +1,6 @@
+---
+"@takumi-rs/core": minor
+"@takumi-rs/wasm": minor
+---
+
+Add `renderSvg` to render a node tree to an SVG document string

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "serde",
  "takumi-core",
  "takumi-raster",
+ "takumi-svg",
 ]
 
 [[package]]
@@ -1626,6 +1627,7 @@ dependencies = [
  "serde_bytes",
  "takumi-core",
  "takumi-raster",
+ "takumi-svg",
  "wasm-bindgen",
 ]
 

--- a/takumi-napi-core/Cargo.toml
+++ b/takumi-napi-core/Cargo.toml
@@ -25,6 +25,10 @@ path = "../takumi-raster"
 default-features = false
 features = ["svg", "rayon"]
 
+[dependencies.takumi-svg]
+path = "../takumi-svg"
+version = "0.1"
+
 [build-dependencies]
 napi-build.workspace = true
 

--- a/takumi-napi-core/src/export.ts
+++ b/takumi-napi-core/src/export.ts
@@ -9,6 +9,7 @@ import type {
   RegisteredFamily,
   RenderAnimationOptions as RenderAnimationOptionsInternal,
   RenderOptions as RenderOptionsInternal,
+  SvgRenderOptions as SvgRenderOptionsInternal,
 } from "../index";
 export type * from "../index";
 import { Renderer as RendererInternal } from "../index";
@@ -80,6 +81,12 @@ export type EncodeFramesOptions = Omit<
     images?: ImageLoader[];
   };
 
+export type SvgRenderOptions = Omit<SvgRenderOptionsInternal, "images"> & {
+  fonts?: FontLoader[];
+  signal?: AbortSignal;
+  images?: ImageLoader[];
+};
+
 async function resolveImageLoaders(images: ImageLoader[]): Promise<ImageSource[]> {
   const bySrc = new Map<string, ImageLoader>();
 
@@ -116,6 +123,22 @@ export class Renderer {
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.render(
+      node,
+      {
+        ...rest,
+        images: resolvedImages,
+        fontFamilies: fontFamilies ?? registeredFamilies,
+      },
+      signal,
+    );
+  }
+
+  async renderSvg(node: Node, options?: SvgRenderOptions) {
+    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
+    const registeredFamilies = await this.prepareFonts(fonts);
+    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+
+    return this.inner.renderSvg(
       node,
       {
         ...rest,

--- a/takumi-napi-core/src/lib.rs
+++ b/takumi-napi-core/src/lib.rs
@@ -10,6 +10,7 @@ mod pool;
 mod render_animation_task;
 mod render_task;
 pub(crate) mod renderer;
+mod svg_render_task;
 
 use std::{fmt::Display, ops::Deref};
 

--- a/takumi-napi-core/src/renderer.rs
+++ b/takumi-napi-core/src/renderer.rs
@@ -23,6 +23,7 @@ use crate::{
   De, deserialize_with_tracing, encode_frames_task::EncodeFramesTask, load_font_task::LoadFontTask,
   map_error, measure_task::MeasureTask, parse_font_input,
   render_animation_task::RenderAnimationTask, render_task::RenderTask,
+  svg_render_task::SvgRenderTask,
 };
 
 /// Represents a single run of text in a measured node.
@@ -155,6 +156,30 @@ pub struct RenderOptions<'env> {
   pub time_ms: Option<i64>,
   /// The output dithering algorithm.
   pub dithering: Option<DitheringAlgorithm>,
+  /// Per-render font stack: ordered family names used as the fallback chain.
+  /// Defaults to all registered families in registration order.
+  pub font_families: Option<Vec<String>>,
+}
+
+/// Options for rendering a node tree to an SVG document. SVG is a vector
+/// format, so the raster-only knobs (`format`, `quality`, `lossless`,
+/// `dithering`, `drawDebugBorder`, `devicePixelRatio`) do not apply.
+#[napi(object)]
+#[derive(Default)]
+pub struct SvgRenderOptions<'env> {
+  /// The width of the viewport. If not provided, it is derived from content.
+  pub width: Option<u32>,
+  /// The height of the viewport. If not provided, it is derived from content.
+  pub height: Option<u32>,
+  /// Images keyed by `src`, each carrying raw bytes.
+  pub images: Option<Vec<ImageSource<'env>>>,
+  /// CSS stylesheets to apply before rendering.
+  pub stylesheets: Option<Vec<String>>,
+  /// Structured keyframes to register alongside stylesheets.
+  #[napi(ts_type = "Keyframes")]
+  pub keyframes: Option<Object<'env>>,
+  /// The animation timeline time in milliseconds.
+  pub time_ms: Option<i64>,
   /// Per-render font stack: ordered family names used as the fallback chain.
   /// Defaults to all registered families in registration order.
   pub font_families: Option<Vec<String>>,
@@ -459,6 +484,31 @@ impl Renderer {
 
     Ok(AsyncTask::with_optional_signal(
       RenderTask::from_options(
+        env,
+        node,
+        options.unwrap_or_default(),
+        Arc::clone(&self.state),
+      )?,
+      signal,
+    ))
+  }
+
+  /// Renders a node tree into an SVG document string asynchronously.
+  #[napi(
+    ts_args_type = "source: Node, options?: SvgRenderOptions, signal?: AbortSignal",
+    ts_return_type = "Promise<string>"
+  )]
+  pub fn render_svg(
+    &self,
+    env: Env,
+    source: Object,
+    options: Option<SvgRenderOptions>,
+    signal: Option<AbortSignal>,
+  ) -> Result<AsyncTask<SvgRenderTask>> {
+    let node: Node = deserialize_with_tracing(source)?;
+
+    Ok(AsyncTask::with_optional_signal(
+      SvgRenderTask::from_options(
         env,
         node,
         options.unwrap_or_default(),

--- a/takumi-napi-core/src/svg_render_task.rs
+++ b/takumi-napi-core/src/svg_render_task.rs
@@ -1,0 +1,93 @@
+use std::{
+  collections::HashMap,
+  mem::take,
+  sync::{Arc, RwLock},
+};
+
+use napi::bindgen_prelude::*;
+use takumi_core::layout::{Viewport, node::Node, style::StyleSheet};
+
+use crate::{
+  buffer_from_object, map_error, parse_stylesheet,
+  renderer::{ImageCacheMode, RendererState, SvgRenderOptions, deserialize_keyframes},
+};
+
+pub struct SvgRenderTask {
+  pub node: Option<Node>,
+  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub viewport: Viewport,
+  pub time_ms: u64,
+  pub stylesheet: StyleSheet,
+  pub images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+  pub font_families: Option<Vec<String>>,
+}
+
+impl SvgRenderTask {
+  pub(crate) fn from_options(
+    env: Env,
+    node: Node,
+    options: SvgRenderOptions,
+    state: Arc<RwLock<RendererState>>,
+  ) -> Result<Self> {
+    Ok(SvgRenderTask {
+      node: Some(node),
+      state,
+      viewport: Viewport::new((options.width, options.height)),
+      time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
+      stylesheet: parse_stylesheet(
+        options.stylesheets,
+        deserialize_keyframes(options.keyframes)?,
+      )?,
+      images: options
+        .images
+        .unwrap_or_default()
+        .into_iter()
+        .map(|image| {
+          Ok((
+            Arc::from(image.src),
+            (
+              buffer_from_object(env, image.data)?,
+              image.cache.unwrap_or_default(),
+            ),
+          ))
+        })
+        .collect::<Result<_>>()?,
+      font_families: options.font_families,
+    })
+  }
+}
+
+impl Task for SvgRenderTask {
+  type Output = String;
+  type JsValue = String;
+
+  fn compute(&mut self) -> Result<Self::Output> {
+    let Some(node) = self.node.take() else {
+      unreachable!()
+    };
+
+    let state = self
+      .state
+      .read()
+      .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
+
+    let images = state.decode_images(take(&mut self.images))?;
+
+    takumi_svg::render(
+      takumi_svg::SvgOptions::builder()
+        .viewport(self.viewport)
+        .images(images)
+        .stylesheet(take(&mut self.stylesheet))
+        .time_ms(self.time_ms)
+        .node(node)
+        .fonts(&state.fonts)
+        .font_families(take(&mut self.font_families))
+        .build(),
+    )
+    .map_err(map_error)
+  }
+
+  fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+    Ok(output)
+  }
+}

--- a/takumi-napi-core/tests/render-svg.test.ts
+++ b/takumi-napi-core/tests/render-svg.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { container, text } from "@takumi-rs/helpers";
 import { Glob } from "bun";
 import { Renderer } from "../src/export";
 
-const glob = new Glob("../assets/fonts/**/*.{woff2,ttf}");
+const repoRoot = join(import.meta.dir, "../..");
+const glob = new Glob("assets/fonts/**/*.{woff2,ttf}");
 const fontBuffers = await Promise.all(
-  (await Array.fromAsync(glob.scan())).map((file) => Bun.file(file).arrayBuffer()),
+  (await Array.fromAsync(glob.scan({ cwd: repoRoot, absolute: true }))).map((file) =>
+    Bun.file(file).arrayBuffer(),
+  ),
 );
 
 const renderer = new Renderer();
@@ -40,34 +44,37 @@ describe("renderSvg", () => {
     expect(svg).toContain("</svg>");
   });
 
-  test("applies timeMs to stylesheet animation", async () => {
-    const svg = await renderer.renderSvg(
-      { type: "container", tagName: "div" },
-      {
-        width: 200,
-        height: 100,
-        timeMs: 500,
-        stylesheets: [
-          `
-            div {
-              width: 100px;
-              height: 100px;
-              background: red;
-              animation-name: grow;
-              animation-duration: 1000ms;
-              animation-timing-function: linear;
-              animation-fill-mode: both;
-            }
+  test("interpolates a stylesheet animation at timeMs", async () => {
+    const stylesheets = [
+      `
+        div {
+          width: 100px;
+          height: 100px;
+          background: red;
+          animation-name: grow;
+          animation-duration: 1000ms;
+          animation-timing-function: linear;
+          animation-fill-mode: both;
+        }
 
-            @keyframes grow {
-              from { width: 100px; }
-              to { width: 200px; }
-            }
-          `,
-        ],
-      },
-    );
+        @keyframes grow {
+          from { width: 100px; }
+          to { width: 200px; }
+        }
+      `,
+    ];
 
-    expect(svg).toContain("<svg");
+    const at = (timeMs: number) =>
+      renderer.renderSvg(
+        { type: "container", tagName: "div" },
+        { width: 220, height: 120, timeMs, stylesheets },
+      );
+
+    const [start, mid, end] = await Promise.all([at(0), at(500), at(1000)]);
+
+    expect(start).toContain('width="100"');
+    expect(mid).toContain('width="150"');
+    expect(end).toContain('width="200"');
+    expect(mid).not.toBe(start);
   });
 });

--- a/takumi-napi-core/tests/render-svg.test.ts
+++ b/takumi-napi-core/tests/render-svg.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { container, text } from "@takumi-rs/helpers";
+import { Glob } from "bun";
+import { Renderer } from "../src/export";
+
+const glob = new Glob("../assets/fonts/**/*.{woff2,ttf}");
+const fontBuffers = await Promise.all(
+  (await Array.fromAsync(glob.scan())).map((file) => Bun.file(file).arrayBuffer()),
+);
+
+const renderer = new Renderer();
+await Promise.all(fontBuffers.map((font) => renderer.registerFont(font)));
+
+const node = container({
+  children: [text("Vector")],
+  style: {
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "white",
+    width: "100%",
+    height: "100%",
+  },
+});
+
+describe("renderSvg", () => {
+  test("returns an SVG document string", async () => {
+    const svg = await renderer.renderSvg(node, { width: 200, height: 100 });
+
+    expect(typeof svg).toBe("string");
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg).toContain('width="200"');
+    expect(svg).toContain('height="100"');
+  });
+
+  test("auto-calculates dimensions without options", async () => {
+    const svg = await renderer.renderSvg(node);
+
+    expect(svg).toMatch(/^<svg/);
+    expect(svg).toContain("</svg>");
+  });
+
+  test("applies timeMs to stylesheet animation", async () => {
+    const svg = await renderer.renderSvg(
+      { type: "container", tagName: "div" },
+      {
+        width: 200,
+        height: 100,
+        timeMs: 500,
+        stylesheets: [
+          `
+            div {
+              width: 100px;
+              height: 100px;
+              background: red;
+              animation-name: grow;
+              animation-duration: 1000ms;
+              animation-timing-function: linear;
+              animation-fill-mode: both;
+            }
+
+            @keyframes grow {
+              from { width: 100px; }
+              to { width: 200px; }
+            }
+          `,
+        ],
+      },
+    );
+
+    expect(svg).toContain("<svg");
+  });
+});

--- a/takumi-wasm/Cargo.toml
+++ b/takumi-wasm/Cargo.toml
@@ -30,6 +30,10 @@ path = "../takumi-raster"
 default-features = false
 features = ["svg"]
 
+[dependencies.takumi-svg]
+path = "../takumi-svg"
+version = "0.1"
+
 # https://github.com/rust-lang/rust/issues/93294
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [

--- a/takumi-wasm/src/dts-header.d.ts
+++ b/takumi-wasm/src/dts-header.d.ts
@@ -71,6 +71,14 @@ export type RenderOptions = {
   fontFamilies?: string[];
 };
 
+/**
+ * SVG is a vector format, so the raster-only knobs do not apply.
+ */
+export type SvgRenderOptions = Omit<
+  RenderOptions,
+  "format" | "quality" | "drawDebugBorder" | "devicePixelRatio" | "dithering"
+>;
+
 export type RenderAnimationOptions = {
   scenes: AnimationSceneSource[];
   width: number;

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -10,6 +10,7 @@ import {
   type RegisteredFamily,
   type RenderAnimationOptions as RenderAnimationOptionsInternal,
   type RenderOptions as RenderOptionsInternal,
+  type SvgRenderOptions as SvgRenderOptionsInternal,
 } from "../pkg/takumi_wasm";
 
 export * from "../pkg/takumi_wasm";
@@ -68,6 +69,11 @@ export type EncodeFramesOptions = Omit<EncodeFramesOptionsInternal, "images" | "
     images?: ImageLoader[];
   };
 
+export type SvgRenderOptions = Omit<SvgRenderOptionsInternal, "images"> & {
+  fonts?: FontLoader[];
+  images?: ImageLoader[];
+};
+
 async function resolveImageLoaders(images: ImageLoader[]): Promise<ImageSource[]> {
   const bySrc = new Map<string, ImageLoader>();
 
@@ -116,6 +122,18 @@ export class Renderer {
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderAsDataUrl(node, {
+      ...rest,
+      images: resolvedImages,
+      fontFamilies: fontFamilies ?? registeredFamilies,
+    });
+  }
+
+  async renderSvg(node: Node, options?: SvgRenderOptions) {
+    const { fonts, fontFamilies, images, ...rest } = options ?? {};
+    const registeredFamilies = await this.prepareFonts(fonts);
+    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+
+    return this.inner.renderSvg(node, {
       ...rest,
       images: resolvedImages,
       fontFamilies: fontFamilies ?? registeredFamilies,

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -23,6 +23,10 @@ extern "C" {
   #[wasm_bindgen(typescript_type = "RenderOptions")]
   pub type RenderOptionsType;
 
+  /// JavaScript object representing SVG render options.
+  #[wasm_bindgen(typescript_type = "SvgRenderOptions")]
+  pub type SvgRenderOptionsType;
+
   /// JavaScript object representing animation render options.
   #[wasm_bindgen(typescript_type = "RenderAnimationOptions")]
   pub type RenderAnimationOptionsType;
@@ -83,6 +87,30 @@ pub struct RenderOptions {
   pub time_ms: Option<i64>,
   /// The output dithering algorithm.
   pub dithering: Option<DitheringAlgorithm>,
+  /// Per-render font stack: ordered family names used as the fallback chain.
+  /// Defaults to all registered families in registration order.
+  pub font_families: Option<Vec<String>>,
+}
+
+/// Options for rendering a node tree to an SVG document. SVG is a vector
+/// format, so the raster-only knobs (`format`, `quality`, `dithering`,
+/// `drawDebugBorder`, `devicePixelRatio`) do not apply.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SvgRenderOptions {
+  /// The width of the viewport in pixels.
+  pub width: Option<u32>,
+  /// The height of the viewport in pixels.
+  pub height: Option<u32>,
+  /// Pre-fetched image resources to use during rendering.
+  pub images: Option<Vec<ImageSource>>,
+  /// CSS stylesheets to apply before rendering.
+  pub stylesheets: Option<Vec<String>>,
+  /// Structured keyframes to register alongside stylesheets.
+  #[serde(default, deserialize_with = "deserialize_optional_keyframes")]
+  pub(crate) keyframes: Option<Vec<KeyframesRule>>,
+  /// The animation timeline time in milliseconds.
+  pub time_ms: Option<i64>,
   /// Per-render font stack: ordered family names used as the fallback chain.
   /// Defaults to all registered families in registration order.
   pub font_families: Option<Vec<String>>,

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -266,6 +266,40 @@ impl Renderer {
     Ok(buffer)
   }
 
+  /// Renders a node tree into an SVG document string.
+  #[wasm_bindgen(js_name = renderSvg)]
+  pub fn render_svg(
+    &self,
+    node: NodeType,
+    options: Option<SvgRenderOptionsType>,
+  ) -> Result<String, JsValue> {
+    let node: Node = from_value(node.into()).map_err(map_error)?;
+    let options: SvgRenderOptions = options
+      .map(|options| from_value(options.into()).map_err(map_error))
+      .transpose()?
+      .unwrap_or_default();
+
+    let images = self.fetch_resources_map(options.images.as_deref())?;
+    let stylesheet =
+      self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
+    let state = self.read_state()?;
+
+    let svg = takumi_svg::render(
+      takumi_svg::SvgOptions::builder()
+        .viewport(Viewport::new((options.width, options.height)))
+        .images(images)
+        .stylesheet(stylesheet)
+        .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
+        .node(node)
+        .fonts(&state)
+        .font_families(options.font_families)
+        .build(),
+    )
+    .map_err(map_error)?;
+
+    Ok(svg)
+  }
+
   /// Measures a node tree and returns layout information.
   #[wasm_bindgen(js_name = measure)]
   pub fn measure(

--- a/takumi-wasm/tests/render-svg.test.ts
+++ b/takumi-wasm/tests/render-svg.test.ts
@@ -44,34 +44,37 @@ describe("renderSvg", () => {
     expect(svg).toContain("</svg>");
   });
 
-  test("applies timeMs to stylesheet animation", async () => {
-    const svg = await renderer.renderSvg(
-      { type: "container", tagName: "div" },
-      {
-        width: 200,
-        height: 100,
-        timeMs: 500,
-        stylesheets: [
-          `
-            div {
-              width: 100px;
-              height: 100px;
-              background: red;
-              animation-name: grow;
-              animation-duration: 1000ms;
-              animation-timing-function: linear;
-              animation-fill-mode: both;
-            }
+  test("interpolates a stylesheet animation at timeMs", async () => {
+    const stylesheets = [
+      `
+        div {
+          width: 100px;
+          height: 100px;
+          background: red;
+          animation-name: grow;
+          animation-duration: 1000ms;
+          animation-timing-function: linear;
+          animation-fill-mode: both;
+        }
 
-            @keyframes grow {
-              from { width: 100px; }
-              to { width: 200px; }
-            }
-          `,
-        ],
-      },
-    );
+        @keyframes grow {
+          from { width: 100px; }
+          to { width: 200px; }
+        }
+      `,
+    ];
 
-    expect(svg).toContain("<svg");
+    const at = (timeMs: number) =>
+      renderer.renderSvg(
+        { type: "container", tagName: "div" },
+        { width: 220, height: 120, timeMs, stylesheets },
+      );
+
+    const [start, mid, end] = await Promise.all([at(0), at(500), at(1000)]);
+
+    expect(start).toContain('width="100"');
+    expect(mid).toContain('width="150"');
+    expect(end).toContain('width="200"');
+    expect(mid).not.toBe(start);
   });
 });

--- a/takumi-wasm/tests/render-svg.test.ts
+++ b/takumi-wasm/tests/render-svg.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { container, text } from "@takumi-rs/helpers";
+import { Renderer } from "../bundlers/node";
+
+const fontsRoot = join(import.meta.dir, "../../assets/fonts");
+const manropeFont = await readFile(join(fontsRoot, "manrope/manrope-latin-wght-normal.woff2"));
+
+const renderer = new Renderer();
+
+afterAll(() => {
+  renderer.free();
+});
+
+await renderer.registerFont(manropeFont);
+
+const node = container({
+  children: [text("Vector")],
+  style: {
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "white",
+    width: "100%",
+    height: "100%",
+  },
+});
+
+describe("renderSvg", () => {
+  test("returns an SVG document string", async () => {
+    const svg = await renderer.renderSvg(node, { width: 200, height: 100 });
+
+    expect(typeof svg).toBe("string");
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg).toContain('width="200"');
+    expect(svg).toContain('height="100"');
+  });
+
+  test("auto-calculates dimensions without options", async () => {
+    const svg = await renderer.renderSvg(node);
+
+    expect(svg).toMatch(/^<svg/);
+    expect(svg).toContain("</svg>");
+  });
+
+  test("applies timeMs to stylesheet animation", async () => {
+    const svg = await renderer.renderSvg(
+      { type: "container", tagName: "div" },
+      {
+        width: 200,
+        height: 100,
+        timeMs: 500,
+        stylesheets: [
+          `
+            div {
+              width: 100px;
+              height: 100px;
+              background: red;
+              animation-name: grow;
+              animation-duration: 1000ms;
+              animation-timing-function: linear;
+              animation-fill-mode: both;
+            }
+
+            @keyframes grow {
+              from { width: 100px; }
+              to { width: 200px; }
+            }
+          `,
+        ],
+      },
+    );
+
+    expect(svg).toContain("<svg");
+  });
+});


### PR DESCRIPTION
## What

Expose the `takumi-svg` vector backend through both language bindings as a `renderSvg` method that returns an SVG document string.

| Binding | Signature |
| --- | --- |
| `@takumi-rs/core` (napi) | `renderSvg(node, options?, signal?): Promise<string>` |
| `@takumi-rs/wasm` | `renderSvg(node, options?): string` |

## Design

SVG is not modelled as another `OutputFormat` variant: it produces text, not a `Bitmap` encoding, and honours a different option subset. A separate method keeps each return type and option set honest — the most-specific type, with misuse made impossible rather than silently ignored.

`SvgRenderOptions` drops the raster-only knobs: `format`, `quality`, `lossless`, `dithering`, `drawDebugBorder`, `devicePixelRatio` (SVG is vector, so DPR is meaningless). The wasm TS type derives via `Omit<RenderOptions, ...>` to avoid duplicating field docs.

Out of scope: animation (the svg crate has no animation path) and a data-url helper.

## Tests

`renderSvg` parity test per binding: asserts well-formed `<svg>…</svg>` markup, viewport dimensions, and `timeMs`-driven keyframe resolution. Full suites green (napi 51, wasm 49); clippy clean on all three crates.

https://claude.ai/code/session_01PffFyJn2SZ3q1aSdLAyiBb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SVG rendering support with a new `renderSvg()` method on the Renderer class
  * Customize SVG output with the new `SvgRenderOptions` configuration for dimensions, fonts, images, and stylesheets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->