### PR TITLE
Scene module: tighten cohesion + fold napi resolution boilerplate

### DIFF
--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -1,0 +1,46 @@
+//! Transform geometry helpers shared across backends.
+
+use taffy::{Point, geometry::Size};
+
+use crate::layout::style::Affine;
+
+/// Transforms a rect's four corners and returns the axis-aligned `(min_x, min_y,
+/// max_x, max_y)` extents, or `None` if any corner is non-finite.
+pub fn transformed_rect_extents(
+  origin: Point<f32>,
+  size: Size<f32>,
+  transform: Affine,
+) -> Option<(f32, f32, f32, f32)> {
+  let corners = [
+    transform.transform_point(origin),
+    transform.transform_point(Point {
+      x: origin.x + size.width,
+      y: origin.y,
+    }),
+    transform.transform_point(Point {
+      x: origin.x,
+      y: origin.y + size.height,
+    }),
+    transform.transform_point(Point {
+      x: origin.x + size.width,
+      y: origin.y + size.height,
+    }),
+  ];
+
+  let mut min_x = f32::INFINITY;
+  let mut min_y = f32::INFINITY;
+  let mut max_x = f32::NEG_INFINITY;
+  let mut max_y = f32::NEG_INFINITY;
+  for point in corners {
+    min_x = min_x.min(point.x);
+    min_y = min_y.min(point.y);
+    max_x = max_x.max(point.x);
+    max_y = max_y.max(point.y);
+  }
+
+  if !min_x.is_finite() || !min_y.is_finite() || !max_x.is_finite() || !max_y.is_finite() {
+    return None;
+  }
+
+  Some((min_x, min_y, max_x, max_y))
+}

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1038,6 +1038,25 @@ impl RenderNode {
       .is_some_and(|children| children.iter().any(RenderNode::is_anonymous_text_item))
   }
 
+  /// Resolves the descendant at `path` (child indices from this node). An empty
+  /// path returns `self`.
+  pub fn node_at_path(&self, path: &[usize]) -> Option<&RenderNode> {
+    let mut current = self;
+    for &index in path {
+      current = current.children.as_deref()?.get(index)?;
+    }
+    Some(current)
+  }
+
+  /// Mutable [`node_at_path`](Self::node_at_path).
+  pub fn node_at_path_mut(&mut self, path: &[usize]) -> Option<&mut RenderNode> {
+    let mut current = self;
+    for &index in path {
+      current = current.children.as_deref_mut()?.get_mut(index)?;
+    }
+    Some(current)
+  }
+
   pub(crate) fn is_inline_level(&self) -> bool {
     self.context.style.display.is_inline_level()
   }

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod shadow;
 pub mod text_processing;
 
 pub mod error;
+pub mod geometry;
 pub use takumi_css::keyframes;
 pub mod resources;
 pub mod scene;

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -10,6 +10,7 @@ use taffy::{AvailableSpace, Layout, NodeId, Point, TaffyError, geometry::Size};
 use crate::{
   error::{Error, Result},
   font_style::SizedFontStyle,
+  geometry::transformed_rect_extents,
   layout::{
     inline::{
       InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,
@@ -17,90 +18,10 @@ use crate::{
       resolve_inline_max_height, resolve_visual_inline_box, scale_text_fit_x,
       text_fit_line_alignment_correction,
     },
-    style::{Affine, ComputedStyle, Display, SizingContext},
-    tree::{LayoutResults, OrderedChild, RenderNode},
+    style::{Affine, ComputedStyle, Display},
+    tree::{LayoutResults, RenderNode},
   },
 };
-
-/// Transforms a rect's four corners and returns the axis-aligned `(min_x, min_y,
-/// max_x, max_y)` extents, or `None` if any corner is non-finite.
-pub fn transformed_rect_extents(
-  origin: Point<f32>,
-  size: Size<f32>,
-  transform: Affine,
-) -> Option<(f32, f32, f32, f32)> {
-  let corners = [
-    transform.transform_point(origin),
-    transform.transform_point(Point {
-      x: origin.x + size.width,
-      y: origin.y,
-    }),
-    transform.transform_point(Point {
-      x: origin.x,
-      y: origin.y + size.height,
-    }),
-    transform.transform_point(Point {
-      x: origin.x + size.width,
-      y: origin.y + size.height,
-    }),
-  ];
-
-  let mut min_x = f32::INFINITY;
-  let mut min_y = f32::INFINITY;
-  let mut max_x = f32::NEG_INFINITY;
-  let mut max_y = f32::NEG_INFINITY;
-  for point in corners {
-    min_x = min_x.min(point.x);
-    min_y = min_y.min(point.y);
-    max_x = max_x.max(point.x);
-    max_y = max_y.max(point.y);
-  }
-
-  if !min_x.is_finite() || !min_y.is_finite() || !max_x.is_finite() || !max_y.is_finite() {
-    return None;
-  }
-
-  Some((min_x, min_y, max_x, max_y))
-}
-
-pub fn apply_transform(
-  transform: &mut Affine,
-  style: &ComputedStyle,
-  border_box: Size<f32>,
-  sizing: &SizingContext,
-) {
-  *transform *= style.local_transform(border_box, sizing);
-}
-
-/// Resolves a node by its [`NodePaint::path`] (child indices from the root).
-pub fn get_node_by_path<'a>(root: &'a RenderNode, path: &[usize]) -> Option<&'a RenderNode> {
-  let mut current = root;
-  for &index in path {
-    let children = current.children.as_deref()?;
-    current = children.get(index)?;
-  }
-  Some(current)
-}
-
-/// Mutable [`get_node_by_path`].
-pub fn get_node_mut_by_path<'a>(
-  root: &'a mut RenderNode,
-  path: &[usize],
-) -> Option<&'a mut RenderNode> {
-  let mut current = root;
-  for &index in path {
-    let children = current.children.as_deref_mut()?;
-    current = children.get_mut(index)?;
-  }
-  Some(current)
-}
-
-pub fn collect_layout_children(
-  layout_results: &LayoutResults,
-  node_id: NodeId,
-) -> Result<Vec<OrderedChild>> {
-  Ok(layout_results.box_children(node_id)?.to_vec())
-}
 
 /// A node's resolved paint inputs: where it sits in the tree, its accumulated
 /// transform, the container it resolves against, and its device-space bounds.
@@ -297,7 +218,7 @@ pub fn build_stacking_contexts(
   }];
 
   while let Some(visit) = visits.pop() {
-    let Some(current) = get_node_by_path(root, &visit.path) else {
+    let Some(current) = root.node_at_path(&visit.path) else {
       return Err(Error::LayoutError(TaffyError::InvalidInputNode(
         visit.node_id,
       )));
@@ -309,12 +230,10 @@ pub fn build_stacking_contexts(
 
     let mut current_transform = visit.transform;
     current_transform *= Affine::translation(layout.location.x, layout.location.y);
-    apply_transform(
-      &mut current_transform,
-      &current.context.style,
-      layout.size,
-      &current.context.sizing,
-    );
+    current_transform *= current
+      .context
+      .style
+      .local_transform(layout.size, &current.context.sizing);
     if !current_transform.is_invertible() {
       continue;
     }
@@ -383,14 +302,14 @@ pub fn build_stacking_contexts(
       continue;
     }
 
-    let layout_children = collect_layout_children(layout_results, visit.node_id)?;
+    let layout_children = layout_results.box_children(visit.node_id)?;
     let child_container_size = Size {
       width: Some(layout.content_box_width()),
       height: Some(layout.content_box_height()),
     };
     node_content_box.insert(visit.node_id, child_container_size);
 
-    for child in layout_children.into_iter().rev() {
+    for child in layout_children.iter().rev() {
       let mut child_path = visit.path.clone();
       child_path.push(child.render_index);
       let (base_transform, base_container) = match child.hoisted_cb {

--- a/takumi-napi-core/src/export.ts
+++ b/takumi-napi-core/src/export.ts
@@ -117,83 +117,54 @@ export class Renderer {
     return [...new Set(families.flat().map((f) => f.name))];
   }
 
+  /** Registers `fonts` and resolves lazy `images`, yielding the `images`/`fontFamilies`
+   * the napi binding expects. Explicit `fontFamilies` wins over the registered set. */
+  private async resolveResources(
+    fonts: FontLoader[] | undefined,
+    images: ImageLoader[] | undefined,
+    fontFamilies: string[] | undefined,
+  ) {
+    const registeredFamilies = await this.prepareFonts(fonts);
+
+    return {
+      images: images ? await resolveImageLoaders(images) : undefined,
+      fontFamilies: fontFamilies ?? registeredFamilies,
+    };
+  }
+
   async render(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
-    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+    const resolved = await this.resolveResources(fonts, images, fontFamilies);
 
-    return this.inner.render(
-      node,
-      {
-        ...rest,
-        images: resolvedImages,
-        fontFamilies: fontFamilies ?? registeredFamilies,
-      },
-      signal,
-    );
+    return this.inner.render(node, { ...rest, ...resolved }, signal);
   }
 
   async renderSvg(node: Node, options?: SvgRenderOptions) {
     const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
-    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+    const resolved = await this.resolveResources(fonts, images, fontFamilies);
 
-    return this.inner.renderSvg(
-      node,
-      {
-        ...rest,
-        images: resolvedImages,
-        fontFamilies: fontFamilies ?? registeredFamilies,
-      },
-      signal,
-    );
+    return this.inner.renderSvg(node, { ...rest, ...resolved }, signal);
   }
 
   async measure(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
-    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+    const resolved = await this.resolveResources(fonts, images, fontFamilies);
 
-    return this.inner.measure(
-      node,
-      {
-        ...rest,
-        images: resolvedImages,
-        fontFamilies: fontFamilies ?? registeredFamilies,
-      },
-      signal,
-    );
+    return this.inner.measure(node, { ...rest, ...resolved }, signal);
   }
 
   async renderAnimation(options: RenderAnimationOptions) {
     const { fonts, fontFamilies, signal, images, ...rest } = options;
-    const registeredFamilies = await this.prepareFonts(fonts);
-    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+    const resolved = await this.resolveResources(fonts, images, fontFamilies);
 
-    return this.inner.renderAnimation(
-      {
-        ...rest,
-        images: resolvedImages,
-        fontFamilies: fontFamilies ?? registeredFamilies,
-      },
-      signal,
-    );
+    return this.inner.renderAnimation({ ...rest, ...resolved }, signal);
   }
 
   async encodeFrames(frames: AnimationFrameSource[], options: EncodeFramesOptions) {
     const { fonts, fontFamilies, signal, images, ...rest } = options;
-    const registeredFamilies = await this.prepareFonts(fonts);
-    const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
+    const resolved = await this.resolveResources(fonts, images, fontFamilies);
 
-    return this.inner.encodeFrames(
-      frames,
-      {
-        ...rest,
-        images: resolvedImages,
-        fontFamilies: fontFamilies ?? registeredFamilies,
-      },
-      signal,
-    );
+    return this.inner.encodeFrames(frames, { ...rest, ...resolved }, signal);
   }
 
   async registerFont(font: FontLoader) {

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -14,7 +14,7 @@ use crate::{
     Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
   },
 };
-use takumi_core::scene::transformed_rect_extents;
+use takumi_core::geometry::transformed_rect_extents;
 
 pub(crate) enum NodeMaskAction {
   Shell(TinyMask),

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -25,9 +25,7 @@ use crate::{
   scale_text_fit_x,
   stacking_context::paint_context,
 };
-use takumi_core::scene::{
-  apply_transform, build_stacking_contexts, collect_layout_children, get_node_mut_by_path,
-};
+use takumi_core::scene::build_stacking_contexts;
 
 #[derive(Clone, TypedBuilder)]
 /// Options for rendering a node. Construct using [`RenderOptions::builder`] to avoid breaking changes.
@@ -251,7 +249,7 @@ fn collect_measure_result(
         mut transform,
         container_size,
       }) => {
-        let Some(current) = get_node_mut_by_path(node, &path) else {
+        let Some(current) = node.node_at_path_mut(&path) else {
           return Err(Error::LayoutError(TaffyError::InvalidInputNode(node_id)));
         };
         let layout = *layout_results.layout(node_id)?;
@@ -259,12 +257,10 @@ fn collect_measure_result(
 
         transform *= Affine::translation(layout.location.x, layout.location.y);
         let mut local_transform = transform;
-        apply_transform(
-          &mut local_transform,
-          &current.context.style,
-          layout.size,
-          &current.context.sizing,
-        );
+        local_transform *= current
+          .context
+          .style
+          .local_transform(layout.size, &current.context.sizing);
         node_transforms.insert(node_id, local_transform);
 
         let mut children = Vec::new();
@@ -419,7 +415,7 @@ fn collect_measure_result(
           continue;
         }
 
-        let layout_children = collect_layout_children(layout_results, node_id)?;
+        let layout_children = layout_results.box_children(node_id)?;
         if layout_children.is_empty() {
           measured_by_node_id.insert(
             usize::from(node_id),

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -17,9 +17,9 @@ use crate::{
   },
   prepare_node_mask,
 };
-use takumi_core::scene::{
-  NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode, get_node_mut_by_path,
-  transformed_rect_extents,
+use takumi_core::{
+  geometry::transformed_rect_extents,
+  scene::{NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode},
 };
 
 fn bounds_intersects_viewport(bounds: SceneBounds, viewport: CanvasViewport) -> bool {
@@ -281,7 +281,7 @@ fn begin_node_render(
   defer_finish: bool,
   isolation_bounds_hint: Option<SceneBounds>,
 ) -> Result<Option<DeferredNodeRender>> {
-  let Some(current) = get_node_mut_by_path(root, &node_paint.path) else {
+  let Some(current) = root.node_at_path_mut(&node_paint.path) else {
     return Err(Error::LayoutError(TaffyError::InvalidInputNode(
       node_paint.node_id,
     )));
@@ -407,7 +407,7 @@ fn paint_single_node(
       isolated_canvas,
       filter_bounds,
     }) => {
-      let Some(current) = get_node_mut_by_path(root, &path) else {
+      let Some(current) = root.node_at_path_mut(&path) else {
         return Err(Error::LayoutError(TaffyError::InvalidInputNode(
           node_paint.node_id,
         )));
@@ -492,7 +492,7 @@ pub(crate) fn paint_context(
     filter_bounds,
   }) = deferred_root
   {
-    let Some(current) = get_node_mut_by_path(root, &path) else {
+    let Some(current) = root.node_at_path_mut(&path) else {
       let node_id = context
         .root()
         .map_or(layout_results.root_node_id(), |node| node.node_id);

--- a/takumi-svg/src/scene_emit.rs
+++ b/takumi-svg/src/scene_emit.rs
@@ -16,7 +16,7 @@ use takumi_core::{
     style::Affine,
     tree::{LayoutResults, RenderNode},
   },
-  scene::{NodePaint, PaintItemKind, StackingContextNode, get_node_by_path},
+  scene::{NodePaint, PaintItemKind, StackingContextNode},
 };
 
 use crate::{
@@ -46,7 +46,7 @@ fn emit_box(
   results: &LayoutResults,
   doc: &mut SvgDocument,
 ) -> io::Result<Option<(BoxChrome, Affine)>> {
-  let Some(node) = get_node_by_path(root, &np.path) else {
+  let Some(node) = root.node_at_path(&np.path) else {
     return Ok(None);
   };
   let Ok(layout) = results.layout(np.node_id) else {


### PR DESCRIPTION
Post-split API review of the new scene module surfaced two cohesion gaps against standard API-design guidance (Ousterhout deep-module / Parnas information-hiding, Bloch "library absorbs boilerplate"). Pure refactor, no behavior change.

## Scene module cohesion
`takumi-core::scene` was carrying helpers that aren't part of the stacking-context abstraction:

- `get_node_by_path` / `get_node_mut_by_path` — render-tree navigation → now `RenderNode::node_at_path` / `node_at_path_mut` (method, idiomatic, discoverable).
- `transformed_rect_extents` — pure transform geometry, also used by `mask.rs` unrelated to scenes → moved to a new `takumi-core::geometry` module.
- `apply_transform` — a one-line `*t *= style.local_transform(..)` with an unidiomatic `&mut`-first signature → inlined into its two callers.
- `collect_layout_children` — a `box_children(id)?.to_vec()` pass-through that allocated on every call → inlined to borrow the slice directly (no more per-node `Vec`).

Scene is left holding only the stacking-context model.

## napi wrapper DRY
The five render entry points (`render`/`renderSvg`/`measure`/`renderAnimation`/`encodeFrames`) each repeated the font-register + lazy-image-resolve + `fontFamilies` fallback. Extracted into a private `resolveResources`.

## Verification
- `cargo check`/`clippy --workspace --all-features --all-targets`: clean.
- `tsc --noEmit` (takumi-napi-core): clean.
- `svg_parity` (raster↔svg within tolerance) + `svg_render` + scene unit tests: pass — confirms behavior-preserving on both backends.
- No fixture regeneration.

## Deliberately deferred
The review also flagged that the **wasm JS surface** is lower-level than napi's (no lazy font/image loaders, no `AbortSignal`, no discriminated-union output format). Converging the two is a cross-package design change that touches the wasm serde model and its goldens — out of scope for this refactor, tracked as follow-up.

https://claude.ai/code/session_018nPbfmddXd7LBpG7YX5mZ8