### PR TITLE
Core: encapsulate BuiltInlineLayout behind metric accessors

### DIFF
--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -47,6 +47,30 @@ pub struct BuiltInlineLayout<'c> {
   pub line_scales: Vec<f32>,
 }
 
+impl BuiltInlineLayout<'_> {
+  pub fn parent_font_metrics(&self) -> Option<ParentFontMetrics> {
+    get_parent_font_metrics(&self.layout)
+  }
+
+  pub fn line_metrics(&self) -> Vec<ResolvedLineMetrics> {
+    resolve_inline_line_metrics(
+      &self.layout,
+      &self.spans,
+      self.parent_font_metrics(),
+      &self.line_scales,
+    )
+  }
+
+  pub fn line_states(&self) -> Vec<ResolvedInlineLineState> {
+    resolve_inline_line_states(
+      &self.layout,
+      &self.spans,
+      self.parent_font_metrics(),
+      &self.line_scales,
+    )
+  }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InlineLayoutMode {
   Measure,
@@ -1872,11 +1896,8 @@ pub fn resolve_inline_runs<'l>(
     line_scales,
     ..
   } = built;
-  let parent_font_metrics = get_parent_font_metrics(inline_layout);
-  let line_vertical_metrics =
-    resolve_inline_line_metrics(inline_layout, spans, parent_font_metrics, line_scales);
-  let line_states =
-    resolve_inline_line_states(inline_layout, spans, parent_font_metrics, line_scales);
+  let line_vertical_metrics = built.line_metrics();
+  let line_states = built.line_states();
 
   let need_outline = spans.iter().any(|span| match span {
     ProcessedInlineSpan::Text { style, .. } => {

--- a/takumi-core/src/layout/node/text.rs
+++ b/takumi-core/src/layout/node/text.rs
@@ -6,8 +6,7 @@ use crate::{
   layout::{
     inline::{
       InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,
-      create_inline_constraint, create_inline_layout, get_parent_font_metrics,
-      measure_inline_layout,
+      create_inline_constraint, create_inline_layout, measure_inline_layout,
     },
     node::TextData,
   },
@@ -38,7 +37,7 @@ pub(crate) fn measure_text_node(
     mode: InlineLayoutMode::Measure,
   });
 
-  let parent_font_metrics = get_parent_font_metrics(&built.layout);
+  let parent_font_metrics = built.parent_font_metrics();
 
   measure_inline_layout(
     &mut built.layout,

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -16,8 +16,7 @@ use crate::{
     Viewport,
     inline::{
       InlineContentKind, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,
-      collect_inline_items, create_inline_constraint, create_inline_layout,
-      get_parent_font_metrics, measure_inline_layout,
+      collect_inline_items, create_inline_constraint, create_inline_layout, measure_inline_layout,
     },
     matching::{MatchedDeclarationsView, NodeMatchedDeclarations, match_stylesheets_view},
     node::{Node, NodeStyleLayers},
@@ -1836,7 +1835,7 @@ impl RenderNode {
       });
 
       let ceil_width = font_style.parent.resolved_text_wrap_mode() == TextWrapMode::Wrap;
-      let parent_font_metrics = get_parent_font_metrics(&built.layout);
+      let parent_font_metrics = built.parent_font_metrics();
       return measure_inline_layout(
         &mut built.layout,
         &built.spans,

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -14,7 +14,6 @@ use crate::{
   layout::{
     inline::{
       InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,
-      get_parent_font_metrics, resolve_inline_line_metrics, resolve_inline_line_states,
       resolve_inline_max_height, resolve_visual_inline_box, scale_text_fit_x,
       text_fit_line_alignment_correction,
     },
@@ -389,20 +388,8 @@ fn compute_node_paint_bounds(
     layout.border.left + layout.padding.left,
     layout.border.top + layout.padding.top,
   ) * transform;
-  let parent_font_metrics = get_parent_font_metrics(&built.layout);
-
-  let line_vertical_metrics = resolve_inline_line_metrics(
-    &built.layout,
-    &built.spans,
-    parent_font_metrics,
-    &built.line_scales,
-  );
-  let line_states = resolve_inline_line_states(
-    &built.layout,
-    &built.spans,
-    parent_font_metrics,
-    &built.line_scales,
-  );
+  let line_vertical_metrics = built.line_metrics();
+  let line_states = built.line_states();
   for (line_index, line) in built.layout.lines().enumerate() {
     let baseline_shift = line_states[line_index].baseline_shift;
     let resolved_metrics = line_vertical_metrics[line_index];


### PR DESCRIPTION
Third encapsulation pass (after #806 svg, #807 raster). Pure refactor, no output change.

`BuiltInlineLayout` was a pub-field bag: every consumer (`resolve_inline_runs`, scene's `compute_node_paint_bounds`, `tree.rs`, `node/text.rs`) hand-threaded `spans`/`line_scales` and **re-derived** parent font metrics via `get_parent_font_metrics(&built.layout)` at each call site.

Add accessor methods so consumers stop threading and re-deriving:
- `parent_font_metrics()`
- `line_metrics()`
- `line_states()`

scene.rs's paint-bounds path shrinks the most (it no longer re-fetches metrics/spans by hand).

The secondary opportunity — deduplicating the two near-identical per-line positioning loops in `resolve_inline_runs` and `compute_node_paint_bounds` — was deliberately left out: inline layout is parity-critical and the loop merge risks output drift. Methods first; the loop dedup can follow once it's proven safe.

## Verification
- `cargo clippy -p takumi-core --all-features`: clean.
- `cargo test -p takumi-core`: 70 pass.
- `svg_parity`: pass.

https://claude.ai/code/session_018nPbfmddXd7LBpG7YX5mZ8