### PR TITLE
CSS: fix offset-path/clip-path path() not scaled by DPR

### DIFF
--- a/.tegami/offset-path-dpr.md
+++ b/.tegami/offset-path-dpr.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-css": patch
+  "cargo:takumi-raster": patch
+  "cargo:takumi-svg": patch
+---
+
+### Fix `path()` ignoring device-pixel-ratio
+
+`offset-path: path()` and `clip-path: path()` used the authored SVG coordinates verbatim while every other basic shape crossed the dpr boundary through `to_px`. At `devicePixelRatio != 1` the path was mis-scaled by `1/dpr`. The coordinates are now scaled into device space like the other shapes.

--- a/takumi-css/src/style/properties/offset_path.rs
+++ b/takumi-css/src/style/properties/offset_path.rs
@@ -545,7 +545,12 @@ fn basic_shape_to_bezpath(
   let px = |length: Length, full: f32| f64::from(length.to_px(sizing, full));
 
   match shape {
-    BasicShape::Path(path_shape) => BezPath::from_svg(&path_shape.path).ok(),
+    BasicShape::Path(path_shape) => {
+      // path() coords are CSS px; scale to device space like the to_px shapes.
+      let mut path = BezPath::from_svg(&path_shape.path).ok()?;
+      path.apply_affine(kurbo::Affine::scale(f64::from(sizing.to_device(1.0))));
+      Some(path)
+    }
     BasicShape::Polygon(polygon) => {
       let mut coordinates = polygon.coordinates.iter();
       let first = coordinates.next()?;
@@ -835,6 +840,30 @@ mod tests {
       size,
     )
     .unwrap();
+    assert!((point.x - 100.0).abs() < 0.5, "x = {}", point.x);
+  }
+
+  #[test]
+  fn path_coordinates_scale_with_device_pixel_ratio() {
+    let path = OffsetPath::from_str("path('M 0 0 L 100 0')").unwrap();
+    let size = Size {
+      width: 400.0,
+      height: 400.0,
+    };
+    let sizing = SizingContext::builder()
+      .viewport(crate::Viewport::new((400, 400)).with_device_pixel_ratio(2.0))
+      .build();
+
+    let (point, _) = sample_offset_path(
+      &path,
+      Length::Percentage(50.0),
+      &OffsetPosition::Normal,
+      &sizing,
+      size,
+    )
+    .unwrap();
+
+    // The authored 100px line is CSS px; at dpr 2 its midpoint sits at 100 device px.
     assert!((point.x - 100.0).abs() < 0.5, "x = {}", point.x);
   }
 

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -13,6 +13,7 @@ use crate::{
     Affine, Axis, BasicShape, BorderStyle, Color, ComputedStyle, FillRule, ImageScalingAlgorithm,
     Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
   },
+  scale_commands,
 };
 use takumi_core::geometry::transformed_rect_extents;
 
@@ -675,7 +676,9 @@ pub(crate) fn render_clip_shape_mask(
       }
     }
     BasicShape::Path(shape) => {
-      paths.extend(shape.path.as_ref().commands());
+      // path() coords are CSS px; scale to device space like the to_px shapes.
+      let scale = context.sizing.to_device(1.0);
+      paths.extend(scale_commands(shape.path.as_ref().commands(), scale));
     }
   }
 

--- a/takumi-raster/src/path.rs
+++ b/takumi-raster/src/path.rs
@@ -253,6 +253,22 @@ impl PathData for str {
   }
 }
 
+/// Scale a command list's coordinates uniformly (CSS px → device space).
+pub(crate) fn scale_commands(commands: Vec<Command>, scale: f32) -> Vec<Command> {
+  let point = |pt: TinyPoint| TinyPoint::from_xy(pt.x * scale, pt.y * scale);
+
+  commands
+    .into_iter()
+    .map(|command| match command {
+      Command::MoveTo(a) => Command::MoveTo(point(a)),
+      Command::LineTo(a) => Command::LineTo(point(a)),
+      Command::QuadTo(a, b) => Command::QuadTo(point(a), point(b)),
+      Command::CubicTo(a, b, c) => Command::CubicTo(point(a), point(b), point(c)),
+      Command::Close => Command::Close,
+    })
+    .collect()
+}
+
 pub(crate) fn build_path(commands: &[Command]) -> Option<TinyPath> {
   let mut builder = TinyPathBuilder::new();
 

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -408,7 +408,9 @@ pub(crate) fn emit_clip_path_group(
     }
     BasicShape::Path(path) => {
       let even_odd = path.fill_rule.unwrap_or(node.context.style.clip_rule) == FillRule::EvenOdd;
-      let transform = format!("translate({} {})", Num(x), Num(y));
+      // Inner scale lifts CSS-px path() coords to device space; translate offsets after.
+      let scale = sizing.to_device(1.0);
+      let transform = format!("translate({} {}) scale({})", Num(x), Num(y), Num(scale));
       doc.clip_path_transformed(&path.path, even_odd, Some(&transform))?
     }
   };


### PR DESCRIPTION
## Problem

`offset-path: path()` and `clip-path: path()` used the authored SVG coordinates verbatim, while every other basic shape (`circle()`, `ellipse()`, `inset()`, `polygon()`, `ray()`) crosses the single dpr boundary via `Length::to_px → SizingContext::to_device`. So at `devicePixelRatio != 1`, `path()` shapes were mis-scaled by `1/dpr` — element placement / clip drawn `dpr×` too small relative to the box.

Found via an empirical centroid test (a marker on `offset-path: path()` stayed at the same **device** pixel across dpr 1/2/3 instead of scaling). The #849 "single dpr boundary" refactor funneled every conversion through `to_device`; the three raw `path()` literal-coordinate sites slipped that net.

## Fix

Scale the parsed `path()` coordinates into device space at all three sites (audited + adversarially verified with a multi-agent workflow):

- `takumi-css` offset-path sampler — `Affine::scale(to_device(1.0))` on the `BezPath`.
- `takumi-raster` clip mask — new `scale_commands` helper on the parsed command list.
- `takumi-svg` clip transform — inner `scale(s)` in `translate(x y) scale(s)`.

## Verification

- New unit test: `path_coordinates_scale_with_device_pixel_ratio` (sampler at dpr 2).
- Centroid test now constant in CSS space across dpr 1/2/3 (`171 · 342.8 · 514.5` device = `171×dpr`).
- All 205 `takumi` fixture tests pass; **zero golden webps changed** (dpr 1 → `to_device(1.0)=1.0`, no behaviour change).
- `cargo clippy` clean.

https://claude.ai/code/session_018MtirZ85oShW3PeRvvAQLx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `offset-path: path()` and `clip-path: path()` so authored SVG coordinates are correctly scaled for high-DPI displays (when device pixel ratio isn’t 1x), preventing misaligned clipping/motion paths.
  * Updated the rendering of path-based clip shapes and masking to lift CSS-pixel coordinates into device space before applying transforms.
  * Added a test to ensure path positioning stays accurate across device pixel ratios.
* **Documentation**
  * Updated the behavior note for `offset-path: path()` and `clip-path: path()` regarding device-space scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->