### PR TITLE
NAPI: make font reads wait-free under concurrent renders

### DIFF
--- a/.tegami/napi-lockfree-font-reads.md
+++ b/.tegami/napi-lockfree-font-reads.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:@takumi-rs/core": patch
+---
+
+### Make font reads wait-free under concurrent renders
+
+One lock guarded all renderer state, so every `registerFont` blocked in-flight
+renders. Fonts now sit behind an `ArcSwap`, and the image cache moves out of the
+outer lock. Concurrent render-and-register throughput rises 30–50% with lower
+tail latency; single-threaded rendering is unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1620,7 @@ dependencies = [
 name = "takumi-napi"
 version = "0.0.1"
 dependencies = [
+ "arc-swap",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 ]
 
 [workspace.dependencies]
+arc-swap = "1"
 axum = "0.8"
 base64 = "0.22"
 bitflags = "2.11"

--- a/takumi-napi/Cargo.toml
+++ b/takumi-napi/Cargo.toml
@@ -14,6 +14,7 @@ rayon.workspace = true
 parley.workspace = true
 napi.workspace = true
 napi-derive.workspace = true
+arc-swap.workspace = true
 
 [dependencies.takumi-core]
 path = "../takumi-core"

--- a/takumi-napi/src/encode_frames_task.rs
+++ b/takumi-napi/src/encode_frames_task.rs
@@ -1,9 +1,4 @@
-use std::{
-  borrow::Cow,
-  collections::HashMap,
-  mem::take,
-  sync::{Arc, RwLock},
-};
+use std::{borrow::Cow, collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use rayon::prelude::*;
@@ -17,13 +12,13 @@ use crate::{
   buffer_from_object, map_error, parse_stylesheet,
   renderer::{
     AnimationOutputFormat, EncodeFramesOptions, ImageCacheMode, ImageSource, RendererState,
-    webp_lossless,
+    decode_images, webp_lossless,
   },
 };
 
 pub struct EncodeFramesTask {
   pub(crate) frames: Option<Vec<(Node, u32)>>,
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) format: AnimationOutputFormat,
   pub(crate) quality: Option<u8>,
@@ -39,7 +34,7 @@ impl EncodeFramesTask {
     env: Env,
     frames: Vec<(Node, u32)>,
     options: EncodeFramesOptions,
-    state: Arc<RwLock<RendererState>>,
+    state: Arc<RendererState>,
   ) -> Result<Self> {
     Ok(Self {
       frames: Some(frames),
@@ -87,11 +82,8 @@ impl Task for EncodeFramesTask {
       let Some(frames) = self.frames.take() else {
         unreachable!()
       };
-      let state = self
-        .state
-        .read()
-        .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
-      let initialized_images = state.decode_images(take(&mut self.images))?;
+      let fonts = self.state.fonts.load();
+      let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
 
       let viewport = self.viewport;
       let draw_debug_border = self.draw_debug_border;
@@ -107,7 +99,7 @@ impl Task for EncodeFramesTask {
                 .images(initialized_images.clone())
                 .stylesheet(stylesheet.clone())
                 .node(node)
-                .fonts(&state.fonts)
+                .fonts(&fonts)
                 .font_families(font_families.clone())
                 .draw_debug_border(draw_debug_border)
                 .build(),

--- a/takumi-napi/src/load_font_task.rs
+++ b/takumi-napi/src/load_font_task.rs
@@ -1,11 +1,11 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
 
 use crate::{FontInput, RegisteredFamily, renderer::RendererState, resolve_font_resource};
 
 pub struct LoadFontTask {
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
   pub(crate) buffer: Buffer,
   pub(crate) info: FontInput,
 }
@@ -17,15 +17,20 @@ impl Task for LoadFontTask {
   fn compute(&mut self) -> Result<Self::Output> {
     let resource = resolve_font_resource(&self.info, &self.buffer)?;
 
-    let mut state = self
+    // Serialize registrations; readers stay wait-free on the old snapshot meanwhile.
+    let _write = self
       .state
-      .write()
+      .font_write
+      .lock()
       .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
 
-    let registered = state
-      .fonts
+    let mut fonts = self.state.fonts.load_full().as_ref().clone();
+
+    let registered = fonts
       .register(resource)
       .map_err(|e| Error::from_reason(format!("Failed to register font: {e}")))?;
+
+    self.state.fonts.store(Arc::new(fonts));
 
     Ok(registered.into_iter().map(Into::into).collect())
   }

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -1,8 +1,4 @@
-use std::{
-  collections::HashMap,
-  mem::take,
-  sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use takumi_core::layout::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport, node::Node, style::StyleSheet};
@@ -10,12 +6,15 @@ use takumi_raster::measure;
 
 use crate::{
   buffer_from_object, map_error, parse_stylesheet,
-  renderer::{ImageCacheMode, MeasuredNode, RenderOptions, RendererState, deserialize_keyframes},
+  renderer::{
+    ImageCacheMode, MeasuredNode, RenderOptions, RendererState, decode_images,
+    deserialize_keyframes,
+  },
 };
 
 pub struct MeasureTask {
   pub(crate) node: Option<Node>,
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: StyleSheet,
@@ -28,7 +27,7 @@ impl MeasureTask {
     env: Env,
     node: Node,
     options: RenderOptions,
-    state: Arc<RwLock<RendererState>>,
+    state: Arc<RendererState>,
   ) -> Result<Self> {
     Ok(MeasureTask {
       node: Some(node),
@@ -72,12 +71,9 @@ impl Task for MeasureTask {
       unreachable!()
     };
 
-    let state = self
-      .state
-      .read()
-      .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
+    let fonts = self.state.fonts.load();
 
-    let initialized_images = state.decode_images(take(&mut self.images))?;
+    let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
 
     let options = takumi_raster::RenderOptions::builder()
       .viewport(self.viewport)
@@ -85,7 +81,7 @@ impl Task for MeasureTask {
       .stylesheet(take(&mut self.stylesheet))
       .time_ms(self.time_ms)
       .node(node)
-      .fonts(&state.fonts)
+      .fonts(&fonts)
       .font_families(take(&mut self.font_families))
       .build();
 

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -1,9 +1,4 @@
-use std::{
-  borrow::Cow,
-  collections::HashMap,
-  mem::take,
-  sync::{Arc, RwLock},
-};
+use std::{borrow::Cow, collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use takumi_core::layout::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport, node::Node};
@@ -16,13 +11,13 @@ use crate::{
   buffer_from_object, deserialize_with_tracing, map_error, parse_stylesheet,
   renderer::{
     AnimationOutputFormat, ImageCacheMode, ImageSource, RenderAnimationOptions, RendererState,
-    webp_lossless,
+    decode_images, webp_lossless,
   },
 };
 
 pub struct RenderAnimationTask {
   pub(crate) scenes: Option<Vec<(Node, u32)>>,
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) format: AnimationOutputFormat,
   pub(crate) quality: Option<u8>,
@@ -38,7 +33,7 @@ impl RenderAnimationTask {
   pub(crate) fn from_options(
     env: Env,
     options: RenderAnimationOptions,
-    state: Arc<RwLock<RendererState>>,
+    state: Arc<RendererState>,
   ) -> Result<Self> {
     let RenderAnimationOptions {
       scenes,
@@ -114,11 +109,8 @@ impl Task for RenderAnimationTask {
       let Some(scenes) = self.scenes.take() else {
         unreachable!()
       };
-      let state = self
-        .state
-        .read()
-        .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
-      let initialized_images = state.decode_images(take(&mut self.images))?;
+      let fonts = self.state.fonts.load();
+      let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
       let stylesheet = parse_stylesheet(take(&mut self.stylesheets), Vec::new())?;
       let scene_options = scenes
         .into_iter()
@@ -131,7 +123,7 @@ impl Task for RenderAnimationTask {
                 .images(initialized_images.clone())
                 .stylesheet(stylesheet.clone())
                 .node(node)
-                .fonts(&state.fonts)
+                .fonts(&fonts)
                 .font_families(self.font_families.clone())
                 .draw_debug_border(self.draw_debug_border)
                 .build(),

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -1,8 +1,4 @@
-use std::{
-  collections::HashMap,
-  mem::take,
-  sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use takumi_core::layout::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport, node::Node, style::StyleSheet};
@@ -10,13 +6,16 @@ use takumi_raster::{DitheringAlgorithm, render, write_image};
 
 use crate::{
   buffer_from_object, map_error, parse_stylesheet,
-  renderer::{ImageCacheMode, OutputFormat, RenderOptions, RendererState, deserialize_keyframes},
+  renderer::{
+    ImageCacheMode, OutputFormat, RenderOptions, RendererState, decode_images,
+    deserialize_keyframes,
+  },
 };
 
 pub struct RenderTask {
   pub(crate) draw_debug_border: bool,
   pub(crate) node: Option<Node>,
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) format: OutputFormat,
   pub(crate) quality: Option<u8>,
@@ -33,7 +32,7 @@ impl RenderTask {
     env: Env,
     node: Node,
     options: RenderOptions,
-    state: Arc<RwLock<RendererState>>,
+    state: Arc<RendererState>,
   ) -> Result<Self> {
     Ok(RenderTask {
       node: Some(node),
@@ -82,12 +81,9 @@ impl Task for RenderTask {
       unreachable!()
     };
 
-    let state = self
-      .state
-      .read()
-      .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
+    let fonts = self.state.fonts.load();
 
-    let initialized_images = state.decode_images(take(&mut self.images))?;
+    let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
 
     let image = render(
       takumi_raster::RenderOptions::builder()
@@ -97,7 +93,7 @@ impl Task for RenderTask {
         .time_ms(self.time_ms)
         .dithering(self.dithering)
         .node(node)
-        .fonts(&state.fonts)
+        .fonts(&fonts)
         .font_families(take(&mut self.font_families))
         .draw_debug_border(self.draw_debug_border)
         .build(),

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -1,7 +1,9 @@
 use std::{
   collections::HashMap,
-  sync::{Arc, OnceLock, RwLock},
+  sync::{Arc, Mutex, OnceLock},
 };
+
+use arc_swap::ArcSwap;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -84,33 +86,34 @@ impl From<takumi_raster::MeasuredNode> for MeasuredNode {
 /// The main renderer for Takumi image rendering engine (Node.js version).
 #[napi]
 pub struct Renderer {
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
 }
 
 pub(crate) struct RendererState {
-  pub(crate) fonts: Fonts,
+  /// Wait-free reads via `fonts.load()`; registrations serialize on `font_write` and publish
+  /// a fresh `Arc<Fonts>` via `store`. Renders in flight keep their old snapshot alive.
+  pub(crate) fonts: ArcSwap<Fonts>,
+  pub(crate) font_write: Mutex<()>,
   pub(crate) image_cache: ImageCache,
 }
 
-impl RendererState {
-  /// Decodes the per-call image buffers into a `src`-keyed map.
-  pub(crate) fn decode_images(
-    &self,
-    images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
-  ) -> Result<HashMap<Arc<str>, LoadedImageSource>> {
-    let mut map = HashMap::new();
+/// Decodes the per-call image buffers into a `src`-keyed map. The image cache is
+/// `quick_cache::sync` (internally locked, single-flight), so it needs no outer lock.
+pub(crate) fn decode_images(
+  image_cache: &ImageCache,
+  images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+) -> Result<HashMap<Arc<str>, LoadedImageSource>> {
+  let mut map = HashMap::new();
 
-    for (src, (buffer, mode)) in images {
-      let decoded = self
-        .image_cache
-        .get_or_decode(&buffer, mode.into())
-        .map_err(map_error)?;
+  for (src, (buffer, mode)) in images {
+    let decoded = image_cache
+      .get_or_decode(&buffer, mode.into())
+      .map_err(map_error)?;
 
-      map.insert(src, decoded);
-    }
-
-    Ok(map)
+    map.insert(src, decoded);
   }
+
+  Ok(map)
 }
 
 pub(crate) fn deserialize_keyframes(keyframes: Option<Object>) -> Result<Vec<CoreKeyframesRule>> {
@@ -437,10 +440,11 @@ impl Renderer {
     crate::pool::register_cleanup(&env);
 
     Ok(Self {
-      state: Arc::new(RwLock::new(RendererState {
-        fonts: default_fonts()?,
+      state: Arc::new(RendererState {
+        fonts: ArcSwap::from_pointee(default_fonts()?),
+        font_write: Mutex::new(()),
         image_cache: ImageCache::default(),
-      })),
+      }),
     })
   }
 

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -1,20 +1,18 @@
-use std::{
-  collections::HashMap,
-  mem::take,
-  sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use takumi_core::layout::{Viewport, node::Node, style::StyleSheet};
 
 use crate::{
   buffer_from_object, map_error, parse_stylesheet,
-  renderer::{ImageCacheMode, RendererState, SvgRenderOptions, deserialize_keyframes},
+  renderer::{
+    ImageCacheMode, RendererState, SvgRenderOptions, decode_images, deserialize_keyframes,
+  },
 };
 
 pub struct SvgRenderTask {
   pub(crate) node: Option<Node>,
-  pub(crate) state: Arc<RwLock<RendererState>>,
+  pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: StyleSheet,
@@ -27,7 +25,7 @@ impl SvgRenderTask {
     env: Env,
     node: Node,
     options: SvgRenderOptions,
-    state: Arc<RwLock<RendererState>>,
+    state: Arc<RendererState>,
   ) -> Result<Self> {
     Ok(SvgRenderTask {
       node: Some(node),
@@ -66,12 +64,9 @@ impl Task for SvgRenderTask {
       unreachable!()
     };
 
-    let state = self
-      .state
-      .read()
-      .map_err(|e| Error::from_reason(format!("Renderer lock poisoned: {e}")))?;
+    let fonts = self.state.fonts.load();
 
-    let images = state.decode_images(take(&mut self.images))?;
+    let images = decode_images(&self.state.image_cache, take(&mut self.images))?;
 
     takumi_svg::render(
       takumi_svg::SvgOptions::builder()
@@ -80,7 +75,7 @@ impl Task for SvgRenderTask {
         .stylesheet(take(&mut self.stylesheet))
         .time_ms(self.time_ms)
         .node(node)
-        .fonts(&state.fonts)
+        .fonts(&fonts)
         .font_families(take(&mut self.font_families))
         .build(),
     )


### PR DESCRIPTION
## What

The napi `Renderer` held all state behind one `Arc<RwLock<RendererState>>`. Every `registerFont` took a write lock that blocked every in-flight render — and that write lock is on the hot path under the per-render `fonts` model, where each render registers its fonts before drawing.

- `fonts` → `ArcSwap<Fonts>` + a write-side `Mutex`. Renders read wait-free via `load()` and keep their snapshot alive while a registration publishes a fresh `Arc<Fonts>`.
- `image_cache` is `quick_cache::sync` (internally locked, single-flight), so it no longer sits under the outer lock either.

Net `-100/+79` across renderer + the 5 task files; no public API change.

## Why

`registerFont` and `render` no longer contend. The added per-registration `Fonts` clone is sub-microsecond (vs the ~13–34 µs render-local parley snapshot each render already pays), so registration cost is unaffected.

## Numbers

Shared `Renderer`, N=32 DocsTemplate renders, best-of-3 wall.

| Pool | Case | Before (r/s) | After (r/s) | p99 |
|---|---|---|---|---|
| 8 | parallel | ~690 | ~690 | flat |
| 8 | parallel + registerFont | 375–585 (noisy) | 610–645 | −20–40% |
| 4 | parallel + registerFont | 282 | 433 | −35% |

Read lock was never the bottleneck (parallel renders already scaled ~4.7×); the `registerFont` write lock was. Case C now tracks pure-parallel throughput and variance collapses.

## Test

`cargo clippy` clean, 51/51 napi tests pass (incl. `concurrent-load-font`).

https://claude.ai/code/session_01BJjcTbGMFCWJT4sp2cpkkv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved renderer shared-state handling to make font access lock-free during concurrent renders, reducing contention and improving throughput.
  * Updated rendering, measurement, animation, and SVG rendering flows to use the new shared state approach for font loading and image decoding.
* **Documentation**
  * Added a note explaining the updated lock-free font-read behavior in the NAPI layer.
* **Chores**
  * Added a workspace dependency to support lock-free font snapshotting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->