### PR TITLE
Raster: bundle pixel-loop & component param clusters

### DIFF
--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -768,6 +768,27 @@ fn compute_overlay_bounds_for_canvas(
   ))
 }
 
+#[inline(always)]
+fn apply_combined_mask(
+  src: [u8; 4],
+  combined_mask: Option<MaskView<'_>>,
+  dest_x: u32,
+  dest_y: u32,
+) -> Option<[u8; 4]> {
+  let Some(mask) = combined_mask else {
+    return Some(src);
+  };
+  let alpha = mask.alpha_at(dest_x, dest_y);
+  if alpha == 0 {
+    return None;
+  }
+  let src = scale_premultiplied_pixel(src, alpha);
+  if src[3] == 0 {
+    return None;
+  }
+  Some(src)
+}
+
 fn blit_sampled_paint_source_translation(
   pixmap: &mut PixmapMut<'_>,
   source: PaintSource<'_>,
@@ -802,7 +823,7 @@ fn blit_sampled_paint_source_translation(
       y: src_y + 0.5,
     });
     for dest_x in dest_x_min..dest_x_max {
-      let mut src = sample_paint_source(
+      let src = sample_paint_source(
         source,
         sampling.algorithm,
         sample_point.x,
@@ -818,16 +839,9 @@ fn blit_sampled_paint_source_translation(
 
       let dest_x = dest_x as u32;
       let dest_y = dest_y as u32;
-      if let Some(mask) = combined_mask {
-        let alpha = mask.alpha_at(dest_x, dest_y);
-        if alpha == 0 {
-          continue;
-        }
-        src = scale_premultiplied_pixel(src, alpha);
-        if src[3] == 0 {
-          continue;
-        }
-      }
+      let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y) else {
+        continue;
+      };
 
       let index = (dest_y * canvas_width + dest_x) as usize;
       blend_premultiplied_pixel(&mut pixels[index], src, mode);
@@ -895,22 +909,15 @@ fn blit_paint_source_translation(
         let src_row = src_y as usize * source_width as usize;
         for dest_x in dest_x_min..dest_x_max {
           let src_x = (dest_x - offset_x) as u32;
-          let mut src = premultiplied_from_pixel(source_pixels[src_row + src_x as usize]);
+          let src = premultiplied_from_pixel(source_pixels[src_row + src_x as usize]);
           if src[3] == 0 {
             continue;
           }
 
           let dest_x = dest_x as u32;
-          if let Some(mask) = combined_mask {
-            let alpha = mask.alpha_at(dest_x, dest_y as u32);
-            if alpha == 0 {
-              continue;
-            }
-            src = scale_premultiplied_pixel(src, alpha);
-            if src[3] == 0 {
-              continue;
-            }
-          }
+          let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y as u32) else {
+            continue;
+          };
 
           blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
         }
@@ -922,7 +929,7 @@ fn blit_paint_source_translation(
         let dst_row = dest_y as usize * canvas_width as usize;
         for dest_x in dest_x_min..dest_x_max {
           let src_x = (dest_x - offset_x) as f32;
-          let mut src = sample_paint_source(
+          let src = sample_paint_source(
             source,
             ImageScalingAlgorithm::Pixelated,
             src_x,
@@ -935,16 +942,9 @@ fn blit_paint_source_translation(
           }
 
           let dest_x = dest_x as u32;
-          if let Some(mask) = combined_mask {
-            let alpha = mask.alpha_at(dest_x, dest_y as u32);
-            if alpha == 0 {
-              continue;
-            }
-            src = scale_premultiplied_pixel(src, alpha);
-            if src[3] == 0 {
-              continue;
-            }
-          }
+          let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y as u32) else {
+            continue;
+          };
 
           blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
         }
@@ -1006,18 +1006,10 @@ fn blit_solid_translation(
   for dest_y in dest_y_min..dest_y_max {
     let dst_row = dest_y as usize * canvas_width as usize;
     for dest_x in dest_x_min..dest_x_max {
-      let mut src = color;
       let dest_x = dest_x as u32;
-      if let Some(mask) = combined_mask {
-        let alpha = mask.alpha_at(dest_x, dest_y as u32);
-        if alpha == 0 {
-          continue;
-        }
-        src = scale_premultiplied_pixel(src, alpha);
-        if src[3] == 0 {
-          continue;
-        }
-      }
+      let Some(src) = apply_combined_mask(color, combined_mask, dest_x, dest_y as u32) else {
+        continue;
+      };
 
       blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
     }
@@ -1443,22 +1435,15 @@ pub(crate) fn overlay_gradient_tile<T>(
     let dst_row = dest_y as usize * bottom_width as usize;
     for dest_x in dest_x_min..dest_x_max {
       let src_x = (dest_x - offset_x) as u32;
-      let mut src = premultiplied_from_pixel(gradient.sample_pixel(src_x, src_y));
+      let src = premultiplied_from_pixel(gradient.sample_pixel(src_x, src_y));
       if src[3] == 0 {
         continue;
       }
 
       let dest_x = dest_x as u32;
-      if let Some(mask) = combined_mask {
-        let alpha = mask.alpha_at(dest_x, dest_y as u32);
-        if alpha == 0 {
-          continue;
-        }
-        src = scale_premultiplied_pixel(src, alpha);
-        if src[3] == 0 {
-          continue;
-        }
-      }
+      let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y as u32) else {
+        continue;
+      };
 
       blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
     }

--- a/takumi-raster/src/canvas/composite.rs
+++ b/takumi-raster/src/canvas/composite.rs
@@ -12,6 +12,14 @@ use crate::{
 };
 
 #[derive(Clone, Copy)]
+struct DestRegion {
+  bounds: (i32, i32, i32, i32),
+  offset: (i32, i32),
+  canvas_width: usize,
+  mask_stride: usize,
+}
+
+#[derive(Clone, Copy)]
 pub(super) struct Options<'a> {
   pub placement: Placement,
   pub sampling: MaskSamplingOptions,
@@ -49,31 +57,19 @@ pub(super) fn constant(
     return;
   };
 
+  let region = DestRegion {
+    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
+    offset: (offset_x, offset_y),
+    canvas_width: canvas_width as usize,
+    mask_stride: placement.width as usize,
+  };
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
   if mode == BlendMode::Normal && combined_mask.is_none() {
-    constant_normal(
-      pixels,
-      canvas_width as usize,
-      mask,
-      placement.width as usize,
-      color,
-      (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-      (offset_x, offset_y),
-    );
+    constant_normal(pixels, mask, color, region);
     return;
   }
 
-  constant_general(
-    pixels,
-    canvas_width as usize,
-    mask,
-    placement.width as usize,
-    color,
-    mode,
-    combined_mask,
-    (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    (offset_x, offset_y),
-  );
+  constant_general(pixels, mask, color, mode, combined_mask, region);
 }
 
 pub(super) fn source(
@@ -113,44 +109,31 @@ pub(super) fn source(
     return;
   };
   let (offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max) = bounds;
+  let region = DestRegion {
+    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
+    offset: (offset_x, offset_y),
+    canvas_width: canvas_width as usize,
+    mask_stride: options.placement.width as usize,
+  };
 
   if options.color_mode == MaskCompositeColor::SourceOnly
     && options.mode == BlendMode::Normal
-    && try_translation_blit(
-      pixmap,
-      mask,
-      source,
-      &options,
-      (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-      (offset_x, offset_y),
-    )
+    && try_translation_blit(pixmap, mask, source, &options, region)
   {
     return;
   }
 
-  source_general(
-    pixmap,
-    mask,
-    source,
-    &options,
-    (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    (offset_x, offset_y),
-    canvas_width as usize,
-  );
+  source_general(pixmap, mask, source, &options, region);
 }
 
 #[inline]
-fn constant_normal(
-  pixels: &mut [[u8; 4]],
-  canvas_width: usize,
-  mask: &[u8],
-  mask_stride: usize,
-  color: [u8; 4],
-  bounds: (i32, i32, i32, i32),
-  offset: (i32, i32),
-) {
-  let (dest_x_min, dest_x_max, dest_y_min, dest_y_max) = bounds;
-  let (offset_x, offset_y) = offset;
+fn constant_normal(pixels: &mut [[u8; 4]], mask: &[u8], color: [u8; 4], region: DestRegion) {
+  let DestRegion {
+    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
+    offset: (offset_x, offset_y),
+    canvas_width,
+    mask_stride,
+  } = region;
   let span = (dest_x_max - dest_x_min) as usize;
 
   for dest_y in dest_y_min..dest_y_max {
@@ -174,21 +157,21 @@ fn constant_normal(
   }
 }
 
-#[allow(clippy::too_many_arguments)]
 #[inline]
 fn constant_general(
   pixels: &mut [[u8; 4]],
-  canvas_width: usize,
   mask: &[u8],
-  mask_stride: usize,
   color: [u8; 4],
   mode: BlendMode,
   combined_mask: Option<MaskView<'_>>,
-  bounds: (i32, i32, i32, i32),
-  offset: (i32, i32),
+  region: DestRegion,
 ) {
-  let (dest_x_min, dest_x_max, dest_y_min, dest_y_max) = bounds;
-  let (offset_x, offset_y) = offset;
+  let DestRegion {
+    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
+    offset: (offset_x, offset_y),
+    canvas_width,
+    mask_stride,
+  } = region;
 
   for dest_y in dest_y_min..dest_y_max {
     let mask_y = (dest_y - offset_y) as usize;
@@ -223,8 +206,7 @@ fn try_translation_blit(
   mask: &[u8],
   source: PaintSource<'_>,
   options: &Options<'_>,
-  bounds: (i32, i32, i32, i32),
-  offset: (i32, i32),
+  region: DestRegion,
 ) -> bool {
   let transform = options.sampling.canvas_to_source;
   if !transform.only_translation() || transform.x.fract() != 0.0 || transform.y.fract() != 0.0 {
@@ -234,10 +216,12 @@ fn try_translation_blit(
     return false;
   };
 
-  let (dest_x_min, dest_x_max, dest_y_min, dest_y_max) = bounds;
-  let (offset_x, offset_y) = offset;
-  let canvas_width = pixmap.width() as usize;
-  let mask_stride = options.placement.width as usize;
+  let DestRegion {
+    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
+    offset: (offset_x, offset_y),
+    canvas_width,
+    mask_stride,
+  } = region;
   let source_width = source_pixmap.width() as i32;
   let source_height = source_pixmap.height() as i32;
   let source_pixels = source_pixmap.pixels();
@@ -318,19 +302,19 @@ fn try_translation_blit(
   true
 }
 
-#[allow(clippy::too_many_arguments)]
 fn source_general(
   pixmap: &mut PixmapMut<'_>,
   mask: &[u8],
   source: PaintSource<'_>,
   options: &Options<'_>,
-  bounds: (i32, i32, i32, i32),
-  offset: (i32, i32),
-  canvas_width: usize,
+  region: DestRegion,
 ) {
-  let (dest_x_min, dest_x_max, dest_y_min, dest_y_max) = bounds;
-  let (offset_x, offset_y) = offset;
-  let mask_stride = options.placement.width as usize;
+  let DestRegion {
+    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
+    offset: (offset_x, offset_y),
+    canvas_width,
+    mask_stride,
+  } = region;
   let footprint = sampling_footprint(options.sampling.canvas_to_source);
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
 

--- a/takumi-raster/src/canvas/paint_source.rs
+++ b/takumi-raster/src/canvas/paint_source.rs
@@ -102,14 +102,10 @@ impl<'a> PaintSource<'a> {
 
     let width = self.width();
     let height = self.height();
+    let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(dst);
     for y in 0..height {
       for x in 0..width {
-        let pixel = self.get_pixel(x, y);
-        let offset = ((y * width + x) * 4) as usize;
-        dst[offset] = pixel.red();
-        dst[offset + 1] = pixel.green();
-        dst[offset + 2] = pixel.blue();
-        dst[offset + 3] = pixel.alpha();
+        pixels[(y * width + x) as usize] = premultiplied_from_pixel(self.get_pixel(x, y));
       }
     }
   }

--- a/takumi-raster/src/components/blur.rs
+++ b/takumi-raster/src/components/blur.rs
@@ -38,6 +38,12 @@ impl<'a> BlurFormat<'a> {
   }
 }
 
+#[derive(Clone, Copy)]
+struct Dims {
+  width: u32,
+  height: u32,
+}
+
 fn blur_pass_params(
   width: u32,
   height: u32,
@@ -108,18 +114,18 @@ pub(crate) fn apply_blur_rgba_bytes(
   blur_type: BlurType,
   pool: &mut BufferPool,
 ) -> Result<()> {
-  apply_blur_rgba_bytes_internal(data, width, height, radius, blur_type, pool, true)
+  apply_blur_rgba_bytes_internal(data, Dims { width, height }, radius, blur_type, pool, true)
 }
 
 fn apply_blur_rgba_bytes_internal(
   data: &mut [u8],
-  width: u32,
-  height: u32,
+  dims: Dims,
   radius: f32,
   blur_type: BlurType,
   pool: &mut BufferPool,
   allow_downsample: bool,
 ) -> Result<()> {
+  let Dims { width, height } = dims;
   if width == 0 || height == 0 {
     return Ok(());
   }
@@ -137,7 +143,7 @@ fn apply_blur_rgba_bytes_internal(
   if allow_downsample {
     let scale = blur_downsample_scale(width, height, radius, blur_type);
     if scale > 1 {
-      return apply_blur_rgba_downsampled(data, width, height, radius, blur_type, pool, scale);
+      return apply_blur_rgba_downsampled(data, dims, radius, blur_type, pool, scale);
     }
   }
 
@@ -188,63 +194,47 @@ fn blur_downsample_scale(width: u32, height: u32, radius: f32, blur_type: BlurTy
 
 fn apply_blur_rgba_downsampled(
   data: &mut [u8],
-  width: u32,
-  height: u32,
+  dims: Dims,
   radius: f32,
   blur_type: BlurType,
   pool: &mut BufferPool,
   scale: u32,
 ) -> Result<()> {
-  let ds_width = width.div_ceil(scale);
-  let ds_height = height.div_ceil(scale);
-  let ds_len = (ds_width as usize)
-    .saturating_mul(ds_height as usize)
+  let ds_dims = Dims {
+    width: dims.width.div_ceil(scale),
+    height: dims.height.div_ceil(scale),
+  };
+  let ds_len = (ds_dims.width as usize)
+    .saturating_mul(ds_dims.height as usize)
     .saturating_mul(4);
 
   let mut downsampled = pool.acquire_dirty(ds_len);
-  downsample_rgba_box(
-    data,
-    width,
-    height,
-    &mut downsampled,
-    ds_width,
-    ds_height,
-    scale,
-  );
+  downsample_rgba_box(data, dims, &mut downsampled, ds_dims, scale);
 
   let scaled_radius = radius / scale as f32;
   apply_blur_rgba_bytes_internal(
     &mut downsampled,
-    ds_width,
-    ds_height,
+    ds_dims,
     scaled_radius,
     blur_type,
     pool,
     false,
   )?;
 
-  upsample_rgba_bilinear(
-    &downsampled,
-    ds_width,
-    ds_height,
-    data,
-    width,
-    height,
-    scale,
-  );
+  upsample_rgba_bilinear(&downsampled, ds_dims, data, dims, scale);
   pool.release(downsampled);
   Ok(())
 }
 
-fn downsample_rgba_box(
-  src: &[u8],
-  src_width: u32,
-  src_height: u32,
-  dst: &mut [u8],
-  dst_width: u32,
-  dst_height: u32,
-  scale: u32,
-) {
+fn downsample_rgba_box(src: &[u8], src_dims: Dims, dst: &mut [u8], dst_dims: Dims, scale: u32) {
+  let Dims {
+    width: src_width,
+    height: src_height,
+  } = src_dims;
+  let Dims {
+    width: dst_width,
+    height: dst_height,
+  } = dst_dims;
   for dy in 0..dst_height {
     let src_y0 = dy * scale;
     let src_y1 = (src_y0 + scale).min(src_height);
@@ -283,15 +273,15 @@ fn downsample_rgba_box(
   }
 }
 
-fn upsample_rgba_bilinear(
-  src: &[u8],
-  src_width: u32,
-  src_height: u32,
-  dst: &mut [u8],
-  dst_width: u32,
-  dst_height: u32,
-  scale: u32,
-) {
+fn upsample_rgba_bilinear(src: &[u8], src_dims: Dims, dst: &mut [u8], dst_dims: Dims, scale: u32) {
+  let Dims {
+    width: src_width,
+    height: src_height,
+  } = src_dims;
+  let Dims {
+    width: dst_width,
+    height: dst_height,
+  } = dst_dims;
   if src_width == 0 || src_height == 0 {
     dst.fill(0);
     return;
@@ -608,7 +598,9 @@ fn compute_mul_shg(d: u32) -> (u32, i32) {
 mod tests {
   use std::assert_matches;
 
-  use super::{BlurType, apply_blur_rgba_bytes, blur_downsample_scale, upsample_rgba_bilinear};
+  use super::{
+    BlurType, Dims, apply_blur_rgba_bytes, blur_downsample_scale, upsample_rgba_bilinear,
+  };
   use crate::{BufferPool, Error};
 
   #[test]
@@ -648,11 +640,15 @@ mod tests {
 
     upsample_rgba_bilinear(
       &src,
-      src_width,
-      src_height,
+      Dims {
+        width: src_width,
+        height: src_height,
+      },
       &mut actual,
-      dst_width,
-      dst_height,
+      Dims {
+        width: dst_width,
+        height: dst_height,
+      },
       scale,
     );
     upsample_rgba_bilinear_reference(

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -138,6 +138,14 @@ pub(crate) fn draw_decoration_segment(
   );
 }
 
+struct GlyphPaintCtx<'a, 'b> {
+  canvas: &'a mut Canvas,
+  style: &'a SizedFontStyle<'a>,
+  transform: Affine,
+  inline_offset: Point<f32>,
+  paths: &'b [Command],
+}
+
 pub(crate) fn draw_glyph_clip_image(
   glyph: &ResolvedGlyph,
   canvas: &mut Canvas,
@@ -251,26 +259,19 @@ pub(crate) fn draw_glyph_clip_image(
         canvas.buffer_pool.release(mask);
       }
 
-      if let Some(embolden) = outline.embolden() {
-        draw_text_embolden_clip_image(
-          canvas,
-          style,
-          transform,
-          outline.paths(),
-          embolden,
-          clip_image,
-          inline_offset,
-        );
-      }
-
-      draw_text_stroke_clip_image(
+      let mut ctx = GlyphPaintCtx {
         canvas,
         style,
         transform,
-        outline.paths(),
-        clip_image,
         inline_offset,
-      );
+        paths: outline.paths(),
+      };
+
+      if let Some(embolden) = outline.embolden() {
+        draw_text_embolden_clip_image(&mut ctx, embolden, clip_image);
+      }
+
+      draw_text_stroke_clip_image(&mut ctx, clip_image);
     }
   }
 
@@ -321,158 +322,145 @@ pub(crate) fn draw_glyph(
         );
       }
 
+      let mut ctx = GlyphPaintCtx {
+        canvas,
+        style,
+        transform,
+        inline_offset,
+        paths: outline.paths(),
+      };
+
       if let Some(embolden) = outline.embolden() {
-        draw_text_embolden(canvas, style, transform, outline.paths(), color, embolden);
+        draw_text_embolden(&mut ctx, color, embolden);
       }
 
-      draw_text_stroke(canvas, style, transform, outline.paths());
+      draw_text_stroke(&mut ctx);
     }
   }
 
   Ok(())
 }
 
-fn draw_text_stroke_clip_image(
-  canvas: &mut Canvas,
-  style: &SizedFontStyle,
-  transform: Affine,
-  paths: &[Command],
-  clip_image: PaintSource<'_>,
-  inline_offset: Point<f32>,
-) {
-  if style.stroke_width <= 0.0 {
+fn draw_text_stroke_clip_image(ctx: &mut GlyphPaintCtx<'_, '_>, clip_image: PaintSource<'_>) {
+  if ctx.style.stroke_width <= 0.0 {
     return;
   }
 
-  let Some(inverse) = transform.invert() else {
+  let Some(inverse) = ctx.transform.invert() else {
     return;
   };
 
-  let scale = transform.uniform_scale().max(f32::EPSILON);
-  let mut stroke = Stroke::new(style.stroke_width / scale);
-  stroke.join = style.parent.stroke_linejoin.into();
+  let scale = ctx.transform.uniform_scale().max(f32::EPSILON);
+  let mut stroke = Stroke::new(ctx.style.stroke_width / scale);
+  stroke.join = ctx.style.parent.stroke_linejoin.into();
 
   let (stroke_mask, stroke_placement) = render_mask(
-    paths,
-    Some(transform),
+    ctx.paths,
+    Some(ctx.transform),
     Some(stroke.into()),
-    &mut canvas.buffer_pool,
+    &mut ctx.canvas.buffer_pool,
   );
 
-  canvas.composite_mask_color_over_source(
+  ctx.canvas.composite_mask_color_over_source(
     &stroke_mask,
     stroke_placement,
     clip_image,
-    style.text_stroke_color,
+    ctx.style.text_stroke_color,
     MaskSamplingOptions {
-      canvas_to_source: Affine::translation(inline_offset.x, inline_offset.y) * inverse,
+      canvas_to_source: Affine::translation(ctx.inline_offset.x, ctx.inline_offset.y) * inverse,
       sample_bias: Point::ZERO,
-      algorithm: style.parent.image_rendering,
+      algorithm: ctx.style.parent.image_rendering,
     },
     BlendMode::Normal,
   );
 
-  canvas.buffer_pool.release(stroke_mask);
+  ctx.canvas.buffer_pool.release(stroke_mask);
 }
 
 fn draw_text_embolden_clip_image(
-  canvas: &mut Canvas,
-  style: &SizedFontStyle,
-  transform: Affine,
-  paths: &[Command],
+  ctx: &mut GlyphPaintCtx<'_, '_>,
   embolden: f32,
   clip_image: PaintSource<'_>,
-  inline_offset: Point<f32>,
 ) {
   if embolden <= 0.0 {
     return;
   }
 
-  let Some(inverse) = transform.invert() else {
+  let Some(inverse) = ctx.transform.invert() else {
     return;
   };
 
   let mut stroke = Stroke::new(embolden * 2.0);
-  stroke.join = style.parent.stroke_linejoin.into();
+  stroke.join = ctx.style.parent.stroke_linejoin.into();
 
   let (stroke_mask, stroke_placement) = render_mask(
-    paths,
-    Some(transform),
+    ctx.paths,
+    Some(ctx.transform),
     Some(stroke.into()),
-    &mut canvas.buffer_pool,
+    &mut ctx.canvas.buffer_pool,
   );
 
-  canvas.composite_mask_source(
+  ctx.canvas.composite_mask_source(
     &stroke_mask,
     stroke_placement,
     clip_image,
     MaskSamplingOptions {
-      canvas_to_source: Affine::translation(inline_offset.x, inline_offset.y) * inverse,
+      canvas_to_source: Affine::translation(ctx.inline_offset.x, ctx.inline_offset.y) * inverse,
       sample_bias: Point::ZERO,
-      algorithm: style.parent.image_rendering,
+      algorithm: ctx.style.parent.image_rendering,
     },
     BlendMode::Normal,
   );
 
-  canvas.buffer_pool.release(stroke_mask);
+  ctx.canvas.buffer_pool.release(stroke_mask);
 }
 
-fn draw_text_stroke(
-  canvas: &mut Canvas,
-  style: &SizedFontStyle,
-  transform: Affine,
-  paths: &[Command],
-) {
-  if style.stroke_width <= 0.0 {
+fn draw_text_stroke(ctx: &mut GlyphPaintCtx<'_, '_>) {
+  if ctx.style.stroke_width <= 0.0 {
     return;
   }
 
-  let scale = transform.uniform_scale().max(f32::EPSILON);
-  let mut stroke = Stroke::new(style.stroke_width / scale);
-  stroke.join = style.parent.stroke_linejoin.into();
+  let scale = ctx.transform.uniform_scale().max(f32::EPSILON);
+  let mut stroke = Stroke::new(ctx.style.stroke_width / scale);
+  stroke.join = ctx.style.parent.stroke_linejoin.into();
 
   let (stroke_mask, stroke_placement) = render_mask(
-    paths,
-    Some(transform),
+    ctx.paths,
+    Some(ctx.transform),
     Some(stroke.into()),
-    &mut canvas.buffer_pool,
+    &mut ctx.canvas.buffer_pool,
   );
 
-  canvas.draw_mask(
+  ctx.canvas.draw_mask(
     &stroke_mask,
     stroke_placement,
-    style.text_stroke_color,
+    ctx.style.text_stroke_color,
     BlendMode::Normal,
   );
 
-  canvas.buffer_pool.release(stroke_mask);
+  ctx.canvas.buffer_pool.release(stroke_mask);
 }
 
-fn draw_text_embolden(
-  canvas: &mut Canvas,
-  style: &SizedFontStyle,
-  transform: Affine,
-  paths: &[Command],
-  color: Color,
-  embolden: f32,
-) {
+fn draw_text_embolden(ctx: &mut GlyphPaintCtx<'_, '_>, color: Color, embolden: f32) {
   if embolden <= 0.0 {
     return;
   }
 
   let mut stroke = Stroke::new(embolden * 2.0);
-  stroke.join = style.parent.stroke_linejoin.into();
+  stroke.join = ctx.style.parent.stroke_linejoin.into();
 
   let (stroke_mask, stroke_placement) = render_mask(
-    paths,
-    Some(transform),
+    ctx.paths,
+    Some(ctx.transform),
     Some(stroke.into()),
-    &mut canvas.buffer_pool,
+    &mut ctx.canvas.buffer_pool,
   );
 
-  canvas.draw_mask(&stroke_mask, stroke_placement, color, BlendMode::Normal);
+  ctx
+    .canvas
+    .draw_mask(&stroke_mask, stroke_placement, color, BlendMode::Normal);
 
-  canvas.buffer_pool.release(stroke_mask);
+  ctx.canvas.buffer_pool.release(stroke_mask);
 }
 
 fn draw_text_shadow(


### PR DESCRIPTION
Second encapsulation pass (after #806 svg). Pure refactor of the raster backend — no output change. Gated by `cargo test -p takumi --test svg_parity` (raster↔svg parity; local webp goldens are Linux-canonical and unreliable on macOS) + the 61 takumi-raster unit tests + clippy.

Four self-contained bundlings:
- **`DestRegion`** (canvas/composite.rs) — the blit/composite loops threaded `(bounds, offset, canvas_width, mask_stride)`. Bundled; removes both `too_many_arguments` allows in composite.rs.
- **`Dims`** (components/blur.rs) — `apply_blur_rgba_*` / `downsample` / `upsample` threaded loose `(width, height)` and src/dst dimension pairs.
- **`GlyphPaintCtx`** (text_drawing.rs) — the private glyph painters shared `(canvas, style, transform, inline_offset, paths)`.
- **`apply_combined_mask`** (canvas.rs, paint_source.rs) — the 6-line per-pixel combined-mask gate was duplicated across the blit loops; extracted one helper. The pixel math already lives in blend.rs; only the loop scaffolding is deduplicated.

## Verification
- `cargo clippy -p takumi-raster --all-features`: clean.
- `cargo test -p takumi-raster`: 61 pass.
- `svg_parity`: pass — raster output preserved.

## Deferred
The `components/border.rs` paint-context unification (fold `border_box`/`transform` into the side-paint context) is left for a follow-up: the raster border path is trait-based here and needs a fresh refactor rather than a port. The interconnected paint-recursion contexts (`PaintCtx`/`PaintFrame`/`content_origin`) and the `with_pixmap_and_pool` escape hatch are also follow-ups.

https://claude.ai/code/session_018nPbfmddXd7LBpG7YX5mZ8