### PR TITLE
Docs: add takumi users to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Compare rendering output across providers at [image-bench.kane.tw](https://image
 ## Who's Using Takumi
 
 - [Dcard](https://dcard.tw) renders post share images
+- [TanStack](https://tanstack.com) renders OG images for its docs
 - [Fumadocs](https://fumadocs.dev) generates its docs OG images
 - [Nuxt OG Image](https://nuxtseo.com/docs/og-image/renderers/takumi) ships Takumi as a built-in renderer
 - [shiki-image](https://github.com/pi0/shiki-image) turns syntax-highlighted code into images

--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -8,8 +8,38 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
+    title: "TanStack",
+    image: "https://tanstack.com/api/og/query.png",
+    url: "https://tanstack.com",
+    width: 1200,
+    height: 630,
+  },
+  {
     image: "https://www.fumadocs.dev/og/image.webp",
     url: "https://fumadocs.dev/",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Wotaku",
+    image: "https://wotaku.wiki/__og_image__/og.png",
+    url: "https://wotaku.wiki",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Stepperize",
+    image:
+      "https://stepperize.com/api/og?title=Stepperize&description=The+type-safe+way+to+build+multi-step+experiences+in+React.&section=Documentation&variant=website",
+    url: "https://stepperize.com",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Swetrix",
+    image:
+      "https://swetrix.com/api/og-image.png?title=Swetrix&description=Open+source,+privacy-first+web+analytics",
+    url: "https://swetrix.com",
     width: 1200,
     height: 630,
   },
@@ -20,23 +50,18 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
-    image: "https://res.cloudinary.com/alfanjauhari/image/upload/og/works/gcbc.webp",
-    url: "https://www.alfanjauhari.com/",
+    title: "Bookhive",
+    image: "https://bookhive.buzz/og/marketing",
+    url: "https://bookhive.buzz",
     width: 1200,
     height: 630,
   },
   {
-    url: "https://who-to-bother-at.com",
-    image: "https://who-to-bother-at.com/og/vercel",
+    title: "Nakafa",
+    image: "https://nakafa.com/open-graph/en-about.png",
+    url: "https://nakafa.com",
     width: 1200,
     height: 630,
-  },
-  {
-    image:
-      "https://image-bench.kane.tw/render?provider=takumi-webp&template=gradients&width=800&height=400",
-    url: "https://image-bench.kane.tw",
-    width: 800,
-    height: 400,
   },
   {
     image: "https://shotwell.app/og-image.png",
@@ -69,48 +94,23 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
-    title: "TanStack",
-    image: "https://tanstack.com/api/og/query.png",
-    url: "https://tanstack.com",
+    image: "https://res.cloudinary.com/alfanjauhari/image/upload/og/works/gcbc.webp",
+    url: "https://www.alfanjauhari.com/",
     width: 1200,
     height: 630,
   },
   {
-    title: "Wotaku",
-    image: "https://wotaku.wiki/__og_image__/og.png",
-    url: "https://wotaku.wiki",
+    url: "https://who-to-bother-at.com",
+    image: "https://who-to-bother-at.com/og/vercel",
     width: 1200,
     height: 630,
   },
   {
-    title: "Stepperize",
     image:
-      "https://stepperize.com/api/og?title=Stepperize&description=The+type-safe+way+to+build+multi-step+experiences+in+React.&section=Documentation&variant=website",
-    url: "https://stepperize.com",
-    width: 1200,
-    height: 630,
-  },
-  {
-    title: "Swetrix",
-    image:
-      "https://swetrix.com/api/og-image.png?title=Swetrix&description=Open+source,+privacy-first+web+analytics",
-    url: "https://swetrix.com",
-    width: 1200,
-    height: 630,
-  },
-  {
-    title: "Nakafa",
-    image: "https://nakafa.com/open-graph/en-about.png",
-    url: "https://nakafa.com",
-    width: 1200,
-    height: 630,
-  },
-  {
-    title: "Bookhive",
-    image: "https://bookhive.buzz/og/marketing",
-    url: "https://bookhive.buzz",
-    width: 1200,
-    height: 630,
+      "https://image-bench.kane.tw/render?provider=takumi-webp&template=gradients&width=800&height=400",
+    url: "https://image-bench.kane.tw",
+    width: 800,
+    height: 400,
   },
 ];
 

--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -64,7 +64,7 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
-    image: "https://shotwell.app/og-image.png",
+    image: "https://shotwell.app/og/docs/image.webp",
     url: "https://shotwell.app/?utm_source=takumi&utm_medium=showcase&utm_campaign=launch",
     width: 1200,
     height: 630,

--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -68,6 +68,50 @@ export const showcaseProjects: Project[] = [
     width: 1200,
     height: 630,
   },
+  {
+    title: "TanStack",
+    image: "https://tanstack.com/api/og/query.png",
+    url: "https://tanstack.com",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Wotaku",
+    image: "https://wotaku.wiki/__og_image__/og.png",
+    url: "https://wotaku.wiki",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Stepperize",
+    image:
+      "https://stepperize.com/api/og?title=Stepperize&description=The+type-safe+way+to+build+multi-step+experiences+in+React.&section=Documentation&variant=website",
+    url: "https://stepperize.com",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Swetrix",
+    image:
+      "https://swetrix.com/api/og-image.png?title=Swetrix&description=Open+source,+privacy-first+web+analytics",
+    url: "https://swetrix.com",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Nakafa",
+    image: "https://nakafa.com/open-graph/en-about.png",
+    url: "https://nakafa.com",
+    width: 1200,
+    height: 630,
+  },
+  {
+    title: "Bookhive",
+    image: "https://bookhive.buzz/og/marketing",
+    url: "https://bookhive.buzz",
+    width: 1200,
+    height: 630,
+  },
 ];
 
 export const showcaseTemplates: Template[] = [

--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -58,7 +58,7 @@ export const showcaseProjects: Project[] = [
   },
   {
     title: "Nakafa",
-    image: "https://nakafa.com/open-graph/en-about.png",
+    image: "https://nakafa.com/og/en/image.png",
     url: "https://nakafa.com",
     width: 1200,
     height: 630,


### PR DESCRIPTION
## Why
Found public sites rendering OG images with takumi but missing from the showcase.

## What
Added 6 source-verified takumi users: TanStack, Wotaku, Stepperize, Swetrix, Nakafa, Bookhive. Each has a dedicated OG route importing a takumi package; live image URLs return image/png|webp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the showcase gallery with six additional featured projects: TanStack, Wotaku, Stepperize, Swetrix, Bookhive, and Nakafa.
  * Each entry includes a title, image, link, and display dimensions for consistent layout.
  * Updated the gallery ordering to incorporate the new items smoothly alongside existing projects.
* **Documentation**
  * Updated the “Who’s Using Takumi” section to include TanStack with a direct link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->