### PR TITLE
Core: mark node and image enums non-exhaustive

### DIFF
--- a/.tegami/core-enums-non-exhaustive.md
+++ b/.tegami/core-enums-non-exhaustive.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Mark the core node and image enums `#[non_exhaustive]`
+
+`NodeKind`, `ImageSource`, `ImageSourceInput`, and `ImageCacheMode` can now gain
+variants without a breaking change, so the surface stays stable across 1.0.

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -67,6 +67,7 @@ pub struct TextData {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 /// An image source as received from input: URL, raw bytes, or already loaded.
+#[non_exhaustive]
 pub enum ImageSourceInput {
   /// Source URL or path.
   Url(Arc<str>),
@@ -278,6 +279,7 @@ pub struct Node {
 /// Represents the nodes enum.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum NodeKind {
   /// A node that contains other nodes.
   Container {

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -26,6 +26,7 @@ pub type ImageResult = Result<ImageSource, ImageResourceError>;
 
 #[derive(Debug, Clone)]
 /// Represents the source of an image.
+#[non_exhaustive]
 pub enum ImageSource {
   /// An svg image source
   #[cfg(feature = "svg")]
@@ -477,6 +478,7 @@ const DEFAULT_MAX_BYTES: u64 = 64 << 20; // 64 MiB
 /// Cache policy for a decoded image, applied per [`ImageCache::get_or_decode`] call.
 #[derive(Clone, Copy, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ImageCacheMode {
   /// Cache the decoded image for reuse (evictable).
   #[default]

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -551,6 +551,7 @@ pub(crate) fn render_tile(
             }
             RenderedImage::Borrowed { .. } => None,
           },
+          _ => None,
         }
       } else {
         None

--- a/takumi-raster/src/image_drawing.rs
+++ b/takumi-raster/src/image_drawing.rs
@@ -53,6 +53,7 @@ pub(crate) fn process_image_for_object_fit<'i>(
     }
     #[cfg(feature = "svg")]
     ImageSource::Svg(svg) => (svg.tree.size().width(), svg.tree.size().height()),
+    _ => (image_width, image_height),
   };
   let source_to_intrinsic = if image_width == 0.0 || image_height == 0.0 {
     Affine::IDENTITY

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -332,6 +332,7 @@ pub(crate) fn draw_node_content(
     NodeKind::Container { .. } => Ok(()),
     NodeKind::Image(image) => draw_image_node_content(image, context, canvas, layout),
     NodeKind::Text(text) => draw_text_node_content(text, context, canvas, layout),
+    _ => Ok(()),
   }
 }
 

--- a/takumi-svg/src/image.rs
+++ b/takumi-svg/src/image.rs
@@ -95,6 +95,7 @@ fn data_url(src: &ImageSourceInput, context: &RenderContext) -> Option<String> {
     ImageSourceInput::Loaded(source) => loaded_data_url(source),
     // Only resolvable when the render supplied a resource map (usually empty).
     ImageSourceInput::Url(_) => src.resolve(context).ok().and_then(|s| loaded_data_url(&s)),
+    _ => None,
   }
 }
 
@@ -106,6 +107,7 @@ fn loaded_data_url(source: &ImageSource) -> Option<String> {
       .encode_png()
       .map(|png| encode("image/png", &png)),
     ImageSource::Svg(svg) => Some(encode("image/svg+xml", svg.source().as_bytes())),
+    _ => None,
   }
 }
 


### PR DESCRIPTION
## Why

`NodeKind`, `ImageSource`, `ImageSourceInput`, and `ImageCacheMode` are reachable through `takumi::prelude` and freeze into the 1.0 surface. Today they are exhaustive, so adding any variant later — a new node kind, image format, or cache policy (e.g. the planned `immutable`) — is a breaking change. This is one of the irreversible-after-freeze traps to close before tagging rc.

## What

- Mark the four enums `#[non_exhaustive]` so they can grow variants without a major bump.
- Downstream `takumi-raster`/`takumi-svg` matches gain wildcard arms that skip an unknown variant (render nothing) rather than panic — the graceful-degradation contract `#[non_exhaustive]` implies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for newly added or unknown enum values across rendering and image-processing flows, reducing the chance of crashes from exhaustive matching.
  * Added safer fallback behavior when working with node types, image sources, and image cache settings.
  * Ensured unsupported SVG and image cases now fail gracefully instead of breaking processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->