### PR TITLE
JS: keep native core out of edge bundles

### DIFF
--- a/.tegami/edge-native-import.md
+++ b/.tegami/edge-native-import.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:takumi-js": patch
+---
+
+### Keep the native core out of edge bundles
+
+The `@takumi-rs/core` import was reachable from edge builds, pulling its native
+`.node` binding into the bundle and pushing it past the runtime size limit. The
+import is now gated behind an inline `NEXT_RUNTIME !== "edge"` check so the edge
+bundler drops it.

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -21,8 +21,6 @@ async function getImportsImpl(module?: WasmBindings.InitInput) {
     return initializeWasm(importWasmBindings());
   }
 
-  // Inline literal, not a helper: lets the Next edge bundler DCE this import so
-  // the native `.node` isn't pulled into edge bundles.
   if (process.env.NEXT_RUNTIME !== "edge") {
     try {
       return await import("@takumi-rs/core");

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -21,22 +21,26 @@ async function getImportsImpl(module?: WasmBindings.InitInput) {
     return initializeWasm(importWasmBindings());
   }
 
-  try {
-    return await import("@takumi-rs/core");
-  } catch (error) {
-    if (isNodeEnvironment()) {
-      throw new Error(
-        "Failed to load @takumi-rs/core in Node.js runtime. Takumi requires the native napi-rs module in Node environments.",
-        { cause: error },
+  // Inline literal, not a helper: lets the Next edge bundler DCE this import so
+  // the native `.node` isn't pulled into edge bundles.
+  if (process.env.NEXT_RUNTIME !== "edge") {
+    try {
+      return await import("@takumi-rs/core");
+    } catch (error) {
+      if (isNodeEnvironment()) {
+        throw new Error(
+          "Failed to load @takumi-rs/core in Node.js runtime. Takumi requires the native napi-rs module in Node environments.",
+          { cause: error },
+        );
+      }
+
+      console.warn(
+        "Unable to import @takumi-rs/core. Falling back to auto-detection of WASM bindings.",
+        {
+          cause: error,
+        },
       );
     }
-
-    console.warn(
-      "Unable to import @takumi-rs/core. Falling back to auto-detection of WASM bindings.",
-      {
-        cause: error,
-      },
-    );
   }
 
   return initializeWasm(importWasmBindings());


### PR DESCRIPTION
## Problem

`takumi-js/response` on the Next.js **edge** runtime drags the native napi binary `@takumi-rs/core/*.node` (~2.7 MB gzip) into the edge function. It can't even execute on edge, and it blows the Edge code-size limit.

Observed on `image-bench`'s takumi edge route: the deployed function was **4.5 MB gzip** — `core.*.node` (2.67M) + the wasm (1.66M) + glue. The wasm alone fits Pro; the stray `.node` is the entire overage.

## Cause

In `import.ts`, the `import("@takumi-rs/core")` sat behind `shouldSkipCoreImport()`. At runtime that correctly returns `true` on edge (wasm is used), but the bundler can't see through the helper call to prove the dynamic import unreachable — so webpack/turbopack bundle `@takumi-rs/core` and its platform `.node` anyway.

## Fix

Gate the import with an inline, literal `process.env.NEXT_RUNTIME !== "edge"`. Next's DefinePlugin folds it to `false` in edge bundles, so the import is dead-code-eliminated and the `.node` is never traced in. Node and non-Next runtimes are unchanged (the check is `true` off-edge, and `shouldSkipCoreImport()` still handles Cloudflare/Deno/browser early).

## Verification

Patched the installed module in `image-bench` and ran `vercel build`:

| | gzip |
|---|---|
| before | 4.495 MB |
| after  | 2.002 MB |

No `.node` anywhere in `.next` or the regenerated function; no `@takumi-rs/core` in the edge bundle (sourcemaps only); the wasm + edge path are intact.

https://claude.ai/code/session_014kjVdKvxfVNTVeWvaZ32GC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility with the Edge runtime by skipping dynamic import fallback behavior there, resulting in faster and more direct initialization.
* **Documentation**
  * Added guidance/configuration to help ensure native bindings are excluded from Edge bundles to avoid size/runtime limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->