### PR TITLE
Re-release takumi group in sync

### DIFF
--- a/.tegami/resync-beta.md
+++ b/.tegami/resync-beta.md
@@ -1,0 +1,15 @@
+---
+packages:
+  "npm:takumi-js": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/helpers": patch
+  "npm:@takumi-rs/wasm": patch
+  "npm:@takumi-rs/image-response": patch
+---
+
+### Re-release all packages in sync
+
+Earlier beta releases drifted out of lockstep, so some published packages
+depended on versions that were never published. Bump and publish the set
+together so the beta tag is consistent and every inter-package dependency
+resolves.

--- a/takumi-image-response/package.json
+++ b/takumi-image-response/package.json
@@ -41,7 +41,6 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepublishOnly": "jq '.dependencies[\"takumi-js\"] = .version' package.json > tmp.json && mv tmp.json package.json",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {

--- a/takumi-js/package.json
+++ b/takumi-js/package.json
@@ -122,7 +122,6 @@
     "provenance": true
   },
   "scripts": {
-    "prepublishOnly": "jq '.dependencies[\"@takumi-rs/core\"] = .version | .dependencies[\"@takumi-rs/helpers\"] = .version | .dependencies[\"@takumi-rs/wasm\"] = .version' package.json > tmp.json && mv tmp.json package.json",
     "build": "tsdown",
     "test": "bun test",
     "test:bundlers": "bun test tests/bundlers.test.ts",

--- a/takumi-napi/package.json
+++ b/takumi-napi/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "build": "napi build --release --no-const-enum --platform --esm --strip",
     "build:js": "tsdown && bun scripts/patch-dist-loader.ts",
-    "prepublishOnly": "jq '.dependencies[\"@takumi-rs/helpers\"] = .version' package.json > tmp.json && mv tmp.json package.json && bun artifacts && napi prepublish -t npm --no-gh-release",
+    "prepublishOnly": "bun artifacts && napi prepublish -t npm --no-gh-release",
     "artifacts": "napi create-npm-dirs && napi artifacts && napi version",
     "bench": "bun tests/bench/index.tsx",
     "publish-lint": "attw --pack . && publint --strict ."

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -86,7 +86,6 @@
     "build": "wasm-pack build --no-pack --release --out-dir pkg --target web && bun build:js && bun scripts/patch-generated-loader.ts",
     "build:js": "tsdown",
     "build:debug": "wasm-pack build --no-pack --dev --out-dir pkg --target web && bun build:js && bun scripts/patch-generated-loader.ts",
-    "prepublishOnly": "jq '.dependencies[\"@takumi-rs/helpers\"] = .version' package.json > tmp.json && mv tmp.json package.json",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {


### PR DESCRIPTION
Follow-up to #824. Now that the group versions are re-aligned (all at beta.3) and the tegami syncBump+prerelease patch is in, trigger one synced release so npm catches up and dependency specs are correct.

## Why
The earlier desync published broken deps, e.g. `takumi-js@2.0.0-beta.2` depends on `@takumi-rs/helpers@2.0.0-beta.2`, which was never published (helpers only reached beta.1) — `npm install takumi-js@beta` fails to resolve.

## Changes
- **Changeset** (`.tegami/resync-beta.md`): bumps all group packages so tegami publishes them together at one beta version (beta.4) with correct concrete deps.
- **Drop the `jq` helpers-dep pin** from napi `prepublishOnly` (re-applies a commit that missed #824's squash). tegami rewrites workspace deps on publish; the jq was redundant and pinned helpers to core's own version. The napi artifact/version/prepublish steps stay (they publish the platform binary packages).

On merge, tegami CI opens a Version Packages PR (all → beta.4); merging that publishes the synced set.

Note: the tegami patch (`patches/tegami@0.1.1.patch`) stays — it fixes the upstream syncBump-on-prerelease bug and is needed for every future release. Remove only once fixed upstream.

https://claude.ai/code/session_01BJjcTbGMFCWJT4sp2cpkkv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated package synchronization instructions to perform patch-level resynchronization across related packages and re-release them together to correct prior beta version drift.

* **Chores**
  * Adjusted the publishing workflow for several packages to simplify pre-publish steps and avoid modifying dependency versions during publish.
  * Removed redundant pre-publish hooks where they were only used for version rewriting, keeping the rest of the build/publish checks the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->