### PR TITLE
JS: keep Vite WASM loader out of Node bundles

### DIFF
--- a/.tegami/wasm-escape-hatch-no-auto.md
+++ b/.tegami/wasm-escape-hatch-no-auto.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:takumi-js": patch
+---
+
+### Keep the Vite WASM loader out of Node bundles
+
+The WASM escape hatch always carries an explicit `module`, so it now loads
+`wasm-init` directly instead of `@takumi-rs/wasm/auto`. A Next/webpack node
+build that only uses napi no longer drags the Vite `?url` binary loader into
+its graph, where the unresolvable query broke the build.

--- a/takumi-js/src/backend/wasm-init.ts
+++ b/takumi-js/src/backend/wasm-init.ts
@@ -7,10 +7,7 @@ import type { Backend, BackendModule } from "./types";
  * `@takumi-rs/wasm` guards against double init, so a binary already loaded by
  * `@takumi-rs/wasm/auto` (e.g. on Deno) makes this a no-op.
  */
-export async function initWasm(
-  fallback: BackendModule,
-  module: BackendModule | undefined,
-): Promise<Backend> {
+export async function initWasm(module?: BackendModule, fallback?: BackendModule): Promise<Backend> {
   const source = module ?? fallback;
   const resolved = typeof source === "function" ? await source() : await source;
   const input =

--- a/takumi-js/src/backend/wasm.ts
+++ b/takumi-js/src/backend/wasm.ts
@@ -5,4 +5,4 @@ import type { LoadBackend } from "./types";
 // Selected by every non-Node condition (workerd, worker, deno, browser, and the
 // default fallback). `@takumi-rs/wasm/auto` resolves to the right binary loader
 // for the host bundler via its own conditions.
-export const loadBackend: LoadBackend = (module) => initWasm(autoModule, module);
+export const loadBackend: LoadBackend = (module) => initWasm(module, autoModule);

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -1,5 +1,5 @@
 import { loadBackend } from "#backend";
-import type { BackendModule, LoadBackend } from "./backend/types";
+import type { BackendModule } from "./backend/types";
 
 type Imports = Awaited<ReturnType<typeof loadBackend>>;
 
@@ -15,9 +15,7 @@ export function getImports(module?: BackendModule): Promise<Imports> {
   importPromise ??= (
     module === undefined
       ? loadBackend()
-      : import("./backend/wasm").then((wasm: { loadBackend: LoadBackend }) =>
-          wasm.loadBackend(module),
-        )
+      : import("./backend/wasm-init").then(({ initWasm }) => initWasm(module))
   ).catch((error) => {
     importPromise = null;
 


### PR DESCRIPTION
## Problem

Deploying a Next (Turbopack) node route through `takumi-js` broke at build time, with the bundler tracing into the Vite WASM loader:

```
@takumi-rs/wasm/bundlers/vite.mjs
takumi-js/dist/backend/wasm.mjs
takumi-js/dist/render-*.mjs
takumi-js/dist/response.mjs
src/app/render/route.tsx
```

The node route uses napi and never touches WASM at runtime, but `getImports` reached the WASM escape hatch via `import("./backend/wasm")`, whose module eagerly imports `@takumi-rs/wasm/auto`. On a node target `auto` resolves through the `module` condition to `bundlers/vite.mjs`, whose `import "...wasm?url"` query Turbopack/webpack cannot parse — so the lazy chunk fails the whole build.

## Fix

The escape hatch is only taken when the caller passes an explicit `module` (a WASM binary), so the `auto` fallback loader is dead weight there. Route it through `backend/wasm-init` directly. `@takumi-rs/wasm/auto` is now reached only by the default WASM backend (browser / worker / edge), never a node build that just uses napi — so the Vite `?url` loader stays out of the graph.

`initWasm(module, fallback?)` makes the per-bundler binary the optional fallback; the default WASM backend still passes `auto`.

## Validation

`bun test` (incl. `bundlers.test.ts` resolution matrix) and `tsc --noEmit` pass.

https://claude.ai/code/session_01VagweJ2DbhK43Nn6stV3GE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WASM loading for Node, Next.js, and webpack builds so they no longer depend on an incompatible auto-loader path.
  * Prevented build failures caused by an unresolved binary query in non-Vite environments.
  * Kept backend initialization working with the same caching and fallback behavior while making WASM startup more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->