### PR TITLE
NAPI, WASM: declare csstype as a runtime dependency

### DIFF
--- a/.tegami/csstype-dependency.md
+++ b/.tegami/csstype-dependency.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Declare csstype as a runtime dependency
+
+The published type definitions import `csstype`, but it was only a
+devDependency, so consumers hit `Cannot find module 'csstype'`. Move it to
+`dependencies`.

--- a/bun.lock
+++ b/bun.lock
@@ -270,13 +270,13 @@
       "version": "2.0.0-beta.13",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
+        "csstype": "^3.2.3",
       },
       "devDependencies": {
         "@napi-rs/cli": "3.7.2",
         "@types/bun": "catalog:",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
-        "csstype": "^3.2.3",
         "lucide-react": "catalog:",
         "mitata": "^1.0.34",
         "react": "catalog:",
@@ -300,10 +300,10 @@
       "version": "2.0.0-beta.13",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
+        "csstype": "^3.2.3",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
-        "csstype": "^3.2.3",
         "tsdown": "catalog:",
         "unrun": "catalog:",
       },

--- a/takumi-napi/package.json
+++ b/takumi-napi/package.json
@@ -70,14 +70,14 @@
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {
-    "@takumi-rs/helpers": "workspace:*"
+    "@takumi-rs/helpers": "workspace:*",
+    "csstype": "^3.2.3"
   },
   "devDependencies": {
     "@napi-rs/cli": "3.7.2",
     "@types/bun": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "csstype": "^3.2.3",
     "lucide-react": "catalog:",
     "mitata": "^1.0.34",
     "react": "catalog:",

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -116,11 +116,11 @@
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {
-    "@takumi-rs/helpers": "workspace:*"
+    "@takumi-rs/helpers": "workspace:*",
+    "csstype": "^3.2.3"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "csstype": "^3.2.3",
     "tsdown": "catalog:",
     "unrun": "catalog:"
   },


### PR DESCRIPTION
## Why

`@takumi-rs/core` and `@takumi-rs/wasm` re-export types from `csstype` in their published `.d.ts` (it is `neverBundle` in their tsdown configs), but `csstype` was only a devDependency. Consumers therefore hit `Cannot find module 'csstype'` when resolving the types.

## What

Move `csstype` from devDependencies to dependencies in `@takumi-rs/core` and `@takumi-rs/wasm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured published type packages include `csstype` as a runtime dependency, preventing module resolution errors for consumers.
  * Updated package dependency lists so builds and downstream usage work consistently across the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->