### PR TITLE
[codex] add Takumi CLI renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +211,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "color"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +270,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "convert_case"
@@ -193,16 +330,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros 0.6.1",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.7.0",
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
  "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -263,6 +429,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +481,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -321,6 +519,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -404,6 +608,25 @@ dependencies = [
  "parlance",
  "read-fonts",
  "smallvec",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -495,6 +718,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +791,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "harfrust"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +833,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -690,6 +980,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +1014,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -724,6 +1036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +1053,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -802,6 +1120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +1145,34 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
@@ -938,10 +1290,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -996,6 +1437,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,12 +1476,32 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand",
 ]
 
 [[package]]
@@ -1045,6 +1522,19 @@ checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared 0.14.0",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1071,6 +1561,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1204,6 +1703,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1783,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1824,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1329,18 +1905,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
+dependencies = [
+ "cssparser 0.35.0",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors 0.31.0",
+ "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
+dependencies = [
+ "bitflags",
+ "cssparser 0.35.0",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "selectors"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
  "bitflags",
- "cssparser",
+ "cssparser 0.37.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
- "phf_codegen",
+ "phf_codegen 0.13.1",
  "precomputed-hash",
  "rustc-hash",
  "servo_arc",
@@ -1503,6 +2113,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svgtypes"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,12 +2208,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "takumi-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arboard",
+ "base64",
+ "clap",
+ "ego-tree",
+ "parley",
+ "scraper",
+ "serde_json",
+ "takumi",
+ "ureq",
+ "url",
+]
+
+[[package]]
 name = "takumi-core"
 version = "0.1.0-beta.4"
 dependencies = [
  "bytemuck",
  "color",
- "cssparser",
+ "cssparser 0.37.0",
  "dashmap",
  "data-url",
  "gif",
@@ -1578,7 +2242,7 @@ dependencies = [
  "quick_cache",
  "resvg",
  "roxmltree 0.21.1",
- "selectors",
+ "selectors 0.38.0",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1600,13 +2264,13 @@ dependencies = [
  "bitflags",
  "bytemuck",
  "color",
- "cssparser",
+ "cssparser 0.37.0",
  "image",
  "parley",
  "paste",
  "phf 0.14.0",
  "precomputed-hash",
- "selectors",
+ "selectors 0.38.0",
  "serde",
  "serde_json",
  "smallvec",
@@ -1685,6 +2349,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +2377,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1834,6 +2523,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "usvg"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,16 +2591,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1928,6 +2675,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +2715,162 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1962,6 +2895,23 @@ dependencies = [
  "bytes",
  "flate2",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xmlwriter"
@@ -1999,6 +2949,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2988,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "takumi-raster",
   "takumi-css",
   "takumi-svg",
+  "takumi-cli",
   "takumi-napi",
   "takumi-wasm",
   "example/rust",

--- a/takumi-cli/Cargo.toml
+++ b/takumi-cli/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "takumi-cli"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Command-line renderer for Takumi image scenes."
+repository = "https://github.com/kane50613/takumi"
+rust-version = "1.91"
+publish = false
+
+[[bin]]
+name = "takumi"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+arboard = "3.6"
+base64.workspace = true
+clap.workspace = true
+ego-tree = "0.10"
+parley.workspace = true
+scraper = "0.24"
+serde_json.workspace = true
+ureq = "2"
+url = "2"
+
+[dependencies.takumi]
+path = "../takumi"
+
+[lints]
+workspace = true

--- a/takumi-cli/src/main.rs
+++ b/takumi-cli/src/main.rs
@@ -186,9 +186,9 @@ fn main() -> Result<()> {
       .with_context(|| format!("failed to register font {}", font_path.display()))?;
   }
 
-  let stylesheet = load_stylesheets(&cli, source.stylesheets)?;
   let mut images = source.images;
   images.extend(load_images(&cli.images)?);
+  let stylesheet = load_stylesheets(&cli, source.stylesheets, &mut images)?;
   let lang = parse_lang(cli.lang.as_deref())?;
   let font_families = (!cli.font_families.is_empty()).then_some(cli.font_families.clone());
 
@@ -266,13 +266,19 @@ impl From<Dither> for DitheringAlgorithm {
 
 struct RenderSource {
   node: Node,
-  stylesheets: Vec<String>,
+  stylesheets: Vec<StylesheetSource>,
   images: HashMap<Arc<str>, ImageSource>,
 }
 
 #[derive(Clone, Debug)]
+struct StylesheetSource {
+  css: String,
+  base: AssetBase,
+}
+
+#[derive(Clone, Debug)]
 enum AssetBase {
-  File(PathBuf),
+  File { base: PathBuf, root: PathBuf },
   Url(Url),
   None,
 }
@@ -290,7 +296,7 @@ fn read_render_source(input: Option<&str>) -> Result<RenderSource> {
       let contents =
         fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
       if is_html_path(&path) || looks_like_html(&contents) {
-        parse_html_source(&contents, AssetBase::File(html_base))
+        parse_html_source(&contents, file_asset_base(html_base))
       } else {
         parse_json_source(&contents)
       }
@@ -342,6 +348,21 @@ fn resolve_input_path(path: &Path) -> Result<(PathBuf, PathBuf)> {
   Ok((file, base))
 }
 
+fn parent_dir(path: &Path) -> PathBuf {
+  path
+    .parent()
+    .filter(|parent| !parent.as_os_str().is_empty())
+    .unwrap_or_else(|| Path::new("."))
+    .to_path_buf()
+}
+
+fn file_asset_base(root: PathBuf) -> AssetBase {
+  AssetBase::File {
+    base: root.clone(),
+    root,
+  }
+}
+
 fn is_html_path(path: &Path) -> bool {
   matches!(
     path
@@ -361,16 +382,32 @@ fn is_http_url(input: &str) -> bool {
   input.starts_with("https://") || input.starts_with("http://")
 }
 
-fn load_stylesheets(cli: &Cli, mut sources: Vec<String>) -> Result<StyleSheet> {
+fn load_stylesheets(
+  cli: &Cli,
+  mut sources: Vec<StylesheetSource>,
+  images: &mut HashMap<Arc<str>, ImageSource>,
+) -> Result<StyleSheet> {
   sources.reserve(cli.stylesheets.len() + cli.css.len());
   for path in &cli.stylesheets {
-    sources.push(
-      fs::read_to_string(path)
-        .with_context(|| format!("failed to read stylesheet {}", path.display()))?,
-    );
+    let css = fs::read_to_string(path)
+      .with_context(|| format!("failed to read stylesheet {}", path.display()))?;
+    sources.push(StylesheetSource {
+      css,
+      base: file_asset_base(parent_dir(path)),
+    });
   }
-  sources.extend(cli.css.iter().cloned());
-  Ok(StyleSheet::parse_owned_list_loosy(sources))
+  sources.extend(cli.css.iter().cloned().map(|css| StylesheetSource {
+    css,
+    base: AssetBase::None,
+  }));
+
+  for source in &sources {
+    preload_stylesheet_images(source, images)?;
+  }
+
+  Ok(StyleSheet::parse_owned_list_loosy(
+    sources.into_iter().map(|source| source.css).collect(),
+  ))
 }
 
 fn parse_html_source(html: &str, base: AssetBase) -> Result<RenderSource> {
@@ -418,7 +455,7 @@ fn parse_html_source(html: &str, base: AssetBase) -> Result<RenderSource> {
 
 struct HtmlContext {
   base: AssetBase,
-  stylesheets: Vec<String>,
+  stylesheets: Vec<StylesheetSource>,
   images: HashMap<Arc<str>, ImageSource>,
 }
 
@@ -446,7 +483,10 @@ fn collect_styles(node: HtmlNodeRef<'_>, context: &mut HtmlContext) -> Result<()
         })
         .collect::<String>();
       if !css.is_empty() {
-        context.stylesheets.push(css);
+        context.stylesheets.push(StylesheetSource {
+          css,
+          base: context.base.clone(),
+        });
       }
       return Ok(());
     }
@@ -454,7 +494,7 @@ fn collect_styles(node: HtmlNodeRef<'_>, context: &mut HtmlContext) -> Result<()
       if let Some(href) = element.attr("href") {
         context
           .stylesheets
-          .push(load_text_asset(href, &context.base)?);
+          .push(load_linked_stylesheet(href, &context.base)?);
       }
       return Ok(());
     }
@@ -742,12 +782,82 @@ fn preload_image(src: &str, context: &mut HtmlContext) -> Result<()> {
   Ok(())
 }
 
-fn load_text_asset(src: &str, base: &AssetBase) -> Result<String> {
+fn preload_stylesheet_images(
+  source: &StylesheetSource,
+  images: &mut HashMap<Arc<str>, ImageSource>,
+) -> Result<()> {
+  let stylesheet = StyleSheet::parse_loosy(&source.css);
+  let urls = stylesheet_resource_urls(&stylesheet);
+
+  for url in urls {
+    preload_css_image(&url, &source.base, images)?;
+  }
+
+  Ok(())
+}
+
+fn stylesheet_resource_urls(stylesheet: &StyleSheet) -> Vec<String> {
+  let mut urls = Vec::new();
+
+  for rule in &stylesheet.rules {
+    urls.extend(rule.normal_declarations.resource_urls().map(str::to_owned));
+    urls.extend(
+      rule
+        .important_declarations
+        .resource_urls()
+        .map(str::to_owned),
+    );
+  }
+
+  for keyframes in &stylesheet.keyframes {
+    for keyframe in &keyframes.keyframes {
+      urls.extend(keyframe.declarations.resource_urls().map(str::to_owned));
+    }
+  }
+
+  urls
+}
+
+fn preload_css_image(
+  src: &str,
+  base: &AssetBase,
+  images: &mut HashMap<Arc<str>, ImageSource>,
+) -> Result<()> {
+  if src.starts_with("data:") || src.starts_with('#') || images.contains_key(src) {
+    return Ok(());
+  }
+
+  let bytes = load_binary_asset(src, base)?;
+  let image = ImageSource::from_bytes(&bytes)
+    .with_context(|| format!("failed to decode CSS image asset `{src}`"))?;
+  images.insert(Arc::from(src), image);
+  Ok(())
+}
+
+fn load_linked_stylesheet(src: &str, base: &AssetBase) -> Result<StylesheetSource> {
   match resolve_asset(src, base)? {
     ResolvedAsset::File(path) => {
-      fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))
+      let css = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read stylesheet {}", path.display()))?;
+      let root = match base {
+        AssetBase::File { root, .. } => root.clone(),
+        _ => parent_dir(&path),
+      };
+      Ok(StylesheetSource {
+        css,
+        base: AssetBase::File {
+          base: parent_dir(&path),
+          root,
+        },
+      })
     }
-    ResolvedAsset::Url(url) => fetch_text(url.as_str()),
+    ResolvedAsset::Url(url) => {
+      let css = fetch_text(url.as_str())?;
+      Ok(StylesheetSource {
+        css,
+        base: AssetBase::Url(url),
+      })
+    }
   }
 }
 
@@ -773,9 +883,12 @@ fn resolve_asset(src: &str, base: &AssetBase) -> Result<ResolvedAsset> {
   }
 
   match base {
-    AssetBase::File(root) => {
-      let relative = local_asset_path(src).trim_start_matches('/');
-      Ok(ResolvedAsset::File(root.join(relative)))
+    AssetBase::File { base, root } => {
+      let local = local_asset_path(src);
+      let asset_root = if local.starts_with('/') { root } else { base };
+      Ok(ResolvedAsset::File(
+        asset_root.join(local.trim_start_matches('/')),
+      ))
     }
     AssetBase::Url(base) => {
       Ok(ResolvedAsset::Url(base.join(src).with_context(|| {

--- a/takumi-cli/src/main.rs
+++ b/takumi-cli/src/main.rs
@@ -1,0 +1,933 @@
+use std::{
+  borrow::Cow,
+  collections::HashMap,
+  fs,
+  io::{self, IsTerminal, Read, Write},
+  path::{Path, PathBuf},
+  str::FromStr,
+  sync::Arc,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use arboard::{Clipboard, ImageData as ClipboardImage};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use clap::{
+  ArgAction, Parser, ValueEnum,
+  builder::{
+    Styles,
+    styling::{AnsiColor, Effects},
+  },
+};
+use parley::Language;
+use scraper::{
+  ElementRef, Html,
+  node::{Element, Node as HtmlNode},
+};
+use takumi::{
+  prelude::{
+    Direction, DitheringAlgorithm, FontResource, Fonts, ImageData, ImageSource, Node,
+    OutputFormat as TakumiOutputFormat, Quality, RenderOptions, Style, StyleDeclarationBlock,
+    StyleSheet, Viewport, tw::TailwindValues,
+  },
+  render, write_image,
+};
+use url::Url;
+
+const DEFAULT_FONT: &[u8] = include_bytes!("../../assets/fonts/geist/Geist[wght].woff2");
+const KITTY_CHUNK_SIZE: usize = 4096;
+
+#[derive(Debug, Parser)]
+#[command(
+  name = "takumi",
+  version,
+  about = "Render Takumi node JSON or static HTML to an image",
+  styles = clap_styles(),
+  after_help = "Examples:
+  takumi scene.json
+  takumi card.html
+  takumi ./site
+  takumi https://example.com/card.html
+  takumi scene.json -o image.webp --format webp
+  takumi - < scene.json --width 1200 --height 630 --clipboard
+  takumi scene.json --image avatar=./avatar.png --font ./Inter.ttf"
+)]
+struct Cli {
+  /// Takumi node JSON, static HTML file, directory with index.html, URL, or '-' for stdin.
+  input: Option<String>,
+
+  /// Save the encoded image to this path.
+  #[arg(short, long)]
+  output: Option<PathBuf>,
+
+  /// Output image format. Inferred from --output when omitted.
+  #[arg(short, long, value_enum)]
+  format: Option<ImageFormat>,
+
+  /// Quality for JPEG and lossy WebP.
+  #[arg(short, long, value_parser = clap::value_parser!(u8).range(0..=100))]
+  quality: Option<u8>,
+
+  /// Render WebP losslessly. This is the default for WebP when --quality is not set.
+  #[arg(long)]
+  lossless: bool,
+
+  /// CSS viewport width in pixels.
+  #[arg(short = 'W', long, default_value_t = 1200)]
+  width: u32,
+
+  /// CSS viewport height in pixels.
+  #[arg(short = 'H', long, default_value_t = 630)]
+  height: u32,
+
+  /// Device pixel ratio used for rasterization.
+  #[arg(long, default_value_t = 1.0)]
+  dpr: f32,
+
+  /// Render animation styles at this timeline position.
+  #[arg(long, default_value_t = 0)]
+  time_ms: u64,
+
+  /// Draw layout debug borders.
+  #[arg(long)]
+  debug: bool,
+
+  /// Output dithering algorithm.
+  #[arg(long, value_enum, default_value_t = Dither::None)]
+  dithering: Dither,
+
+  /// Register a font file. May be passed multiple times.
+  #[arg(long = "font", value_name = "PATH")]
+  fonts: Vec<PathBuf>,
+
+  /// Skip the bundled Geist font.
+  #[arg(long)]
+  no_default_fonts: bool,
+
+  /// Restrict render fallback families in order. May be passed multiple times.
+  #[arg(long = "font-family", value_name = "NAME")]
+  font_families: Vec<String>,
+
+  /// Default BCP-47 language for shaping and line breaking.
+  #[arg(long)]
+  lang: Option<String>,
+
+  /// Add a CSS stylesheet file. May be passed multiple times.
+  #[arg(long = "stylesheet", value_name = "PATH")]
+  stylesheets: Vec<PathBuf>,
+
+  /// Add inline CSS stylesheet text. May be passed multiple times.
+  #[arg(long = "css", value_name = "TEXT")]
+  css: Vec<String>,
+
+  /// Preload an image as SRC=PATH for image nodes that reference SRC.
+  #[arg(long = "image", value_name = "SRC=PATH", value_parser = parse_image_arg)]
+  images: Vec<ImageArg>,
+
+  /// Copy the rendered bitmap to the system clipboard.
+  #[arg(long)]
+  clipboard: bool,
+
+  /// Disable terminal image preview.
+  #[arg(long = "no-display", action = ArgAction::SetFalse)]
+  preview: bool,
+
+  /// Suppress status messages.
+  #[arg(long)]
+  quiet: bool,
+}
+
+#[derive(Clone, Debug)]
+struct ImageArg {
+  src: String,
+  path: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ImageFormat {
+  Png,
+  Jpeg,
+  Webp,
+  WebpLossless,
+  Ico,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Dither {
+  None,
+  OrderedBayer,
+  FloydSteinberg,
+}
+
+fn clap_styles() -> Styles {
+  Styles::styled()
+    .header(AnsiColor::Green.on_default() | Effects::BOLD)
+    .usage(AnsiColor::Green.on_default() | Effects::BOLD)
+    .literal(AnsiColor::Cyan.on_default())
+    .placeholder(AnsiColor::Yellow.on_default())
+}
+
+fn main() -> Result<()> {
+  let cli = Cli::parse();
+  cli.validate()?;
+
+  let source = read_render_source(cli.input.as_deref())?;
+
+  let mut fonts = Fonts::default();
+  if !cli.no_default_fonts {
+    fonts
+      .register(FontResource::new(DEFAULT_FONT))
+      .context("failed to register bundled Geist font")?;
+  }
+  for font_path in &cli.fonts {
+    let data = fs::read(font_path)
+      .with_context(|| format!("failed to read font {}", font_path.display()))?;
+    fonts
+      .register(FontResource::new(&data))
+      .with_context(|| format!("failed to register font {}", font_path.display()))?;
+  }
+
+  let stylesheet = load_stylesheets(&cli, source.stylesheets)?;
+  let mut images = source.images;
+  images.extend(load_images(&cli.images)?);
+  let lang = parse_lang(cli.lang.as_deref())?;
+  let font_families = (!cli.font_families.is_empty()).then_some(cli.font_families.clone());
+
+  let options = RenderOptions::builder()
+    .viewport(Viewport::new((cli.width, cli.height)).with_device_pixel_ratio(cli.dpr))
+    .node(source.node)
+    .fonts(&fonts)
+    .draw_debug_border(cli.debug)
+    .images(images)
+    .stylesheet(stylesheet)
+    .time_ms(cli.time_ms)
+    .dithering(cli.dithering.into())
+    .font_families(font_families)
+    .lang(lang)
+    .build();
+
+  let bitmap = render(options).context("render failed")?;
+
+  if cli.clipboard {
+    copy_to_clipboard(&bitmap).context("failed to copy image to clipboard")?;
+    status(&cli, "copied", "bitmap copied to clipboard");
+  }
+
+  if let Some(output) = &cli.output {
+    let format = resolve_output_format(cli.format, output, cli.quality, cli.lossless)?;
+    let mut file =
+      fs::File::create(output).with_context(|| format!("failed to create {}", output.display()))?;
+    write_image(&bitmap, &mut file, format)
+      .with_context(|| format!("failed to write {}", output.display()))?;
+    status(&cli, "saved", &output.display().to_string());
+  }
+
+  if cli.preview && io::stdout().is_terminal() {
+    let mut png = Vec::new();
+    write_image(&bitmap, &mut png, TakumiOutputFormat::Png)
+      .context("failed to encode PNG preview")?;
+    write_kitty_image(&png).context("failed to write Kitty graphics preview")?;
+    status(
+      &cli,
+      "rendered",
+      &format!("{}x{} px", bitmap.width(), bitmap.height()),
+    );
+  } else if cli.preview && !cli.quiet {
+    status(
+      &cli,
+      "skipped",
+      "stdout is not a terminal; preview disabled",
+    );
+  }
+
+  Ok(())
+}
+
+impl Cli {
+  fn validate(&self) -> Result<()> {
+    if self.width == 0 || self.height == 0 {
+      bail!("--width and --height must be greater than zero");
+    }
+    if self.dpr <= 0.0 {
+      bail!("--dpr must be greater than zero");
+    }
+    Ok(())
+  }
+}
+
+impl From<Dither> for DitheringAlgorithm {
+  fn from(value: Dither) -> Self {
+    match value {
+      Dither::None => Self::None,
+      Dither::OrderedBayer => Self::OrderedBayer,
+      Dither::FloydSteinberg => Self::FloydSteinberg,
+    }
+  }
+}
+
+struct RenderSource {
+  node: Node,
+  stylesheets: Vec<String>,
+  images: HashMap<Arc<str>, ImageSource>,
+}
+
+#[derive(Clone, Debug)]
+enum AssetBase {
+  File(PathBuf),
+  Url(Url),
+  None,
+}
+
+fn read_render_source(input: Option<&str>) -> Result<RenderSource> {
+  match input {
+    Some(input) if input != "-" && is_http_url(input) => {
+      let url = Url::parse(input).with_context(|| format!("invalid URL: {input}"))?;
+      let html = fetch_text(url.as_str())?;
+      parse_html_source(&html, AssetBase::Url(url))
+    }
+    Some(input) if input != "-" => {
+      let path = Path::new(input);
+      let (path, html_base) = resolve_input_path(path)?;
+      let contents =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+      if is_html_path(&path) || looks_like_html(&contents) {
+        parse_html_source(&contents, AssetBase::File(html_base))
+      } else {
+        parse_json_source(&contents)
+      }
+    }
+    _ => {
+      if io::stdin().is_terminal() {
+        bail!("provide an input path/URL or pipe JSON/HTML to stdin");
+      }
+      let mut input = String::new();
+      io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read stdin")?;
+      if looks_like_html(&input) {
+        parse_html_source(&input, AssetBase::None)
+      } else {
+        parse_json_source(&input)
+      }
+    }
+  }
+}
+
+fn parse_json_source(json: &str) -> Result<RenderSource> {
+  let node = serde_json::from_str::<Node>(json).context("failed to parse Takumi node JSON")?;
+  Ok(RenderSource {
+    node,
+    stylesheets: Vec::new(),
+    images: HashMap::new(),
+  })
+}
+
+fn resolve_input_path(path: &Path) -> Result<(PathBuf, PathBuf)> {
+  if path.is_dir() {
+    let index = path.join("index.html");
+    if !index.is_file() {
+      bail!(
+        "directory input must contain index.html: {}",
+        path.display()
+      );
+    }
+    return Ok((index, path.to_path_buf()));
+  }
+
+  let file = path.to_path_buf();
+  let base = file
+    .parent()
+    .filter(|parent| !parent.as_os_str().is_empty())
+    .unwrap_or_else(|| Path::new("."))
+    .to_path_buf();
+  Ok((file, base))
+}
+
+fn is_html_path(path: &Path) -> bool {
+  matches!(
+    path
+      .extension()
+      .and_then(|extension| extension.to_str())
+      .map(str::to_ascii_lowercase)
+      .as_deref(),
+    Some("html" | "htm")
+  )
+}
+
+fn looks_like_html(input: &str) -> bool {
+  input.trim_start().starts_with('<')
+}
+
+fn is_http_url(input: &str) -> bool {
+  input.starts_with("https://") || input.starts_with("http://")
+}
+
+fn load_stylesheets(cli: &Cli, mut sources: Vec<String>) -> Result<StyleSheet> {
+  sources.reserve(cli.stylesheets.len() + cli.css.len());
+  for path in &cli.stylesheets {
+    sources.push(
+      fs::read_to_string(path)
+        .with_context(|| format!("failed to read stylesheet {}", path.display()))?,
+    );
+  }
+  sources.extend(cli.css.iter().cloned());
+  Ok(StyleSheet::parse_owned_list_loosy(sources))
+}
+
+fn parse_html_source(html: &str, base: AssetBase) -> Result<RenderSource> {
+  let document = Html::parse_document(html);
+  let mut context = HtmlContext {
+    base,
+    stylesheets: Vec::new(),
+    images: HashMap::new(),
+  };
+
+  collect_document_styles(&document, &mut context)?;
+
+  let body = find_first_element(&document, "body");
+  let explicit_body = contains_tag(html, "body");
+  let mut nodes = Vec::new();
+
+  if explicit_body {
+    if let Some(body) = body
+      && let Some(node) = build_element_node(body, &mut context)?
+    {
+      nodes.push(node);
+    }
+  } else if let Some(body) = body {
+    for child in body.children() {
+      build_static_nodes(child, &mut context, &mut nodes)?;
+    }
+  } else {
+    for child in document.tree.root().children() {
+      build_static_nodes(child, &mut context, &mut nodes)?;
+    }
+  }
+
+  let node = match nodes.len() {
+    0 => Node::container([]),
+    1 => nodes.remove(0),
+    _ => Node::container(nodes).with_style(parse_style("width: 100%; height: 100%;")?),
+  };
+
+  Ok(RenderSource {
+    node,
+    stylesheets: context.stylesheets,
+    images: context.images,
+  })
+}
+
+struct HtmlContext {
+  base: AssetBase,
+  stylesheets: Vec<String>,
+  images: HashMap<Arc<str>, ImageSource>,
+}
+
+type HtmlNodeRef<'a> = ego_tree::NodeRef<'a, HtmlNode>;
+
+fn collect_document_styles(document: &Html, context: &mut HtmlContext) -> Result<()> {
+  for child in document.tree.root().children() {
+    collect_styles(child, context)?;
+  }
+  Ok(())
+}
+
+fn collect_styles(node: HtmlNodeRef<'_>, context: &mut HtmlContext) -> Result<()> {
+  let HtmlNode::Element(element) = node.value() else {
+    return Ok(());
+  };
+
+  match element.name() {
+    "style" => {
+      let css = node
+        .children()
+        .filter_map(|child| match child.value() {
+          HtmlNode::Text(text) => Some(text.text.to_string()),
+          _ => None,
+        })
+        .collect::<String>();
+      if !css.is_empty() {
+        context.stylesheets.push(css);
+      }
+      return Ok(());
+    }
+    "link" if is_stylesheet_link(element) => {
+      if let Some(href) = element.attr("href") {
+        context
+          .stylesheets
+          .push(load_text_asset(href, &context.base)?);
+      }
+      return Ok(());
+    }
+    _ => {}
+  }
+
+  for child in node.children() {
+    collect_styles(child, context)?;
+  }
+
+  Ok(())
+}
+
+fn build_static_nodes(
+  node: HtmlNodeRef<'_>,
+  context: &mut HtmlContext,
+  nodes: &mut Vec<Node>,
+) -> Result<()> {
+  match node.value() {
+    HtmlNode::Text(text) => {
+      let value = text.text.to_string();
+      if !value.is_empty() {
+        nodes.push(Node::text(value).with_preset(parse_style("display: inline;")?));
+      }
+    }
+    HtmlNode::Element(_) => {
+      if let Some(render_node) = build_element_node(node, context)? {
+        nodes.push(render_node);
+      }
+    }
+    _ => {}
+  }
+  Ok(())
+}
+
+fn build_element_node(node: HtmlNodeRef<'_>, context: &mut HtmlContext) -> Result<Option<Node>> {
+  let HtmlNode::Element(element) = node.value() else {
+    return Ok(None);
+  };
+
+  let tag = element.name();
+  if matches!(
+    tag,
+    "style" | "script" | "template" | "head" | "meta" | "title" | "link"
+  ) {
+    return Ok(None);
+  }
+
+  if tag == "br" {
+    return Ok(Some(apply_metadata(Node::text("\n"), element)?));
+  }
+
+  if tag == "img" {
+    let Some(src) = element.attr("src") else {
+      bail!("image element must have a src attribute");
+    };
+    preload_image(src, context)?;
+    let data = ImageData::from((
+      src.to_owned(),
+      parse_dimension(element.attr("width")),
+      parse_dimension(element.attr("height")),
+    ));
+    return Ok(Some(apply_metadata(Node::image(data), element)?));
+  }
+
+  if is_void_element(tag) {
+    return Ok(None);
+  }
+
+  if tag == "svg" {
+    let svg = ElementRef::wrap(node)
+      .ok_or_else(|| anyhow!("failed to serialize svg element"))?
+      .html();
+    let data = ImageData::from((
+      svg,
+      parse_dimension(element.attr("width")),
+      parse_dimension(element.attr("height")),
+    ));
+    return Ok(Some(apply_metadata(Node::image(data), element)?));
+  }
+
+  if let Some(text) = only_text_children(node)
+    && !text.is_empty()
+  {
+    return Ok(Some(apply_metadata(Node::text(text), element)?));
+  }
+
+  let mut children = Vec::new();
+  for child in node.children() {
+    build_static_nodes(child, context, &mut children)?;
+  }
+
+  Ok(Some(apply_metadata(Node::container(children), element)?))
+}
+
+fn apply_metadata(mut node: Node, element: &Element) -> Result<Node> {
+  let tag = element.name();
+  node = node.with_tag_name(tag);
+
+  if let Some(preset) = preset_style(tag)? {
+    node = node.with_preset(preset);
+  }
+  if let Some(class_name) = element.attr("class") {
+    node = node.with_class_name(class_name);
+  }
+  if let Some(id) = element.attr("id") {
+    node = node.with_id(id);
+  }
+  if let Some(style) = element
+    .attr("style")
+    .filter(|style| !style.trim().is_empty())
+  {
+    node = node.with_style(parse_style(style)?);
+  }
+  if let Some(tw) = element.attr("tw").filter(|tw| !tw.trim().is_empty()) {
+    node = node.with_tw(
+      TailwindValues::from_str(tw).map_err(|error| anyhow!("invalid tw attribute: {error}"))?,
+    );
+  }
+  if let Some(dir) = parse_direction(element.attr("dir")) {
+    node = node.with_dir(dir);
+  }
+  if let Some(lang) = element.attr("lang") {
+    node = node.with_lang(lang);
+  }
+
+  let attributes = element
+    .attrs()
+    .filter(|(name, value)| should_keep_attribute(name, value))
+    .map(|(name, value)| (Box::<str>::from(name), Box::<str>::from(value)))
+    .collect::<std::collections::BTreeMap<_, _>>();
+
+  if !attributes.is_empty() {
+    node = node.with_attributes(attributes);
+  }
+
+  Ok(node)
+}
+
+fn parse_style(input: &str) -> Result<Style> {
+  let declarations = StyleDeclarationBlock::from_str(input)
+    .with_context(|| format!("failed to parse inline style `{input}`"))?;
+  Ok(Style::from(declarations))
+}
+
+fn preset_style(tag: &str) -> Result<Option<Style>> {
+  let css = match tag {
+    "html" => "display: block;",
+    "body" => "margin: 8px; display: block;",
+    "p" => "margin-top: 1em; margin-bottom: 1em; display: block;",
+    "blockquote" | "figure" => {
+      "margin-top: 1em; margin-bottom: 1em; margin-left: 40px; margin-right: 40px; display: block;"
+    }
+    "figcaption" | "article" | "aside" | "footer" | "header" | "hgroup" | "main" | "nav"
+    | "section" | "div" => "display: block;",
+    "address" => "font-style: italic; display: block;",
+    "center" => "text-align: center; display: block;",
+    "hr" => {
+      "margin-top: 0.5em; margin-bottom: 0.5em; margin-left: auto; margin-right: auto; border-width: 1px; display: block;"
+    }
+    "h1" => {
+      "font-size: 2em; margin-top: 0.67em; margin-bottom: 0.67em; margin-left: 0; margin-right: 0; font-weight: bold; display: block;"
+    }
+    "h2" => {
+      "font-size: 1.5em; margin-top: 0.83em; margin-bottom: 0.83em; margin-left: 0; margin-right: 0; font-weight: bold; display: block;"
+    }
+    "h3" => {
+      "font-size: 1.17em; margin-top: 1em; margin-bottom: 1em; margin-left: 0; margin-right: 0; font-weight: bold; display: block;"
+    }
+    "h4" => {
+      "margin-top: 1.33em; margin-bottom: 1.33em; margin-left: 0; margin-right: 0; font-weight: bold; display: block;"
+    }
+    "h5" => {
+      "font-size: 0.83em; margin-top: 1.67em; margin-bottom: 1.67em; margin-left: 0; margin-right: 0; font-weight: bold; display: block;"
+    }
+    "h6" => {
+      "font-size: 0.67em; margin-top: 2.33em; margin-bottom: 2.33em; margin-left: 0; margin-right: 0; font-weight: bold; display: block;"
+    }
+    "u" => "text-decoration: underline;",
+    "strong" | "b" => "font-weight: bold;",
+    "i" | "em" | "cite" | "dfn" => "font-style: italic;",
+    "code" | "kbd" | "samp" => "font-family: monospace;",
+    "pre" => "font-family: monospace; white-space: pre; margin: 1em 0; display: block;",
+    "mark" => "background-color: yellow; color: black;",
+    "big" => "font-size: 1.2em;",
+    "small" => "font-size: 0.8em;",
+    "s" => "text-decoration: line-through;",
+    _ => return Ok(None),
+  };
+  Ok(Some(parse_style(css)?))
+}
+
+fn parse_direction(dir: Option<&str>) -> Option<Direction> {
+  match dir {
+    Some("ltr") => Some(Direction::Ltr),
+    Some("rtl") => Some(Direction::Rtl),
+    _ => None,
+  }
+}
+
+fn should_keep_attribute(name: &str, value: &str) -> bool {
+  !value.is_empty()
+    && !matches!(
+      name,
+      "class"
+        | "className"
+        | "id"
+        | "style"
+        | "tw"
+        | "ref"
+        | "key"
+        | "dangerouslySetInnerHTML"
+        | "suppressHydrationWarning"
+    )
+}
+
+fn only_text_children(node: HtmlNodeRef<'_>) -> Option<String> {
+  let mut text = String::new();
+
+  for child in node.children() {
+    match child.value() {
+      HtmlNode::Text(value) => text.push_str(value.text.as_ref()),
+      HtmlNode::Comment(_) => {}
+      _ => return None,
+    }
+  }
+
+  Some(text)
+}
+
+fn parse_dimension(value: Option<&str>) -> Option<f32> {
+  value.and_then(|value| value.trim().parse::<f32>().ok())
+}
+
+fn find_first_element<'a>(document: &'a Html, name: &str) -> Option<HtmlNodeRef<'a>> {
+  fn find_in<'a>(node: HtmlNodeRef<'a>, name: &str) -> Option<HtmlNodeRef<'a>> {
+    if let HtmlNode::Element(element) = node.value()
+      && element.name() == name
+    {
+      return Some(node);
+    }
+
+    node.children().find_map(|child| find_in(child, name))
+  }
+
+  document
+    .tree
+    .root()
+    .children()
+    .find_map(|child| find_in(child, name))
+}
+
+fn contains_tag(html: &str, tag: &str) -> bool {
+  let needle = format!("<{tag}");
+  html.to_ascii_lowercase().contains(&needle)
+}
+
+fn is_stylesheet_link(element: &Element) -> bool {
+  element.attr("rel").is_some_and(|rel| {
+    rel
+      .split_ascii_whitespace()
+      .any(|part| part.eq_ignore_ascii_case("stylesheet"))
+  })
+}
+
+fn is_void_element(tag: &str) -> bool {
+  matches!(
+    tag,
+    "area" | "base" | "col" | "embed" | "hr" | "input" | "param" | "source" | "track" | "wbr"
+  )
+}
+
+fn preload_image(src: &str, context: &mut HtmlContext) -> Result<()> {
+  if src.starts_with("data:") || src.trim_start().starts_with("<svg") {
+    return Ok(());
+  }
+  if context.images.contains_key(src) {
+    return Ok(());
+  }
+
+  let bytes = load_binary_asset(src, &context.base)?;
+  let image = ImageSource::from_bytes(&bytes)
+    .with_context(|| format!("failed to decode image asset `{src}`"))?;
+  context.images.insert(Arc::from(src), image);
+  Ok(())
+}
+
+fn load_text_asset(src: &str, base: &AssetBase) -> Result<String> {
+  match resolve_asset(src, base)? {
+    ResolvedAsset::File(path) => {
+      fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))
+    }
+    ResolvedAsset::Url(url) => fetch_text(url.as_str()),
+  }
+}
+
+fn load_binary_asset(src: &str, base: &AssetBase) -> Result<Vec<u8>> {
+  match resolve_asset(src, base)? {
+    ResolvedAsset::File(path) => {
+      fs::read(&path).with_context(|| format!("failed to read {}", path.display()))
+    }
+    ResolvedAsset::Url(url) => fetch_bytes(url.as_str()),
+  }
+}
+
+enum ResolvedAsset {
+  File(PathBuf),
+  Url(Url),
+}
+
+fn resolve_asset(src: &str, base: &AssetBase) -> Result<ResolvedAsset> {
+  if is_http_url(src) {
+    return Ok(ResolvedAsset::Url(
+      Url::parse(src).with_context(|| format!("invalid asset URL: {src}"))?,
+    ));
+  }
+
+  match base {
+    AssetBase::File(root) => {
+      let relative = local_asset_path(src).trim_start_matches('/');
+      Ok(ResolvedAsset::File(root.join(relative)))
+    }
+    AssetBase::Url(base) => {
+      Ok(ResolvedAsset::Url(base.join(src).with_context(|| {
+        format!("failed to resolve `{src}` against {base}")
+      })?))
+    }
+    AssetBase::None => bail!("cannot resolve relative asset `{src}` without an input path or URL"),
+  }
+}
+
+fn local_asset_path(src: &str) -> &str {
+  let query = src.find('?').unwrap_or(src.len());
+  let fragment = src.find('#').unwrap_or(src.len());
+  &src[..query.min(fragment)]
+}
+
+fn fetch_text(url: &str) -> Result<String> {
+  ureq::get(url)
+    .call()
+    .with_context(|| format!("failed to fetch {url}"))?
+    .into_string()
+    .with_context(|| format!("failed to read response text from {url}"))
+}
+
+fn fetch_bytes(url: &str) -> Result<Vec<u8>> {
+  let response = ureq::get(url)
+    .call()
+    .with_context(|| format!("failed to fetch {url}"))?;
+  let mut bytes = Vec::new();
+  response
+    .into_reader()
+    .read_to_end(&mut bytes)
+    .with_context(|| format!("failed to read response bytes from {url}"))?;
+  Ok(bytes)
+}
+
+fn load_images(args: &[ImageArg]) -> Result<HashMap<Arc<str>, ImageSource>> {
+  let mut images = HashMap::with_capacity(args.len());
+  for arg in args {
+    let bytes = fs::read(&arg.path)
+      .with_context(|| format!("failed to read image {}", arg.path.display()))?;
+    let source = ImageSource::from_bytes(&bytes)
+      .with_context(|| format!("failed to decode image {}", arg.path.display()))?;
+    images.insert(Arc::from(arg.src.as_str()), source);
+  }
+  Ok(images)
+}
+
+fn parse_lang(lang: Option<&str>) -> Result<Option<Language>> {
+  lang
+    .map(|value| Language::parse(value).map_err(|_| anyhow!("invalid BCP-47 language: {value}")))
+    .transpose()
+}
+
+fn resolve_output_format(
+  requested: Option<ImageFormat>,
+  output: &Path,
+  quality: Option<u8>,
+  lossless: bool,
+) -> Result<TakumiOutputFormat> {
+  let format = match requested {
+    Some(format) => format,
+    None => infer_format(output).ok_or_else(|| {
+      anyhow!(
+        "could not infer output format from {}; pass --format",
+        output.display()
+      )
+    })?,
+  };
+
+  Ok(match format {
+    ImageFormat::Png => TakumiOutputFormat::Png,
+    ImageFormat::Jpeg => TakumiOutputFormat::Jpeg {
+      quality: quality.map_or_else(Quality::default, Quality::new),
+    },
+    ImageFormat::Webp if lossless || quality.is_none() => TakumiOutputFormat::WebPLossless,
+    ImageFormat::Webp => TakumiOutputFormat::WebP {
+      quality: quality.map_or_else(Quality::default, Quality::new),
+    },
+    ImageFormat::WebpLossless => TakumiOutputFormat::WebPLossless,
+    ImageFormat::Ico => TakumiOutputFormat::Ico,
+  })
+}
+
+fn infer_format(path: &Path) -> Option<ImageFormat> {
+  match path
+    .extension()
+    .and_then(|extension| extension.to_str())
+    .map(str::to_ascii_lowercase)
+    .as_deref()
+  {
+    Some("png") => Some(ImageFormat::Png),
+    Some("jpg" | "jpeg") => Some(ImageFormat::Jpeg),
+    Some("webp") => Some(ImageFormat::Webp),
+    Some("ico") => Some(ImageFormat::Ico),
+    _ => None,
+  }
+}
+
+fn copy_to_clipboard(bitmap: &takumi::prelude::Bitmap) -> Result<()> {
+  let mut clipboard = Clipboard::new()?;
+  clipboard.set_image(ClipboardImage {
+    width: bitmap.width() as usize,
+    height: bitmap.height() as usize,
+    bytes: Cow::Borrowed(bitmap.as_raw()),
+  })?;
+  Ok(())
+}
+
+fn write_kitty_image(png: &[u8]) -> Result<()> {
+  let encoded = STANDARD.encode(png);
+  let mut stdout = io::stdout().lock();
+  let mut chunks = encoded.as_bytes().chunks(KITTY_CHUNK_SIZE).peekable();
+  let mut first = true;
+
+  while let Some(chunk) = chunks.next() {
+    let more = chunks.peek().is_some();
+    let m = u8::from(more);
+    if first {
+      write!(stdout, "\x1b_Ga=T,f=100,q=2,m={m};")?;
+      first = false;
+    } else {
+      write!(stdout, "\x1b_Gm={m};")?;
+    }
+    stdout.write_all(chunk)?;
+    write!(stdout, "\x1b\\")?;
+  }
+
+  writeln!(stdout)?;
+  stdout.flush()?;
+  Ok(())
+}
+
+fn status(cli: &Cli, label: &str, message: &str) {
+  if cli.quiet {
+    return;
+  }
+  eprintln!("\x1b[32m{label:>8}\x1b[0m {message}");
+}
+
+fn parse_image_arg(value: &str) -> Result<ImageArg, String> {
+  let (src, path) = value
+    .split_once('=')
+    .ok_or_else(|| "expected SRC=PATH".to_owned())?;
+  if src.is_empty() {
+    return Err("SRC must not be empty".to_owned());
+  }
+  if path.is_empty() {
+    return Err("PATH must not be empty".to_owned());
+  }
+  Ok(ImageArg {
+    src: src.to_owned(),
+    path: PathBuf::from(path),
+  })
+}


### PR DESCRIPTION
## Summary

Adds a Rust `takumi` CLI binary in a new `takumi-cli` workspace crate.

The CLI can render Takumi node JSON and static HTML sources, including file input, stdin, directories resolved through `index.html`, and static HTML URLs. It supports terminal preview through the Kitty graphics protocol for Ghostty-compatible terminals, saving encoded output, copying rendered bitmaps to the clipboard, viewport sizing, DPR, fonts, stylesheets, inline CSS, debug borders, dithering, and image asset preloading.

## Details

- Adds `takumi-cli` to the Cargo workspace.
- Parses Takumi node JSON directly through the existing `Node` serde surface.
- Adds a native Rust static HTML parser path using `scraper`.
- Extracts `<style>` blocks and linked stylesheets.
- Converts static HTML into Takumi container/text/image nodes.
- Resolves directory input as `<dir>/index.html`.
- Resolves local and URL-based image assets for `<img>` nodes.
- Keeps explicit `--image SRC=PATH` overrides for manual asset injection.

## Validation

- `cargo fmt --check`
- `cargo check -p takumi-cli`
- `cargo clippy -p takumi-cli --all-targets -- -D warnings`
- Smoke-tested JSON input, HTML stdin, HTML file input, directory `index.html`, linked CSS, local image assets, and URL HTML input.