### PR TITLE
Patch tegami to pack into package dir

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -309,6 +309,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "tegami@0.1.4": "patches/tegami@0.1.4.patch",
+  },
   "catalog": {
     "@types/bun": "^1.3.14",
     "@types/node": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "unrun": "^0.3.1",
     "typescript": "6.0.3",
     "vite": "^8.1.0"
+  },
+  "patchedDependencies": {
+    "tegami@0.1.4": "patches/tegami@0.1.4.patch"
   }
 }

--- a/patches/tegami@0.1.4.patch
+++ b/patches/tegami@0.1.4.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/providers/npm.js b/dist/providers/npm.js
+index a9be7d3aa5afa44a51cef9ab417fabce1abc4908..2ee1b971b92f7ca49a826125d02539cc0c3cc344 100644
+--- a/dist/providers/npm.js
++++ b/dist/providers/npm.js
+@@ -81,7 +81,7 @@ var NpmRegistryClient = class {
+ 	async publish(pkg, { packageStore }) {
+ 		const distTag = packageStore.npm?.distTag;
+ 		if (this.client === "bun") {
+-			const tarball = "pkg.tgz";
++			const tarball = path.resolve(pkg.path, "pkg.tgz");
+ 			const packResult = await x("bun", [
+ 				"pm",
+ 				"pack",


### PR DESCRIPTION
## What

Patch `tegami@0.1.4` so `bun pm pack` writes `pkg.tgz` to the package directory instead of the workspace root.

## Why

In the [failing release run](https://github.com/kane50613/takumi/actions/runs/28083905326/job/83147348736) every npm package failed to publish with:

```
npm error path .../takumi-js/pkg.tgz
npm error enoent ENOENT: no such file or directory
```

Root cause: `bun pm pack --filename pkg.tgz` resolves the filename against the **workspace root**, not the package's `cwd`. Reproduced locally — `bun pm pack --filename pkg.tgz` run inside `takumi-js/` wrote the tarball to the repo root. tegami then runs `npm publish pkg.tgz` from the package dir, which can't find it ([bun#15601](https://github.com/oven-sh/bun/issues/15601)).

## Fix

Upstream already fixed this in [fuma-nama/tegami@1afe6d6](https://github.com/fuma-nama/tegami/commit/1afe6d6d883e7aea4b5f13c0a1cb6e8e28b7aa61) by passing an absolute path. That commit isn't in any published release yet, and tegami ships from a monorepo subpackage with no committed build output, so a GitHub install isn't viable. Instead, apply the same one-line change via `bun patch` (recorded in `patchedDependencies` + lockfile, so it survives `bun install --frozen-lockfile` in CI).

Drop the patch once a tegami release containing the upstream fix is published.

https://claude.ai/code/session_01EJGRtZYYVw1PPCJe6UhYrJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publishing reliability by using a resolved archive path, which helps prevent publish/pack failures in Bun-based workflows.
* **Chores**
  * Added a pinned patch update for a third-party package to keep the fix applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->