### PR TITLE
SVG: bundle pass-through parameter clusters into context structs

### DIFF
--- a/takumi-svg/src/gradient.rs
+++ b/takumi-svg/src/gradient.rs
@@ -31,7 +31,7 @@ use takumi_core::{
 };
 
 use crate::{
-  APPROX_CHARS_PER_NUMBER, GradientStop, IDENTITY, Rgba, SvgDocument,
+  APPROX_CHARS_PER_NUMBER, Frame, GradientStop, IDENTITY, Rgba, SvgDocument,
   box_model::{PathData, rect_path_data},
   image::{PRESERVE_ASPECT_NONE, data_url_for_url},
 };
@@ -47,191 +47,337 @@ struct LayerPlacement {
   ys: Vec<f32>,
 }
 
-/// Emits every background gradient/image for a node, painted bottom-up (CSS lists
-/// the topmost layer first, so the slice is walked in reverse). `background-size`,
-/// `-position`, and `-repeat` are honored per layer (cycling the last value when
-/// shorter than the image list, matching the raster backend).
-pub(crate) fn emit_background_images(
-  images: &[BackgroundImage],
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  emit_image_layers(
-    images,
-    &context.style.background_size,
-    &context.style.background_position,
-    &context.style.background_repeat,
-    context,
-    x,
-    y,
-    w,
-    h,
-    doc,
-  )
+/// Emits background/mask image layers for one node into an SVG document. Bundles
+/// the render context and output doc so the layer/tile chain threads only the
+/// per-tile [`Frame`] geometry, not the whole `(context, x, y, w, h, doc)` tuple.
+pub(crate) struct LayerEmitter<'a, 'd> {
+  context: &'a RenderContext,
+  doc: &'d mut SvgDocument,
 }
 
-/// Emits a list of background/mask image layers honoring per-layer size/position/
-/// repeat. Shared by `background-image` and `mask-image`.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn emit_image_layers(
-  images: &[BackgroundImage],
-  sizes: &[BackgroundSize],
-  positions: &[BackgroundPosition],
-  repeats: &[BackgroundRepeat],
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  if w <= 0.0 || h <= 0.0 {
-    return Ok(());
+impl<'a, 'd> LayerEmitter<'a, 'd> {
+  pub(crate) fn new(context: &'a RenderContext, doc: &'d mut SvgDocument) -> Self {
+    Self { context, doc }
   }
-  let last_size = sizes.last().copied().unwrap_or_default();
-  let last_position = positions.last().copied().unwrap_or_default();
-  let last_repeat = repeats.last().copied().unwrap_or_default();
 
-  for (index, image) in images.iter().enumerate().rev() {
-    if matches!(image, BackgroundImage::None) {
-      continue;
+  /// Emits every background gradient/image for a node, painted bottom-up (CSS
+  /// lists the topmost layer first, so the slice is walked in reverse).
+  /// `background-size`, `-position`, and `-repeat` are honored per layer (cycling
+  /// the last value when shorter than the image list, matching the raster backend).
+  pub(crate) fn background_images(
+    &mut self,
+    images: &[BackgroundImage],
+    frame: Frame,
+  ) -> io::Result<()> {
+    self.image_layers(
+      images,
+      &self.context.style.background_size,
+      &self.context.style.background_position,
+      &self.context.style.background_repeat,
+      frame,
+    )
+  }
+
+  /// Emits a list of background/mask image layers honoring per-layer size/
+  /// position/repeat. Shared by `background-image` and `mask-image`.
+  pub(crate) fn image_layers(
+    &mut self,
+    images: &[BackgroundImage],
+    sizes: &[BackgroundSize],
+    positions: &[BackgroundPosition],
+    repeats: &[BackgroundRepeat],
+    frame: Frame,
+  ) -> io::Result<()> {
+    if frame.w <= 0.0 || frame.h <= 0.0 {
+      return Ok(());
     }
-    let size = sizes.get(index).copied().unwrap_or(last_size);
-    let position = positions.get(index).copied().unwrap_or(last_position);
-    let repeat = repeats.get(index).copied().unwrap_or(last_repeat);
-    emit_layer(image, size, position, repeat, context, x, y, w, h, doc)?;
-  }
-  Ok(())
-}
+    let last_size = sizes.last().copied().unwrap_or_default();
+    let last_position = positions.last().copied().unwrap_or_default();
+    let last_repeat = repeats.last().copied().unwrap_or_default();
 
-#[allow(clippy::too_many_arguments)]
-fn emit_layer(
-  image: &BackgroundImage,
-  size: BackgroundSize,
-  position: BackgroundPosition,
-  repeat: BackgroundRepeat,
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  let placement = resolve_placement(image, size, position, repeat, context, w, h);
-  let Some(placement) = placement else {
-    return Ok(());
-  };
-  if placement.tile_w <= 0.0 || placement.tile_h <= 0.0 {
-    return Ok(());
+    for (index, image) in images.iter().enumerate().rev() {
+      if matches!(image, BackgroundImage::None) {
+        continue;
+      }
+      let size = sizes.get(index).copied().unwrap_or(last_size);
+      let position = positions.get(index).copied().unwrap_or(last_position);
+      let repeat = repeats.get(index).copied().unwrap_or(last_repeat);
+      self.layer(image, size, position, repeat, frame)?;
+    }
+    Ok(())
   }
 
-  // A single tile filling the box at the origin is the common case (no-repeat or
-  // an exact fit); paint it directly. Otherwise tile via a <pattern>.
-  if placement.xs.len() == 1 && placement.ys.len() == 1 {
-    let tx = x + placement.xs[0];
-    let ty = y + placement.ys[0];
-    // A `cover`/positioned tile can extend past the box; clip it so it does not
-    // bleed outside the element (the raster backend clips background to the box).
-    let overflows = tx < x - 1e-3
-      || ty < y - 1e-3
-      || tx + placement.tile_w > x + w + 1e-3
-      || ty + placement.tile_h > y + h + 1e-3;
-    if overflows {
-      let token = begin_box_clip(doc, x, y, w, h)?;
-      emit_tile(
-        image,
-        context,
-        tx,
-        ty,
+  fn layer(
+    &mut self,
+    image: &BackgroundImage,
+    size: BackgroundSize,
+    position: BackgroundPosition,
+    repeat: BackgroundRepeat,
+    frame: Frame,
+  ) -> io::Result<()> {
+    let Some(placement) = resolve_placement(
+      image,
+      size,
+      position,
+      repeat,
+      self.context,
+      frame.w,
+      frame.h,
+    ) else {
+      return Ok(());
+    };
+    if placement.tile_w <= 0.0 || placement.tile_h <= 0.0 {
+      return Ok(());
+    }
+
+    // A single tile filling the box at the origin is the common case (no-repeat
+    // or an exact fit); paint it directly. Otherwise tile via a <pattern>.
+    if placement.xs.len() == 1 && placement.ys.len() == 1 {
+      let tile = Frame::new(
+        frame.x + placement.xs[0],
+        frame.y + placement.ys[0],
         placement.tile_w,
         placement.tile_h,
-        doc,
-      )?;
-      return doc.end_group(token);
+      );
+      // A `cover`/positioned tile can extend past the box; clip it so it does not
+      // bleed outside the element (the raster backend clips background to the box).
+      let overflows = tile.x < frame.x - 1e-3
+        || tile.y < frame.y - 1e-3
+        || tile.x + tile.w > frame.x + frame.w + 1e-3
+        || tile.y + tile.h > frame.y + frame.h + 1e-3;
+      if overflows {
+        let token = self.begin_box_clip(frame)?;
+        self.tile(image, tile)?;
+        return self.doc.end_group(token);
+      }
+      return self.tile(image, tile);
     }
-    return emit_tile(
-      image,
-      context,
-      tx,
-      ty,
-      placement.tile_w,
-      placement.tile_h,
-      doc,
+
+    self.tiled_pattern(image, frame, &placement)
+  }
+
+  /// Opens a group clipped to the layer box so tiles that extend past the edges
+  /// (cover/positioned/repeated) don't bleed outside it.
+  fn begin_box_clip(&mut self, frame: Frame) -> io::Result<crate::GroupToken> {
+    let clip = self
+      .doc
+      .clip_path(&rect_path_data(frame.x, frame.y, frame.w, frame.h))?;
+    self.doc.begin_group(IDENTITY, 1.0, Some(&clip), None)
+  }
+
+  fn tiled_pattern(
+    &mut self,
+    image: &BackgroundImage,
+    frame: Frame,
+    placement: &LayerPlacement,
+  ) -> io::Result<()> {
+    // A `<pattern>` repeats on both axes, so only use it when both axes have
+    // multiple evenly-spaced tiles; otherwise a single row/column would wrongly
+    // repeat on the other axis, so emit the explicit grid.
+    let even_x = is_even_step(&placement.xs, placement.tile_w);
+    let even_y = is_even_step(&placement.ys, placement.tile_h);
+    if let (Some(step_x), Some(step_y)) = (even_x, even_y)
+      && placement.xs.len() > 1
+      && placement.ys.len() > 1
+    {
+      let origin_x = frame.x + placement.xs[0];
+      let origin_y = frame.y + placement.ys[0];
+      let (token, paint) = self.doc.begin_pattern(origin_x, origin_y, step_x, step_y)?;
+      self.tile(
+        image,
+        Frame::new(0.0, 0.0, placement.tile_w, placement.tile_h),
+      )?;
+      self.doc.end_pattern(token)?;
+      return self
+        .doc
+        .rect_paint(frame.x, frame.y, frame.w, frame.h, &paint);
+    }
+
+    // Explicit tile grid, clipped to the box so edge tiles don't bleed outside.
+    let token = self.begin_box_clip(frame)?;
+    for &ty in &placement.ys {
+      for &tx in &placement.xs {
+        self.tile(
+          image,
+          Frame::new(
+            frame.x + tx,
+            frame.y + ty,
+            placement.tile_w,
+            placement.tile_h,
+          ),
+        )?;
+      }
+    }
+    self.doc.end_group(token)
+  }
+
+  /// Paints one tile of a layer into `rect`.
+  fn tile(&mut self, image: &BackgroundImage, rect: Frame) -> io::Result<()> {
+    match image {
+      BackgroundImage::Linear(gradient) => self.linear(gradient, rect),
+      BackgroundImage::Radial(gradient) => self.radial(gradient, rect),
+      BackgroundImage::Conic(gradient) => self.conic(gradient, rect),
+      BackgroundImage::Url(url) => self.url(url, rect),
+      BackgroundImage::None => Ok(()),
+    }
+  }
+
+  fn url(&mut self, url: &str, rect: Frame) -> io::Result<()> {
+    let Some(href) = data_url_for_url(url, self.context) else {
+      return Ok(());
+    };
+    self.doc.image(
+      rect.x,
+      rect.y,
+      rect.w,
+      rect.h,
+      &href,
+      Some(PRESERVE_ASPECT_NONE),
+    )
+  }
+
+  fn linear(&mut self, gradient: &LinearGradient, rect: Frame) -> io::Result<()> {
+    let Frame { x, y, w, h } = rect;
+    let tile = LinearGradientTile::new(
+      gradient,
+      w as u32,
+      h as u32,
+      &self.context.sizing,
+      self.context.current_color,
     );
-  }
-
-  emit_tiled_pattern(image, context, x, y, w, h, &placement, doc)
-}
-
-/// Opens a group clipped to the layer box `(x, y, w, h)` so tiles that extend
-/// past the edges (cover/positioned/repeated) don't bleed outside it.
-fn begin_box_clip(
-  doc: &mut SvgDocument,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-) -> io::Result<crate::GroupToken> {
-  let clip = doc.clip_path(&rect_path_data(x, y, w, h))?;
-  doc.begin_group(IDENTITY, 1.0, Some(&clip), None)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn emit_tiled_pattern(
-  image: &BackgroundImage,
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  placement: &LayerPlacement,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  // A `<pattern>` repeats on both axes, so only use it when both axes have
-  // multiple evenly-spaced tiles; otherwise a single row/column would wrongly
-  // repeat on the other axis, so emit the explicit grid.
-  let even_x = is_even_step(&placement.xs, placement.tile_w);
-  let even_y = is_even_step(&placement.ys, placement.tile_h);
-  if let (Some(step_x), Some(step_y)) = (even_x, even_y)
-    && placement.xs.len() > 1
-    && placement.ys.len() > 1
-  {
-    let origin_x = x + placement.xs[0];
-    let origin_y = y + placement.ys[0];
-    let (token, paint) = doc.begin_pattern(origin_x, origin_y, step_x, step_y)?;
-    emit_tile(
-      image,
-      context,
-      0.0,
-      0.0,
-      placement.tile_w,
-      placement.tile_h,
-      doc,
-    )?;
-    doc.end_pattern(token)?;
-    return doc.rect_paint(x, y, w, h, &paint);
-  }
-
-  // Explicit tile grid, clipped to the box so edge tiles don't bleed outside.
-  let token = begin_box_clip(doc, x, y, w, h)?;
-  for &ty in &placement.ys {
-    for &tx in &placement.xs {
-      emit_tile(
-        image,
-        context,
-        x + tx,
-        y + ty,
-        placement.tile_w,
-        placement.tile_h,
-        doc,
-      )?;
+    let resolved = resolve_stops_along_axis(
+      &gradient.stops,
+      tile.axis_length.max(1e-6),
+      &self.context.sizing,
+      self.context.current_color,
+    );
+    if resolved.is_empty() {
+      return Ok(());
     }
+
+    // Map an axis position (px from one edge of the gradient line) to a point.
+    let max_extent = tile.axis_length / 2.0;
+    let (cx, cy) = (x + w / 2.0, y + h / 2.0);
+    let point_at = |t: f32| {
+      (
+        cx + (t - max_extent) * tile.dir_x,
+        cy + (t - max_extent) * tile.dir_y,
+      )
+    };
+
+    let (t0, t1, base, span) = if gradient.repeating {
+      let first = resolved.first().map_or(0.0, |s| s.position);
+      let last = resolved.last().map_or(tile.axis_length, |s| s.position);
+      (first, last, first, last - first)
+    } else {
+      (0.0, tile.axis_length, 0.0, tile.axis_length)
+    };
+
+    let stops = if gradient.repeating {
+      svg_stops(&resolved, base, span)
+    } else {
+      lut_svg_stops(&resolved, tile.axis_length, gradient.interpolation)
+    };
+    let paint = self
+      .doc
+      .linear_gradient(point_at(t0), point_at(t1), gradient.repeating, &stops)?;
+    self.doc.rect_paint(x, y, w, h, &paint)
   }
-  doc.end_group(token)
+
+  fn radial(&mut self, gradient: &RadialGradient, rect: Frame) -> io::Result<()> {
+    let Frame { x, y, w, h } = rect;
+    let tile = RadialGradientTile::new(
+      gradient,
+      w as u32,
+      h as u32,
+      &self.context.sizing,
+      self.context.current_color,
+    );
+    let resolved = resolve_stops_along_axis(
+      &gradient.stops,
+      tile.radius_scale.max(1e-6),
+      &self.context.sizing,
+      self.context.current_color,
+    );
+    if resolved.is_empty() {
+      return Ok(());
+    }
+
+    let radius_x = tile.inv_radius_x.recip();
+    let radius_y = tile.inv_radius_y.recip();
+    let (r, base, span) = if gradient.repeating {
+      let first = resolved.first().map_or(0.0, |s| s.position);
+      let last = resolved.last().map_or(tile.radius_scale, |s| s.position);
+      ((last - first).max(1e-6), first, last - first)
+    } else {
+      (tile.radius_scale, 0.0, tile.radius_scale)
+    };
+    let scale = (
+      (radius_x / tile.radius_scale.max(1e-6)).max(1e-6),
+      (radius_y / tile.radius_scale.max(1e-6)).max(1e-6),
+    );
+
+    let stops = if gradient.repeating {
+      svg_stops(&resolved, base, span)
+    } else {
+      lut_svg_stops(&resolved, tile.radius_scale, gradient.interpolation)
+    };
+    let paint = self.doc.radial_gradient(
+      (x + tile.cx, y + tile.cy),
+      r,
+      scale,
+      gradient.repeating,
+      &stops,
+    )?;
+    self.doc.rect_paint(x, y, w, h, &paint)
+  }
+
+  fn conic(&mut self, gradient: &ConicGradient, rect: Frame) -> io::Result<()> {
+    let Frame { x, y, w, h } = rect;
+    let tile = ConicGradientTile::new(
+      gradient,
+      w as u32,
+      h as u32,
+      &self.context.sizing,
+      self.context.current_color,
+    );
+    let lut_len = tile.color_lut.len();
+    if lut_len == 0 {
+      return Ok(());
+    }
+
+    let (ccx, ccy) = (x + tile.cx, y + tile.cy);
+    let radius = [(x, y), (x + w, y), (x, y + h), (x + w, y + h)]
+      .into_iter()
+      .map(|(px, py)| (px - ccx).hypot(py - ccy))
+      .fold(0.0_f32, f32::max);
+
+    let clip = self.doc.clip_path(&rect_path_data(x, y, w, h))?;
+    let group = self.doc.begin_group(IDENTITY, 1.0, Some(&clip), None)?;
+    for i in 0..CONIC_WEDGES {
+      let a0 = i as f32 / CONIC_WEDGES as f32 * TAU;
+      let a1 = (i + 1) as f32 / CONIC_WEDGES as f32 * TAU;
+      let mid = (a0 + a1) / 2.0;
+      let adjusted = (mid - tile.start_rad).rem_euclid(TAU);
+      let idx = tile.lut_index_for_adjusted_angle_with_len(adjusted, lut_len);
+      let color = tile.color_lut[idx].demultiply();
+      let fill = Rgba([color.red(), color.green(), color.blue(), color.alpha()]);
+      if fill.0[3] == 0 {
+        continue;
+      }
+      let (x0, y0) = (ccx + radius * a0.sin(), ccy - radius * a0.cos());
+      let (x1, y1) = (ccx + radius * a1.sin(), ccy - radius * a1.cos());
+      let mut wedge = PathData::with_capacity(6 * APPROX_CHARS_PER_NUMBER);
+      wedge.command(b'M');
+      wedge.pair(ccx, ccy);
+      wedge.command(b'L');
+      wedge.pair(x0, y0);
+      wedge.pair(x1, y1);
+      wedge.close();
+      self.doc.path(&wedge.into_string(), fill)?;
+    }
+    self.doc.end_group(group)
+  }
 }
 
 /// Returns the uniform step between positions (tile size when there is a single
@@ -347,44 +493,6 @@ fn intrinsic_sizing(image: &BackgroundImage, context: &RenderContext) -> Intrins
   }
 }
 
-/// Paints one tile of a layer into the rect `(tx, ty, tile_w, tile_h)`.
-fn emit_tile(
-  image: &BackgroundImage,
-  context: &RenderContext,
-  tx: f32,
-  ty: f32,
-  tile_w: f32,
-  tile_h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  match image {
-    BackgroundImage::Linear(gradient) => {
-      emit_linear(gradient, context, tx, ty, tile_w, tile_h, doc)
-    }
-    BackgroundImage::Radial(gradient) => {
-      emit_radial(gradient, context, tx, ty, tile_w, tile_h, doc)
-    }
-    BackgroundImage::Conic(gradient) => emit_conic(gradient, context, tx, ty, tile_w, tile_h, doc),
-    BackgroundImage::Url(url) => emit_url(url, context, tx, ty, tile_w, tile_h, doc),
-    BackgroundImage::None => Ok(()),
-  }
-}
-
-fn emit_url(
-  url: &str,
-  context: &RenderContext,
-  tx: f32,
-  ty: f32,
-  tile_w: f32,
-  tile_h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  let Some(href) = data_url_for_url(url, context) else {
-    return Ok(());
-  };
-  doc.image(tx, ty, tile_w, tile_h, &href, Some(PRESERVE_ASPECT_NONE))
-}
-
 fn svg_stops(stops: &[ResolvedGradientStop], base: f32, span: f32) -> Vec<GradientStop> {
   let span = span.max(1e-6);
   stops
@@ -471,166 +579,4 @@ fn lut_svg_stops(
   }
   stops.sort_by(|a, b| a.offset.total_cmp(&b.offset));
   stops
-}
-
-fn emit_linear(
-  gradient: &LinearGradient,
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  let tile = LinearGradientTile::new(
-    gradient,
-    w as u32,
-    h as u32,
-    &context.sizing,
-    context.current_color,
-  );
-  let resolved = resolve_stops_along_axis(
-    &gradient.stops,
-    tile.axis_length.max(1e-6),
-    &context.sizing,
-    context.current_color,
-  );
-  if resolved.is_empty() {
-    return Ok(());
-  }
-
-  // Map an axis position (px from one edge of the gradient line) to a point.
-  let max_extent = tile.axis_length / 2.0;
-  let (cx, cy) = (x + w / 2.0, y + h / 2.0);
-  let point_at = |t: f32| {
-    (
-      cx + (t - max_extent) * tile.dir_x,
-      cy + (t - max_extent) * tile.dir_y,
-    )
-  };
-
-  let (t0, t1, base, span) = if gradient.repeating {
-    let first = resolved.first().map_or(0.0, |s| s.position);
-    let last = resolved.last().map_or(tile.axis_length, |s| s.position);
-    (first, last, first, last - first)
-  } else {
-    (0.0, tile.axis_length, 0.0, tile.axis_length)
-  };
-
-  let stops = if gradient.repeating {
-    svg_stops(&resolved, base, span)
-  } else {
-    lut_svg_stops(&resolved, tile.axis_length, gradient.interpolation)
-  };
-  let paint = doc.linear_gradient(point_at(t0), point_at(t1), gradient.repeating, &stops)?;
-  doc.rect_paint(x, y, w, h, &paint)
-}
-
-fn emit_radial(
-  gradient: &RadialGradient,
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  let tile = RadialGradientTile::new(
-    gradient,
-    w as u32,
-    h as u32,
-    &context.sizing,
-    context.current_color,
-  );
-  let resolved = resolve_stops_along_axis(
-    &gradient.stops,
-    tile.radius_scale.max(1e-6),
-    &context.sizing,
-    context.current_color,
-  );
-  if resolved.is_empty() {
-    return Ok(());
-  }
-
-  let radius_x = tile.inv_radius_x.recip();
-  let radius_y = tile.inv_radius_y.recip();
-  let (r, base, span) = if gradient.repeating {
-    let first = resolved.first().map_or(0.0, |s| s.position);
-    let last = resolved.last().map_or(tile.radius_scale, |s| s.position);
-    ((last - first).max(1e-6), first, last - first)
-  } else {
-    (tile.radius_scale, 0.0, tile.radius_scale)
-  };
-  let scale = (
-    (radius_x / tile.radius_scale.max(1e-6)).max(1e-6),
-    (radius_y / tile.radius_scale.max(1e-6)).max(1e-6),
-  );
-
-  let stops = if gradient.repeating {
-    svg_stops(&resolved, base, span)
-  } else {
-    lut_svg_stops(&resolved, tile.radius_scale, gradient.interpolation)
-  };
-  let paint = doc.radial_gradient(
-    (x + tile.cx, y + tile.cy),
-    r,
-    scale,
-    gradient.repeating,
-    &stops,
-  )?;
-  doc.rect_paint(x, y, w, h, &paint)
-}
-
-fn emit_conic(
-  gradient: &ConicGradient,
-  context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
-  doc: &mut SvgDocument,
-) -> io::Result<()> {
-  let tile = ConicGradientTile::new(
-    gradient,
-    w as u32,
-    h as u32,
-    &context.sizing,
-    context.current_color,
-  );
-  let lut_len = tile.color_lut.len();
-  if lut_len == 0 {
-    return Ok(());
-  }
-
-  let (ccx, ccy) = (x + tile.cx, y + tile.cy);
-  let radius = [(x, y), (x + w, y), (x, y + h), (x + w, y + h)]
-    .into_iter()
-    .map(|(px, py)| (px - ccx).hypot(py - ccy))
-    .fold(0.0_f32, f32::max);
-
-  let clip = doc.clip_path(&rect_path_data(x, y, w, h))?;
-  let group = doc.begin_group(IDENTITY, 1.0, Some(&clip), None)?;
-  for i in 0..CONIC_WEDGES {
-    let a0 = i as f32 / CONIC_WEDGES as f32 * TAU;
-    let a1 = (i + 1) as f32 / CONIC_WEDGES as f32 * TAU;
-    let mid = (a0 + a1) / 2.0;
-    let adjusted = (mid - tile.start_rad).rem_euclid(TAU);
-    let idx = tile.lut_index_for_adjusted_angle_with_len(adjusted, lut_len);
-    let color = tile.color_lut[idx].demultiply();
-    let fill = Rgba([color.red(), color.green(), color.blue(), color.alpha()]);
-    if fill.0[3] == 0 {
-      continue;
-    }
-    let (x0, y0) = (ccx + radius * a0.sin(), ccy - radius * a0.cos());
-    let (x1, y1) = (ccx + radius * a1.sin(), ccy - radius * a1.cos());
-    let mut wedge = PathData::with_capacity(6 * APPROX_CHARS_PER_NUMBER);
-    wedge.command(b'M');
-    wedge.pair(ccx, ccy);
-    wedge.command(b'L');
-    wedge.pair(x0, y0);
-    wedge.pair(x1, y1);
-    wedge.close();
-    doc.path(&wedge.into_string(), fill)?;
-  }
-  doc.end_group(group)
 }

--- a/takumi-svg/src/image.rs
+++ b/takumi-svg/src/image.rs
@@ -16,7 +16,7 @@ use takumi_core::{
   resources::image::ImageSource,
 };
 
-use crate::{SvgDocument, box_model::rect_path_data};
+use crate::{Frame, SvgDocument, box_model::rect_path_data};
 
 pub(crate) const PRESERVE_ASPECT_NONE: &str = "none";
 
@@ -41,12 +41,10 @@ fn position_axis(component: PositionComponent, context: &RenderContext, availabl
 pub(crate) fn emit_image(
   image: &ImageData,
   context: &RenderContext,
-  x: f32,
-  y: f32,
-  w: f32,
-  h: f32,
+  content: Frame,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
+  let Frame { x, y, w, h } = content;
   if w <= 0.0 || h <= 0.0 {
     return Ok(());
   }

--- a/takumi-svg/src/lib.rs
+++ b/takumi-svg/src/lib.rs
@@ -61,6 +61,22 @@ use takumi_core::{
 
 pub(crate) const IDENTITY: Affine = Affine::IDENTITY;
 
+/// An axis-aligned rectangle in absolute SVG user space: top-left `(x, y)` and
+/// size `(w, h)`. Bundles the box geometry threaded through the emission chain.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Frame {
+  pub x: f32,
+  pub y: f32,
+  pub w: f32,
+  pub h: f32,
+}
+
+impl Frame {
+  pub(crate) fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
+    Self { x, y, w, h }
+  }
+}
+
 /// A single stop in a gradient.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GradientStop {

--- a/takumi-svg/src/lib.rs
+++ b/takumi-svg/src/lib.rs
@@ -719,7 +719,6 @@ impl SvgDocument {
 
   /// Strokes an open/closed path (for dashed/dotted borders). `dasharray` and
   /// `linecap` are optional.
-  #[allow(clippy::too_many_arguments)]
   pub(crate) fn stroke_path(
     &mut self,
     data: &str,

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -691,6 +691,15 @@ fn emit_image_node(
 /// Uniform `dashed`/`dotted`/`double` borders stroke a centerline rounded-rect.
 /// 3D styles (groove/ridge/inset/outset) approximate as a solid fill. `x`/`y` are
 /// the absolute border-box top-left; `size` is the border-box size.
+/// The absolute placement of a border box: the `[1,0,0,1,x,y]` device-space
+/// transform and the border-box size, threaded together through the stroke
+/// emitters.
+#[derive(Clone, Copy)]
+struct BorderGeom {
+  matrix: [f32; 6],
+  size: Size<f32>,
+}
+
 pub(crate) fn emit_borders(
   border: &BorderProperties,
   x: f32,
@@ -703,18 +712,19 @@ pub(crate) fn emit_borders(
   }
 
   let matrix = [1.0, 0.0, 0.0, 1.0, x, y];
+  let geom = BorderGeom { matrix, size };
 
   // Uniform dashed/dotted/double borders need stroke-based rendering, not fills.
   if let Some(color) = border.has_uniform_visible_color() {
     let width = border.width.top;
     if border.is_uniform_all_sides_style(BorderStyle::Dashed) {
-      return emit_stroked_border(border, color, width, matrix, size, BorderStyle::Dashed, doc);
+      return emit_stroked_border(border, color, width, geom, BorderStyle::Dashed, doc);
     }
     if border.is_uniform_all_sides_style(BorderStyle::Dotted) {
-      return emit_stroked_border(border, color, width, matrix, size, BorderStyle::Dotted, doc);
+      return emit_stroked_border(border, color, width, geom, BorderStyle::Dotted, doc);
     }
     if border.is_uniform_all_sides_style(BorderStyle::Double) {
-      return emit_double_border(border, color, width, matrix, size, doc);
+      return emit_double_border(border, color, width, geom, doc);
     }
   }
 
@@ -777,7 +787,7 @@ pub(crate) fn emit_borders(
     }
     match style {
       BorderStyle::Dashed | BorderStyle::Dotted => {
-        emit_side_pattern(border, side, width, color, style, matrix, size, doc)?;
+        emit_side_pattern(border, side, width, color, style, geom, doc)?;
       }
       _ => {
         let mut polygon = Vec::new();
@@ -793,17 +803,16 @@ pub(crate) fn emit_borders(
 /// inset by half the side's width and shortened at each end by half the adjacent
 /// side's width (matching the raster backend's per-side stroke). Dash intervals
 /// mirror the uniform stroked path (dashed `3w 2w`, dotted `0 2w` + round caps).
-#[allow(clippy::too_many_arguments)]
 fn emit_side_pattern(
   border: &BorderProperties,
   side: BorderSide,
   width: f32,
   color: Color,
   style: BorderStyle,
-  matrix: [f32; 6],
-  size: Size<f32>,
+  geom: BorderGeom,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
+  let BorderGeom { matrix, size } = geom;
   let (half_top, half_right, half_bottom, half_left) = (
     border.width.top / 2.0,
     border.width.right / 2.0,
@@ -893,12 +902,8 @@ pub(crate) fn emit_outline(
 
 /// Builds the centerline rounded-rect path (border box inset by `inset` on each
 /// side, radii shrunk by `inset`) for stroking dashed/dotted/ring borders.
-fn centerline_path(
-  border: &BorderProperties,
-  inset: f32,
-  matrix: [f32; 6],
-  size: Size<f32>,
-) -> String {
+fn centerline_path(border: &BorderProperties, inset: f32, geom: BorderGeom) -> String {
+  let BorderGeom { matrix, size } = geom;
   let mut shrunk = *border;
   shrunk.expand_by(Rect {
     top: -inset,
@@ -920,15 +925,15 @@ fn emit_stroked_border(
   border: &BorderProperties,
   color: Color,
   width: f32,
-  matrix: [f32; 6],
-  size: Size<f32>,
+  geom: BorderGeom,
   style: BorderStyle,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
   if color.0[3] == 0 || width <= 0.0 {
     return Ok(());
   }
-  let data = centerline_path(border, width / 2.0, matrix, size);
+  let size = geom.size;
+  let data = centerline_path(border, width / 2.0, geom);
   let half = width / 2.0;
   let mut center = *border;
   center.expand_by(Rect {
@@ -970,8 +975,7 @@ fn emit_double_border(
   border: &BorderProperties,
   color: Color,
   width: f32,
-  matrix: [f32; 6],
-  size: Size<f32>,
+  geom: BorderGeom,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
   if color.0[3] == 0 || width <= 0.0 {
@@ -979,10 +983,10 @@ fn emit_double_border(
   }
   let third = width / 3.0;
   // Outer ring centered at third/2 from the outer edge.
-  let outer = centerline_path(border, third / 2.0, matrix, size);
+  let outer = centerline_path(border, third / 2.0, geom);
   doc.stroke_path(&outer, Rgba(color.0), third, None, None)?;
   // Inner ring centered at width - third/2 from the outer edge.
-  let inner = centerline_path(border, width - third / 2.0, matrix, size);
+  let inner = centerline_path(border, width - third / 2.0, geom);
   doc.stroke_path(&inner, Rgba(color.0), third, None, None)
 }
 

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -26,9 +26,9 @@ use takumi_core::{
 use typed_builder::TypedBuilder;
 
 use crate::{
-  APPROX_CHARS_PER_NUMBER, IDENTITY, Num, Rgba, SvgDocument,
+  APPROX_CHARS_PER_NUMBER, Frame, IDENTITY, Num, Rgba, SvgDocument,
   box_model::{PathData, element_transform, path_data},
-  gradient::{emit_background_images, emit_image_layers},
+  gradient::LayerEmitter,
   image::emit_image,
   scene_emit::emit_scene,
   text::{emit_inline_content, emit_text},
@@ -277,7 +277,8 @@ pub(crate) fn emit_background(
     doc.rect(x, y, width, height, Rgba(background.0))?;
   }
   if let Some(images) = style.background_image.as_deref() {
-    emit_background_images(images, &node.context, x, y, width, height, doc)?;
+    LayerEmitter::new(&node.context, doc)
+      .background_images(images, Frame::new(x, y, width, height))?;
   }
   if let Some(group) = bg_group {
     doc.end_group(group)?;
@@ -309,17 +310,12 @@ pub(crate) fn emit_mask_group(
   }
 
   let (token, reference) = doc.begin_mask()?;
-  emit_image_layers(
+  LayerEmitter::new(&node.context, doc).image_layers(
     images,
     &style.mask_size,
     &style.mask_position,
     &style.mask_repeat,
-    &node.context,
-    x,
-    y,
-    width,
-    height,
-    doc,
+    Frame::new(x, y, width, height),
   )?;
   doc.end_mask(token)?;
   Ok(Some(doc.begin_masked_group(&reference)?))
@@ -675,15 +671,16 @@ fn emit_image_node(
   let iy = y + layout.border.top + layout.padding.top;
   let (iw, ih) = (layout.content_box_width(), layout.content_box_height());
 
+  let content = Frame::new(ix, iy, iw, ih);
   let border = BorderProperties::from_context(&node.context, layout.size, layout.border);
   if border.is_zero() {
-    return emit_image(image, &node.context, ix, iy, iw, ih, doc);
+    return emit_image(image, &node.context, content, doc);
   }
 
   let path = padding_box_path_data(&border, layout.border, layout.size, x, y);
   let clip = doc.clip_path(&path)?;
   let group = doc.begin_group(IDENTITY, 1.0, Some(&clip), None)?;
-  emit_image(image, &node.context, ix, iy, iw, ih, doc)?;
+  emit_image(image, &node.context, content, doc)?;
   doc.end_group(group)
 }
 

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -27,7 +27,7 @@ use takumi_core::{
 };
 
 use crate::{
-  Affine, IDENTITY, Num, Rgba, SvgDocument, box_model::path_data, gradient::emit_background_images,
+  Affine, Frame, IDENTITY, Num, Rgba, SvgDocument, box_model::path_data, gradient::LayerEmitter,
   image::encode, render::emit_inline_box,
 };
 
@@ -333,7 +333,7 @@ fn emit_clip_text_glyphs(
     doc.rect(bx, by, bw, bh, background)?;
   }
   if let Some(images) = context.style.background_image.as_deref() {
-    emit_background_images(images, context, bx, by, bw, bh, doc)?;
+    LayerEmitter::new(context, doc).background_images(images, Frame::new(bx, by, bw, bh))?;
   }
   doc.end_group(group)?;
 

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -31,6 +31,36 @@ use crate::{
   image::encode, render::emit_inline_box,
 };
 
+/// Where a run of inline text sits: its container `layout` (border/padding and
+/// content size) and the container's absolute border-box top-left
+/// `(origin_x, origin_y)`. Bundles the geometry threaded through the run/glyph
+/// emitters; the shadow pass shifts `origin_*` per shadow.
+#[derive(Clone, Copy)]
+struct TextFrame {
+  layout: Layout,
+  origin_x: f32,
+  origin_y: f32,
+}
+
+impl TextFrame {
+  fn new(layout: Layout, origin_x: f32, origin_y: f32) -> Self {
+    Self {
+      layout,
+      origin_x,
+      origin_y,
+    }
+  }
+
+  /// Shifts the origin by `(dx, dy)` (for the text-shadow pass).
+  fn shifted(self, dx: f32, dy: f32) -> Self {
+    Self {
+      origin_x: self.origin_x + dx,
+      origin_y: self.origin_y + dy,
+      ..self
+    }
+  }
+}
+
 /// Emits a leaf [`TextData`] node. `origin_x`/`origin_y` are the element's
 /// absolute border-box top-left; `layout` carries border/padding and content size.
 pub(crate) fn emit_text(
@@ -70,9 +100,7 @@ pub(crate) fn emit_text(
     &built.spans,
     &font_style,
     context,
-    layout,
-    origin_x,
-    origin_y,
+    TextFrame::new(layout, origin_x, origin_y),
   )
 }
 
@@ -114,9 +142,7 @@ pub(crate) fn emit_inline_content(
     &built.spans,
     &font_style,
     context,
-    layout,
-    origin_x,
-    origin_y,
+    TextFrame::new(layout, origin_x, origin_y),
   )?;
 
   for inline_box in &runs.inline_boxes {
@@ -129,16 +155,13 @@ pub(crate) fn emit_inline_content(
 
 /// Paints a resolved run layout in CSS text-decoration order: shadows, under/over
 /// decorations, glyphs, then line-through.
-#[allow(clippy::too_many_arguments)]
 fn emit_runs(
   doc: &mut SvgDocument,
   runs: &InlineRunLayout<'_>,
   spans: &[ProcessedInlineSpan<'_>],
   font_style: &SizedFontStyle,
   context: &RenderContext,
-  layout: Layout,
-  origin_x: f32,
-  origin_y: f32,
+  frame: TextFrame,
 ) -> io::Result<()> {
   let stroke =
     (font_style.stroke_width > 0.0 && font_style.text_stroke_color.0[3] != 0).then_some((
@@ -159,44 +182,31 @@ fn emit_runs(
       None
     };
     let group = doc.begin_group(IDENTITY, 1.0, None, filter.as_deref())?;
+    let shadow_frame = frame.shifted(shadow.offset_x, shadow.offset_y);
     for run in &runs.runs {
-      emit_run_glyphs(
-        doc,
-        run,
-        font_style,
-        layout,
-        origin_x + shadow.offset_x,
-        origin_y + shadow.offset_y,
-        Some(color),
-        None,
-        None,
-      )?;
+      emit_run_glyphs(doc, run, font_style, shadow_frame, Some(color), None, None)?;
     }
     doc.end_group(group)?;
   }
 
   for run in &runs.runs {
-    emit_run_decorations(doc, run, layout, origin_x, origin_y, false)?;
+    emit_run_decorations(doc, run, frame, false)?;
   }
 
   if context.style.background_clip == BackgroundClip::Text {
-    emit_clip_text_glyphs(
-      doc, runs, font_style, context, layout, origin_x, origin_y, stroke,
-    )?;
+    emit_clip_text_glyphs(doc, runs, font_style, context, frame, stroke)?;
   } else {
     for run in &runs.runs {
-      emit_run_glyphs(
-        doc, run, font_style, layout, origin_x, origin_y, None, stroke, None,
-      )?;
+      emit_run_glyphs(doc, run, font_style, frame, None, stroke, None)?;
     }
   }
 
   // Text outlines stroke between the glyphs and the line-through, matching the
   // raster backend's painting order.
-  emit_inline_outlines(doc, runs, spans, origin_x, origin_y)?;
+  emit_inline_outlines(doc, runs, spans, frame.origin_x, frame.origin_y)?;
 
   for run in &runs.runs {
-    emit_run_decorations(doc, run, layout, origin_x, origin_y, true)?;
+    emit_run_decorations(doc, run, frame, true)?;
   }
   Ok(())
 }
@@ -289,15 +299,12 @@ fn emit_outline_island(
 /// can't reach the stroke-widened ring, so the background would only fill the thin
 /// glyph interior. A mask honors the stroke, so the background fills the full
 /// fill+stroke coverage.
-#[allow(clippy::too_many_arguments)]
 fn emit_clip_text_glyphs(
   doc: &mut SvgDocument,
   runs: &InlineRunLayout<'_>,
   font_style: &SizedFontStyle,
   context: &RenderContext,
-  layout: Layout,
-  origin_x: f32,
-  origin_y: f32,
+  frame: TextFrame,
   stroke: Option<(Rgba, f32, &str)>,
 ) -> io::Result<()> {
   let white = Rgba([255, 255, 255, 255]);
@@ -307,16 +314,7 @@ fn emit_clip_text_glyphs(
   let (mask_token, mask_ref) = doc.begin_mask()?;
   let mut any = false;
   for run in &runs.runs {
-    any |= emit_clip_text_mask_glyphs(
-      doc,
-      run,
-      layout,
-      origin_x,
-      origin_y,
-      white,
-      stroke_width,
-      join,
-    )?;
+    any |= emit_clip_text_mask_glyphs(doc, run, frame, white, stroke_width, join)?;
   }
   doc.end_mask(mask_token)?;
   if !any {
@@ -325,8 +323,8 @@ fn emit_clip_text_glyphs(
 
   let cc = context.current_color;
   let background = Rgba(context.style.background_color.resolve(cc).0);
-  let (bx, by) = (origin_x, origin_y);
-  let (bw, bh) = (layout.size.width, layout.size.height);
+  let (bx, by) = (frame.origin_x, frame.origin_y);
+  let (bw, bh) = (frame.layout.size.width, frame.layout.size.height);
 
   let group = doc.begin_masked_group(&mask_ref)?;
   if background.0[3] != 0 {
@@ -340,9 +338,7 @@ fn emit_clip_text_glyphs(
   // The `color` (brush) fills the glyph interiors on top of the background, with
   // the real text stroke (a transparent stroke adds nothing visible).
   for run in &runs.runs {
-    emit_run_glyphs(
-      doc, run, font_style, layout, origin_x, origin_y, None, stroke, None,
-    )?;
+    emit_run_glyphs(doc, run, font_style, frame, None, stroke, None)?;
   }
   Ok(())
 }
@@ -350,19 +346,16 @@ fn emit_clip_text_glyphs(
 /// Paints a run's outline glyphs white into the active mask with both fill and
 /// stroke (and any faux-bold embolden), so the mask covers the full fill+stroke
 /// glyph coverage. Returns whether any glyph was emitted.
-#[allow(clippy::too_many_arguments)]
 fn emit_clip_text_mask_glyphs(
   doc: &mut SvgDocument,
   run: &PositionedInlineRun<'_>,
-  layout: Layout,
-  origin_x: f32,
-  origin_y: f32,
+  frame: TextFrame,
   color: Rgba,
   stroke_width: f32,
   join: &str,
 ) -> io::Result<bool> {
   let run_transform = run.transform(IDENTITY);
-  let glyph_offset = run.glyph_offset(layout);
+  let glyph_offset = run.glyph_offset(frame.layout);
   let mut any = false;
   for glyph in run.glyph_run.positioned_glyphs() {
     let Some(ResolvedGlyph::Outline(outline)) = run.resolved_glyphs.get(&glyph.id) else {
@@ -370,7 +363,7 @@ fn emit_clip_text_mask_glyphs(
     };
     let matrix =
       run_transform * Affine::translation(glyph_offset.x + glyph.x, glyph_offset.y + glyph.y);
-    let cols = offset(matrix.to_cols_array(), origin_x, origin_y).to_cols_array();
+    let cols = offset(matrix.to_cols_array(), frame.origin_x, frame.origin_y).to_cols_array();
     let data = path_data(outline.paths(), cols);
     if data.is_empty() {
       continue;
@@ -393,9 +386,7 @@ fn emit_clip_text_mask_glyphs(
 fn emit_run_decorations(
   doc: &mut SvgDocument,
   run: &PositionedInlineRun<'_>,
-  layout: Layout,
-  origin_x: f32,
-  origin_y: f32,
+  frame: TextFrame,
   over: bool,
 ) -> io::Result<()> {
   let transform = run.transform(IDENTITY);
@@ -403,9 +394,9 @@ fn emit_run_decorations(
   let opacity_group = (opacity < 1.0)
     .then(|| doc.begin_group(IDENTITY, opacity, None, None))
     .transpose()?;
-  for decoration in run_decorations(&run.glyph_run, layout, run.baseline_shift, transform) {
+  for decoration in run_decorations(&run.glyph_run, frame.layout, run.baseline_shift, transform) {
     if decoration.over == over {
-      emit_decoration(doc, &decoration, origin_x, origin_y)?;
+      emit_decoration(doc, &decoration, frame.origin_x, frame.origin_y)?;
     }
   }
   if let Some(group) = opacity_group {
@@ -418,20 +409,17 @@ fn emit_run_decorations(
 /// suppresses bitmaps/COLR; `stroke` adds `-webkit-text-stroke` to outlines. When
 /// `clip_data` is `Some`, outline glyph paths are appended to it (for a
 /// `background-clip: text` `<clipPath>`) instead of being painted.
-#[allow(clippy::too_many_arguments)]
 fn emit_run_glyphs(
   doc: &mut SvgDocument,
   run: &PositionedInlineRun<'_>,
   font_style: &SizedFontStyle,
-  layout: Layout,
-  origin_x: f32,
-  origin_y: f32,
+  frame: TextFrame,
   color_override: Option<Rgba>,
   stroke: Option<(Rgba, f32, &str)>,
   mut clip_data: Option<&mut String>,
 ) -> io::Result<()> {
   let run_transform = run.transform(IDENTITY);
-  let glyph_offset = run.glyph_offset(layout);
+  let glyph_offset = run.glyph_offset(frame.layout);
   let fill_color = run.glyph_run.style().brush.color;
   let bold_join = line_join_str(font_style.parent.stroke_linejoin);
 
@@ -455,7 +443,7 @@ fn emit_run_glyphs(
     };
     let matrix =
       run_transform * Affine::translation(glyph_offset.x + glyph.x, glyph_offset.y + glyph.y);
-    let placed = offset(matrix.to_cols_array(), origin_x, origin_y);
+    let placed = offset(matrix.to_cols_array(), frame.origin_x, frame.origin_y);
     let cols = placed.to_cols_array();
 
     match resolved {


### PR DESCRIPTION
First of a few encapsulation passes (Ousterhout deep-module / no pass-through variables). Pure refactor of the SVG backend, no output change.

The SVG emitters threaded the same geometry/context tuples through every layer of the call chain. Bundle each recurring cluster into a small value/struct so functions carry one frame, not five loose floats:

- **`LayerEmitter` + `Frame`** — the background/mask gradient/image chain threaded `(context, x, y, w, h, doc)` through 11 functions. `Frame{x,y,w,h}` carries the box; `LayerEmitter{context, doc}` owns the sink. Removes 3 `too_many_arguments` allows.
- **`TextFrame`** — the run/glyph/decoration/clip-text emitters threaded `(layout, origin_x, origin_y)`. Collapsed into one frame (the shadow pass shifts its origin). Removes 4 allows.
- **`BorderGeom`** — the dashed/dotted/double stroke emitters shared a `(matrix, size)` pair. Removes 1 allow. Plus a stale allow on `stroke_path` (only 5 args).

**takumi-svg now carries zero `clippy::too_many_arguments` allows.**

## Verification
- `cargo clippy -p takumi-svg --all-features`: clean.
- `svg_parity` (raster↔svg within tolerance) + `svg_render`: pass — output byte-preserving on both backends.
- No fixture/SVG-output change.

Follow-up passes (raster canvas pixel-op scaffolding, raster decoration/paint-recurse contexts, inline `BuiltInlineLayout`) will land as separate PRs.

https://claude.ai/code/session_018nPbfmddXd7LBpG7YX5mZ8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal SVG rendering architecture with several improvements: consolidated gradient and background image emission into a unified handler, introduced standardized coordinate representation across image and text rendering pipelines, and streamlined border geometry management. These structural changes improve code organization, maintainability, and overall consistency while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->