### PR TITLE
CI: install cargo-rdme in release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,7 @@ jobs:
         with:
           stage: release
           components: clippy,rustfmt
+          binstall: cargo-rdme@1.5.1
 
       - name: Download helpers artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## What

Add `cargo-rdme@1.5.1` to the release job's `setup-rust` binstall list.

## Why

The release commit created by `bun tegami ci` triggers the lefthook pre-commit hook, which runs `cargo rdme --force` to keep READMEs formatted/in sync. The release job had no `cargo-rdme` installed, so that step would fail. Pinned to v1.5.1 to match the test job.

https://claude.ai/code/session_01EJGRtZYYVw1PPCJe6UhYrJ