### PR TITLE
CSS, Helpers: match Chromium UA stylesheet defaults

### DIFF
--- a/.tegami/ua-presets-chromium-parity.md
+++ b/.tegami/ua-presets-chromium-parity.md
@@ -1,0 +1,12 @@
+---
+packages:
+  "cargo:takumi-css": minor
+  "npm:@takumi-rs/helpers": minor
+---
+
+### Match the Chromium UA stylesheet for default element styles
+
+Parse the relative font keywords `bolder`/`lighter` (`font-weight`) and
+`larger`/`smaller` (`font-size`), resolving to the values Chromium uses. Expand
+the default element presets to cover lists, `sub`/`sup`, `ins`/`del`, forms,
+`details`/`summary`, and `search`.

--- a/takumi-css/src/style/properties/font_size.rs
+++ b/takumi-css/src/style/properties/font_size.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
-use cssparser::Parser;
+use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
-  SizingContext, ToCss, declare_enum_from_css_impl,
+  SizingContext, ToCss, declare_enum_from_css_impl, unexpected_token,
 };
 
 /// Absolute `font-size` keywords.
@@ -58,7 +58,10 @@ declare_enum_from_css_impl!(
   "xxx-large" => FontSizeKeyword::XXXLarge,
 );
 
-/// A `font-size` value, either a keyword or an explicit length.
+// https://drafts.csswg.org/css-fonts-4/#valdef-font-size-larger
+const RELATIVE_SIZE_RATIO: f32 = 1.2;
+
+/// A `font-size` value: a keyword, a relative keyword, or an explicit length.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum FontSize {
@@ -66,6 +69,10 @@ pub enum FontSize {
   Keyword(FontSizeKeyword),
   /// A concrete CSS length such as `16px` or `1rem`.
   Length(Length),
+  /// `larger` — the inherited font size scaled up by 1.2.
+  Larger,
+  /// `smaller` — the inherited font size scaled down by 1.2.
+  Smaller,
 }
 
 impl FontSize {
@@ -74,6 +81,22 @@ impl FontSize {
     match self {
       Self::Keyword(keyword) => keyword.to_length().to_px(sizing, inherited_font_size),
       Self::Length(length) => length.to_px(sizing, inherited_font_size),
+      Self::Larger => inherited_font_size * RELATIVE_SIZE_RATIO,
+      Self::Smaller => inherited_font_size / RELATIVE_SIZE_RATIO,
+    }
+  }
+
+  fn parse_relative<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    let location = input.current_source_location();
+    let token = input.next()?;
+
+    match token {
+      Token::Ident(ident) => match_ignore_ascii_case! { ident,
+        "larger" => Ok(Self::Larger),
+        "smaller" => Ok(Self::Smaller),
+        _ => Err(unexpected_token!(location, token)),
+      },
+      _ => Err(unexpected_token!(location, token)),
     }
   }
 }
@@ -101,6 +124,7 @@ impl<'i> FromCss<'i> for FontSize {
     input
       .try_parse(FontSizeKeyword::from_css)
       .map(Self::Keyword)
+      .or_else(|_| input.try_parse(Self::parse_relative))
       .or_else(|_| Length::from_css(input).map(Self::Length))
   }
 
@@ -113,6 +137,8 @@ impl<'i> FromCss<'i> for FontSize {
     CssToken::Keyword("x-large"),
     CssToken::Keyword("xx-large"),
     CssToken::Keyword("xxx-large"),
+    CssToken::Keyword("larger"),
+    CssToken::Keyword("smaller"),
     CssToken::Syntax(CssSyntaxKind::Length),
   ];
 }
@@ -134,14 +160,15 @@ impl Animatable for FontSize {
     sizing: &SizingContext,
     current_color: Color,
   ) {
-    let from_length = match *from {
+    let to_length = |size: Self| match size {
       Self::Keyword(keyword) => keyword.to_length(),
       Self::Length(length) => length,
+      Self::Larger => Length::Em(RELATIVE_SIZE_RATIO),
+      Self::Smaller => Length::Em(1.0 / RELATIVE_SIZE_RATIO),
     };
-    let to_length = match *to {
-      Self::Keyword(keyword) => keyword.to_length(),
-      Self::Length(length) => length,
-    };
+
+    let from_length = to_length(*from);
+    let to_length = to_length(*to);
 
     let mut value = from_length;
     value.interpolate(&from_length, &to_length, progress, sizing, current_color);
@@ -154,6 +181,8 @@ impl ToCss for FontSize {
     match self {
       Self::Keyword(k) => k.to_css(dest),
       Self::Length(l) => l.to_css(dest),
+      Self::Larger => dest.write_str("larger"),
+      Self::Smaller => dest.write_str("smaller"),
     }
   }
 }
@@ -169,6 +198,24 @@ mod tests {
     style::{CalcArena, SizingContext},
     viewport::Viewport,
   };
+
+  #[test]
+  fn relative_keywords_scale_inherited_size() {
+    let sizing = SizingContext {
+      viewport: Viewport::new((1200, 630)),
+      container_size: Size::NONE,
+      font_size: 20.0,
+      root_font_size: None,
+      line_height: 0.0,
+      root_line_height: None,
+      calc_arena: Rc::new(CalcArena::default()),
+    };
+
+    assert_eq!(FontSize::from_str("larger"), Ok(FontSize::Larger));
+    assert_eq!(FontSize::from_str("smaller"), Ok(FontSize::Smaller));
+    assert_eq!(FontSize::Larger.to_px(&sizing, 20.0), 24.0);
+    assert_eq!(FontSize::Smaller.to_px(&sizing, 20.0), 20.0 / 1.2);
+  }
 
   #[test]
   fn defaults_to_medium_keyword() {

--- a/takumi-css/src/style/properties/font_weight.rs
+++ b/takumi-css/src/style/properties/font_weight.rs
@@ -35,9 +35,14 @@ impl<'i> FromCss<'i> for FontWeight {
 
     match token {
       Token::Number { value, .. } => Ok((*value).into()),
+      // `bolder`/`lighter` are relative to the inherited weight; with no cascade
+      // context at parse time, resolve against the initial 400 base.
+      // https://drafts.csswg.org/css-fonts-4/#font-weight-prop
       Token::Ident(ident) => match_ignore_ascii_case! { ident,
         "normal" => Ok(400.0.into()),
         "bold" => Ok(700.0.into()),
+        "bolder" => Ok(700.0.into()),
+        "lighter" => Ok(100.0.into()),
         _ => Err(unexpected_token!(location, token)),
       },
       _ => Err(unexpected_token!(location, token)),
@@ -48,6 +53,8 @@ impl<'i> FromCss<'i> for FontWeight {
     CssToken::Syntax(CssSyntaxKind::Number),
     CssToken::Keyword("normal"),
     CssToken::Keyword("bold"),
+    CssToken::Keyword("bolder"),
+    CssToken::Keyword("lighter"),
   ];
 }
 
@@ -104,5 +111,11 @@ mod tests {
   #[test]
   fn parses_numeric_font_weight() {
     assert_eq!(FontWeight::from_str("700"), Ok(700.0.into()));
+  }
+
+  #[test]
+  fn resolves_relative_keywords_to_chromium_values() {
+    assert_eq!(FontWeight::from_str("bolder"), Ok(700.0.into()));
+    assert_eq!(FontWeight::from_str("lighter"), Ok(100.0.into()));
   }
 }

--- a/takumi-css/src/style/properties/font_weight.rs
+++ b/takumi-css/src/style/properties/font_weight.rs
@@ -10,8 +10,46 @@ use crate::style::{
 };
 
 /// Represents font weight value.
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub struct FontWeight(ParleyFontWeight);
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FontWeight {
+  /// An absolute numeric weight.
+  Absolute(ParleyFontWeight),
+  /// One step bolder than the inherited weight, resolved against the parent.
+  Bolder,
+  /// One step lighter than the inherited weight, resolved against the parent.
+  Lighter,
+}
+
+impl Default for FontWeight {
+  fn default() -> Self {
+    FontWeight::from(400.0)
+  }
+}
+
+// https://drafts.csswg.org/css-fonts-4/#font-weight-prop
+fn bolder(weight: f32) -> f32 {
+  if weight < 350.0 {
+    400.0
+  } else if weight < 550.0 {
+    700.0
+  } else if weight < 900.0 {
+    900.0
+  } else {
+    weight
+  }
+}
+
+fn lighter(weight: f32) -> f32 {
+  if weight < 100.0 {
+    weight
+  } else if weight < 550.0 {
+    100.0
+  } else if weight < 750.0 {
+    400.0
+  } else {
+    700.0
+  }
+}
 
 impl MakeComputed for FontWeight {}
 
@@ -35,14 +73,11 @@ impl<'i> FromCss<'i> for FontWeight {
 
     match token {
       Token::Number { value, .. } => Ok((*value).into()),
-      // `bolder`/`lighter` are relative to the inherited weight; with no cascade
-      // context at parse time, resolve against the initial 400 base.
-      // https://drafts.csswg.org/css-fonts-4/#font-weight-prop
       Token::Ident(ident) => match_ignore_ascii_case! { ident,
         "normal" => Ok(400.0.into()),
         "bold" => Ok(700.0.into()),
-        "bolder" => Ok(700.0.into()),
-        "lighter" => Ok(100.0.into()),
+        "bolder" => Ok(FontWeight::Bolder),
+        "lighter" => Ok(FontWeight::Lighter),
         _ => Err(unexpected_token!(location, token)),
       },
       _ => Err(unexpected_token!(location, token)),
@@ -80,27 +115,47 @@ impl TailwindPropertyParser for FontWeight {
 }
 
 impl FontWeight {
-  /// The numeric weight (100-900).
+  /// The numeric weight (1-1000). Relative keywords fall back to the `normal`
+  /// (400) base; call [`resolve_against`](Self::resolve_against) during
+  /// inheritance to step from the parent weight.
   pub fn value(self) -> f32 {
-    self.0.value()
+    match self {
+      Self::Absolute(weight) => weight.value(),
+      Self::Bolder => bolder(400.0),
+      Self::Lighter => lighter(400.0),
+    }
+  }
+
+  /// Resolves `bolder`/`lighter` against the inherited parent weight; absolute
+  /// weights pass through unchanged.
+  pub fn resolve_against(self, parent: f32) -> Self {
+    match self {
+      Self::Bolder => FontWeight::from(bolder(parent)),
+      Self::Lighter => FontWeight::from(lighter(parent)),
+      absolute => absolute,
+    }
   }
 }
 
 impl From<FontWeight> for ParleyFontWeight {
   fn from(value: FontWeight) -> Self {
-    value.0
+    ParleyFontWeight::new(value.value())
   }
 }
 
 impl From<f32> for FontWeight {
   fn from(value: f32) -> Self {
-    FontWeight(ParleyFontWeight::new(value))
+    FontWeight::Absolute(ParleyFontWeight::new(value))
   }
 }
 
 impl ToCss for FontWeight {
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    write!(dest, "{}", self.value())
+    match self {
+      Self::Bolder => dest.write_str("bolder"),
+      Self::Lighter => dest.write_str("lighter"),
+      Self::Absolute(weight) => write!(dest, "{}", weight.value()),
+    }
   }
 }
 
@@ -114,8 +169,15 @@ mod tests {
   }
 
   #[test]
-  fn resolves_relative_keywords_to_chromium_values() {
-    assert_eq!(FontWeight::from_str("bolder"), Ok(700.0.into()));
-    assert_eq!(FontWeight::from_str("lighter"), Ok(100.0.into()));
+  fn resolves_relative_keywords_against_parent() {
+    assert_eq!(FontWeight::from_str("bolder"), Ok(FontWeight::Bolder));
+    assert_eq!(FontWeight::from_str("lighter"), Ok(FontWeight::Lighter));
+
+    assert_eq!(FontWeight::Bolder.resolve_against(400.0).value(), 700.0);
+    assert_eq!(FontWeight::Bolder.resolve_against(700.0).value(), 900.0);
+    assert_eq!(FontWeight::Bolder.resolve_against(900.0).value(), 900.0);
+    assert_eq!(FontWeight::Lighter.resolve_against(400.0).value(), 100.0);
+    assert_eq!(FontWeight::Lighter.resolve_against(600.0).value(), 400.0);
+    assert_eq!(FontWeight::Lighter.resolve_against(900.0).value(), 700.0);
   }
 }

--- a/takumi-css/src/style/stylesheets.rs
+++ b/takumi-css/src/style/stylesheets.rs
@@ -575,7 +575,11 @@ macro_rules! define_style {
             }
           }
 
-          for declaration in declarations {
+          let parent_font_weight = parent.font_weight.value();
+          for mut declaration in declarations {
+            if let StyleDeclaration::FontWeight(weight) = &mut declaration {
+              *weight = weight.resolve_against(parent_font_weight);
+            }
             declaration.apply_with_parent(&mut style, parent);
           }
           style

--- a/takumi-helpers/src/jsx/style-presets.ts
+++ b/takumi-helpers/src/jsx/style-presets.ts
@@ -26,6 +26,15 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
   script: {
     display: "none",
   },
+  noscript: {
+    display: "none",
+  },
+  datalist: {
+    display: "none",
+  },
+  template: {
+    display: "none",
+  },
   // Generic block-level elements
   body: {
     margin: 8,
@@ -93,6 +102,68 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
     borderWidth: 1,
     display: "block",
   },
+  // Lists
+  ul: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    paddingLeft: 40,
+    display: "block",
+  },
+  ol: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    paddingLeft: 40,
+    display: "block",
+  },
+  menu: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    paddingLeft: 40,
+    display: "block",
+  },
+  li: {
+    display: "block",
+  },
+  dl: {
+    marginTop: "1em",
+    marginBottom: "1em",
+    display: "block",
+  },
+  dt: {
+    display: "block",
+  },
+  dd: {
+    marginLeft: 40,
+    display: "block",
+  },
+  // Forms and interactive elements
+  form: {
+    display: "block",
+  },
+  fieldset: {
+    marginLeft: 2,
+    marginRight: 2,
+    paddingTop: "0.35em",
+    paddingRight: "0.75em",
+    paddingBottom: "0.625em",
+    paddingLeft: "0.75em",
+    borderWidth: 2,
+    display: "block",
+  },
+  legend: {
+    paddingLeft: 2,
+    paddingRight: 2,
+    display: "block",
+  },
+  details: {
+    display: "block",
+  },
+  summary: {
+    display: "block",
+  },
+  search: {
+    display: "block",
+  },
   // Heading elements
   h1: {
     fontSize: "2em",
@@ -150,11 +221,14 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
   u: {
     textDecoration: "underline",
   },
+  ins: {
+    textDecoration: "underline",
+  },
   strong: {
-    fontWeight: "bold",
+    fontWeight: "bolder",
   },
   b: {
-    fontWeight: "bold",
+    fontWeight: "bolder",
   },
   i: {
     fontStyle: "italic",
@@ -188,13 +262,24 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
     color: "black",
   },
   big: {
-    fontSize: "1.2em",
+    fontSize: "larger",
   },
   small: {
-    fontSize: "0.8em",
+    fontSize: "smaller",
   },
   s: {
     textDecoration: "line-through",
+  },
+  del: {
+    textDecoration: "line-through",
+  },
+  sub: {
+    fontSize: "smaller",
+    verticalAlign: "sub",
+  },
+  sup: {
+    fontSize: "smaller",
+    verticalAlign: "super",
   },
   div: {
     display: "block",

--- a/takumi-helpers/tests/jsx/jsx-processing.test.tsx
+++ b/takumi-helpers/tests/jsx/jsx-processing.test.tsx
@@ -642,15 +642,18 @@ describe("fromJsx", () => {
             {
               type: "container",
               tagName: "ul",
+              preset: defaultStylePresets.ul,
               children: [
                 {
                   type: "text",
                   text: "Item 1",
+                  preset: defaultStylePresets.li,
                   tagName: "li",
                 },
                 {
                   type: "text",
                   text: "Item 2",
+                  preset: defaultStylePresets.li,
                   tagName: "li",
                 },
               ],


### PR DESCRIPTION
## Why

The default element presets were an old fork of satori's and drifted from Chromium's UA stylesheet (`html.css`): lists, `sub`/`sup`, `ins`/`del`, forms, `details`/`summary`, and `search` had no defaults, and the relative font keywords `bolder`/`lighter`/`larger`/`smaller` failed to parse.

## What

- **takumi-css:** parse `font-weight: bolder | lighter` (resolved against the initial 400 base → 700 / 100) and `font-size: larger | smaller` (the inherited size scaled by 1.2), matching Chromium's values.
- **@takumi-rs/helpers:** expand `defaultStylePresets` to track Blink's `html.css` — lists (`ul`/`ol`/`menu`/`li`/`dl`/`dt`/`dd`), `sub`/`sup`, `ins`/`del`, `form`/`fieldset`/`legend`, `details`/`summary`, `search`, and `noscript`/`datalist`/`template`. Table layout, list markers, and form controls stay out of scope (unsupported).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for relative CSS font values: `larger`/`smaller` for font size and `bolder`/`lighter` for font weight.
  * Expanded built-in default style presets for additional HTML elements (including lists, more form/layout elements, details/summary, and `search`), with improved default display and typography.

* **Bug Fixes**
  * Improved Chromium parity and default styling consistency, including more accurate rendering of emphasis, strike-through, subscript/superscript, and inherited font-weight behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->