### PR TITLE
CSS: mark property-identifier enums non-exhaustive

### DIFF
--- a/.tegami/css-property-enums-non-exhaustive.md
+++ b/.tegami/css-property-enums-non-exhaustive.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-css": minor
+---
+
+### Mark the property-identifier enums `#[non_exhaustive]`
+
+`LonghandId`, `ShorthandId`, `PropertyId`, and `StyleDeclaration` gain a variant
+for every CSS property, so supporting a new property stays non-breaking across
+1.0.

--- a/takumi-css/src/style/stylesheets.rs
+++ b/takumi-css/src/style/stylesheets.rs
@@ -165,6 +165,7 @@ macro_rules! define_style {
       /// Identifies a single longhand property.
       #[repr(u8)]
       #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+      #[non_exhaustive]
       pub enum LonghandId {
         $(
           #[doc = concat!("The `", stringify!($longhand), "` longhand.")]
@@ -191,6 +192,7 @@ macro_rules! define_style {
       /// Identifies a shorthand property that expands into longhands.
       #[repr(u8)]
       #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+      #[non_exhaustive]
       pub enum ShorthandId {
         $(
           #[doc = concat!("The `", stringify!($shorthand), "` shorthand.")]
@@ -294,6 +296,7 @@ macro_rules! define_style {
 
       /// Identifies any property: longhand, shorthand, custom, or ignored.
       #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+      #[non_exhaustive]
       pub enum PropertyId {
         /// An unrecognized property that is dropped.
         Ignored,
@@ -635,6 +638,7 @@ macro_rules! define_style {
       /// A single specified declaration stored in a declaration block.
       #[allow(private_interfaces)]
       #[derive(Debug, Clone, PartialEq)]
+      #[non_exhaustive]
       pub enum StyleDeclaration {
         $(
           /// An explicit specified value for a non-shorthand property.


### PR DESCRIPTION
## Why

`LonghandId`, `ShorthandId`, `PropertyId`, and `StyleDeclaration` gain a variant for every CSS property. They are part of the 1.0 surface, so while they stay exhaustive every new property is a breaking change — and adding properties is this crate's main growth axis. Another irreversible-after-freeze trap to close before rc.

## What

- Mark the four macro-generated property-identifier enums `#[non_exhaustive]`.
- No downstream crate matches them exhaustively (only constructs variants), and same-crate matches are unaffected by `#[non_exhaustive]`, so nothing else changes.

`MeasuredNode`/`MeasuredTextRun` (a separate WATCH-tier item) are intentionally left out — they need a constructor first since external tests build them as literals; tracked for a focused follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved future compatibility for CSS property handling, reducing the risk of breakage when new properties are added.
  * Updated public-facing style APIs to be more flexible for upcoming CSS changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->