### PR TITLE
Docs: document v2 output formats and Google Fonts helpers

### DIFF
--- a/docs/content/docs/architecture.mdx
+++ b/docs/content/docs/architecture.mdx
@@ -20,7 +20,7 @@ The details are described in the [Reference](/docs/reference#node-types) section
 
 To bridge the gap between JSX and nodes, we provide a `fromJsx` helper function that helps mapping elements to nodes, and handle React specific features like Server Components and Fragments.
 
-The rules for this function are simple, you can just [look at the implementation](https://github.com/kane50613/takumi/blob/master/takumi-helpers/src/jsx/jsx.ts) to understand it.
+The rules for this function are simple, you can just [look at the implementation](https://github.com/kane50613/takumi/blob/master/takumi-helpers/src/jsx/index.ts) to understand it.
 
 - React (Server) Components are resolved to their final values before processing.
 - `<img>` and `<svg>` elements become an Image node with style applied.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -15,6 +15,7 @@
     "typography-and-fonts",
     "tailwind-css",
     "load-images",
+    "output-formats",
     "keyframe-animation",
     "--- Advanced ---",
     "architecture",

--- a/docs/content/docs/output-formats.mdx
+++ b/docs/content/docs/output-formats.mdx
@@ -1,0 +1,83 @@
+---
+title: Output Formats
+description: Choose a raster format, set the pixel density, or emit vector SVG.
+icon: Image
+---
+
+`render()` returns encoded image bytes. The `format` option picks the encoder; the rest of this page covers the knobs each one exposes, the pixel-density control, and the separate vector-SVG path.
+
+## Picking a format
+
+`format` is part of a discriminated union, so the format-specific options only appear on the formats that accept them. `quality` cannot pair with PNG, and `lossless` is WebP-only.
+
+```tsx
+import { render } from "takumi-js";
+
+await render(<OgImage />, { width: 1200, height: 630, format: "png" });
+await render(<OgImage />, { width: 1200, height: 630, format: "jpeg", quality: 80 });
+await render(<OgImage />, { width: 1200, height: 630, format: "webp", lossless: true });
+```
+
+| Format          | Alpha | Notes                                                                                   |
+| :-------------- | :---- | :-------------------------------------------------------------------------------------- |
+| `png` (default) | Yes   | Lossless. Use when you need transparency or exact pixels.                               |
+| `jpeg`          | No    | Lossy; `quality` 0–100. Alpha is flattened. Smallest files for photographic content.    |
+| `webp`          | Yes   | Lossy with `quality`, or `lossless: true`. Omitting both encodes losslessly.            |
+| `ico`           | Yes   | Favicon container, PNG-encoded inside.                                                  |
+| `raw`           | Yes   | Uncompressed RGBA bytes, `width × height × 4`. For video pipelines and custom encoders. |
+
+`quality` only applies to `jpeg` and lossy `webp`. For WebP, `lossless` wins over `quality`.
+
+<Callout type="info">
+  On `@takumi-rs/wasm`, WebP is always lossless — lossy WebP encoding is native-only. The `quality`
+  and `lossless` knobs are absent from the WASM types.
+</Callout>
+
+### Raw frames
+
+`format: "raw"` skips encoding and hands back the RGBA buffer directly. Feed it to ffmpeg or any encoder you already run. The [keyframe animation](/docs/keyframe-animation) page streams raw frames into ffmpeg for video output.
+
+## Device pixel ratio
+
+`devicePixelRatio` scales the output resolution without touching the layout. A `1200 × 630` render at `devicePixelRatio: 2` produces a `2400 × 1260` image whose elements keep their CSS sizes — the same trick a retina screen uses.
+
+```tsx
+await render(<OgImage />, { width: 1200, height: 630, devicePixelRatio: 2 });
+```
+
+## Dithering
+
+`dithering` trades a little noise for smoother gradients when colors are quantized during encoding, removing visible banding.
+
+- `none` (default)
+- `ordered-bayer`
+- `floyd-steinberg`
+
+```tsx
+await render(<Gradient />, { width: 1200, height: 630, dithering: "floyd-steinberg" });
+```
+
+## Animated output
+
+`renderAnimation()` encodes a sequence as WebP, APNG, or GIF. See [Keyframe Animation](/docs/keyframe-animation).
+
+## Vector SVG
+
+`renderSvg()` is the second output backend. It takes the same input and resource pipeline as `render()`, but returns an `<svg>` document string instead of a raster bitmap — real `<rect>`, `<path>`, gradients, glyph outlines, and embedded images, drawn from the same layout. If you came from [satori](https://github.com/vercel/satori) for its SVG output, this is the direct equivalent.
+
+```tsx
+import { render, renderSvg } from "takumi-js";
+
+const png = await render(<OgImage />, { width: 1200, height: 630 });
+const svg = await renderSvg(<OgImage />, { width: 1200, height: 630 });
+```
+
+Because SVG is a vector format, the raster-only knobs — `format`, `quality`, `lossless`, `dithering`, `drawDebugBorder`, `devicePixelRatio` — do not apply.
+
+## Cancellation
+
+Every render takes an optional `AbortSignal`. Pass `signal` to abort a render that is still fetching fonts or images; an already-aborted signal throws before any work starts.
+
+```tsx
+await render(<OgImage />, { width: 1200, height: 630, signal: request.signal });
+```

--- a/docs/content/docs/tailwind-css.mdx
+++ b/docs/content/docs/tailwind-css.mdx
@@ -52,7 +52,7 @@ Generally speaking, this is not recommended as it won't be able to cover all the
 ### Limitations
 
 - No custom theme config, but arbitrary values are supported.
-- Read the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi/src/layout/style/tw/map.rs) for all supported classes.
+- Read the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-css/src/style/tw/map.rs) for all supported classes.
 
 ### Usage
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -33,6 +33,46 @@ export function GET() {
 
 The same `fonts` option works on `render`, `renderAnimation`, and `encodeFrames`.
 
+### From Google Fonts
+
+`googleFont` fetches a family's CSS from Google Fonts and returns ready-to-use `fonts` entries — one lazy loader per `woff2` file, downloaded only when the renderer first needs it. Reference the family by its name in `font-family`.
+
+```tsx
+import { render } from "takumi-js";
+import { googleFont } from "takumi-js/helpers";
+
+const image = await render(<div style={{ fontFamily: "Inter" }}>Hello</div>, {
+  width: 1200,
+  height: 630,
+  fonts: await googleFont("Inter", { weight: [400, 700] }),
+});
+```
+
+`weight` takes one weight, an array, or a range like `"100..900"` that loads the variable font and leaves CSS `font-weight` in control. `style` is `"normal"`, `"italic"`, or both. `text` limits the download to the glyphs that string uses — worth it for OG images, where you know the text up front.
+
+```tsx
+fonts: await googleFont("Inter", { weight: 700, style: "italic", text: title }),
+```
+
+#### Content-driven subsets
+
+For multilingual content where you can't predict which scripts appear, `googleFontSubsets` loads only the subsets the content actually renders. Give it your content and the families to draw from; it scans the codepoints, fetches every family's metadata in one request, and keeps just the subsets whose `unicode-range` intersects.
+
+```tsx
+import { render } from "takumi-js";
+import { fromJsx } from "takumi-js/helpers/jsx";
+import { googleFontSubsets } from "takumi-js/helpers";
+
+const element = <div style={{ fontFamily: "Inter" }}>Hello 你好 こんにちは</div>;
+
+const { node } = await fromJsx(element);
+const fonts = await googleFontSubsets(node, ["Inter", "Noto Sans JP", "Noto Sans TC"]);
+
+const image = await render(node, { width: 1200, height: 630, fonts });
+```
+
+Each subset registers under a unique internal name, while `font-family: Inter` expands across every subset, so each script routes to the file that covers it. Pass a `Map` as `cache` to reuse the parsed metadata across renders — useful when a playground re-renders on every edit.
+
 ### Preloading with `registerFont`
 
 `registerFont` is the escape hatch for preloading: register a font on a renderer up front, outside the request path, then reuse that renderer. It accepts the same entry shape as `fonts` and resolves to the families it produced.


### PR DESCRIPTION
## What

Fills the documentation gaps left by the v2 work. Three additions plus two stale-link fixes.

### Output Formats (new page)

`render()`'s output options had no home — `format`, quality, dithering, and pixel density were only mentioned in passing in the upgrade guide. New **Output Formats** page under Guide covers:

- The `format` discriminated union (`png`, `jpeg`, `webp`, `ico`, `raw`) and which knobs each accepts
- JPEG/WebP `quality`, WebP `lossless`, and the WASM difference (WebP is always lossless there)
- `raw` RGBA frames for video pipelines
- `devicePixelRatio` for retina output
- `dithering` (`ordered-bayer` / `floyd-steinberg`)
- Vector SVG via `renderSvg()` and the raster-only knobs that don't apply to it
- `AbortSignal` cancellation

### Google Fonts (Typography & Fonts)

Documents `googleFont` and `googleFontSubsets` (shipped in #814), which had no docs:

- `googleFont(family, options)` — weight ranges / variable fonts, `style`, `text` subsetting
- `googleFontSubsets(content, families)` — content-driven subset loading for multilingual output

### Stale links

- `architecture.mdx`: `jsx/jsx.ts` → `jsx/index.ts`
- `tailwind-css.mdx`: tw map moved to `takumi-css/src/style/tw/map.rs`

## Verification

`npx fumadocs-mdx` compiles all content cleanly.

https://claude.ai/code/session_01TfC3is8npA6hWQu7DVMW9u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed guide for output format configuration, including raster rendering quality settings, vector SVG support, animated output formats (WebP/APNG/GIF), and render cancellation via AbortSignal
  * Documented Google Fonts integration with font-family configuration options, weight and style selection, and content-driven subset optimization for efficient font loading
  * Updated documentation site structure and improved internal reference links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->