### PR TITLE
CI: publish napi platform packages on release

### DIFF
--- a/.tegami/napi-platform-publish.md
+++ b/.tegami/napi-platform-publish.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "npm:@takumi-rs/core": patch
+---
+
+### Ship the native platform packages
+
+Publish the per-platform `@takumi-rs/core-*` packages and inject their
+`optionalDependencies` during release. Installs once again resolve a native
+binary instead of falling back to the WASM escape hatch.

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { readFile, writeFile } from "fs/promises";
 import path from "path";
 import { tegami, type PackageOptions, type TegamiPlugin } from "tegami";
@@ -56,6 +57,25 @@ function workspaceProtocol(): TegamiPlugin {
   };
 }
 
+// Tegami publishes a pre-packed tarball, which skips npm's `prepublishOnly` — so
+// @takumi-rs/core's napi platform packages never ship and its `optionalDependencies`
+// stay empty. Stage and publish them at publish time instead, before the core tarball
+// is built, so the platform versions exist and core carries the matching optionalDeps.
+function napiPlatformPackages(): TegamiPlugin {
+  return {
+    name: "napi-platform-packages",
+    async willPublish({ pkg }) {
+      if (pkg.name !== "@takumi-rs/core") return;
+
+      const run = (cmd: string, args: string[]) =>
+        execFileSync(cmd, args, { cwd: pkg.path, stdio: "inherit" });
+
+      run("bun", ["run", "artifacts"]);
+      run("bunx", ["napi", "prepublish", "-t", "npm", "--no-gh-release"]);
+    },
+  };
+}
+
 // v2 beta line; clear this for the stable 2.0.0 release.
 const prerelease = "beta";
 
@@ -87,6 +107,7 @@ for (const name of independentCrates) {
 const paper = tegami({
   plugins: [
     github({ repo: "kane50613/takumi", cli: { versionPr: { base: "master" } } }),
+    napiPlatformPackages(),
     workspaceProtocol(),
   ],
   groups: {


### PR DESCRIPTION
## Why

The beta `@takumi-rs/core` ships with no native binary: its `optionalDependencies` are empty and the per-platform `@takumi-rs/core-*` packages are stuck at `beta.6`. So on Node, `import("@takumi-rs/core")` finds nothing to load and rendering falls back (or fails) — the WASM `module` escape hatch is the only way through.

Root cause is the Tegami migration. Tegami publishes a pre-packed tarball (`bun pm pack` → `npm publish <tarball>`), and tarball publish never runs npm's `prepublishOnly` lifecycle. napi's whole platform-publish step lived in that hook (`bun artifacts && napi prepublish`), so it silently stopped running: no platform packages, no injected optionalDeps. `core@1.8.7` (the last changesets-era release) still carries the 8 exact-pinned optionalDeps that make native resolve — the beta line lost them.

## What

Add a Tegami plugin that hooks `@takumi-rs/core`'s `willPublish`. Before the core tarball is built, it runs the napi flow the lifecycle hook used to:

- `bun run artifacts` — `napi create-npm-dirs` + `artifacts` (copy the downloaded `.node` binaries into `npm/<triple>/`) + `version`.
- `napi prepublish -t npm --no-gh-release` — inject the platform `optionalDependencies` into core and `npm publish` each platform package (skips already-published versions).

Platform packages publish first, so the core tarball carries optionalDeps that already resolve. The CI release job already builds all 8 targets and downloads them into `takumi-napi/artifacts`, so no workflow change is needed.

Notes for review:
- Each `@takumi-rs/core-*` package must be set up for npm trusted publishing (OIDC) under this repo/workflow, same as `@takumi-rs/core`, or the publish step will fail.
- `napi prepublish` runs `npm publish` with no `--tag`, so platform packages land on `latest`. Resolution is unaffected (core pins exact versions), but `latest` on those packages will point at the beta. Add `--skip-optional-publish` + a tagged publish loop if that matters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native platform packages are now published as part of the release process.
  * Installs should now resolve to platform-specific native binaries more reliably, reducing fallback to the WebAssembly build.
* **Bug Fixes**
  * Improved package publishing so the correct native artifacts are included for supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->