### PR TITLE
Crate: apply fontFamilies as the root default font

### DIFF
--- a/.tegami/fontfamilies-default.md
+++ b/.tegami/fontfamilies-default.md
@@ -1,0 +1,12 @@
+---
+packages:
+  "cargo:takumi-css": patch
+  "cargo:takumi-raster": patch
+---
+
+### Apply `fontFamilies` as the default font
+
+Text without an explicit `font-family` ignored the render's `fontFamilies` (and
+any fonts passed through it), always using the embedded fallback. The
+`fontFamilies` stack is now the root default, so passed fonts render without a
+per-node `font-family`.

--- a/takumi-css/src/style/properties/font_family.rs
+++ b/takumi-css/src/style/properties/font_family.rs
@@ -27,6 +27,19 @@ pub enum FontFamilyToken {
 impl MakeComputed for FontFamily {}
 
 impl FontFamily {
+  /// Named families ending in `sans-serif`. The trailing generic is the last resort: the
+  /// fallback bucket only holds resolved `fontFamilies`, so an unresolved name would otherwise
+  /// leave text unrendered.
+  pub fn from_names(names: impl IntoIterator<Item = String>) -> Self {
+    let mut tokens = names
+      .into_iter()
+      .map(FontFamilyToken::Owned)
+      .collect::<Vec<_>>();
+    tokens.push(FontFamilyToken::Generic(GenericFamily::SansSerif));
+
+    Self(tokens.into_boxed_slice())
+  }
+
   /// The families as fontique query families, in declaration order.
   pub fn query_families(&self) -> impl Iterator<Item = QueryFamily<'_>> + Clone {
     self.0.iter().map(|token| match token {
@@ -202,6 +215,18 @@ mod tests {
       Ok(FontFamily(Box::new([FontFamilyToken::Owned(
         "Noto Sans TC".to_string()
       )])))
+    );
+  }
+
+  #[test]
+  fn from_names_appends_sans_serif_last_resort() {
+    assert_eq!(
+      FontFamily::from_names(["Geist".to_string(), "Inter".to_string()]),
+      FontFamily(Box::new([
+        FontFamilyToken::Owned(String::from("Geist")),
+        FontFamilyToken::Owned(String::from("Inter")),
+        FontFamilyToken::Generic(GenericFamily::SansSerif),
+      ]))
     );
   }
 

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -18,7 +18,7 @@ use crate::{
       resolve_visual_inline_box, text_fit_line_alignment_correction,
     },
     node::Node,
-    style::{Affine, ComputedStyle, StyleSheet},
+    style::{Affine, ComputedStyle, FontFamily, StyleSheet},
     tree::{LayoutResults, LayoutTree, RenderNode},
   },
   resources::image::ImageSource,
@@ -27,11 +27,14 @@ use crate::{
 };
 use takumi_core::scene::build_stacking_contexts;
 
-/// Root computed style carrying the render-level default `lang`, inherited by
-/// every node that does not set its own.
-fn root_style(lang: Option<Language>) -> Box<ComputedStyle> {
+/// Root computed style carrying the render-level `lang` and `fontFamilies` defaults,
+/// inherited by every node that does not set its own.
+fn root_style(lang: Option<Language>, font_families: Option<&[String]>) -> Box<ComputedStyle> {
   Box::new(ComputedStyle {
     lang,
+    font_family: font_families.map_or_else(FontFamily::default, |names| {
+      FontFamily::from_names(names.iter().cloned())
+    }),
     ..Default::default()
   })
 }
@@ -215,7 +218,7 @@ pub fn measure<'g>(options: RenderOptions<'g>) -> Result<MeasuredNode> {
     .stylesheet(stylesheet.into())
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
-    .style(root_style(lang))
+    .style(root_style(lang, font_families.as_deref()))
     .build();
 
   let mut root = RenderNode::from_node(&render_context, node);
@@ -544,7 +547,7 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
     .stylesheet(stylesheet.into())
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
-    .style(root_style(lang))
+    .style(root_style(lang, font_families.as_deref()))
     .build();
 
   let mut root = RenderNode::from_node(&render_context, node);


### PR DESCRIPTION
## Problem

Passing `fonts` (or `fontFamilies`) to a render never affected text without an explicit `font-family`. Only nodes that set `font-family` themselves picked up the registered font; everything else fell back to the embedded Manrope.

Reproduced in `@takumi-rs/wasm` — these three render byte-identically (all Manrope), only an explicit per-node `fontFamily` worked:

```
fonts only (no fontFamilies)      sha=fd8382f6  ← Manrope
fonts + fontFamilies:[Geist]      sha=fd8382f6  ← Manrope
fonts + node fontFamily:Geist     sha=5dfae91a  ← Geist
no fonts (Manrope baseline)       sha=fd8382f6
```

## Root cause

- The root default `font-family` is the `sans-serif` generic.
- The embedded Manrope claims the `sans-serif` generic and is registered first, so it always wins for unstyled text.
- The JS font API can't assign a generic to a registered font.
- `fontFamilies` only fed `snapshot_with_fallbacks` (the fallback bucket), which is consulted *after* the primary family resolves — and `sans-serif → Manrope` always resolves first, so the bucket was never reached.

## Fix

Set the root element's `font-family` from `fontFamilies`, ending in the `sans-serif` generic. The named families become the default; the trailing generic is the last-resort. Unlike a browser, takumi's fallback bucket is built from the *resolved* `fontFamilies`, so it's empty when none resolve — the generic guarantees text still reaches the embedded sans-serif font instead of disappearing.

The JS wrapper already derives `fontFamilies` from `fonts`, so passing `fonts` now Just Works. After the fix all three cases render Geist; "no fonts" stays Manrope; and a `fontFamilies` entry that doesn't resolve still renders via the embedded last-resort.

https://claude.ai/code/session_01HFT1obMZVZuaNcR6YwnMqh