### PR TITLE
NAPI, WASM: let cached font buffers be garbage-collected

### DIFF
--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -104,8 +104,29 @@ async function resolveImageLoaders(images: ImageLoader[]): Promise<ImageSource[]
 }
 
 export class Renderer {
-  private fontMapping = new Map<string | ByteBuf, Promise<RegisteredFamily[]>>();
+  private fontsByKey = new Map<string, Promise<RegisteredFamily[]>>();
+  private fontsByData = new WeakMap<ByteBuf, Promise<RegisteredFamily[]>>();
   private inner = new RendererInternal();
+
+  private getFont(key: string | ByteBuf) {
+    return typeof key === "string" ? this.fontsByKey.get(key) : this.fontsByData.get(key);
+  }
+
+  private setFont(key: string | ByteBuf, family: Promise<RegisteredFamily[]>) {
+    if (typeof key === "string") {
+      this.fontsByKey.set(key, family);
+    } else {
+      this.fontsByData.set(key, family);
+    }
+  }
+
+  private deleteFont(key: string | ByteBuf) {
+    if (typeof key === "string") {
+      this.fontsByKey.delete(key);
+    } else {
+      this.fontsByData.delete(key);
+    }
+  }
 
   private async prepareFonts(fonts: FontLoader[] | undefined) {
     if (!fonts) {
@@ -170,7 +191,7 @@ export class Renderer {
   async registerFont(font: FontLoader) {
     const key = createFontKey(font);
 
-    const cached = this.fontMapping.get(key);
+    const cached = this.getFont(key);
     if (cached) {
       return cached;
     }
@@ -183,17 +204,17 @@ export class Renderer {
     if (isBuffer(extracted)) {
       const binded = register(extracted);
 
-      this.fontMapping.set(key, Promise.resolve(binded));
+      this.setFont(key, Promise.resolve(binded));
 
       return binded;
     }
 
     const promise = extracted.then(register).catch((error) => {
-      this.fontMapping.delete(key);
+      this.deleteFont(key);
       throw error;
     });
 
-    this.fontMapping.set(key, promise);
+    this.setFont(key, promise);
 
     return promise;
   }

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -91,8 +91,29 @@ async function resolveImageLoaders(images: ImageLoader[]): Promise<ImageSource[]
 }
 
 export class Renderer {
-  private fontMapping = new Map<string | ByteBuf, Promise<RegisteredFamily[]>>();
+  private fontsByKey = new Map<string, Promise<RegisteredFamily[]>>();
+  private fontsByData = new WeakMap<ByteBuf, Promise<RegisteredFamily[]>>();
   private inner = new RendererInternal();
+
+  private getFont(key: string | ByteBuf) {
+    return typeof key === "string" ? this.fontsByKey.get(key) : this.fontsByData.get(key);
+  }
+
+  private setFont(key: string | ByteBuf, family: Promise<RegisteredFamily[]>) {
+    if (typeof key === "string") {
+      this.fontsByKey.set(key, family);
+    } else {
+      this.fontsByData.set(key, family);
+    }
+  }
+
+  private deleteFont(key: string | ByteBuf) {
+    if (typeof key === "string") {
+      this.fontsByKey.delete(key);
+    } else {
+      this.fontsByData.delete(key);
+    }
+  }
 
   private async prepareFonts(fonts: FontLoader[] | undefined) {
     if (!fonts) {
@@ -183,7 +204,7 @@ export class Renderer {
   async registerFont(font: FontLoader) {
     const key = createFontKey(font);
 
-    const cached = this.fontMapping.get(key);
+    const cached = this.getFont(key);
     if (cached) {
       return cached;
     }
@@ -196,17 +217,17 @@ export class Renderer {
     if (isBuffer(extracted)) {
       const binded = register(extracted);
 
-      this.fontMapping.set(key, Promise.resolve(binded));
+      this.setFont(key, Promise.resolve(binded));
 
       return binded;
     }
 
     const promise = extracted.then(register).catch((error) => {
-      this.fontMapping.delete(key);
+      this.deleteFont(key);
       throw error;
     });
 
-    this.fontMapping.set(key, promise);
+    this.setFont(key, promise);
 
     return promise;
   }

--- a/takumi-wasm/tsconfig.json
+++ b/takumi-wasm/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../tsconfig.base.json"
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  }
 }


### PR DESCRIPTION
## What

`Renderer.registerFont` (napi + wasm) cached registrations in a `Map` keyed by either a string descriptor or the font buffer itself. Buffer keys pinned the data for the renderer's lifetime, even after the caller dropped its reference.

Split the cache: buffer keys go in a `WeakMap` (released once nothing else holds the buffer), string descriptors stay in a `Map` (primitives can't be weak keys). Three small helpers route by key type so the narrowing typechecks.

## wasm typecheck fix

`takumi-wasm` couldn't resolve the `Buffer` global, so `ByteBuf = Uint8Array | ArrayBuffer | Buffer` referenced an unknown type and the font type guard collapsed to `never`, breaking `registerFont`/`extractFontBuffer`/`createFontKey`. `skipLibCheck` hid the underlying error since it lives in the generated `.d.ts`. napi only typechecked by accident — one of its tests does `import { Glob } from "bun"`, which pulls in `bun-types` for the whole program. Added `"types": ["bun"]` to the wasm tsconfig so the package typechecks on its own.

## Concurrency

The get-check-set in `registerFont` has no `await` between the cache read and write, so it stays atomic on the event loop — concurrent same-key calls still dedupe to one in-flight promise. The `WeakMap` adds no GC race: the in-scope buffer reference keeps the key alive for the call's duration.

## Verification

- `tsc --noEmit` clean for both packages (was 22 errors in wasm).
- `bun test` green: napi font/binary tests, all wasm tests (49 pass).

https://claude.ai/code/session_018MtirZ85oShW3PeRvvAQLx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized font caching implementation across renderers for improved performance and memory efficiency.
  * Enhanced error handling to ensure proper cache cleanup on font registration failures.

* **Chores**
  * Updated build configuration to support additional development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->