### PR TITLE
Docs: surface vector SVG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **A Rust rendering engine that turns JSX, HTML, and node trees into images. No headless browser required.**
 
-Render OpenGraph cards, animated GIFs, and video frames from Node.js, Cloudflare Workers, browsers, or any Rust application.
+Render OpenGraph cards, animated GIFs, video frames, and vector SVG from Node.js, Cloudflare Workers, browsers, or any Rust application.
 Drop-in compatible with `next/og`.
 
 [![npm version](https://img.shields.io/npm/v/takumi-js?label=takumi-js)](https://www.npmjs.com/package/takumi-js)
@@ -107,6 +107,7 @@ Start from the [Rust example](./example/rust).
 | **Selectors**                      |      Limited       | Complex selectors, `:is()`, `:where()`, `::before`, `::after` |
 | **`backdrop-filter`, blend modes** |         ✗          |                              ✅                               |
 | **Animated output**                |         ✗          |             **WebP / APNG / GIF / video frames**              |
+| **Vector SVG output**              |     ✅ Native      |            ✅ **Plus raster and animated output**             |
 | **Headless browser**               |         ✗          |                               ✗                               |
 | **`ImageResponse` API**            |     ✅ Native      |                       ✅ **Compatible**                       |
 
@@ -134,12 +135,17 @@ The input contract is a node tree, so any template system that serializes to HTM
 
 A **time axis** threads through the pipeline: the renderer takes a timestamp, so a PNG is the tree at `t=0` and a GIF is the same tree sampled across `t`. CSS `@keyframes`, the `animation` shorthand, and Tailwind animation utilities (`animate-spin`, `animate-bounce`, arbitrary values) all resolve at render time.
 
+The same layout drives a second backend: `renderSvg()` (Rust `render_svg`, behind the `svg-backend` feature) emits a real `<svg>` document built from `<rect>`, `<path>`, gradients, and glyph outlines, so you can ship scalable vector output instead of pixels. If you reached for [satori](https://github.com/vercel/satori) to get SVG, this is the drop-in path.
+
 ```mermaid
 flowchart LR
-    A[Templates] --> N[Node Tree] --> P[Rendering Pipeline] --> F[(Raw Pixels)]
+    A[Templates] --> N[Node Tree] --> P[Rendering Pipeline]
     C[Stylesheets] --> P
     R[Resources] --> P
     D(Time Axis) -.-> P
+
+    P --> F[(Raw Pixels)]
+    P --> S[Vector SVG]
 
     F --> G[PNG / JPEG / WebP / ICO]
     F --> H[GIF / APNG]

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -57,7 +57,7 @@ self.onmessage = async (event: MessageEvent) => {
 
         const start = performance.now();
         const animationOptions = options.animation;
-        const outputBuffer = animationOptions
+        const outputBuffer = await (animationOptions
           ? (() => {
               const format = animationOptions.format ?? "webp";
               const fps = animationOptions.fps ?? 30;
@@ -82,7 +82,7 @@ self.onmessage = async (event: MessageEvent) => {
               ...options,
               stylesheets: effectiveStylesheets,
               images,
-            });
+            }));
         const duration = performance.now() - start;
 
         postMessage(

--- a/docs/content/docs/architecture.mdx
+++ b/docs/content/docs/architecture.mdx
@@ -8,11 +8,11 @@ icon: ToyBrick
 
 ### Format
 
-Takumi uses JSON format as its the most universal format that can be easily serialized and deserialized.
+Takumi uses JSON as it's the most universal format to serialize and deserialize.
 
 ### Node
 
-HTML is complex, it defines [a lot of elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements) that are used to build the web. But since we are building static images, only three types of nodes are required: **an image, a text, or a container**.
+HTML is complex, it defines [a lot of elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements) that are used to build the web. But since we are building static images, only three types of nodes are required: **a container, an image, or text**.
 
 The details are described in the [Reference](/docs/reference#node-types) section.
 
@@ -65,4 +65,4 @@ The package is published as [`@takumi-rs/core`](https://www.npmjs.com/package/@t
 
 This is relatively rare, but if you are using a Edge runtime or browser, you can use the `@takumi-rs/wasm` entrypoint.
 
-And to keep the wasm file small, woff font loading is not supported and theres no bundled fonts (so font needs to be loaded to render text).
+And to keep the wasm file small, woff font loading is not supported and there's no bundled fonts (so font needs to be loaded to render text).

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -34,14 +34,17 @@ It converts any template into a **node tree** with three node kinds: `container`
 3. **Compositing**: stacking contexts, blend modes, filters, transforms, SVG via [resvg](https://github.com/linebender/resvg)
 4. **Output**: PNG, JPEG, WebP, ICO for statics; GIF, APNG, WebP for animations; raw RGBA frames for video pipelines
 
-A **time axis** threads through the pipeline. Animations, GIFs, and video frames are not a separate API. They're the same renderer called at timestamp `t`.
+A **time axis** threads through the pipeline. Animations, GIFs, and video frames are not a separate API. They're the same renderer called at timestamp `t`. The same layout also feeds a vector backend: `renderSvg()` emits a real `<svg>` document instead of pixels.
 
 ```mermaid
 flowchart LR
-    A[Templates] --> N[Node Tree] --> P[Rendering Pipeline] --> F[(Raw Pixels)]
+    A[Templates] --> N[Node Tree] --> P[Rendering Pipeline]
     C[Stylesheets] --> P
     R[Resources] --> P
     D(Time Axis) -.-> P
+
+    P --> F[(Raw Pixels)]
+    P --> S[Vector SVG]
 
     F --> G[PNG / JPEG / WebP / ICO]
     F --> H[GIF / APNG]

--- a/docs/content/docs/layout-engine.mdx
+++ b/docs/content/docs/layout-engine.mdx
@@ -47,5 +47,3 @@ export function GET() {
   return new ImageResponse(<img src="https://placehold.co/1200x600" width={1200} height={600} />);
 }
 ```
-
-##

--- a/docs/content/docs/tailwind-css.mdx
+++ b/docs/content/docs/tailwind-css.mdx
@@ -45,7 +45,7 @@ export default defineConfig({
 
 ## Native Parser
 
-Prior Takumi has abaility to parse stylesheets, a built in parser is built for Tailwind CSS.
+Before Takumi could parse full stylesheets, a built-in parser handled Tailwind CSS.
 
 Generally speaking, this is not recommended as it won't be able to cover all the features of Tailwind CSS, but as a quick solution for simple use cases, it can be a good option.
 

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -32,7 +32,7 @@ If the issue still exists, please file an issue on [our GitHub repository](https
 
 <Accordions type="single">
   <Accordion title="Cannot find native binding.">
-This happens when the `@takumi-rs/core` package failed to find the native binding. Make sure you have finished the [Additional Bundler Setup](/docs/index#additional-bundler-setup) step.
+This happens when the `@takumi-rs/core` package failed to find the native binding.
 
 If you are using package manager with virtual store such as `pnpm` or `yarn`, add the following to your `.npmrc` file and re-run `pnpm i` to allow hoisting of the native binary.
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -76,7 +76,7 @@ For variable fonts, `font-weight` has the same effect as `font-variation-setting
 
 #### Dynamic fetching
 
-If you are using `ImageResponse` API, theres a satori compatible `emoji` option.
+If you are using `ImageResponse` API, there's a satori compatible `emoji` option.
 
 ```tsx twoslash
 import { ImageResponse } from "takumi-js/response";

--- a/docs/content/docs/upgrade/v1.mdx
+++ b/docs/content/docs/upgrade/v1.mdx
@@ -37,7 +37,7 @@ Verify your templates and explicitly add `display: flex` (or the `flex` Tailwind
 
 ## JavaScript / TypeScript
 
-### Unified Runtime Dectection & Fallback
+### Unified Runtime Detection & Fallback
 
 For better DX, `takumi-js` now automatically detects the best bindings for your environment Node.js, Workers, etc.
 That means you no longer need to worry about importing NAPI or WASM bindings.
@@ -49,7 +49,7 @@ import { ImageResponse } from "takumi-js/response"; // [!code ++]
 
 ### `emoji` Option for Dynamic Emojis Loading
 
-To improve the compability with Next.js's `ImageResponse` API, `takumi-js` now supports an `emoji` option that allows you to specify a custom emoji provider.
+To improve the compatibility with Next.js's `ImageResponse` API, `takumi-js` now supports an `emoji` option that allows you to specify a custom emoji provider.
 
 By default it's set to `twemoji`, if you want to source emoji glyphs from a custom font, simply set it to `from-font` and make sure an emoji font is included in the `fonts` option.
 

--- a/docs/content/docs/upgrade/v2.mdx
+++ b/docs/content/docs/upgrade/v2.mdx
@@ -5,21 +5,66 @@ description: Walks through the breaking changes in v2 and how to upgrade from v1
 
 v2 makes fonts and images explicit per-render resources, tightens rendering to match the web platform, and splits the Rust crate into focused backends. This page covers the breaking changes; for everything else see the [releases](https://github.com/kane50613/takumi/releases).
 
+## Upgrade with an AI agent
+
+Most v2 breakages surface as type or compile errors, so a coding agent can do the bulk of the work. Bump the packages you use:
+
+```bash
+npm install takumi-js@beta @takumi-rs/core@beta @takumi-rs/wasm@beta
+```
+
+Then paste the prompt below. Apply only the lines for packages you import, then run the type checker (`cargo check` for Rust) and fix the rest.
+
+```text
+Upgrade this project from Takumi v1 to v2. Apply `old -> new` for the packages it imports.
+
+JS (takumi-js, @takumi-rs/*):
+- await every render/renderAnimation/renderSvg/measure/encodeFrames (all async now)
+- new Renderer({fonts}) -> new Renderer(); pass fonts per call: render(node, {fonts:[inter]})
+- loadFont/loadFonts/loadFontSync -> registerFont (only to reuse a font across renders)
+- render option fetchedResources -> images (keyed by src; no global image store)
+- format is a union: {format:"jpeg",quality} or {format:"webp",lossless:true}
+- createImageResponse(opts)(jsx) -> new ImageResponse(jsx, opts)
+
+Rust (takumi crate):
+- use takumi::prelude::*; use takumi::render;   (internals now behind the `unstable` feature)
+- GlobalContext -> Fonts, passed via RenderOptions::builder().fonts(&fonts)
+- Cargo feature "raster" -> "raster-backend" (+ rayon); enable "svg-backend" for render_svg
+- OutputFormat::Jpeg/WebP carry Quality; lossless -> WebPLossless; write_image(img, &mut out, fmt)
+- measure_layout -> measure, render_sequence_animation -> render_animation; render -> Bitmap
+- render_for_layout drops the current_color argument
+
+CSS defaults changed, verify visually: position relative -> static; border/outline width
+0 -> medium (3px); negative scale reflects; line-clamp is a shorthand; currentColor in SVG
+images is no longer tinted.
+```
+
+The sections below carry the rationale and full samples behind each line.
+
 ## JavaScript
+
+### Rendering is now always async
+
+The WASM `Renderer` returned bytes synchronously in v1, while the Node binding was already async. v2 aligns the two: the WASM `Renderer` is async too, so `render`, `renderAnimation`, `renderSvg`, `measure`, and `encodeFrames` now share one signature across both bindings. That async surface is also what lets fonts and images arrive through loaders, resolved per call. Await every call; using the result directly now hands you a `Promise`.
+
+```ts
+const image = renderer.render(node, options); // [!code --]
+const image = await renderer.render(node, options); // [!code ++]
+```
 
 ### The `Renderer` constructor takes no arguments
 
-`new Renderer(...)` no longer accepts fonts or a context. Construct it bare and register fonts afterwards. The embedded default fonts are decoded once and shared across every renderer.
+`new Renderer(...)` no longer accepts fonts or a context. Construct it bare and pass the fonts a render needs through that render's `fonts` option. Most code needs nothing more; the embedded default fonts are decoded once and shared across every renderer.
 
 ```ts
 const renderer = new Renderer({ fonts: [archivo] }); // [!code --]
 const renderer = new Renderer(); // [!code ++]
-await renderer.registerFont(archivo); // [!code ++]
+const image = await renderer.render(node, { fonts: [archivo] }); // [!code ++]
 ```
 
 ### `loadFont`, `loadFonts`, and `loadFontSync` become `registerFont`
 
-A single `registerFont` replaces the three loaders. It accepts either raw bytes or a `{ name, data, weight, style }` descriptor, and resolves to the families it produced.
+Passing `fonts` per render covers most cases. To register a font once and reuse it across many renders, a single `registerFont` replaces the three loaders. It accepts either raw bytes or a `{ name, data, weight, style }` descriptor, and resolves to the families it produced.
 
 ```ts
 renderer.loadFonts([archivo, geist]); // [!code --]


### PR DESCRIPTION
Takumi already ships the SVG backend (`renderSvg()` / `render_svg`), but the README and docs intro still described only the raster and animated paths. This adds the vector SVG output where readers look for it, documents the v2 async rendering change, plus docs cleanup and a playground type fix. No architecture changes.

## SVG output
- **README hero** lists vector SVG alongside cards, GIFs, and video frames.
- **Comparison table** gains a `Vector SVG output` row: parity with satori, plus Takumi's raster and animated output.
- **Core Architecture** notes `renderSvg()` / `render_svg` (behind the `svg-backend` feature) as a second backend over the same layout.
- **Pipeline diagrams** (README and `docs/index.mdx`) branch the Rendering Pipeline into Raw Pixels and Vector SVG.

## Upgrade guide
- Document that WASM rendering is now async, aligning the WASM and Node bindings on one signature and enabling font/image loaders. Await every call.
- Add an **Upgrade with an AI agent** section: bump the packages, then a copy-paste prompt pointing a coding agent at the machine-readable upgrade page (`llms.mdx`).

## Docs cleanup
- Drop the broken `Additional Bundler Setup` link in `troubleshooting.mdx` and an empty trailing heading in `layout-engine.mdx`.
- Align node-kind ordering (`container`, `image`, `text`) in `architecture.mdx` with the README and intro.
- Fix typos in `architecture.mdx`, `tailwind-css.mdx`, `typography-and-fonts.mdx`, and `upgrade/v1.mdx`.

## Playground
- `worker.ts` awaited nothing: `renderer.render`/`renderAnimation` return a `Promise<Uint8Array>` (the async change above), so it passed an unresolved promise to `postMessage` and read `.buffer` off it. Await the result before transferring and timing it. This was the type error the playground hit.

## Known gaps left for follow-up
- No dedicated `renderSvg()` guide page (only the upgrade note and intro mention).
- `encodeFrames` is a public API with no docs.
- `integration/index.mdx` is a frontmatter-only stub.

https://claude.ai/code/session_015dXea3oK3x5NVab2D4bAVZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README to clarify support for OpenGraph cards, animated GIFs, video frames, and vector SVG output, including updated comparison and architecture details for vector SVG rendering.
  * Updated “How it works”/architecture visuals and wording to show the rendering pipeline now branches to both Raw Pixels and Vector SVG.
  * Refined multiple doc pages with wording/grammar and corrected upgrade guidance, including a new “Upgrade with an AI agent” section and refreshed v2 async usage instructions.
* **Tests**
  * Updated the docs playground worker to properly await rendered output before reporting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->