### PR TITLE
JS: explain a failed native backend load

### DIFF
--- a/.tegami/node-backend-load-error.md
+++ b/.tegami/node-backend-load-error.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "npm:takumi-js": patch
+---
+
+### Explain a failed native backend load
+
+When `@takumi-rs/core` can't load on Node, the render now throws an error
+pointing at the `module` option for the WASM backend, instead of surfacing the
+raw native loader failure.

--- a/takumi-js/src/backend/node.ts
+++ b/takumi-js/src/backend/node.ts
@@ -3,4 +3,10 @@ import type { LoadBackend } from "./types";
 // Dynamic import so bundlers don't inline the native addon — its `.node` binary
 // must resolve from node_modules at runtime, which a bundled-in copy breaks.
 // Selected by the `node`/`bun` condition, so it never reaches a worker/edge bundle.
-export const loadBackend: LoadBackend = () => import("@takumi-rs/core");
+export const loadBackend: LoadBackend = () =>
+  import("@takumi-rs/core").catch((cause) => {
+    throw new Error(
+      "Failed to load the native @takumi-rs/core backend. On a runtime without the native addon, pass a `module` (a WASM binary) to render with the WASM backend instead.",
+      { cause },
+    );
+  });


### PR DESCRIPTION
## Why

On Node, `takumi-js` (and `@takumi-rs/image-response`, which re-exports it) selects the native `@takumi-rs/core` backend by import condition. When the native addon can't load, the failure surfaces as the raw napi loader error, which gives no hint about the WASM escape hatch — the `module` option. The default Node path reads as broken rather than recoverable.

This is sharper right now because the beta `@takumi-rs/core` ships with no native binary: its `optionalDependencies` are empty and the `@takumi-rs/core-*` platform packages are stuck at `beta.6`. That gap is a separate release-pipeline fix (the napi platform publish never runs under Tegami's tarball publish); this change just makes the failure self-explanatory in the meantime and for any genuinely unsupported runtime.

## What

Wrap the `@takumi-rs/core` dynamic import in `backend/node.ts` so a load failure rethrows with a message pointing at the `module` WASM binary option, preserving the original error as `cause`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error shown when the native backend can’t load in Node, making it clearer that a WASM `module` option may be required.
  * Preserved the original failure details behind the new message for easier troubleshooting.

* **Documentation**
  * Added guidance for this loading issue and the expected fallback behavior when the native backend is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->