### PR TITLE
Helpers: fix variable fonts CSS parsing for variable Google Fonts

### DIFF
--- a/.tegami/google-fonts-variable-weight.md
+++ b/.tegami/google-fonts-variable-weight.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:@takumi-rs/helpers": patch
+---
+
+### Render every weight of a variable Google Font
+
+A variable font is served as one woff2 reused across weights. `googleFonts` now
+collapses those faces into a single weightless face so the renderer drives the
+`wght` axis, instead of pinning every weight to the file's default and leaving
+`font-weight: 700` looking regular.

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -248,6 +248,36 @@ function parseSubsetFaces(css: string): SubsetFace[] {
   return faces;
 }
 
+/**
+ * A variable font reuses one woff2 across weights: the same `src` url repeats per subset, one
+ * `@font-face` per weight. Collapse each shared url to a single weightless face so the renderer
+ * drives the `wght` axis. Registering the file once per weight pins every weight to the file's
+ * default, so `font-weight: 700` renders regular. Static fonts give a distinct url per weight and
+ * pass through untouched.
+ */
+function mergeVariableFaces(faces: SubsetFace[]): SubsetFace[] {
+  const weightsByUrl = new Map<string, Set<number | undefined>>();
+  for (const face of faces) {
+    const weights = weightsByUrl.get(face.url) ?? new Set();
+    weights.add(face.weight);
+    weightsByUrl.set(face.url, weights);
+  }
+
+  const seen = new Set<string>();
+  const merged: SubsetFace[] = [];
+  for (const face of faces) {
+    if (seen.has(face.url)) {
+      continue;
+    }
+
+    seen.add(face.url);
+    const sharedAcrossWeights = (weightsByUrl.get(face.url)?.size ?? 0) > 1;
+    merged.push(sharedAcrossWeights ? { ...face, weight: undefined } : face);
+  }
+
+  return merged;
+}
+
 /** Collect every codepoint the content will render. */
 export function collectCodepoints(source: string | Node | Node[]): Set<number> {
   const codepoints = new Set<number>();
@@ -342,5 +372,5 @@ export async function googleFonts(options: GoogleFontsOptions): Promise<FontSubs
 
   const css = await fetchCssCached(buildUrl(options), options);
 
-  return parseSubsetFaces(css).map((face) => toSubset(face, options));
+  return mergeVariableFaces(parseSubsetFaces(css)).map((face) => toSubset(face, options));
 }

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -85,6 +85,49 @@ describe("googleFonts", () => {
     expect(fonts.every((f) => !f.key.includes("gstatic"))).toBe(true);
   });
 
+  test("collapses a variable font's shared woff2 into one weightless face", async () => {
+    // A variable font: both weight blocks share one woff2 url.
+    const variableCss = `
+      @font-face {
+        font-family: 'Public Sans';
+        font-style: normal;
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/public-sans-variable.woff2) format('woff2');
+        unicode-range: U+0000-00FF;
+      }
+      @font-face {
+        font-family: 'Public Sans';
+        font-style: normal;
+        font-weight: 700;
+        src: url(https://fonts.gstatic.com/public-sans-variable.woff2) format('woff2');
+        unicode-range: U+0000-00FF;
+      }
+    `;
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(url.includes("/css2") ? new Response(variableCss) : new Response(bytes(url))),
+    );
+
+    const fonts = await googleFonts({
+      families: [{ family: "Public Sans", weight: [400, 700] }],
+      fetch: fetchMock,
+    });
+
+    expect(fonts).toHaveLength(1);
+    expect(fonts[0]?.weight).toBeUndefined();
+
+    // A static font keeps a distinct url per weight, so faces stay split.
+    const staticMock = mock((url: string) =>
+      Promise.resolve(
+        url.includes("/css2") ? new Response(twoWeightCss) : new Response(bytes(url)),
+      ),
+    );
+    const staticFonts = await googleFonts({
+      families: [{ family: "Inter", weight: [400, 700] }],
+      fetch: staticMock,
+    });
+    expect(staticFonts.map((f) => f.weight).sort()).toEqual([400, 700]);
+  });
+
   test("builds the family/axis and sends a woff2 UA", async () => {
     let requestedUrl = "";
     let ua = "";
@@ -188,7 +231,7 @@ describe("googleFonts", () => {
 
     expect(new URL(requestedUrl).searchParams.get("family")).toBe("Inter:wght@100..900");
     expect(fonts).toHaveLength(1);
-    expect(fonts[0]!.weight).toBeUndefined();
+    expect(fonts[0]?.weight).toBeUndefined();
   });
 
   test("requests every family in a single css2 call", async () => {


### PR DESCRIPTION
## Bug

`font-weight: 700` rendered as **regular** for variable Google Fonts (e.g. Public Sans). Static fonts (Poppins) and CJK were fine — the breakage was font-specific, which made it confusing to track down.

## Root cause

For a **variable** font, Google serves a modern browser **one variable woff2 reused across every requested weight** — the CSS repeats the same `src` url, one `@font-face` per weight:

```
# Public Sans (variable): latin 400 and 700 → SAME url
ijwRs572Xtc6ZYQws9YVwnNGfJ4.woff2   (400)
ijwRs572Xtc6ZYQws9YVwnNGfJ4.woff2   (700)

# Poppins (static): distinct url per weight
pxiEyp8kv8JHgFVrJJfecg.woff2        (400)
pxiByp8kv8JHgFVrLCz7Z11lFc-K.woff2  (700)
```

Takumi registered that shared file once per weight with a fixed weight override and never set a variation coordinate, so every weight resolved to the file's default → bold looked regular.

Approaches that don't work universally:
- Discrete weights (`wght@400;700`) + modern UA → variable fonts collapse to one file (the bug).
- A weight **range** (`wght@400..700`) → variable fonts work, but Google returns **HTTP 400** for non-variable fonts like Poppins.
- Downgrading the UA → static instances for everything, but loses variable fonts and woff2-era subsetting.

## Fix

Detect the variable case at parse time: when several `@font-face` blocks share one woff2 url, collapse them into a single **weightless** face so the renderer drives the `wght` axis (parley already applies variation coordinates). Static fonts keep their distinct per-weight urls and pass through unchanged. Works with the normal discrete-weight API and a current UA.

Verified end-to-end (render `font-weight:400` vs `700`, compare output): Public Sans → 3 weightless faces, bold correct; Poppins → 6 per-weight faces, bold correct.

https://claude.ai/code/session_01EJGRtZYYVw1PPCJe6UhYrJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Fonts processing for variable fonts by merging repeated `woff2` sources across multiple weights, so weight selection can align with the font’s axes instead of being tied to a single file.
* **Tests**
  * Added coverage ensuring duplicate-source variable-font faces are collapsed to a weightless result, while static fonts with distinct sources still return separate weighted faces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->