### PR TITLE
CI: pin cargo-rdme to v1.5.1, drop nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          binstall: cargo-audit,cargo-llvm-cov,cargo-rdme@2.0.1,cargo-machete
+          binstall: cargo-audit,cargo-llvm-cov,cargo-rdme@1.5.1,cargo-machete
           components: rustfmt,clippy
           stage: test
 
@@ -67,6 +67,15 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test README.md is up to date
+        run: |
+          fail=0
+          while read -r dir; do
+            (cd "$dir" && cargo rdme --check) || fail=1
+          done < <(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.publish != []) | select(any(.targets[]; .kind | index("lib"))) | .manifest_path | rtrimstr("/Cargo.toml")')
+          exit $fail
 
       - name: Run tests
         run: CARGO_PROFILE_TEST_STRIP="debuginfo" cargo test
@@ -105,18 +114,6 @@ jobs:
           echo ""
           cat changed_files.txt
           exit 1
-
-      - name: Install nightly toolchain for cargo-rdme
-        run: rustup toolchain install nightly --profile minimal # for cargo-rdme v2
-
-      - name: Test README.md is up to date
-        run: |
-          fail=0
-          while read -r dir; do
-            (cd "$dir" && cargo rdme --check) || fail=1
-          done < <(cargo metadata --format-version 1 --no-deps \
-            | jq -r '.packages[] | select(.publish != []) | select(any(.targets[]; .kind | index("lib"))) | .manifest_path | rtrimstr("/Cargo.toml")')
-          exit $fail
 
       - name: Run security audit
         run: cargo audit

--- a/takumi-svg/README.md
+++ b/takumi-svg/README.md
@@ -7,7 +7,7 @@ Vector SVG output for takumi.
 [`render`] turns a takumi node tree into real SVG (`<rect>`, `<path>`,
 `<linearGradient>`/`<radialGradient>`, `<filter>`, `<clipPath>`, glyph outline
 `<path>`s, embedded `<image>`) rather than wrapping a rasterized bitmap in a
-`data:` URL. The document is built with [`quick_xml`](https://docs.rs/quick_xml/latest/quick_xml/) so every attribute and
+`data:` URL. The document is built with [`quick_xml`] so every attribute and
 value is correctly escaped.
 
 Coverage: backgrounds, borders, border-radius (backgrounds/clip), linear and

--- a/takumi/README.md
+++ b/takumi/README.md
@@ -4,7 +4,7 @@
 
 Takumi renders UI component trees to images. This crate is the facade users
 depend on: entry-point **functions** live at the crate root and the _curated,
-stable_ data structures live in [`crate::prelude`](https://docs.rs/takumi/latest/takumi/prelude/). Glob the prelude for the types
+stable_ data structures live in [`crate::prelude`]. Glob the prelude for the types
 and call the functions from the crate root.
 
 The backend crates expose a much larger surface than is meant for general use


### PR DESCRIPTION
## What

- Pin `cargo-rdme` to `1.5.1` (stable) in CI, replacing `2.0.1`.
- Remove the "Install nightly toolchain for cargo-rdme" step — v2 needed nightly, v1 runs on stable.
- Move the README freshness check ahead of the test run so it fails earlier.
- Regenerate `takumi` and `takumi-svg` READMEs under v1.5.1.

## Why

cargo-rdme v2 requires the nightly toolchain, which broke the README check in CI ([failing run](https://github.com/kane50613/takumi/actions/runs/28078986104/job/83129384383)).

https://claude.ai/code/session_01EJGRtZYYVw1PPCJe6UhYrJ