### PR TITLE
Core: make SvgSource.tree private behind a dimensions accessor

### DIFF
--- a/.tegami/svgsource-tree-private.md
+++ b/.tegami/svgsource-tree-private.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Stop exposing the parsed SVG tree as a public field
+
+`SvgSource::tree` was a public `resvg::usvg::Tree` field, leaking `usvg` into
+the API. It is now `pub(crate)`, with a `dimensions()` accessor for the canvas
+size that callers actually need.

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -62,10 +62,10 @@ pub(crate) fn measure_image_node(
 
   let intrinsic_size = match &image_source {
     #[cfg(feature = "svg")]
-    ImageSource::Svg(svg) => Size {
-      width: svg.tree.size().width(),
-      height: svg.tree.size().height(),
-    },
+    ImageSource::Svg(svg) => {
+      let (width, height) = svg.dimensions();
+      Size { width, height }
+    }
     ImageSource::Gif(gif) => {
       let frame = gif.frame_at_time(context.time_ms);
       Size {

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -44,7 +44,7 @@ pub struct SvgSource {
   /// Original SVG source, for embedding directly in a vector backend.
   source: Box<str>,
   /// Parsed SVG tree used for size and initial metadata.
-  pub tree: resvg::usvg::Tree,
+  pub(crate) tree: resvg::usvg::Tree,
   /// Intrinsic dimensions (non-percentage `width`/`height`) and `viewBox`
   /// aspect ratio, for CSS `background-size`/`mask-size` resolution.
   intrinsic: SvgIntrinsic,
@@ -53,6 +53,13 @@ pub struct SvgSource {
 
 #[cfg(feature = "svg")]
 impl SvgSource {
+  /// The SVG canvas dimensions in pixels, from the root `width`/`height` or
+  /// `viewBox`.
+  pub fn dimensions(&self) -> (f32, f32) {
+    let size = self.tree.size();
+    (size.width(), size.height())
+  }
+
   /// The original SVG markup, for embedding directly in a vector backend.
   pub fn source(&self) -> &str {
     &self.source
@@ -353,7 +360,7 @@ impl ImageSource {
   pub fn size(&self, sizing: &SizingContext) -> (f32, f32) {
     let (width, height) = match self {
       #[cfg(feature = "svg")]
-      ImageSource::Svg(svg) => (svg.tree.size().width(), svg.tree.size().height()),
+      ImageSource::Svg(svg) => svg.dimensions(),
       ImageSource::Bitmap(bitmap) => (bitmap.width() as f32, bitmap.height() as f32),
       ImageSource::Gif(gif) => {
         let frame = &gif.frames[0].buffer;

--- a/takumi-raster/src/image_drawing.rs
+++ b/takumi-raster/src/image_drawing.rs
@@ -52,7 +52,7 @@ pub(crate) fn process_image_for_object_fit<'i>(
       (rendered.width() as f32, rendered.height() as f32)
     }
     #[cfg(feature = "svg")]
-    ImageSource::Svg(svg) => (svg.tree.size().width(), svg.tree.size().height()),
+    ImageSource::Svg(svg) => svg.dimensions(),
     _ => (image_width, image_height),
   };
   let source_to_intrinsic = if image_width == 0.0 || image_height == 0.0 {


### PR DESCRIPTION
## Why

`SvgSource::tree` was a public `resvg::usvg::Tree` field — exposing the full parsed SVG tree as public mutable data and leaking the churny 0.x `usvg` type into the 1.0 surface. Part of the pre-rc encapsulation pass to stop leaking dependency types and internal representation.

## What

- `tree` is now `pub(crate)`; intra-crate rasterization keeps direct access.
- Add `SvgSource::dimensions() -> (f32, f32)` for the canvas size, the only thing external/cross-crate callers read; route the `.tree.size()` reads through it.

The remaining `usvg` leak via `ImageResourceError::SvgParseError` is handled together with the other foreign error payloads in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG image sizing by deriving canvas width/height through a single dimensions source across layout and raster rendering.
  * Fixed inconsistent SVG measurements that could lead to incorrect scaling or cropping behavior in different parts of the app.
* **New Features**
  * Added a public way to retrieve SVG dimensions from an SVG image source for more reliable downstream layout and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->