### PR TITLE
WASM, Docs: render docs OG images with WASM at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,12 +754,6 @@ jobs:
           name: helpers-dist
           path: takumi-helpers/dist
 
-      - name: Download N-API bindings artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: bindings-x86_64-unknown-linux-gnu
-          path: takumi-napi
-
       - name: Download WASM artifact
         uses: actions/download-artifact@v8
         with:

--- a/.tegami/vite-ssr-wasm-asset.md
+++ b/.tegami/vite-ssr-wasm-asset.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Resolve the SSR WASM asset without guessing the output dir
+
+The Vite bundler entry mapped the `?url` asset to disk by guessing a `client/`
+directory, which broke dev (`/@fs/` URLs) and frameworks with a different layout
+(e.g. Waku's `public/`). It now reads the asset colocated with the server chunk
+via `import.meta.url`, with the `client/` paths kept as fallbacks.

--- a/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
+++ b/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
@@ -41,8 +41,7 @@ export async function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs
       width: 1200,
       height: 630,
       format: "webp",
-      // Static build-time generation: use WASM so prerendering doesn't depend on the
-      // native napi binding resolving inside the Vercel build sandbox.
+      // WASM: static prerender shouldn't depend on the native binding resolving in the build sandbox.
       module: wasmModule,
     },
   );

--- a/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
+++ b/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
@@ -1,5 +1,6 @@
 import type { ImageSource } from "takumi-js";
 import { ImageResponse } from "takumi-js/response";
+import wasmModule from "takumi-js/wasm";
 import type { ApiContext } from "waku/router";
 import DocsTemplate from "../../../../../../../takumi-template/src/templates/docs-template";
 import { source } from "~/source";
@@ -33,6 +34,9 @@ export function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs]/imag
       width: 1200,
       height: 630,
       format: "webp",
+      // Static build-time generation: use WASM so prerendering doesn't depend on the
+      // native napi binding resolving inside the Vercel build sandbox.
+      module: wasmModule,
     },
   );
 }

--- a/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
+++ b/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
@@ -1,4 +1,5 @@
 import type { ImageSource } from "takumi-js";
+import { googleFontSubsets } from "takumi-js/helpers";
 import { ImageResponse } from "takumi-js/response";
 import wasmModule from "takumi-js/wasm";
 import type { ApiContext } from "waku/router";
@@ -13,12 +14,17 @@ const images: ImageSource[] = [
   },
 ];
 
-export function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs]/image.webp">) {
+export async function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs]/image.webp">) {
   const page = source.getPage(params.slugs ?? []);
 
   if (!page) {
     return new Response(undefined, { status: 404 });
   }
+
+  const fonts = await googleFontSubsets(
+    `${page.data.title} ${page.data.description ?? ""} Takumi`,
+    ["Geist"],
+  );
 
   return new ImageResponse(
     <DocsTemplate
@@ -31,6 +37,7 @@ export function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs]/imag
     />,
     {
       images,
+      fonts,
       width: 1200,
       height: 630,
       format: "webp",

--- a/takumi-wasm/bundlers/vite.mjs
+++ b/takumi-wasm/bundlers/vite.mjs
@@ -1,18 +1,31 @@
 import url from "../pkg/takumi_wasm_bg.wasm?url";
 
+// `?url` is a browser path; map it to a file for server reads. Vite emits the asset next to the
+// importing server chunk, so resolve relative to import.meta.url, not the framework output dir.
 async function processUrl() {
   if (typeof process !== "undefined" && process.versions?.node != null) {
     const { readFile } = await import("node:fs/promises");
+    const path = decodeURIComponent(url.replace(/[?#].*$/, ""));
 
-    if (!url.startsWith("/")) {
-      return readFile(new URL(url, import.meta.url));
+    // Dev SSR serves an `/@fs/<abs-path>` URL.
+    if (path.startsWith("/@fs/")) {
+      return readFile(path.slice("/@fs".length));
     }
 
-    for (const candidate of [`../client${url}`, `../../client${url}`]) {
+    if (!path.startsWith("/")) {
+      return readFile(new URL(path, import.meta.url));
+    }
+
+    const basename = path.slice(path.lastIndexOf("/") + 1);
+    const candidates = [`./${basename}`, `../client${path}`, `../../client${path}`];
+
+    let lastError;
+    for (const candidate of candidates) {
       try {
         return await readFile(new URL(candidate, import.meta.url));
       } catch (error) {
         if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+          lastError = error;
           continue;
         }
 
@@ -20,7 +33,7 @@ async function processUrl() {
       }
     }
 
-    throw new Error(`Unable to locate Takumi WASM asset for SSR: ${url}`);
+    throw new Error(`Unable to locate Takumi WASM asset for SSR: ${url}`, { cause: lastError });
   }
 
   return fetch(new URL(url, import.meta.url)).then((response) => response.arrayBuffer());


### PR DESCRIPTION
## Problem

`deploy-docs` fails in `vercel build` even though the napi artifact is downloaded:

```
Failed to load @takumi-rs/core in Node.js runtime.
  cause: Cannot find native binding ...
    cause: Cannot find module '@takumi-rs/core-linux-x64-gnu/core.linux-x64-gnu.node'
```

The docs OG route (`_api/og/docs/[...slugs]/image.webp.tsx`) is `render: "static"`, so it prerenders during `vercel build`. Inside the Vercel CLI sandbox the native `@takumi-rs/core` binding isn't resolvable — both the relative `../core.linux-x64-gnu.node` and the optional platform package miss.

## Fix

Static OG generation doesn't need the native binding. Pass the WASM `module` to `ImageResponse` so prerendering uses the portable bindings (same ones the playground already runs).

https://claude.ai/code/session_01HFT1obMZVZuaNcR6YwnMqh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined documentation deployment by skipping an unnecessary Linux bindings artifact download during CI.
* **Bug Fixes**
  * Improved SSR WASM asset resolution to correctly handle Vite dev filesystem URLs and framework-specific output layouts.
* **New Features**
  * Enhanced Open Graph image rendering to use page-aware font subsets and ensure the correct WASM module is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->