### PR TITLE
Helpers, NAPI, WASM: subset Google Fonts inside render

### DIFF
--- a/.tegami/google-fonts-object-api.md
+++ b/.tegami/google-fonts-object-api.md
@@ -1,0 +1,16 @@
+---
+packages:
+  "npm:@takumi-rs/helpers": minor
+---
+
+### Subset Google Fonts inside `render`
+
+`googleFonts({ families })` returns every coverage subset of each family, with its
+`unicode-range`, a distinct name under one `subsetOf`, and a stable key. `render`
+registers only the subsets the content draws, so a multilingual image pulls a
+handful of blocks instead of whole fonts. Set `subset: false` to register
+everything; call `subsetFonts({ fonts, source })` to trim a set yourself.
+
+This replaces `googleFont` and `googleFontSubsets` with one object-shaped
+`googleFonts`. Distinct subset names mean a glyph routes to the file that covers it
+rather than a same-named sibling that lacks it.

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -68,7 +68,7 @@ self.onmessage = async (event: MessageEvent) => {
 
         const [images, fonts] = await Promise.all([
           fetchResources(resourceUrls, { cache: fetchCache }),
-          googleFonts(GOOGLE_FONTS, { cache: fontCssCache }),
+          googleFonts({ families: GOOGLE_FONTS, cache: fontCssCache }),
         ]);
 
         const start = performance.now();

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -1,4 +1,4 @@
-import { fetchResources, extractResourceUrls, googleFontSubsets } from "takumi-js/helpers";
+import { fetchResources, extractResourceUrls, googleFonts } from "takumi-js/helpers";
 import { extractEmojis } from "takumi-js/helpers/emoji";
 import { fromJsx } from "takumi-js/helpers/jsx";
 import wasm, { init, Renderer } from "takumi-js/wasm";
@@ -68,7 +68,7 @@ self.onmessage = async (event: MessageEvent) => {
 
         const [images, fonts] = await Promise.all([
           fetchResources(resourceUrls, { cache: fetchCache }),
-          googleFontSubsets(node, GOOGLE_FONTS, { cache: fontCssCache }),
+          googleFonts(GOOGLE_FONTS, { cache: fontCssCache }),
         ]);
 
         const start = performance.now();

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -8,11 +8,10 @@ icon: Wrench
 
 ## Fonts
 
-| Helper                            | Use                                                                                                                                                 |
-| :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `googleFont(family, options?)`    | Load one Google Fonts family as `fonts` entries. See [Fonts & text](/docs/typography-and-fonts#from-google-fonts).                                  |
-| `googleFonts(families, options?)` | Load several families in one request; `render` keeps the subsets used. See [Multilingual content](/docs/typography-and-fonts#multilingual-content). |
-| `subsetFonts(fonts, source)`      | Trim font subsets to the codepoints `source` renders (what `render` does internally).                                                               |
+| Helper                           | Use                                                                                                                                           |
+| :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| `googleFonts(options)`           | Load Google Fonts families in one request; `render` keeps the subsets used. See [Fonts & text](/docs/typography-and-fonts#from-google-fonts). |
+| `subsetFonts({ fonts, source })` | Trim font subsets to the codepoints `source` renders (what `render` does internally).                                                         |
 
 ## Building nodes
 

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -8,10 +8,11 @@ icon: Wrench
 
 ## Fonts
 
-| Helper                                          | Use                                                                                                                    |
-| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
-| `googleFont(family, options?)`                  | Load one Google Fonts family as `fonts` entries. See [Fonts & text](/docs/typography-and-fonts#from-google-fonts).     |
-| `googleFontSubsets(source, families, options?)` | Load only the subsets your content needs. See [Multilingual content](/docs/typography-and-fonts#multilingual-content). |
+| Helper                            | Use                                                                                                                                                 |
+| :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `googleFont(family, options?)`    | Load one Google Fonts family as `fonts` entries. See [Fonts & text](/docs/typography-and-fonts#from-google-fonts).                                  |
+| `googleFonts(families, options?)` | Load several families in one request; `render` keeps the subsets used. See [Multilingual content](/docs/typography-and-fonts#multilingual-content). |
+| `subsetFonts(fonts, source)`      | Trim font subsets to the codepoints `source` renders (what `render` does internally).                                                               |
 
 ## Building nodes
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -64,26 +64,26 @@ fonts: await googleFont("Inter", { weight: 700, style: "italic", text: title }),
 
 ### Multilingual content
 
-`googleFontSubsets` loads only the subsets the content needs, for when you can't predict which scripts appear. Give it your content and the families to draw from. It scans the text, fetches each family's metadata in one request, and keeps the subsets that match.
+When you can't predict which scripts appear, load several families with `googleFonts` and let `render` trim them. It fetches every family's metadata in one request and returns all their coverage subsets; `render` scans the node tree and registers only the subsets the content draws, so unused scripts download nothing.
 
 ```tsx
 import { render } from "takumi-js";
-import { fromJsx } from "takumi-js/helpers/jsx";
-import { googleFontSubsets } from "takumi-js/helpers";
+import { googleFonts } from "takumi-js/helpers";
 
-const element = <div style={{ fontFamily: "Inter" }}>Hello 你好 こんにちは</div>;
-
-const { node } = await fromJsx(element);
-const fonts = await googleFontSubsets(node, ["Inter", "Noto Sans JP", "Noto Sans TC"]);
-
-const image = await render(node, { width: 1200, height: 630, fonts });
+const image = await render(<div style={{ fontFamily: "Inter" }}>Hello 你好 こんにちは</div>, {
+  width: 1200,
+  height: 630,
+  fonts: await googleFonts(["Inter", "Noto Sans JP", "Noto Sans TC"]),
+});
 ```
 
-Each subset registers under its own internal name. `font-family: Inter` still expands across all of them, so each script finds the file that covers it. Pass a `Map` as `cache` to reuse the metadata across renders, skipping the metadata fetch on each re-render.
+Each subset registers under its own internal name; `font-family: Inter` still expands across all of them, so each script finds the file that covers it. Pass a `Map` as `cache` to reuse the metadata across renders.
 
 ```tsx
-const fonts = await googleFontSubsets(node, ["Inter"], { cache });
+const fonts = await googleFonts(["Inter"], { cache });
 ```
+
+`render` trims the subsets itself, so the same `fonts` array works for any content. To trim ahead of time, or with `subset: false` to opt out of the automatic pass, call `subsetFonts(fonts, node)`.
 
 ### Preloading with `registerFont`
 
@@ -110,7 +110,7 @@ const image = await renderer.render(node, {
 });
 ```
 
-A missing glyph walks the chain until a family covers it. `googleFontSubsets` builds on this: each subset registers under its own internal name, while one logical family name in `font-family` expands across them.
+A missing glyph walks the chain until a family covers it. `googleFonts` builds on this: each subset registers under its own internal name, while one logical family name in `font-family` expands across them.
 
 ### Variable axes & OpenType features
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -38,33 +38,7 @@ The takumi-js functions `render`, `renderAnimation`, and `renderSvg` take the sa
 
 ### From Google Fonts
 
-`googleFont` fetches a family from Google Fonts and returns `fonts` entries. You get one lazy loader per `woff2` file. Each file downloads only when the renderer first needs it. Use the family by its name in `font-family`.
-
-```tsx
-import { render } from "takumi-js";
-import { googleFont } from "takumi-js/helpers";
-
-const image = await render(<div style={{ fontFamily: "Inter" }}>Hello</div>, {
-  width: 1200,
-  height: 630,
-  fonts: await googleFont("Inter", { weight: [400, 700] }),
-});
-```
-
-| Option    | Accepts                                            | Effect                                                        |
-| --------- | -------------------------------------------------- | ------------------------------------------------------------- |
-| `weight`  | one weight, an array, or a range like `"100..900"` | A range loads the variable font; CSS `font-weight` drives it. |
-| `style`   | `"normal"`, `"italic"`, or both                    | Which styles to fetch.                                        |
-| `text`    | a string                                           | Downloads only the glyphs that string uses.                   |
-| `display` | a `font-display` value                             | Maps to CSS `font-display`.                                   |
-
-```tsx
-fonts: await googleFont("Inter", { weight: 700, style: "italic", text: title }),
-```
-
-### Multilingual content
-
-When you can't predict which scripts appear, load several families with `googleFonts` and let `render` trim them. It fetches every family's metadata in one request and returns all their coverage subsets; `render` scans the node tree and registers only the subsets the content draws, so unused scripts download nothing.
+`googleFonts` fetches families from Google Fonts in one request and returns `fonts` entries: one lazy loader per coverage subset, downloaded when the renderer first needs it. `render` registers only the subsets the content draws, so unused weights and scripts download nothing. Reference each family by name in `font-family`.
 
 ```tsx
 import { render } from "takumi-js";
@@ -73,17 +47,26 @@ import { googleFonts } from "takumi-js/helpers";
 const image = await render(<div style={{ fontFamily: "Inter" }}>Hello 你好 こんにちは</div>, {
   width: 1200,
   height: 630,
-  fonts: await googleFonts(["Inter", "Noto Sans JP", "Noto Sans TC"]),
+  fonts: await googleFonts({ families: ["Inter", "Noto Sans JP", "Noto Sans TC"] }),
 });
 ```
 
-Each subset registers under its own internal name; `font-family: Inter` still expands across all of them, so each script finds the file that covers it. Pass a `Map` as `cache` to reuse the metadata across renders.
+Pass an object instead of a name to set a family's weight or style:
 
 ```tsx
-const fonts = await googleFonts(["Inter"], { cache });
+fonts: await googleFonts({ families: [{ family: "Inter", weight: [400, 700], style: "italic" }] }),
 ```
 
-`render` trims the subsets itself, so the same `fonts` array works for any content. To trim ahead of time, or with `subset: false` to opt out of the automatic pass, call `subsetFonts(fonts, node)`.
+| Option     | Accepts                                       | Effect                                                        |
+| ---------- | --------------------------------------------- | ------------------------------------------------------------- |
+| `families` | names, or `{ family, weight, style }` objects | The families to load.                                         |
+| `weight`   | a weight, an array, or a range `"100..900"`   | A range loads the variable font; CSS `font-weight` drives it. |
+| `style`    | `"normal"`, `"italic"`, or both               | Which styles to fetch.                                        |
+| `text`     | a string                                      | Downloads only the glyphs that string uses.                   |
+| `display`  | a `font-display` value                        | Maps to CSS `font-display`.                                   |
+| `cache`    | a `Map`                                       | Reuses the metadata CSS across renders.                       |
+
+Each subset registers under its own internal name; `font-family: Inter` expands across all of them, so each script finds the file that covers it. `render` trims the set to the content, so the same `fonts` work for any text. To trim ahead of time, or when `subset: false` opts out of the automatic pass, call `subsetFonts({ fonts, source })`, where `source` is the string, node, or node array you render.
 
 ### Preloading with `registerFont`
 

--- a/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
+++ b/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
@@ -1,5 +1,5 @@
 import type { ImageSource } from "takumi-js";
-import { googleFontSubsets } from "takumi-js/helpers";
+import { googleFonts } from "takumi-js/helpers";
 import { ImageResponse } from "takumi-js/response";
 import wasmModule from "takumi-js/wasm";
 import type { ApiContext } from "waku/router";
@@ -21,10 +21,7 @@ export async function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs
     return new Response(undefined, { status: 404 });
   }
 
-  const fonts = await googleFontSubsets(
-    `${page.data.title} ${page.data.description ?? ""} Takumi`,
-    ["Geist"],
-  );
+  const fonts = await googleFonts(["Geist"]);
 
   return new ImageResponse(
     <DocsTemplate

--- a/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
+++ b/docs/src/pages/_api/og/docs/[...slugs]/image.webp.tsx
@@ -21,7 +21,7 @@ export async function GET(_: Request, { params }: ApiContext<"/og/docs/[...slugs
     return new Response(undefined, { status: 404 });
   }
 
-  const fonts = await googleFonts(["Geist"]);
+  const fonts = await googleFonts({ families: ["Geist"] });
 
   return new ImageResponse(
     <DocsTemplate

--- a/example/twitter-images/components/google-fonts-showcase.tsx
+++ b/example/twitter-images/components/google-fonts-showcase.tsx
@@ -12,8 +12,8 @@ export const images = [{ src: "takumi.svg", path: "takumi.svg" }];
 type Greeting = { text: string; family: string; weight: number; size: number; accent?: boolean };
 
 // Greetings across scripts, each in a different Google Font. Latin chrome (brand, tagline)
-// runs in Inter. `googleFontSubsets` (see index.tsx) loads only the subsets this content
-// renders, one css2 request, and expands each family into its coverage subsets.
+// runs in Inter. `googleFonts` (see index.tsx) loads every family in one css2 request, and
+// `render` keeps only the coverage subsets this content actually draws.
 const greetings: Greeting[] = [
   { text: "Hello", family: "Poppins", weight: 700, size: 92, accent: true },
   { text: "你好", family: "Noto Sans SC", weight: 700, size: 100 },

--- a/example/twitter-images/index.tsx
+++ b/example/twitter-images/index.tsx
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { type OutputFormat } from "takumi-js";
 import { Renderer } from "takumi-js/node";
 import { fromJsx } from "takumi-js/helpers/jsx";
-import { googleFontSubsets } from "takumi-js/helpers";
+import { googleFonts } from "takumi-js/helpers";
 import * as FiveHundredStars from "./components/500-stars";
 import * as GithubSocialPreview from "./components/github-social-preview";
 import * as OgImage from "./components/og-image";
@@ -57,7 +57,7 @@ async function render(
     })),
   );
   const loaders = fontLoaders(module);
-  const subsets = "googleFonts" in module ? await googleFontSubsets(node, module.googleFonts) : [];
+  const subsets = "googleFonts" in module ? await googleFonts(module.googleFonts) : [];
   const fonts = [...loaders, ...subsets];
   const renderStart = performance.now();
 

--- a/example/twitter-images/index.tsx
+++ b/example/twitter-images/index.tsx
@@ -57,7 +57,8 @@ async function render(
     })),
   );
   const loaders = fontLoaders(module);
-  const subsets = "googleFonts" in module ? await googleFonts(module.googleFonts) : [];
+  const subsets =
+    "googleFonts" in module ? await googleFonts({ families: module.googleFonts }) : [];
   const fonts = [...loaders, ...subsets];
   const renderStart = performance.now();
 

--- a/example/twitter-images/render-video.tsx
+++ b/example/twitter-images/render-video.tsx
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Renderer } from "takumi-js/node";
 import { fromJsx } from "takumi-js/helpers/jsx";
-import { googleFontSubsets } from "takumi-js/helpers";
+import { googleFonts } from "takumi-js/helpers";
 
 // Logical width; rendered straight to 1080p (devicePixelRatio keeps it crisp, no supersample).
 const W = 1600;
@@ -146,7 +146,7 @@ const framesPerSeg = Math.round((FPS * SEG_MS) / 1000);
 
 for (const seg of segments) {
   const { node } = await fromJsx(still(seg));
-  const fonts = await googleFontSubsets(node, [
+  const fonts = await googleFonts([
     { family: seg.family, weight: seg.weight },
     { family: UI, weight: 600 },
   ]);

--- a/example/twitter-images/render-video.tsx
+++ b/example/twitter-images/render-video.tsx
@@ -146,10 +146,12 @@ const framesPerSeg = Math.round((FPS * SEG_MS) / 1000);
 
 for (const seg of segments) {
   const { node } = await fromJsx(still(seg));
-  const fonts = await googleFonts([
-    { family: seg.family, weight: seg.weight },
-    { family: UI, weight: 600 },
-  ]);
+  const fonts = await googleFonts({
+    families: [
+      { family: seg.family, weight: seg.weight },
+      { family: UI, weight: 600 },
+    ],
+  });
   const renderer = new Renderer();
   for (let f = 0; f < framesPerSeg; f++) {
     const buf = await renderer.render(node, {

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -75,32 +75,8 @@ type SubsetFace = {
   ranges: [number, number][];
 };
 
-/**
- * Load a Google Font as descriptors you can pass to a renderer's `fonts`. Fetches the
- * Google Fonts CSS, reads the `woff2` URLs, and returns one loader per file. Each file
- * downloads when the renderer first needs it; the renderer skips files it already loaded.
- *
- * @example
- * fonts: await googleFont("Inter", { weight: [400, 700] })
- * @example
- * fonts: await googleFont("Inter", { weight: "100..900" }) // variable
- * @example
- * fonts: await googleFont("Inter", { weight: 700, style: "italic", text: "Hello" })
- */
-export async function googleFont(family: string, options: GoogleFontOptions = {}) {
-  const css = await fetchCss(buildCssUrl(family, options), options);
-
-  return parseSubsetFaces(css).map((face) => ({
-    name: family,
-    key: face.url,
-    weight: face.weight,
-    style: face.style,
-    data: () => fetchOk(face.url, options).then((r) => r.arrayBuffer()),
-  }));
-}
-
-/** A loaded Google Font subset, ready to hand to a renderer's `fonts`. */
-export type GoogleFontSubset = {
+/** A loaded font subset, ready to hand to a renderer's `fonts`. */
+export type FontSubset = {
   /** Unique internal family name (`"{family} {subset}"`); never written in CSS. */
   name: string;
   /** Logical family authors reference in `font-family`; expands to every loaded subset. */
@@ -109,9 +85,47 @@ export type GoogleFontSubset = {
   key: string;
   weight?: number;
   style?: string;
+  /** Inclusive codepoint ranges this subset covers; empty means it covers everything. */
+  ranges: [number, number][];
   /** Fetches the subset bytes; the renderer skips files it has already loaded. */
   data: () => Promise<ArrayBuffer>;
 };
+
+function toSubset(face: SubsetFace, options: FetchOptions): FontSubset {
+  return {
+    name: `${face.family} ${face.subset}`,
+    subsetOf: face.family,
+    key: face.url,
+    weight: face.weight,
+    style: face.style,
+    ranges: face.ranges,
+    data: () => fetchOk(face.url, options).then((r) => r.arrayBuffer()),
+  };
+}
+
+/**
+ * Load one Google Font family as subset descriptors you can pass to a renderer's `fonts`.
+ * Each subset keeps its `unicode-range`, registers uniquely-named under its `subsetOf`
+ * family (which `font-family: {family}` expands across), and downloads only when the
+ * renderer first needs it — so glyphs route to the subset that covers them, never to a
+ * same-named sibling that lacks them. Pass the result straight to `render`, which drops
+ * the subsets the content doesn't use; or trim them yourself with {@link subsetFonts}.
+ *
+ * @example
+ * fonts: await googleFont("Inter", { weight: [400, 700] })
+ * @example
+ * fonts: await googleFont("Inter", { weight: "100..900" }) // variable
+ * @example
+ * fonts: await googleFont("Inter", { weight: 700, style: "italic", text: "Hello" })
+ */
+export async function googleFont(
+  family: string,
+  options: GoogleFontOptions = {},
+): Promise<FontSubset[]> {
+  const css = await fetchCss(buildCssUrl(family, options), options);
+
+  return parseSubsetFaces(css).map((face) => toSubset(face, options));
+}
 
 /** A Google family to load, plus how — same options as {@link googleFont} minus `text`. */
 export type GoogleFontFamily = string | ({ family: string } & Omit<GoogleFontOptions, "text">);
@@ -184,7 +198,7 @@ function parseSubsetFaces(css: string): SubsetFace[] {
 }
 
 /** Collect every codepoint the content will render. */
-function collectCodepoints(source: string | Node | Node[]): Set<number> {
+export function collectCodepoints(source: string | Node | Node[]): Set<number> {
   const codepoints = new Set<number>();
 
   const add = (text: string) => {
@@ -227,7 +241,19 @@ function rangesCover(ranges: [number, number][], codepoints: Set<number>): boole
   return false;
 }
 
-export type GoogleFontSubsetsOptions = FetchOptions & {
+/** Drop the subsets `source` never renders, keeping each covering one and any range-less
+ * fallback (a full font, or a `text=` Google subset). Pure — no network — so a renderer can
+ * run it on the final node tree without re-fetching. Works on any descriptor carrying
+ * `ranges`; entries without it are always kept. */
+export function subsetFonts<T>(fonts: T[], source: string | Node | Node[]): T[] {
+  const codepoints = collectCodepoints(source);
+
+  return fonts.filter((font) =>
+    rangesCover((font as { ranges?: [number, number][] }).ranges ?? [], codepoints),
+  );
+}
+
+export type GoogleFontsOptions = FetchOptions & {
   /**
    * Cache for the Google Fonts CSS, keyed by request URL. Reuse one across renders (e.g. a
    * playground re-rendering on every edit) so the metadata is fetched and parsed only once.
@@ -244,7 +270,7 @@ function buildSubsetsUrl(specs: Exclude<GoogleFontFamily, string>[]) {
   return url.toString();
 }
 
-async function fetchSubsetsCss(url: string, options: GoogleFontSubsetsOptions) {
+async function fetchSubsetsCss(url: string, options: GoogleFontsOptions) {
   const cached = options.cache?.get(url);
   if (cached !== undefined) {
     return cached;
@@ -256,33 +282,21 @@ async function fetchSubsetsCss(url: string, options: GoogleFontSubsetsOptions) {
 }
 
 /**
- * Load only the Google Font subsets that `source` actually renders: scan its codepoints,
- * fetch every family's metadata in ONE css2 request, and keep just the intersecting
- * `unicode-range` subsets. Each registers uniquely-named under its `subsetOf` family, which
- * `font-family: {family}` expands across, so every script routes to the subset that covers
- * it. No font anxiety.
+ * Load several Google Font families in ONE css2 request, returning every subset descriptor
+ * (see {@link googleFont}). Hand the result to `render`, which keeps only the subsets the
+ * content uses; or pre-trim with {@link subsetFonts}. Subsets download lazily, so the unused
+ * ones cost nothing.
  *
  * @example
- * const fonts = await googleFontSubsets(element, ["Inter", "Noto Sans JP"]);
+ * const fonts = await googleFonts(["Inter", "Noto Sans JP"]);
  * await render(element, { width, height, fonts });
  */
-export async function googleFontSubsets(
-  source: string | Node | Node[],
+export async function googleFonts(
   families: GoogleFontFamily[],
-  options: GoogleFontSubsetsOptions = {},
-): Promise<GoogleFontSubset[]> {
-  const codepoints = collectCodepoints(source);
+  options: GoogleFontsOptions = {},
+): Promise<FontSubset[]> {
   const specs = families.map((family) => (typeof family === "string" ? { family } : family));
   const css = await fetchSubsetsCss(buildSubsetsUrl(specs), options);
 
-  return parseSubsetFaces(css)
-    .filter((face) => rangesCover(face.ranges, codepoints))
-    .map((face) => ({
-      name: `${face.family} ${face.subset}`,
-      subsetOf: face.family,
-      key: face.url,
-      weight: face.weight,
-      style: face.style,
-      data: () => fetchOk(face.url, options).then((r) => r.arrayBuffer()),
-    }));
+  return parseSubsetFaces(css).map((face) => toSubset(face, options));
 }

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -269,11 +269,15 @@ export function subsetFonts<T>({
 }
 
 /** Apply {@link subsetFonts} unless `subset` is `false`. Passes `undefined` fonts through. */
-export function pickFonts<T>(
-  fonts: T[] | undefined,
-  source: string | Node | Node[],
-  subset: boolean | undefined,
-): T[] | undefined {
+export function pickFonts<T>({
+  fonts,
+  source,
+  subset,
+}: {
+  fonts: T[] | undefined;
+  source: string | Node | Node[];
+  subset?: boolean;
+}): T[] | undefined {
   return fonts && subset !== false ? subsetFonts({ fonts, source }) : fonts;
 }
 

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -6,25 +6,39 @@ const chromeUserAgent =
 
 type FontStyle = "normal" | "italic";
 
-export type GoogleFontOptions = FetchOptions & {
-  /**
-   * `400` for one weight, `[400, 700]` for several, or a range like `"100..900"` to load
-   * the variable font. A range leaves the weight unset so CSS `font-weight` controls it.
-   * @default 400
-   */
-  weight?: number | number[] | `${number}..${number}`;
-  /** `"normal"`, `"italic"`, or both. @default "normal" */
-  style?: FontStyle | FontStyle[];
-  /** Limit the download to the glyphs used in this text. Recommended for OG images. */
+/** One family to load. A bare string loads weight 400, normal style. */
+export type GoogleFontFamily =
+  | string
+  | {
+      family: string;
+      /** `400`, `[400, 700]`, or a range like `"100..900"` for the variable font. @default 400 */
+      weight?: number | number[] | `${number}..${number}`;
+      /** `"normal"`, `"italic"`, or both. @default "normal" */
+      style?: FontStyle | FontStyle[];
+    };
+
+export type GoogleFontsOptions = FetchOptions & {
+  /** The families to load, each as a name or a name plus its weight/style axis. */
+  families: GoogleFontFamily[];
+  /** Download only the glyphs this text uses. Drops each subset's `unicode-range`. */
   text?: string;
   /** `font-display` strategy passed through to the CSS request. */
   display?: "auto" | "block" | "swap" | "fallback" | "optional";
+  /**
+   * Cache for the Google Fonts CSS, keyed by request URL. Reuse one across renders (e.g. a
+   * playground re-rendering on each edit) so the metadata is fetched and parsed once.
+   */
+  cache?: Pick<Map<string, string>, "has" | "get" | "set">;
 };
 
 const GOOGLE_FONTS_CSS = "https://fonts.googleapis.com/css2";
 
-/** The `family=` value for one family + its weight/style axis, e.g. `Inter:wght@400`. */
-function familyValue(family: string, { weight = 400, style = "normal" }: GoogleFontOptions) {
+/** The `family=` value for one family plus its weight/style axis, e.g. `Inter:wght@400`. */
+function familyValue({
+  family,
+  weight = 400,
+  style = "normal",
+}: Exclude<GoogleFontFamily, string>) {
   const weights = (Array.isArray(weight) ? [...weight].sort((a, b) => a - b) : [weight]).map(
     String,
   );
@@ -44,9 +58,14 @@ function familyValue(family: string, { weight = 400, style = "normal" }: GoogleF
   return `${family}:${axis}`;
 }
 
-function buildCssUrl(family: string, options: GoogleFontOptions) {
+function buildUrl(options: GoogleFontsOptions) {
   const url = new URL(GOOGLE_FONTS_CSS);
-  url.searchParams.append("family", familyValue(family, options));
+  for (const family of options.families) {
+    url.searchParams.append(
+      "family",
+      familyValue(typeof family === "string" ? { family } : family),
+    );
+  }
   if (options.display) {
     url.searchParams.set("display", options.display);
   }
@@ -63,10 +82,21 @@ function fetchCss(url: string, options: FetchOptions) {
   }).then((r) => r.text());
 }
 
+async function fetchCssCached(url: string, options: GoogleFontsOptions) {
+  const cached = options.cache?.get(url);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const css = await fetchCss(url, options);
+  options.cache?.set(url, css);
+  return css;
+}
+
 const fontFaceBlockPattern = /(?:\/\*\s*([^*]+?)\s*\*\/\s*)?@font-face\s*\{([^}]*)\}/g;
 
 type SubsetFace = {
-  /** Logical family from the block's `font-family` (groups subsets across one request). */
+  /** Logical family from the block's `font-family`; groups subsets across one request. */
   family: string;
   subset: string;
   url: string;
@@ -81,54 +111,32 @@ export type FontSubset = {
   name: string;
   /** Logical family authors reference in `font-family`; expands to every loaded subset. */
   subsetOf: string;
-  /** Subset woff2 URL, also the dedup key. */
+  /** Stable dedup key (`"{name}:{weight}:{style}:{range}"`), independent of the rotating woff2 URL. */
   key: string;
   weight?: number;
   style?: string;
-  /** Inclusive codepoint ranges this subset covers; empty means it covers everything. */
+  /** Inclusive codepoint ranges this subset covers; empty covers everything. */
   ranges: [number, number][];
-  /** Fetches the subset bytes; the renderer skips files it has already loaded. */
+  /** Fetches the subset bytes. The renderer skips files it has already loaded. */
   data: () => Promise<ArrayBuffer>;
 };
 
 function toSubset(face: SubsetFace, options: FetchOptions): FontSubset {
+  const name = `${face.family} ${face.subset}`;
+  const range = face.ranges.map(([lo, hi]) => `${lo}-${hi}`).join(",");
+
   return {
-    name: `${face.family} ${face.subset}`,
+    name,
     subsetOf: face.family,
-    key: face.url,
+    // Stable coverage identity, not the woff2 URL Google may rotate, so the renderer dedups
+    // across calls yet never merges two subsets that cover different ranges.
+    key: `${name}:${face.weight ?? ""}:${face.style ?? ""}:${range}`,
     weight: face.weight,
     style: face.style,
     ranges: face.ranges,
     data: () => fetchOk(face.url, options).then((r) => r.arrayBuffer()),
   };
 }
-
-/**
- * Load one Google Font family as subset descriptors you can pass to a renderer's `fonts`.
- * Each subset keeps its `unicode-range`, registers uniquely-named under its `subsetOf`
- * family (which `font-family: {family}` expands across), and downloads only when the
- * renderer first needs it — so glyphs route to the subset that covers them, never to a
- * same-named sibling that lacks them. Pass the result straight to `render`, which drops
- * the subsets the content doesn't use; or trim them yourself with {@link subsetFonts}.
- *
- * @example
- * fonts: await googleFont("Inter", { weight: [400, 700] })
- * @example
- * fonts: await googleFont("Inter", { weight: "100..900" }) // variable
- * @example
- * fonts: await googleFont("Inter", { weight: 700, style: "italic", text: "Hello" })
- */
-export async function googleFont(
-  family: string,
-  options: GoogleFontOptions = {},
-): Promise<FontSubset[]> {
-  const css = await fetchCss(buildCssUrl(family, options), options);
-
-  return parseSubsetFaces(css).map((face) => toSubset(face, options));
-}
-
-/** A Google family to load, plus how — same options as {@link googleFont} minus `text`. */
-export type GoogleFontFamily = string | ({ family: string } & Omit<GoogleFontOptions, "text">);
 
 /** Parse `U+0460-052F, U+20B4, U+30??` into inclusive `[lo, hi]` codepoint ranges. */
 function parseUnicodeRange(value: string): [number, number][] {
@@ -241,11 +249,18 @@ function rangesCover(ranges: [number, number][], codepoints: Set<number>): boole
   return false;
 }
 
-/** Drop the subsets `source` never renders, keeping each covering one and any range-less
- * fallback (a full font, or a `text=` Google subset). Pure — no network — so a renderer can
- * run it on the final node tree without re-fetching. Works on any descriptor carrying
- * `ranges`; entries without it are always kept. */
-export function subsetFonts<T>(fonts: T[], source: string | Node | Node[]): T[] {
+/**
+ * Keep the subsets `source` renders, dropping the rest. Range-less fallbacks (a full font or a
+ * `text=` subset) always stay. Runs without network, so a renderer can apply it to the final
+ * node tree. Works on any descriptor carrying `ranges`; entries without it are kept.
+ */
+export function subsetFonts<T>({
+  fonts,
+  source,
+}: {
+  fonts: T[];
+  source: string | Node | Node[];
+}): T[] {
   const codepoints = collectCodepoints(source);
 
   return fonts.filter((font) =>
@@ -253,50 +268,32 @@ export function subsetFonts<T>(fonts: T[], source: string | Node | Node[]): T[] 
   );
 }
 
-export type GoogleFontsOptions = FetchOptions & {
-  /**
-   * Cache for the Google Fonts CSS, keyed by request URL. Reuse one across renders (e.g. a
-   * playground re-rendering on every edit) so the metadata is fetched and parsed only once.
-   */
-  cache?: Pick<Map<string, string>, "has" | "get" | "set">;
-};
-
-/** One css2 request for every family — Google returns all their subsets in a single CSS. */
-function buildSubsetsUrl(specs: Exclude<GoogleFontFamily, string>[]) {
-  const url = new URL(GOOGLE_FONTS_CSS);
-  for (const spec of specs) {
-    url.searchParams.append("family", familyValue(spec.family, spec));
-  }
-  return url.toString();
-}
-
-async function fetchSubsetsCss(url: string, options: GoogleFontsOptions) {
-  const cached = options.cache?.get(url);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const css = await fetchCss(url, options);
-  options.cache?.set(url, css);
-  return css;
+/** Apply {@link subsetFonts} unless `subset` is `false`. Passes `undefined` fonts through. */
+export function pickFonts<T>(
+  fonts: T[] | undefined,
+  source: string | Node | Node[],
+  subset: boolean | undefined,
+): T[] | undefined {
+  return fonts && subset !== false ? subsetFonts({ fonts, source }) : fonts;
 }
 
 /**
- * Load several Google Font families in ONE css2 request, returning every subset descriptor
- * (see {@link googleFont}). Hand the result to `render`, which keeps only the subsets the
- * content uses; or pre-trim with {@link subsetFonts}. Subsets download lazily, so the unused
- * ones cost nothing.
+ * Load Google Font families in one css2 request, returning every coverage subset. Each keeps
+ * its `unicode-range` and registers uniquely-named under its `subsetOf` family, which
+ * `font-family: {family}` expands across, so a glyph routes to the subset that covers it.
+ * Subsets download lazily. Hand the result to `render`, which registers only the subsets the
+ * content uses; or trim them first with {@link subsetFonts}.
  *
  * @example
- * const fonts = await googleFonts(["Inter", "Noto Sans JP"]);
+ * const fonts = await googleFonts({ families: ["Inter", "Noto Sans JP"] });
  * await render(element, { width, height, fonts });
  */
-export async function googleFonts(
-  families: GoogleFontFamily[],
-  options: GoogleFontsOptions = {},
-): Promise<FontSubset[]> {
-  const specs = families.map((family) => (typeof family === "string" ? { family } : family));
-  const css = await fetchSubsetsCss(buildSubsetsUrl(specs), options);
+export async function googleFonts(options: GoogleFontsOptions): Promise<FontSubset[]> {
+  if (options.families.length === 0) {
+    return [];
+  }
+
+  const css = await fetchCssCached(buildUrl(options), options);
 
   return parseSubsetFaces(css).map((face) => toSubset(face, options));
 }

--- a/takumi-helpers/test/fonts.test.ts
+++ b/takumi-helpers/test/fonts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { googleFont, googleFonts, subsetFonts } from "../src/fonts";
+import { googleFonts, subsetFonts } from "../src/fonts";
 import type { Node } from "../src/types";
 
 const bytes = (s: string) => new TextEncoder().encode(s).buffer;
@@ -37,7 +37,7 @@ const mockInter = () =>
     Promise.resolve(url.includes("/css2") ? new Response(interCss) : new Response(bytes(url))),
   );
 
-describe("googleFont", () => {
+describe("googleFonts", () => {
   const twoWeightCss = `
     @font-face {
       font-family: 'Inter';
@@ -53,26 +53,8 @@ describe("googleFont", () => {
     }
   `;
 
-  test("resolves every weight to a keyed loader under one subsetOf", async () => {
-    const fetchMock = mock((url: string) =>
-      Promise.resolve(
-        url.includes("/css2") ? new Response(twoWeightCss) : new Response(bytes(url)),
-      ),
-    );
-
-    const fonts = await googleFont("Inter", { weight: [400, 700], fetch: fetchMock });
-
-    expect(fonts).toHaveLength(2);
-    expect(fonts.map((f) => f.weight).sort()).toEqual([400, 700]);
-    expect(fonts.every((f) => f.subsetOf === "Inter")).toBe(true);
-    expect(fonts.map((f) => f.key).sort()).toEqual([
-      "https://fonts.gstatic.com/inter-400.woff2",
-      "https://fonts.gstatic.com/inter-700.woff2",
-    ]);
-  });
-
   test("gives each coverage subset a distinct name so glyphs can't collide", async () => {
-    const fonts = await googleFont("Inter", { fetch: mockInter() });
+    const fonts = await googleFonts({ families: ["Inter"], fetch: mockInter() });
 
     // Same family, three faces — distinct names, each carrying its own range.
     expect(fonts.map((f) => f.name).sort()).toEqual([
@@ -84,18 +66,26 @@ describe("googleFont", () => {
     expect(fonts.find((f) => f.name === "Inter latin")!.ranges).toEqual([[0x0, 0xff]]);
   });
 
-  test("downloads bytes lazily — only the CSS is fetched up front", async () => {
-    const fetchMock = mockInter();
+  test("resolves every weight to a keyed loader under one subsetOf", async () => {
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(
+        url.includes("/css2") ? new Response(twoWeightCss) : new Response(bytes(url)),
+      ),
+    );
 
-    const fonts = await googleFont("Inter", { fetch: fetchMock });
+    const fonts = await googleFonts({
+      families: [{ family: "Inter", weight: [400, 700] }],
+      fetch: fetchMock,
+    });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    await fonts[0]!.data();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fonts.map((f) => f.weight).sort()).toEqual([400, 700]);
+    expect(fonts.every((f) => f.subsetOf === "Inter")).toBe(true);
+    // Keys are stable composites of identity, not the woff2 URL, and unique per face.
+    expect(new Set(fonts.map((f) => f.key)).size).toBe(2);
+    expect(fonts.every((f) => !f.key.includes("gstatic"))).toBe(true);
   });
 
-  test("requests the right family/axis and a woff2 UA", async () => {
+  test("builds the family/axis and sends a woff2 UA", async () => {
     let requestedUrl = "";
     let ua = "";
     const fetchMock = mock((url: string, init?: RequestInit) => {
@@ -107,9 +97,8 @@ describe("googleFont", () => {
       return Promise.resolve(new Response(bytes(url)));
     });
 
-    await googleFont("Open Sans", {
-      weight: [700, 400],
-      style: ["normal", "italic"],
+    await googleFonts({
+      families: [{ family: "Open Sans", weight: [700, 400], style: ["normal", "italic"] }],
       fetch: fetchMock,
     });
 
@@ -136,23 +125,14 @@ describe("googleFont", () => {
       );
     });
 
-    const fonts = await googleFont("Inter", { weight: "100..900", fetch: fetchMock });
+    const fonts = await googleFonts({
+      families: [{ family: "Inter", weight: "100..900" }],
+      fetch: fetchMock,
+    });
 
     expect(new URL(requestedUrl).searchParams.get("family")).toBe("Inter:wght@100..900");
     expect(fonts).toHaveLength(1);
     expect(fonts[0]!.weight).toBeUndefined();
-  });
-});
-
-describe("googleFonts", () => {
-  test("returns every subset, distinctly named, without filtering", async () => {
-    const fonts = await googleFonts(["Inter"], { fetch: mockInter() });
-
-    expect(fonts.map((f) => f.name).sort()).toEqual([
-      "Inter cyrillic",
-      "Inter greek",
-      "Inter latin",
-    ]);
   });
 
   test("requests every family in a single css2 call", async () => {
@@ -164,19 +144,35 @@ describe("googleFonts", () => {
       );
     });
 
-    await googleFonts(["Inter", "Noto Sans JP"], { fetch: fetchMock });
+    await googleFonts({ families: ["Inter", "Noto Sans JP"], fetch: fetchMock });
 
     const families = new URL(requestedUrl).searchParams.getAll("family");
     expect(families).toEqual(["Inter:wght@400", "Noto Sans JP:wght@400"]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  test("passes text and display through to the CSS request", async () => {
+    let requestedUrl = "";
+    const fetchMock = mock((url: string) => {
+      if (url.includes("/css2")) requestedUrl = url;
+      return Promise.resolve(
+        url.includes("/css2") ? new Response(interCss) : new Response(bytes(url)),
+      );
+    });
+
+    await googleFonts({ families: ["Inter"], text: "Hello", display: "swap", fetch: fetchMock });
+
+    const params = new URL(requestedUrl).searchParams;
+    expect(params.get("text")).toBe("Hello");
+    expect(params.get("display")).toBe("swap");
+  });
+
   test("reuses the CSS cache across calls, fetching metadata once", async () => {
     const fetchMock = mockInter();
     const cache = new Map<string, string>();
 
-    await googleFonts(["Inter"], { fetch: fetchMock, cache });
-    await googleFonts(["Inter"], { fetch: fetchMock, cache });
+    await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
+    await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
 
     const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
     expect(cssCalls).toHaveLength(1);
@@ -184,29 +180,36 @@ describe("googleFonts", () => {
 
   test("downloads subset bytes lazily — only CSS up front", async () => {
     const fetchMock = mockInter();
-    const fonts = await googleFonts(["Inter"], { fetch: fetchMock });
+    const fonts = await googleFonts({ families: ["Inter"], fetch: fetchMock });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     await fonts[0]!.data();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  test("returns nothing for an empty families list without a request", async () => {
+    const fetchMock = mockInter();
+
+    expect(await googleFonts({ families: [], fetch: fetchMock })).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("subsetFonts", () => {
   test("keeps only the subsets the text renders", async () => {
-    const fonts = await googleFonts(["Inter"], { fetch: mockInter() });
+    const fonts = await googleFonts({ families: ["Inter"], fetch: mockInter() });
 
-    expect(subsetFonts(fonts, "Hi").map((f) => f.name)).toEqual(["Inter latin"]);
-    expect(subsetFonts(fonts, "Привет").map((f) => f.name)).toEqual(["Inter cyrillic"]);
+    expect(subsetFonts({ fonts, source: "Hi" }).map((f) => f.name)).toEqual(["Inter latin"]);
+    expect(subsetFonts({ fonts, source: "Привет" }).map((f) => f.name)).toEqual(["Inter cyrillic"]);
     expect(
-      subsetFonts(fonts, "Hi Привет Γειά")
+      subsetFonts({ fonts, source: "Hi Привет Γειά" })
         .map((f) => f.name)
         .sort(),
     ).toEqual(["Inter cyrillic", "Inter greek", "Inter latin"]);
   });
 
   test("scans a node tree for codepoints", async () => {
-    const fonts = await googleFonts(["Inter"], { fetch: mockInter() });
+    const fonts = await googleFonts({ families: ["Inter"], fetch: mockInter() });
     const node: Node = {
       type: "container",
       children: [
@@ -216,7 +219,7 @@ describe("subsetFonts", () => {
     };
 
     expect(
-      subsetFonts(fonts, node)
+      subsetFonts({ fonts, source: node })
         .map((f) => f.name)
         .sort(),
     ).toEqual(["Inter greek", "Inter latin"]);
@@ -231,13 +234,16 @@ describe("subsetFonts", () => {
     };
 
     // "Hi" is Latin only: the ranged Greek subset drops, the range-less fallback stays.
-    expect(subsetFonts([fallback, greek], "Hi")).toEqual([fallback]);
+    expect(subsetFonts({ fonts: [fallback, greek], source: "Hi" })).toEqual([fallback]);
   });
 
   test("regression: a multi-subset family can't tofu — covering subset survives, sibling drops", async () => {
     // The bug: same-named subsets collide so a glyph routes to a file lacking it.
     // The fix: googleFonts names subsets distinctly + subsetFonts keeps the covering one by range.
-    const fonts = subsetFonts(await googleFonts(["Inter"], { fetch: mockInter() }), "Hello");
+    const fonts = subsetFonts({
+      fonts: await googleFonts({ families: ["Inter"], fetch: mockInter() }),
+      source: "Hello",
+    });
 
     expect(fonts).toHaveLength(1);
     expect(fonts[0]!.name).toBe("Inter latin");

--- a/takumi-helpers/test/fonts.test.ts
+++ b/takumi-helpers/test/fonts.test.ts
@@ -1,11 +1,44 @@
 import { describe, expect, mock, test } from "bun:test";
-import { googleFont, googleFontSubsets } from "../src/fonts";
+import { googleFont, googleFonts, subsetFonts } from "../src/fonts";
 import type { Node } from "../src/types";
 
 const bytes = (s: string) => new TextEncoder().encode(s).buffer;
 
+/** Realistic multi-subset CSS: three same-named faces split by `unicode-range`. */
+const interCss = `
+  /* cyrillic */
+  @font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400;
+    src: url(https://fonts.gstatic.com/inter-cyrillic.woff2) format('woff2');
+    unicode-range: U+0400-045F;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400;
+    src: url(https://fonts.gstatic.com/inter-greek.woff2) format('woff2');
+    unicode-range: U+0370-03FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400;
+    src: url(https://fonts.gstatic.com/inter-latin.woff2) format('woff2');
+    unicode-range: U+0000-00FF;
+  }
+`;
+
+const mockInter = () =>
+  mock((url: string) =>
+    Promise.resolve(url.includes("/css2") ? new Response(interCss) : new Response(bytes(url))),
+  );
+
 describe("googleFont", () => {
-  const css = `
+  const twoWeightCss = `
     @font-face {
       font-family: 'Inter';
       font-style: normal;
@@ -20,58 +53,46 @@ describe("googleFont", () => {
     }
   `;
 
-  test("resolves every weight in the CSS to a keyed loader", async () => {
+  test("resolves every weight to a keyed loader under one subsetOf", async () => {
     const fetchMock = mock((url: string) =>
-      Promise.resolve(url.includes("/css2") ? new Response(css) : new Response(bytes(url))),
+      Promise.resolve(
+        url.includes("/css2") ? new Response(twoWeightCss) : new Response(bytes(url)),
+      ),
     );
 
     const fonts = await googleFont("Inter", { weight: [400, 700], fetch: fetchMock });
 
     expect(fonts).toHaveLength(2);
     expect(fonts.map((f) => f.weight).sort()).toEqual([400, 700]);
-    expect(fonts.every((f) => f.name === "Inter")).toBe(true);
+    expect(fonts.every((f) => f.subsetOf === "Inter")).toBe(true);
     expect(fonts.map((f) => f.key).sort()).toEqual([
       "https://fonts.gstatic.com/inter-400.woff2",
       "https://fonts.gstatic.com/inter-700.woff2",
     ]);
   });
 
-  test("downloads bytes lazily — only the CSS is fetched up front", async () => {
-    const robotoCss = `
-      @font-face {
-        font-family: 'Roboto';
-        font-style: normal;
-        font-weight: 400;
-        src: url(https://fonts.gstatic.com/roboto-400.woff2) format('woff2');
-      }
-    `;
-    const fetchMock = mock((url: string) =>
-      Promise.resolve(url.includes("/css2") ? new Response(robotoCss) : new Response(bytes(url))),
-    );
+  test("gives each coverage subset a distinct name so glyphs can't collide", async () => {
+    const fonts = await googleFont("Inter", { fetch: mockInter() });
 
-    const fonts = await googleFont("Roboto", { weight: 400, fetch: fetchMock });
-
-    // Only the CSS request so far — no font bytes fetched until data() is called.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    const [loader] = fonts;
-    const data = await loader!.data();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(new TextDecoder().decode(data)).toBe("https://fonts.gstatic.com/roboto-400.woff2");
+    // Same family, three faces — distinct names, each carrying its own range.
+    expect(fonts.map((f) => f.name).sort()).toEqual([
+      "Inter cyrillic",
+      "Inter greek",
+      "Inter latin",
+    ]);
+    expect(fonts.every((f) => f.subsetOf === "Inter")).toBe(true);
+    expect(fonts.find((f) => f.name === "Inter latin")!.ranges).toEqual([[0x0, 0xff]]);
   });
 
-  test("attaches an abort signal to every request when timeout is set", async () => {
-    const inits: (RequestInit | undefined)[] = [];
-    const fetchMock = mock((url: string, init?: RequestInit) => {
-      inits.push(init);
-      return Promise.resolve(url.includes("/css2") ? new Response(css) : new Response(bytes(url)));
-    });
+  test("downloads bytes lazily — only the CSS is fetched up front", async () => {
+    const fetchMock = mockInter();
 
-    const fonts = await googleFont("Inter", { weight: 400, timeout: 5000, fetch: fetchMock });
+    const fonts = await googleFont("Inter", { fetch: fetchMock });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
     await fonts[0]!.data();
-
-    expect(inits).toHaveLength(2);
-    expect(inits.every((init) => init?.signal instanceof AbortSignal)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test("requests the right family/axis and a woff2 UA", async () => {
@@ -81,7 +102,7 @@ describe("googleFont", () => {
       if (url.includes("/css2")) {
         requestedUrl = url;
         ua = new Headers(init?.headers).get("User-Agent") ?? "";
-        return Promise.resolve(new Response(css));
+        return Promise.resolve(new Response(twoWeightCss));
       }
       return Promise.resolve(new Response(bytes(url)));
     });
@@ -96,18 +117,6 @@ describe("googleFont", () => {
       "Open Sans:ital,wght@0,400;0,700;1,400;1,700",
     );
     expect(ua).toContain("Chrome");
-  });
-
-  test("a single weight builds a `wght@<n>` axis", async () => {
-    let requestedUrl = "";
-    const fetchMock = mock((url: string) => {
-      if (url.includes("/css2")) requestedUrl = url;
-      return Promise.resolve(url.includes("/css2") ? new Response(css) : new Response(bytes(url)));
-    });
-
-    await googleFont("Inter", { weight: 700, fetch: fetchMock });
-
-    expect(new URL(requestedUrl).searchParams.get("family")).toBe("Inter:wght@700");
   });
 
   test("a weight range requests the variable font and leaves weight unset", async () => {
@@ -132,52 +141,18 @@ describe("googleFont", () => {
     expect(new URL(requestedUrl).searchParams.get("family")).toBe("Inter:wght@100..900");
     expect(fonts).toHaveLength(1);
     expect(fonts[0]!.weight).toBeUndefined();
-    expect(fonts[0]!.key).toBe("https://fonts.gstatic.com/inter-variable.woff2");
   });
 });
 
-describe("googleFontSubsets", () => {
-  const interCss = `
-    /* cyrillic */
-    @font-face {
-      font-family: 'Inter';
-      font-style: normal;
-      font-weight: 400;
-      src: url(https://fonts.gstatic.com/inter-cyrillic.woff2) format('woff2');
-      unicode-range: U+0400-045F;
-    }
-    /* greek */
-    @font-face {
-      font-family: 'Inter';
-      font-style: normal;
-      font-weight: 400;
-      src: url(https://fonts.gstatic.com/inter-greek.woff2) format('woff2');
-      unicode-range: U+0370-03FF;
-    }
-    /* latin */
-    @font-face {
-      font-family: 'Inter';
-      font-style: normal;
-      font-weight: 400;
-      src: url(https://fonts.gstatic.com/inter-latin.woff2) format('woff2');
-      unicode-range: U+0000-00FF;
-    }
-  `;
-
-  const mockFetch = () =>
-    mock((url: string) =>
-      Promise.resolve(url.includes("/css2") ? new Response(interCss) : new Response(bytes(url))),
-    );
-
-  test("keeps only the intersecting subsets, each uniquely named under one subsetOf", async () => {
-    const fonts = await googleFontSubsets("Hi Привет Γειά", ["Inter"], { fetch: mockFetch() });
+describe("googleFonts", () => {
+  test("returns every subset, distinctly named, without filtering", async () => {
+    const fonts = await googleFonts(["Inter"], { fetch: mockInter() });
 
     expect(fonts.map((f) => f.name).sort()).toEqual([
       "Inter cyrillic",
       "Inter greek",
       "Inter latin",
     ]);
-    expect(fonts.every((f) => f.subsetOf === "Inter")).toBe(true);
   });
 
   test("requests every family in a single css2 call", async () => {
@@ -189,14 +164,49 @@ describe("googleFontSubsets", () => {
       );
     });
 
-    await googleFontSubsets("Hi", ["Inter", "Noto Sans JP"], { fetch: fetchMock });
+    await googleFonts(["Inter", "Noto Sans JP"], { fetch: fetchMock });
 
     const families = new URL(requestedUrl).searchParams.getAll("family");
     expect(families).toEqual(["Inter:wght@400", "Noto Sans JP:wght@400"]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  test("reuses the CSS cache across calls, fetching metadata once", async () => {
+    const fetchMock = mockInter();
+    const cache = new Map<string, string>();
+
+    await googleFonts(["Inter"], { fetch: fetchMock, cache });
+    await googleFonts(["Inter"], { fetch: fetchMock, cache });
+
+    const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
+    expect(cssCalls).toHaveLength(1);
+  });
+
+  test("downloads subset bytes lazily — only CSS up front", async () => {
+    const fetchMock = mockInter();
+    const fonts = await googleFonts(["Inter"], { fetch: fetchMock });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await fonts[0]!.data();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("subsetFonts", () => {
+  test("keeps only the subsets the text renders", async () => {
+    const fonts = await googleFonts(["Inter"], { fetch: mockInter() });
+
+    expect(subsetFonts(fonts, "Hi").map((f) => f.name)).toEqual(["Inter latin"]);
+    expect(subsetFonts(fonts, "Привет").map((f) => f.name)).toEqual(["Inter cyrillic"]);
+    expect(
+      subsetFonts(fonts, "Hi Привет Γειά")
+        .map((f) => f.name)
+        .sort(),
+    ).toEqual(["Inter cyrillic", "Inter greek", "Inter latin"]);
+  });
+
   test("scans a node tree for codepoints", async () => {
+    const fonts = await googleFonts(["Inter"], { fetch: mockInter() });
     const node: Node = {
       type: "container",
       children: [
@@ -205,30 +215,32 @@ describe("googleFontSubsets", () => {
       ],
     };
 
-    const fonts = await googleFontSubsets(node, ["Inter"], { fetch: mockFetch() });
-
-    expect(fonts.map((f) => f.name).sort()).toEqual(["Inter greek", "Inter latin"]);
+    expect(
+      subsetFonts(fonts, node)
+        .map((f) => f.name)
+        .sort(),
+    ).toEqual(["Inter greek", "Inter latin"]);
   });
 
-  test("reuses the CSS cache across renders, fetching metadata once", async () => {
-    const fetchMock = mockFetch();
-    const cache = new Map<string, string>();
+  test("keeps range-less fallbacks (full fonts, text= subsets) regardless of content", () => {
+    const fallback = { name: "Local", weight: 400, data: () => Promise.resolve(bytes("x")) };
+    const greek = {
+      name: "Inter greek",
+      ranges: [[0x370, 0x3ff]] as [number, number][],
+      data: () => Promise.resolve(bytes("g")),
+    };
 
-    await googleFontSubsets("Hello", ["Inter"], { fetch: fetchMock, cache });
-    await googleFontSubsets("Привет", ["Inter"], { fetch: fetchMock, cache });
-
-    // One CSS fetch total — the second render hits the cache.
-    const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
-    expect(cssCalls).toHaveLength(1);
+    // "Hi" is Latin only: the ranged Greek subset drops, the range-less fallback stays.
+    expect(subsetFonts([fallback, greek], "Hi")).toEqual([fallback]);
   });
 
-  test("downloads subset bytes lazily — only CSS up front", async () => {
-    const fetchMock = mockFetch();
-    const fonts = await googleFontSubsets("Hello", ["Inter"], { fetch: fetchMock });
+  test("regression: a multi-subset family can't tofu — covering subset survives, sibling drops", async () => {
+    // The bug: same-named subsets collide so a glyph routes to a file lacking it.
+    // The fix: googleFonts names subsets distinctly + subsetFonts keeps the covering one by range.
+    const fonts = subsetFonts(await googleFonts(["Inter"], { fetch: mockInter() }), "Hello");
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const data = await fonts[0]!.data();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(new TextDecoder().decode(data)).toBe("https://fonts.gstatic.com/inter-latin.woff2");
+    expect(fonts).toHaveLength(1);
+    expect(fonts[0]!.name).toBe("Inter latin");
+    expect(fonts[0]!.subsetOf).toBe("Inter");
   });
 });

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -14,9 +14,9 @@ import type {
 export type * from "../index";
 import { Renderer as RendererInternal } from "../index";
 
-import { pickFonts } from "@takumi-rs/helpers";
+import { extractResourceUrls, pickFonts } from "@takumi-rs/helpers";
 
-export { extractResourceUrls } from "@takumi-rs/helpers";
+export { extractResourceUrls };
 
 export type FontLoader =
   | Font

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -14,13 +14,26 @@ import type {
 export type * from "../index";
 import { Renderer as RendererInternal } from "../index";
 
+import { subsetFonts } from "@takumi-rs/helpers";
+
 export { extractResourceUrls } from "@takumi-rs/helpers";
 
 export type FontLoader =
   | Font
   | (Omit<FontDetails, "data"> & {
       data: () => Promise<FontDetails["data"]> | FontDetails["data"];
+      /** Inclusive codepoint ranges this face covers; lets `render` skip it when unused. */
+      ranges?: [number, number][];
     } & ({ key: string } | { name: string }));
+
+/** Keeps only the `fonts` whose `ranges` cover `source`, unless `subset` is `false`. */
+function pickFonts(
+  fonts: FontLoader[] | undefined,
+  source: Node | Node[],
+  subset: boolean | undefined,
+) {
+  return fonts && subset !== false ? subsetFonts(fonts, source) : fonts;
+}
 
 type ImageLoaderData = ImageSource["data"];
 
@@ -49,6 +62,8 @@ export type RenderOptions = Omit<
     fonts?: FontLoader[];
     signal?: AbortSignal;
     images?: ImageLoader[];
+    /** Register only the `fonts` subsets the content renders. @default true */
+    subset?: boolean;
   };
 
 /**
@@ -69,6 +84,8 @@ export type RenderAnimationOptions = Omit<
     fonts?: FontLoader[];
     signal?: AbortSignal;
     images?: ImageLoader[];
+    /** Register only the `fonts` subsets the content renders. @default true */
+    subset?: boolean;
   };
 
 export type EncodeFramesOptions = Omit<
@@ -79,12 +96,16 @@ export type EncodeFramesOptions = Omit<
     fonts?: FontLoader[];
     signal?: AbortSignal;
     images?: ImageLoader[];
+    /** Register only the `fonts` subsets the content renders. @default true */
+    subset?: boolean;
   };
 
 export type SvgRenderOptions = Omit<SvgRenderOptionsInternal, "images"> & {
   fonts?: FontLoader[];
   signal?: AbortSignal;
   images?: ImageLoader[];
+  /** Register only the `fonts` subsets the content renders. @default true */
+  subset?: boolean;
 };
 
 async function resolveImageLoaders(images: ImageLoader[]): Promise<ImageSource[]> {
@@ -154,36 +175,58 @@ export class Renderer {
   }
 
   async render(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const resolved = await this.resolveResources(fonts, images, fontFamilies);
+    const { fonts, fontFamilies, signal, images, subset, ...rest } = options ?? {};
+    const resolved = await this.resolveResources(
+      pickFonts(fonts, node, subset),
+      images,
+      fontFamilies,
+    );
 
     return this.inner.render(node, { ...rest, ...resolved }, signal);
   }
 
   async renderSvg(node: Node, options?: SvgRenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const resolved = await this.resolveResources(fonts, images, fontFamilies);
+    const { fonts, fontFamilies, signal, images, subset, ...rest } = options ?? {};
+    const resolved = await this.resolveResources(
+      pickFonts(fonts, node, subset),
+      images,
+      fontFamilies,
+    );
 
     return this.inner.renderSvg(node, { ...rest, ...resolved }, signal);
   }
 
   async measure(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const resolved = await this.resolveResources(fonts, images, fontFamilies);
+    const { fonts, fontFamilies, signal, images, subset, ...rest } = options ?? {};
+    const resolved = await this.resolveResources(
+      pickFonts(fonts, node, subset),
+      images,
+      fontFamilies,
+    );
 
     return this.inner.measure(node, { ...rest, ...resolved }, signal);
   }
 
   async renderAnimation(options: RenderAnimationOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options;
-    const resolved = await this.resolveResources(fonts, images, fontFamilies);
+    const { fonts, fontFamilies, signal, images, subset, ...rest } = options;
+    const nodes = options.scenes.map((scene) => scene.node);
+    const resolved = await this.resolveResources(
+      pickFonts(fonts, nodes, subset),
+      images,
+      fontFamilies,
+    );
 
     return this.inner.renderAnimation({ ...rest, ...resolved }, signal);
   }
 
   async encodeFrames(frames: AnimationFrameSource[], options: EncodeFramesOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options;
-    const resolved = await this.resolveResources(fonts, images, fontFamilies);
+    const { fonts, fontFamilies, signal, images, subset, ...rest } = options;
+    const nodes = frames.map((frame) => frame.node);
+    const resolved = await this.resolveResources(
+      pickFonts(fonts, nodes, subset),
+      images,
+      fontFamilies,
+    );
 
     return this.inner.encodeFrames(frames, { ...rest, ...resolved }, signal);
   }

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -168,7 +168,7 @@ export class Renderer {
   async render(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, signal, images, subset, ...rest } = options ?? {};
     const resolved = await this.resolveResources(
-      pickFonts(fonts, node, subset),
+      pickFonts({ fonts, source: node, subset }),
       images,
       fontFamilies,
     );
@@ -179,7 +179,7 @@ export class Renderer {
   async renderSvg(node: Node, options?: SvgRenderOptions) {
     const { fonts, fontFamilies, signal, images, subset, ...rest } = options ?? {};
     const resolved = await this.resolveResources(
-      pickFonts(fonts, node, subset),
+      pickFonts({ fonts, source: node, subset }),
       images,
       fontFamilies,
     );
@@ -190,7 +190,7 @@ export class Renderer {
   async measure(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, signal, images, subset, ...rest } = options ?? {};
     const resolved = await this.resolveResources(
-      pickFonts(fonts, node, subset),
+      pickFonts({ fonts, source: node, subset }),
       images,
       fontFamilies,
     );
@@ -202,7 +202,7 @@ export class Renderer {
     const { fonts, fontFamilies, signal, images, subset, ...rest } = options;
     const nodes = options.scenes.map((scene) => scene.node);
     const resolved = await this.resolveResources(
-      pickFonts(fonts, nodes, subset),
+      pickFonts({ fonts, source: nodes, subset }),
       images,
       fontFamilies,
     );
@@ -214,7 +214,7 @@ export class Renderer {
     const { fonts, fontFamilies, signal, images, subset, ...rest } = options;
     const nodes = frames.map((frame) => frame.node);
     const resolved = await this.resolveResources(
-      pickFonts(fonts, nodes, subset),
+      pickFonts({ fonts, source: nodes, subset }),
       images,
       fontFamilies,
     );

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -14,7 +14,7 @@ import type {
 export type * from "../index";
 import { Renderer as RendererInternal } from "../index";
 
-import { subsetFonts } from "@takumi-rs/helpers";
+import { pickFonts } from "@takumi-rs/helpers";
 
 export { extractResourceUrls } from "@takumi-rs/helpers";
 
@@ -25,15 +25,6 @@ export type FontLoader =
       /** Inclusive codepoint ranges this face covers; lets `render` skip it when unused. */
       ranges?: [number, number][];
     } & ({ key: string } | { name: string }));
-
-/** Keeps only the `fonts` whose `ranges` cover `source`, unless `subset` is `false`. */
-function pickFonts(
-  fonts: FontLoader[] | undefined,
-  source: Node | Node[],
-  subset: boolean | undefined,
-) {
-  return fonts && subset !== false ? subsetFonts(fonts, source) : fonts;
-}
 
 type ImageLoaderData = ImageSource["data"];
 

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -16,9 +16,9 @@ import {
 export * from "../pkg/takumi_wasm";
 export { default } from "../pkg/takumi_wasm";
 
-import { pickFonts } from "@takumi-rs/helpers";
+import { extractResourceUrls, pickFonts } from "@takumi-rs/helpers";
 
-export { extractResourceUrls } from "@takumi-rs/helpers";
+export { extractResourceUrls };
 
 export type FontLoader =
   | Font

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -139,7 +139,7 @@ export class Renderer {
 
   async render(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
+    const registeredFamilies = await this.prepareFonts(pickFonts({ fonts, source: node, subset }));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.render(node, {
@@ -151,7 +151,7 @@ export class Renderer {
 
   async renderAsDataUrl(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
+    const registeredFamilies = await this.prepareFonts(pickFonts({ fonts, source: node, subset }));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderAsDataUrl(node, {
@@ -163,7 +163,7 @@ export class Renderer {
 
   async renderSvg(node: Node, options?: SvgRenderOptions) {
     const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
+    const registeredFamilies = await this.prepareFonts(pickFonts({ fonts, source: node, subset }));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderSvg(node, {
@@ -175,7 +175,7 @@ export class Renderer {
 
   async measure(node: Node, options?: RenderOptions) {
     const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
+    const registeredFamilies = await this.prepareFonts(pickFonts({ fonts, source: node, subset }));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.measure(node, {
@@ -188,7 +188,7 @@ export class Renderer {
   async renderAnimation(options: RenderAnimationOptions) {
     const { fonts, fontFamilies, images, subset, ...rest } = options;
     const nodes = options.scenes.map((scene) => scene.node);
-    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, nodes, subset));
+    const registeredFamilies = await this.prepareFonts(pickFonts({ fonts, source: nodes, subset }));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderAnimation({
@@ -201,7 +201,7 @@ export class Renderer {
   async encodeFrames(frames: AnimationFrameSource[], options: EncodeFramesOptions) {
     const { fonts, fontFamilies, images, subset, ...rest } = options;
     const nodes = frames.map((frame) => frame.node);
-    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, nodes, subset));
+    const registeredFamilies = await this.prepareFonts(pickFonts({ fonts, source: nodes, subset }));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.encodeFrames(frames, {

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -16,7 +16,7 @@ import {
 export * from "../pkg/takumi_wasm";
 export { default } from "../pkg/takumi_wasm";
 
-import { subsetFonts } from "@takumi-rs/helpers";
+import { pickFonts } from "@takumi-rs/helpers";
 
 export { extractResourceUrls } from "@takumi-rs/helpers";
 
@@ -27,15 +27,6 @@ export type FontLoader =
       /** Inclusive codepoint ranges this face covers; lets `render` skip it when unused. */
       ranges?: [number, number][];
     } & ({ key: string } | { name: string }));
-
-/** Keeps only the `fonts` whose `ranges` cover `source`, unless `subset` is `false`. */
-function pickFonts(
-  fonts: FontLoader[] | undefined,
-  source: Node | Node[],
-  subset: boolean | undefined,
-) {
-  return fonts && subset !== false ? subsetFonts(fonts, source) : fonts;
-}
 
 type ImageLoaderData = ImageSource["data"];
 

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -16,13 +16,26 @@ import {
 export * from "../pkg/takumi_wasm";
 export { default } from "../pkg/takumi_wasm";
 
+import { subsetFonts } from "@takumi-rs/helpers";
+
 export { extractResourceUrls } from "@takumi-rs/helpers";
 
 export type FontLoader =
   | Font
   | (Omit<FontDetails, "data"> & {
       data: () => Promise<FontDetails["data"]> | FontDetails["data"];
+      /** Inclusive codepoint ranges this face covers; lets `render` skip it when unused. */
+      ranges?: [number, number][];
     } & ({ key: string } | { name: string }));
+
+/** Keeps only the `fonts` whose `ranges` cover `source`, unless `subset` is `false`. */
+function pickFonts(
+  fonts: FontLoader[] | undefined,
+  source: Node | Node[],
+  subset: boolean | undefined,
+) {
+  return fonts && subset !== false ? subsetFonts(fonts, source) : fonts;
+}
 
 type ImageLoaderData = ImageSource["data"];
 
@@ -46,6 +59,8 @@ export type RenderOptions = Omit<RenderOptionsInternal, "images" | "format" | "q
   OutputFormatOptions & {
     fonts?: FontLoader[];
     images?: ImageLoader[];
+    /** Register only the `fonts` subsets the content renders. @default true */
+    subset?: boolean;
   };
 
 /**
@@ -61,17 +76,23 @@ export type RenderAnimationOptions = Omit<RenderAnimationOptionsInternal, "image
   AnimationOutputFormatOptions & {
     fonts?: FontLoader[];
     images?: ImageLoader[];
+    /** Register only the `fonts` subsets the content renders. @default true */
+    subset?: boolean;
   };
 
 export type EncodeFramesOptions = Omit<EncodeFramesOptionsInternal, "images" | "format"> &
   AnimationOutputFormatOptions & {
     fonts?: FontLoader[];
     images?: ImageLoader[];
+    /** Register only the `fonts` subsets the content renders. @default true */
+    subset?: boolean;
   };
 
 export type SvgRenderOptions = Omit<SvgRenderOptionsInternal, "images"> & {
   fonts?: FontLoader[];
   images?: ImageLoader[];
+  /** Register only the `fonts` subsets the content renders. @default true */
+  subset?: boolean;
 };
 
 async function resolveImageLoaders(images: ImageLoader[]): Promise<ImageSource[]> {
@@ -126,8 +147,8 @@ export class Renderer {
   }
 
   async render(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
+    const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
+    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.render(node, {
@@ -138,8 +159,8 @@ export class Renderer {
   }
 
   async renderAsDataUrl(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
+    const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
+    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderAsDataUrl(node, {
@@ -150,8 +171,8 @@ export class Renderer {
   }
 
   async renderSvg(node: Node, options?: SvgRenderOptions) {
-    const { fonts, fontFamilies, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
+    const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
+    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderSvg(node, {
@@ -162,8 +183,8 @@ export class Renderer {
   }
 
   async measure(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, images, ...rest } = options ?? {};
-    const registeredFamilies = await this.prepareFonts(fonts);
+    const { fonts, fontFamilies, images, subset, ...rest } = options ?? {};
+    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, node, subset));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.measure(node, {
@@ -174,8 +195,9 @@ export class Renderer {
   }
 
   async renderAnimation(options: RenderAnimationOptions) {
-    const { fonts, fontFamilies, images, ...rest } = options;
-    const registeredFamilies = await this.prepareFonts(fonts);
+    const { fonts, fontFamilies, images, subset, ...rest } = options;
+    const nodes = options.scenes.map((scene) => scene.node);
+    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, nodes, subset));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.renderAnimation({
@@ -186,8 +208,9 @@ export class Renderer {
   }
 
   async encodeFrames(frames: AnimationFrameSource[], options: EncodeFramesOptions) {
-    const { fonts, fontFamilies, images, ...rest } = options;
-    const registeredFamilies = await this.prepareFonts(fonts);
+    const { fonts, fontFamilies, images, subset, ...rest } = options;
+    const nodes = frames.map((frame) => frame.node);
+    const registeredFamilies = await this.prepareFonts(pickFonts(fonts, nodes, subset));
     const resolvedImages = images ? await resolveImageLoaders(images) : undefined;
 
     return this.inner.encodeFrames(frames, {


### PR DESCRIPTION
## What

One object-shaped helper loads Google Fonts; `render` subsets them to the content.

```ts
import { render } from "takumi-js";
import { googleFonts } from "takumi-js/helpers";

const fonts = await googleFonts({ families: ["Public Sans", "Noto Sans TC"] });
await render(html, { width: 1200, height: 600, fonts });
// render scans the node tree and registers only the subsets it draws, across families
```

## Why

The old `googleFont` dropped each subset's `unicode-range` and named every subset of a family identically. A multi-subset family (Public Sans, any Noto) then collided: glyphs routed to a same-named sibling that lacked them → tofu. Correct rendering required reaching for a separate `googleFontSubsets`.

Now correctness is the default. `googleFonts` returns coverage subsets, each with its range and a distinct name under one `subsetOf`, so a glyph routes to the file that covers it even unfiltered. The subset pass is a download optimisation, not a correctness crutch. Standard subset URLs stay CDN-cacheable across pages (unlike a per-content `text=` request).

## API (breaking, `2.0.0-beta` line)

- `googleFonts({ families, text?, display?, cache? })` → `FontSubset[]`. One css2 request; lazy downloads.
- `subsetFonts({ fonts, source })` → pure filter; keeps range-less fallbacks (full fonts, `text=` subsets).
- `pickFonts({ fonts, source, subset })` → the default-on gate, shared by both bindings.
- `render`/`measure`/`renderSvg`/`renderAnimation`/`encodeFrames` gain `subset?: boolean` (default `true`); animation unions every scene's codepoints.
- Each `FontSubset.key` is a stable identity (`{name}:{weight}:{style}:{range}`), not the rotating woff2 URL, so the renderer dedups across calls yet never merges subsets of different coverage.
- **Removed** `googleFont` and `googleFontSubsets`.

## Regression

`takumi-helpers/test/fonts.test.ts` pins the footgun: a multi-subset family yields distinctly-named subsets, `subsetFonts` keeps only the covering one plus range-less fallbacks, and an empty `families` list makes no request. Verified end-to-end against the local napi build — Latin + CJK route correctly with zero tofu.

Only `@takumi-rs/helpers` bumps (minor); the bindings follow as dependents.

https://claude.ai/code/session_018MtirZ85oShW3PeRvvAQLx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter Google Font handling with `googleFonts` to load multiple families in one request.
  * Introduced subset-based font trimming for rendered output, with a `subset` option to enable/disable it.
  * Added utilities to manually trim font subsets (`subsetFonts`) when desired.
* **Bug Fixes**
  * Reduced unnecessary font downloads by ensuring only the needed coverage subsets are registered for rendering, images, videos, and previews.
* **Documentation**
  * Updated font/typography guidance and helper references to reflect the new `googleFonts` + subset workflow, including multilingual and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->