### PR TITLE
Docs: add Astro integration guide

### DIFF
--- a/docs/content/docs/integration/astro.mdx
+++ b/docs/content/docs/integration/astro.mdx
@@ -1,0 +1,74 @@
+---
+title: Astro
+description: Generate Open Graph images for every page at build time.
+---
+
+[astro-takumi](https://github.com/vikas5914/astro-takumi) renders an Open Graph image for every page of an Astro site. During the build it reads each emitted page, renders a React component — or a [built-in preset](https://github.com/vikas5914/astro-takumi#presets) — through Takumi, and writes the image next to the HTML.
+
+<Steps>
+  <Step>
+    ### Add the integration
+
+    `astro add` wires the integration into your config. React and a font are needed too — React authors the image and never ships to the client, and fonts must be declared explicitly since system fonts are unavailable.
+
+    ```npm
+    npx astro add astro-takumi
+    ```
+
+    ```npm
+    npm i -D react
+    npm i @fontsource/roboto
+    ```
+
+  </Step>
+  <Step>
+    ### Configure the integration
+
+    Pass the fonts to render with and a `render` function. The presets cover common layouts; `site` is required so Takumi can build absolute image URLs.
+
+    <Callout>astro-takumi runs in `astro:build:done`, so it only covers statically rendered pages.</Callout>
+
+    ```js title="astro.config.mjs"
+    import { defineConfig } from "astro/config";
+    import * as fs from "node:fs";
+    import astroTakumi, { presets } from "astro-takumi";
+
+    export default defineConfig({
+      site: "https://example.com",
+      integrations: [
+        astroTakumi({
+          options: {
+            fonts: [fs.readFileSync("node_modules/@fontsource/roboto/files/roboto-latin-400-normal.woff")],
+          },
+          render: presets.blackAndWhite,
+        }),
+      ],
+    });
+    ```
+
+  </Step>
+  <Step>
+    ### Reference the image from your layout
+
+    `getImagePath` returns the URL of the image generated for the current page. The build fails if `og:image` does not match it.
+
+    ```astro title="src/layouts/Layout.astro"
+    ---
+    import { getImagePath } from "astro-takumi";
+
+    const { title } = Astro.props;
+    const { url, site } = Astro;
+
+    const openGraphImageUrl = getImagePath({ url, site });
+    ---
+
+    <head>
+      <title>{title}</title>
+      <meta property="og:title" content={title} />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content={openGraphImageUrl} />
+    </head>
+    ```
+
+  </Step>
+</Steps>

--- a/docs/content/docs/integration/astro.mdx
+++ b/docs/content/docs/integration/astro.mdx
@@ -66,6 +66,7 @@ description: Generate Open Graph images for every page at build time.
       <title>{title}</title>
       <meta property="og:title" content={title} />
       <meta property="og:type" content="website" />
+      <meta property="og:url" content={url.href} />
       <meta property="og:image" content={openGraphImageUrl} />
     </head>
     ```

--- a/docs/content/docs/integration/astro.mdx
+++ b/docs/content/docs/integration/astro.mdx
@@ -16,8 +16,7 @@ description: Generate Open Graph images for every page at build time.
     ```
 
     ```npm
-    npm i -D react
-    npm i @fontsource/roboto
+    npm i -D react @fontsource/roboto
     ```
 
   </Step>
@@ -31,6 +30,7 @@ description: Generate Open Graph images for every page at build time.
     ```js title="astro.config.mjs"
     import { defineConfig } from "astro/config";
     import * as fs from "node:fs";
+    import { fileURLToPath } from "node:url";
     import astroTakumi, { presets } from "astro-takumi";
 
     export default defineConfig({
@@ -38,7 +38,7 @@ description: Generate Open Graph images for every page at build time.
       integrations: [
         astroTakumi({
           options: {
-            fonts: [fs.readFileSync("node_modules/@fontsource/roboto/files/roboto-latin-400-normal.woff")],
+            fonts: [fs.readFileSync(fileURLToPath(import.meta.resolve("@fontsource/roboto/files/roboto-latin-400-normal.woff")))],
           },
           render: presets.blackAndWhite,
         }),
@@ -50,7 +50,7 @@ description: Generate Open Graph images for every page at build time.
   <Step>
     ### Reference the image from your layout
 
-    `getImagePath` returns the URL of the image generated for the current page. The build fails if `og:image` does not match it.
+    `getImagePath` returns the URL of the image generated for the current page. The build fails if the `og:image` value does not match that path.
 
     ```astro title="src/layouts/Layout.astro"
     ---

--- a/docs/content/docs/integration/astro.mdx
+++ b/docs/content/docs/integration/astro.mdx
@@ -3,13 +3,13 @@ title: Astro
 description: Generate Open Graph images for every page at build time.
 ---
 
-[astro-takumi](https://github.com/vikas5914/astro-takumi) renders an Open Graph image for every page of an Astro site. During the build it reads each emitted page, renders a React component — or a [built-in preset](https://github.com/vikas5914/astro-takumi#presets) — through Takumi, and writes the image next to the HTML.
+[astro-takumi](https://github.com/vikas5914/astro-takumi) renders an Open Graph image for every page of an Astro site. During the build it reads each emitted page, renders a React component (or a [built-in preset](https://github.com/vikas5914/astro-takumi#presets)) through Takumi, and writes the image next to the HTML.
 
 <Steps>
   <Step>
     ### Add the integration
 
-    `astro add` wires the integration into your config. React and a font are needed too — React authors the image and never ships to the client, and fonts must be declared explicitly since system fonts are unavailable.
+    `astro add` wires the integration into your config. You also install React and a font: React describes the layout and never ships to the client, and you declare every font yourself since system fonts are unavailable.
 
     ```npm
     npx astro add astro-takumi
@@ -23,7 +23,7 @@ description: Generate Open Graph images for every page at build time.
   <Step>
     ### Configure the integration
 
-    Pass the fonts to render with and a `render` function. The presets cover common layouts; `site` is required so Takumi can build absolute image URLs.
+    Give it the fonts to render with and a `render` function. The presets cover common layouts; set `site` so Takumi can build absolute image URLs.
 
     <Callout>astro-takumi runs in `astro:build:done`, so it only covers statically rendered pages.</Callout>
 
@@ -50,7 +50,7 @@ description: Generate Open Graph images for every page at build time.
   <Step>
     ### Reference the image from your layout
 
-    `getImagePath` returns the URL of the image generated for the current page. The build fails if the `og:image` value does not match that path.
+    `getImagePath` returns the URL of the image Takumi generates for the current page. The build fails if the `og:image` value does not match that path.
 
     ```astro title="src/layouts/Layout.astro"
     ---

--- a/docs/content/docs/integration/meta.json
+++ b/docs/content/docs/integration/meta.json
@@ -1,5 +1,5 @@
 {
   "defaultOpen": true,
   "icon": "ToyBrick",
-  "pages": ["astro", "nextjs", "nuxt", "sveltekit", "tanstack-start"]
+  "pages": ["nextjs", "nuxt", "sveltekit", "tanstack-start", "astro"]
 }

--- a/docs/content/docs/integration/meta.json
+++ b/docs/content/docs/integration/meta.json
@@ -1,5 +1,5 @@
 {
   "defaultOpen": true,
   "icon": "ToyBrick",
-  "pages": ["nextjs", "nuxt", "sveltekit", "tanstack-start"]
+  "pages": ["astro", "nextjs", "nuxt", "sveltekit", "tanstack-start"]
 }

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
         light: "github-light",
         dark: "github-dark",
       },
-      langs: ["ts", "tsx", "js", "svelte"],
+      langs: ["ts", "tsx", "js", "svelte", "astro"],
       transformers: [
         ...(rehypeCodeDefaultOptions.transformers ?? []),
         transformerTwoslash({


### PR DESCRIPTION
## Why
[astro-takumi](https://github.com/vikas5914/astro-takumi) is an actively maintained Astro integration that generates an Open Graph image per page through Takumi, but the docs had no entry for it. Astro users had no pointer.

## What
- New `integration/astro.mdx`: install, configure with a preset, reference the image via `getImagePath`. Modeled on the Nuxt page since both document a third-party integration.
- Register `astro` in the Shiki `langs` list so the `.astro` code fence highlights.
- List the page in `integration/meta.json`.

Notes for review: astro-takumi is GPL-3.0-only (Takumi is MIT) and pins `@takumi-rs/core@^1.8.7` (V1, not the V2 beta the rest of the docs target). It runs in `astro:build:done`, so static-only. None block documenting it; the page stays a neutral pointer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Astro integration documentation page explaining how to generate Open Graph images for every page at build time.
  * Updated the integrations index to include Astro.
  * Expanded documentation code highlighting to support Astro snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->