### PR TITLE
JS: add renderSvg and renderAnimation

### DIFF
--- a/.changeset/js-render-svg-animation.md
+++ b/.changeset/js-render-svg-animation.md
@@ -1,0 +1,5 @@
+---
+"takumi-js": minor
+---
+
+Add top-level `renderSvg` and `renderAnimation` functions, mirroring `render`: same JSX/HTML/node input and resource pipeline, returning a vector SVG string and an encoded animation respectively.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -70,6 +70,8 @@ Parse CSS `@keyframes` and the `animation` shorthand property. Render frame-by-f
 
 Full SVG parsing and rasterization via [resvg](https://github.com/linebender/resvg). Use inline SVG or reference external files.
 
+Takumi also emits **vector SVG** output: call `renderSvg()` to get a real `<svg>` document (`<rect>`, `<path>`, gradients, glyph outlines, embedded images) instead of a raster bitmap — the same layout, as a scalable vector.
+
 ### Flexible Runtime
 
 Takumi runs everywhere without changing your code:

--- a/docs/content/docs/keyframe-animation.mdx
+++ b/docs/content/docs/keyframe-animation.mdx
@@ -53,40 +53,36 @@ const output = await render(<div tw="animate-[move_1s_ease-in-out_infinite_alter
 
 Use stylesheet `@keyframes` when you want the animation to travel with the JSX tree and then render it with either `renderAnimation()` or `render()` + `stylesheets`.
 
+`renderAnimation()` takes the scenes directly: each scene's JSX (or HTML string, or node tree) is transformed and its `<style>` is extracted automatically, and image resources are fetched once across every scene.
+
 ```tsx twoslash title="render.tsx"
 // @noErrors
-import { Renderer } from "takumi-js/node";
-import { fromJsx } from "takumi-js/helpers/jsx";
+import { renderAnimation } from "takumi-js";
 
-const renderer = new Renderer();
-
-const { node, stylesheets } = await fromJsx(
-  <div tw="w-full h-full items-center justify-center">
-    <style>{`
-      @keyframes move {
-        from {
-          transform: translateX(0);
-        }
-
-        to {
-          transform: translateX(60px);
-        }
-      }
-    `}</style>
-    <div tw="w-10 h-10 bg-red-500 animate-[move_1s_ease-in-out_infinite_alternate]" />
-  </div>,
-);
-
-const output = await renderer.renderAnimation({
+const output = await renderAnimation({
   width: 100,
   height: 100,
   fps: 30,
   format: "webp",
-  stylesheets,
   scenes: [
     {
       durationMs: 1000,
-      node,
+      node: (
+        <div tw="w-full h-full items-center justify-center">
+          <style>{`
+            @keyframes move {
+              from {
+                transform: translateX(0);
+              }
+
+              to {
+                transform: translateX(60px);
+              }
+            }
+          `}</style>
+          <div tw="w-10 h-10 bg-red-500 animate-[move_1s_ease-in-out_infinite_alternate]" />
+        </div>
+      ),
     },
   ],
 });

--- a/docs/content/docs/upgrade/v2.mdx
+++ b/docs/content/docs/upgrade/v2.mdx
@@ -68,6 +68,19 @@ export function GET() {
 
 `renderAnimation` and `encodeFrames` now take `fonts` and `fontFamilies`, matching `render`.
 
+### Render to vector SVG
+
+`takumi-js` now exports `renderSvg()` alongside `render()`. It takes the same input (JSX, an HTML string, or a node tree) and the same resource pipeline, but returns a real `<svg>` document — `<rect>`, `<path>`, gradients, glyph outlines, embedded images — instead of a raster bitmap. If you came from [satori](https://github.com/vercel/satori) for its SVG output, this is the direct equivalent; keep using `render()` for a PNG/WebP.
+
+```tsx
+import { render, renderSvg } from "takumi-js";
+
+const png = await render(<OgImage />, { width: 1200, height: 630 });
+const svg = await renderSvg(<OgImage />, { width: 1200, height: 630 }); // [!code ++]
+```
+
+The top-level `renderAnimation()` is exported the same way, so the full sequence — image, animation, and vector — is available without constructing a `Renderer`.
+
 ## CSS & rendering
 
 ### `currentColor` in SVG images is no longer tinted by the host color

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -24,11 +24,16 @@ export type {
   MeasuredNode,
   MeasuredTextRun,
   OutputFormat,
-  RenderAnimationOptions,
 } from "@takumi-rs/core";
-export { render } from "./render";
+export { render, renderAnimation, renderSvg } from "./render";
 
-export type { RenderOptions } from "./render";
+export type {
+  RenderAnimationOptions,
+  RenderAnimationScene,
+  RenderInput,
+  RenderOptions,
+  RenderSvgOptions,
+} from "./render";
 
 declare module "react" {
   interface DOMAttributes<T> {

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -8,10 +8,12 @@ import type { ReactNode } from "react";
 import type { FetchResourcesOptions, Node, ReactElementLike } from "@takumi-rs/helpers";
 import { fromHtml } from "@takumi-rs/helpers/html";
 
-type InnerRenderOptions = napi.RenderOptions | wasm.RenderOptions;
+type Renderer = napi.Renderer | wasm.Renderer;
+type ImageLoader = napi.ImageLoader | wasm.ImageLoader;
 
-type RenderOptionsWithRenderer = InnerRenderOptions & {
-  renderer: napi.Renderer | wasm.Renderer;
+/** The managed-renderer plumbing shared by every entry point. */
+type SharedRenderExtras = {
+  renderer: Renderer;
   signal?: AbortSignal;
   jsx?: FromJsxOptions;
   resourcesOptions?: FetchResourcesOptions;
@@ -29,12 +31,43 @@ export type ManagedRendererOptions = {
   module?: wasm.InitInput | Promise<wasm.InitInput> | { default: wasm.InitInput };
 };
 
-export type RenderOptionsWithoutRenderer = Omit<RenderOptionsWithRenderer, "renderer"> &
-  ManagedRendererOptions;
+/**
+ * Adds the managed-renderer plumbing to a set of inner options. Either bring your
+ * own `renderer`, or let Takumi resolve one (optionally pointing at a WASM
+ * `module`).
+ */
+type Managed<TInner> =
+  | (TInner & SharedRenderExtras)
+  | (TInner & Omit<SharedRenderExtras, "renderer"> & ManagedRendererOptions);
 
-export type RenderOptions = RenderOptionsWithRenderer | RenderOptionsWithoutRenderer;
+type InnerRenderOptions = napi.RenderOptions | wasm.RenderOptions;
+type InnerSvgRenderOptions = napi.SvgRenderOptions | wasm.SvgRenderOptions;
+type InnerRenderAnimationOptions = napi.RenderAnimationOptions | wasm.RenderAnimationOptions;
 
-let globalRenderer: napi.Renderer | wasm.Renderer | undefined;
+export type RenderOptions = Managed<InnerRenderOptions>;
+export type RenderSvgOptions = Managed<InnerSvgRenderOptions>;
+
+/** A single animation scene whose content is any renderable input. */
+export type RenderAnimationScene = Omit<napi.AnimationSceneSource, "node"> & {
+  /** The content to render for this scene: JSX, an HTML string, or a node tree. */
+  node: RenderInput;
+};
+
+export type RenderAnimationOptions = Managed<
+  Omit<InnerRenderAnimationOptions, "scenes"> & {
+    /** The scenes to render sequentially. */
+    scenes: RenderAnimationScene[];
+  }
+>;
+
+/** The subset of options the shared pipeline reads, across every entry point. */
+type PipelineOptions = Partial<SharedRenderExtras> &
+  ManagedRendererOptions & {
+    images?: ImageLoader[];
+    stylesheets?: string[];
+  };
+
+let globalRenderer: Renderer | undefined;
 
 export type RenderInput = ReactNode | ReactElementLike | Node | string;
 
@@ -46,7 +79,7 @@ function isTakumiNode(element: unknown): element is Node {
   return element.type === "container" || element.type === "text" || element.type === "image";
 }
 
-async function transformElement(element: RenderInput, options?: RenderOptions) {
+async function transformElement(element: RenderInput, options?: PipelineOptions) {
   if (isTakumiNode(element)) {
     return {
       node: element,
@@ -59,6 +92,45 @@ async function transformElement(element: RenderInput, options?: RenderOptions) {
   }
 
   return fromJsx(element, options?.jsx);
+}
+
+/** Resolves the renderer to use: a caller-supplied one, or the shared global. */
+async function resolveRenderer(options?: PipelineOptions): Promise<Renderer> {
+  if (options && "renderer" in options && options.renderer) {
+    return options.renderer;
+  }
+
+  const imports = await getImports(options?.module);
+  return (globalRenderer ??= new imports.Renderer());
+}
+
+/** Transforms an input into a node tree and extracts its emojis. */
+async function resolveContent(element: RenderInput, options?: PipelineOptions) {
+  const { node: originalNode, stylesheets } = await transformElement(element, options);
+  const emojiType = options?.emoji ?? "twemoji";
+  const node = emojiType !== "from-font" ? extractEmojis(originalNode, emojiType) : originalNode;
+
+  return { node, stylesheets };
+}
+
+/** Merges caller-supplied images with the resources fetched from the nodes. */
+async function collectImages(nodes: Node[], options?: PipelineOptions): Promise<ImageLoader[]> {
+  const providedImages = new Map<string, ImageLoader>();
+
+  for (const image of options?.images ?? []) {
+    providedImages.set(image.src, image);
+  }
+
+  const urls = [...new Set(nodes.flatMap((node) => extractResourceUrls(node)))].filter(
+    (url) => !providedImages.has(url),
+  );
+  const fetched = await fetchResources(urls, options?.resourcesOptions);
+
+  return [...providedImages.values(), ...fetched];
+}
+
+function mergeStylesheets(options: PipelineOptions | undefined, extra: string[]): string[] {
+  return [...(options?.stylesheets ?? []), ...extra];
 }
 
 /**
@@ -84,29 +156,9 @@ async function transformElement(element: RenderInput, options?: RenderOptions) {
 export async function render(element: RenderInput, options?: RenderOptions) {
   options?.signal?.throwIfAborted();
 
-  const imports = await getImports(options && "module" in options ? options.module : undefined);
-  const isExternalRenderer = options && "renderer" in options;
-  const renderer = isExternalRenderer
-    ? options.renderer
-    : (globalRenderer ??= new imports.Renderer());
-
-  const { node: originalNode, stylesheets } = await transformElement(element, options);
-  const emojiType = options?.emoji ?? "twemoji";
-
-  const node = emojiType !== "from-font" ? extractEmojis(originalNode, emojiType) : originalNode;
-
-  const providedImages = new Map<string, napi.ImageLoader | wasm.ImageLoader>();
-
-  for (const image of options?.images ?? []) {
-    providedImages.set(image.src, image);
-  }
-
-  const fetched = await fetchResources(
-    extractResourceUrls(node).filter((url) => !providedImages.has(url)),
-    options?.resourcesOptions,
-  );
-
-  const images = [...providedImages.values(), ...fetched];
+  const renderer = await resolveRenderer(options);
+  const { node, stylesheets } = await resolveContent(element, options);
+  const images = await collectImages([node], options);
 
   // The WASM renderer is synchronous and ignores the signal argument, so honor an
   // abort that happened during the async font/resource loading before the blocking call.
@@ -115,6 +167,96 @@ export async function render(element: RenderInput, options?: RenderOptions) {
   return renderer.render(node, {
     ...options,
     images,
-    stylesheets: [...(options?.stylesheets ?? []), ...stylesheets],
+    stylesheets: mergeStylesheets(options, stylesheets),
+  });
+}
+
+/**
+ * Renders a React element, HTML string, or Takumi node tree into a vector SVG
+ * document string.
+ *
+ * Same input handling and resource pipeline as {@link render}, but emits real SVG
+ * (`<rect>`, `<path>`, gradients, glyph outlines, embedded images) instead of a
+ * raster bitmap.
+ *
+ * @example
+ * ```tsx
+ * import { renderSvg } from "takumi-js";
+ *
+ * const svg = await renderSvg(
+ *   <div tw="bg-blue-500 text-white p-4">Hello World</div>,
+ *   { width: 1200, height: 630 }
+ * );
+ * ```
+ *
+ * @returns A promise that resolves to the SVG document string.
+ */
+export async function renderSvg(element: RenderInput, options?: RenderSvgOptions): Promise<string> {
+  options?.signal?.throwIfAborted();
+
+  const renderer = await resolveRenderer(options);
+  const { node, stylesheets } = await resolveContent(element, options);
+  const images = await collectImages([node], options);
+
+  options?.signal?.throwIfAborted();
+
+  return renderer.renderSvg(node, {
+    ...options,
+    images,
+    stylesheets: mergeStylesheets(options, stylesheets),
+  });
+}
+
+/**
+ * Renders a sequence of scenes into an animated image (WebP / APNG / GIF).
+ *
+ * Each scene's content goes through the same input handling and resource pipeline
+ * as {@link render}; resources are fetched once across all scenes.
+ *
+ * @example
+ * ```tsx
+ * import { renderAnimation } from "takumi-js";
+ *
+ * const webp = await renderAnimation({
+ *   width: 600,
+ *   height: 400,
+ *   fps: 30,
+ *   format: "webp",
+ *   scenes: [
+ *     { node: <div tw="bg-red-500 w-full h-full" />, durationMs: 500 },
+ *     { node: <div tw="bg-blue-500 w-full h-full" />, durationMs: 500 },
+ *   ],
+ * });
+ * ```
+ *
+ * @returns A promise that resolves to the encoded animation (Buffer/Uint8Array).
+ */
+export async function renderAnimation(options: RenderAnimationOptions) {
+  options.signal?.throwIfAborted();
+
+  const renderer = await resolveRenderer(options);
+  const scenes = await Promise.all(
+    options.scenes.map(async (scene) => {
+      const { node, stylesheets } = await resolveContent(scene.node, options);
+      return { node, durationMs: scene.durationMs, stylesheets };
+    }),
+  );
+
+  const images = await collectImages(
+    scenes.map((scene) => scene.node),
+    options,
+  );
+  const stylesheets = mergeStylesheets(
+    options,
+    scenes.flatMap((scene) => scene.stylesheets),
+  );
+
+  options.signal?.throwIfAborted();
+
+  return renderer.renderAnimation({
+    ...options,
+    scenes: scenes.map(({ node, durationMs }) => ({ node, durationMs })),
+    images,
+    stylesheets,
   });
 }


### PR DESCRIPTION
Adds top-level `renderSvg` and `renderAnimation` to `takumi-js`, alongside `render`.

## JS
`render` already wrapped the renderer's `render` method with input transform (JSX/HTML/node), emoji extraction, and resource fetching. The two new functions reuse the same pipeline:

- **`renderSvg(element, options)`** → vector SVG document string. Same input + resources as `render`, but emits real `<svg>` (`<rect>`, `<path>`, gradients, glyph outlines, embedded images) instead of a raster bitmap.
- **`renderAnimation({ scenes, ... })`** → encoded animation (WebP/APNG/GIF). Each scene's content is any `RenderInput` (JSX/HTML/node); scenes are transformed and their `<style>` extracted automatically, and image resources are fetched once across all scenes.

The shared steps (renderer resolution, content/emoji resolution, image collection) are factored out of `render` so all three entry points share them — no duplicated pipeline. New exports: `renderSvg`, `renderAnimation`, and types `RenderSvgOptions`, `RenderAnimationOptions`, `RenderAnimationScene`, `RenderInput`.

## Docs
- **Home page** (`index.mdx`): note vector-SVG output via `renderSvg()`.
- **Keyframe animation** (`keyframe-animation.mdx`): the stylesheet example now drives the top-level `renderAnimation()` (no manual `Renderer` / `fromJsx`).
- **v2 upgrade guide** (`upgrade/v2.mdx`): a `renderSvg` section for users coming from [satori](https://github.com/vercel/satori)'s SVG output — `render()` for PNG/WebP, `renderSvg()` for vector.

## Verification
- `tsc --noEmit` (takumi-js): clean. The union-renderer (`napi | wasm`) method calls and the `Managed<...>` option types check out under `strict`.

Changeset: `takumi-js` minor.

https://claude.ai/code/session_018nPbfmddXd7LBpG7YX5mZ8