### PR TITLE
CI: restore napi bindings build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         working-directory: takumi-helpers
         run: bun test
 
-  build-and-test-napi:
+  build-napi:
     needs: build-helpers
     strategy:
       fail-fast: false
@@ -255,21 +255,10 @@ jobs:
             takumi-napi/index.d.ts
           if-no-files-found: error
 
-      - name: Test bindings
-        if: ${{ !contains(matrix.settings.target, 'musl') }}
-        working-directory: takumi-napi
-        run: bun test
-
-      - name: Test bindings in Alpine (musl)
-        if: contains(matrix.settings.target, 'musl')
-        run: |
-          docker run --rm -v $PWD:/workspace -w /workspace/takumi-napi \
-            oven/bun:alpine bun test
-
   build-js:
     name: Build takumi-js
     runs-on: ubuntu-slim
-    needs: [build-helpers, build-and-test-napi, build-wasm]
+    needs: [build-helpers, build-napi, build-wasm]
     steps:
       - uses: actions/checkout@v7
 
@@ -311,9 +300,9 @@ jobs:
           if-no-files-found: error
 
   test-js:
-    name: Test takumi-js, templates & examples
+    name: Test takumi-js
     runs-on: ubuntu-slim
-    needs: [build-helpers, build-js, build-and-test-napi, build-wasm]
+    needs: [build-helpers, build-napi, build-wasm]
     steps:
       - uses: actions/checkout@v7
 
@@ -340,45 +329,17 @@ jobs:
           name: wasm-package
           path: takumi-wasm
 
-      - name: Download takumi-js artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: js-dist
-          path: takumi-js/dist
-
       - name: Install dependencies
-        run: >
-          bun install --frozen-lockfile
-          --filter ./takumi-js
-          --filter ./takumi-template
-          --filter ./example/cloudflare-workers
-          --filter ./example/tanstack-start
-          --filter ./example/waku-ssr
+        run: bun install --frozen-lockfile --filter ./takumi-js
 
       - name: Test takumi-js
         working-directory: takumi-js
         run: bun test
 
-      - name: Test template
-        working-directory: takumi-template
-        run: bun test
-
-      - name: Test cloudflare-workers example
-        working-directory: example/cloudflare-workers
-        run: bun run test
-
-      - name: Test tanstack-start example
-        working-directory: example/tanstack-start
-        run: bun run test
-
-      - name: Test waku-ssr example
-        working-directory: example/waku-ssr
-        run: bun run test
-
   build-image-response:
     name: Build @takumi-rs/image-response
     runs-on: ubuntu-slim
-    needs: [build-helpers, build-js, build-and-test-napi, build-wasm]
+    needs: [build-helpers, build-js, build-napi, build-wasm]
     steps:
       - uses: actions/checkout@v7
 
@@ -428,7 +389,7 @@ jobs:
   check-packaging:
     name: Check packaging (attw + publint)
     runs-on: ubuntu-slim
-    needs: [build-helpers, build-js, build-and-test-napi, build-wasm, build-image-response]
+    needs: [build-helpers, build-js, build-napi, build-wasm, build-image-response]
     steps:
       - uses: actions/checkout@v7
 
@@ -473,6 +434,163 @@ jobs:
       - name: Check exports with attw and publint
         run: bun publish-lint
 
+  test-template:
+    name: Test Templates
+    runs-on: ubuntu-slim
+    needs: [build-helpers, build-js, build-napi, build-wasm]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@main
+        with:
+          bun-version: canary
+
+      - name: Download helpers artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: helpers-dist
+          path: takumi-helpers/dist
+
+      - name: Download N-API bindings artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: bindings-x86_64-unknown-linux-gnu
+          path: takumi-napi
+
+      - name: Download takumi-js artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: js-dist
+          path: takumi-js/dist
+
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-package
+          path: takumi-wasm
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter ./takumi-template
+
+      - name: Test template
+        working-directory: takumi-template
+        run: bun test
+
+  test-examples:
+    name: Test Example Integrations
+    runs-on: ubuntu-slim
+    needs: [build-helpers, build-js, build-napi, build-wasm]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@main
+        with:
+          bun-version: canary
+
+      - name: Download helpers artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: helpers-dist
+          path: takumi-helpers/dist
+
+      - name: Download N-API bindings artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: bindings-x86_64-unknown-linux-gnu
+          path: takumi-napi
+
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-package
+          path: takumi-wasm
+
+      - name: Download takumi-js artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: js-dist
+          path: takumi-js/dist
+
+      - name: Install dependencies
+        run: >
+          bun install --frozen-lockfile
+          --filter ./example/cloudflare-workers
+          --filter ./example/tanstack-start
+          --filter ./example/waku-ssr
+
+      - name: Test cloudflare-workers example
+        working-directory: example/cloudflare-workers
+        run: bun run test
+
+      - name: Test tanstack-start example
+        working-directory: example/tanstack-start
+        run: bun run test
+
+      - name: Test waku-ssr example
+        working-directory: example/waku-ssr
+        run: bun run test
+
+  test-napi:
+    needs: [build-napi, build-helpers]
+    name: Test @takumi-rs/core for ${{ matrix.settings.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: windows-2025
+            target: x86_64-pc-windows-msvc
+          - host: windows-11-arm
+            target: aarch64-pc-windows-msvc
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            build: bun run build --target x86_64-apple-darwin
+          - host: macos-15
+            target: aarch64-apple-darwin
+          - host: ubuntu-slim
+            target: x86_64-unknown-linux-gnu
+          - host: ubuntu-latest # ubuntu-slim doesn't run docker daemon
+            target: x86_64-unknown-linux-musl
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@main
+        with:
+          bun-version: canary
+
+      - name: Download helpers artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: helpers-dist
+          path: takumi-helpers/dist
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter ./takumi-napi
+
+      - name: Download N-API bindings artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: takumi-napi
+
+      - name: Test bindings
+        if: ${{ !contains(matrix.settings.target, 'musl') }}
+        working-directory: takumi-napi
+        run: bun test
+
+      - name: Test bindings in Alpine (musl)
+        if: contains(matrix.settings.target, 'musl')
+        run: |
+          docker run --rm -v $PWD:/workspace -w /workspace/takumi-napi \
+            oven/bun:alpine bun test
+
   build-wasm:
     name: Build @takumi-rs/wasm
     runs-on: ubuntu-latest
@@ -487,7 +605,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          # pinned to match build-and-test-napi (see comment there)
+          # pinned to match build-napi (see comment there)
           toolchain: nightly-2026-06-04
           targets: wasm32-unknown-unknown
           components: rust-src
@@ -643,7 +761,9 @@ jobs:
         test-js,
         build-image-response,
         check-packaging,
-        build-and-test-napi,
+        test-napi,
+        test-template,
+        test-examples,
         test-wasm,
       ]
     steps:


### PR DESCRIPTION
Reverts 014e036e, which broke CI by dropping the napi bindings artifact download from the template/example test jobs.

https://claude.ai/code/session_01HFT1obMZVZuaNcR6YwnMqh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Internal CI/CD pipeline improvements were made to streamline build and testing processes, including restructured workflows for better organization and more efficient artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->