### PR TITLE
Core: encapsulate glyph pixmap and color-layer paths

### DIFF
--- a/.tegami/encapsulate-glyph-fields.md
+++ b/.tegami/encapsulate-glyph-fields.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Encapsulate glyph pixmap and color-layer paths behind accessors
+
+`ResolvedBitmapGlyph::pixmap` and `ResolvedColorLayer::paths` were public fields
+exposing `tiny_skia` types. They are now `pub(crate)` with `pixmap()`/`paths()`
+accessors.

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -53,7 +53,7 @@ pub enum ResolvedGlyph {
 #[derive(Clone)]
 pub struct ResolvedBitmapGlyph {
   /// Source bitmap.
-  pub pixmap: Pixmap,
+  pub(crate) pixmap: Pixmap,
   /// Horizontal scale from source to placement.
   pub scale_x: f32,
   /// Vertical scale from source to placement.
@@ -63,6 +63,11 @@ pub struct ResolvedBitmapGlyph {
 }
 
 impl ResolvedBitmapGlyph {
+  /// The source bitmap for this glyph.
+  pub fn pixmap(&self) -> &Pixmap {
+    &self.pixmap
+  }
+
   /// Write the glyph's alpha channel into `mask`, scaling to the placement size.
   pub fn write_alpha_mask(&self, mask: &mut [u8]) {
     let width = self.placement.width as usize;
@@ -138,11 +143,18 @@ pub enum ResolvedOutlineGlyph {
 #[derive(Clone)]
 pub struct ResolvedColorLayer {
   /// Outline path commands for this layer.
-  pub paths: Vec<Command>,
+  pub(crate) paths: Vec<Command>,
   /// Index into the font's color palette.
   pub palette_index: u16,
   /// Layer opacity, 0..=1.
   pub alpha: f32,
+}
+
+impl ResolvedColorLayer {
+  /// Outline path commands for this layer.
+  pub fn paths(&self) -> &[Command] {
+    &self.paths
+  }
 }
 
 /// Pixel placement of a rendered glyph.

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -293,10 +293,10 @@ pub(crate) fn draw_glyph(
       transform *= Affine::translation(bitmap.placement.left as f32, -bitmap.placement.top as f32);
       transform *= Affine::scale(bitmap.scale_x, bitmap.scale_y);
       canvas.overlay_sampled_pixmap(
-        bitmap.pixmap.as_ref(),
+        bitmap.pixmap().as_ref(),
         Size {
-          width: bitmap.pixmap.width(),
-          height: bitmap.pixmap.height(),
+          width: bitmap.pixmap().width(),
+          height: bitmap.pixmap().height(),
         },
         Default::default(),
         transform,
@@ -528,8 +528,12 @@ fn draw_color_outline_image(
       Color([record.red(), record.green(), record.blue(), alpha])
     };
 
-    let (mask, placement) =
-      render_mask(&layer.paths, Some(transform), None, &mut canvas.buffer_pool);
+    let (mask, placement) = render_mask(
+      layer.paths(),
+      Some(transform),
+      None,
+      &mut canvas.buffer_pool,
+    );
     canvas.draw_mask(&mask, placement, color, BlendMode::Normal);
     canvas.buffer_pool.release(mask);
   }

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -497,11 +497,11 @@ fn emit_run_glyphs(
         if color_override.is_some() || clip_data.is_some() {
           continue;
         }
-        let Ok(png) = bitmap.pixmap.encode_png() else {
+        let Ok(png) = bitmap.pixmap().encode_png() else {
           continue;
         };
         flush_glyph_run(doc, &mut merged, fill, stroke)?;
-        let (width, height) = (bitmap.pixmap.width(), bitmap.pixmap.height());
+        let (width, height) = (bitmap.pixmap().width(), bitmap.pixmap().height());
         let bitmap_matrix = placed
           * Affine::translation(bitmap.placement.left as f32, -(bitmap.placement.top as f32))
           * Affine::scale(bitmap.scale_x, bitmap.scale_y);


### PR DESCRIPTION
## Why

Pre-rc encapsulation: stop exposing raw glyph buffers and `tiny_skia` types as public fields.

## What

- `ResolvedBitmapGlyph::pixmap` (`tiny_skia::Pixmap`) → `pub(crate)` + `pixmap()` accessor.
- `ResolvedColorLayer::paths` → `pub(crate)` + `paths()` accessor.
- takumi-raster/takumi-svg text backends read through the accessors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text rendering by making bitmap and color-layer handling more robust.
  * Fixed SVG and raster output paths to use the updated glyph data access flow, helping ensure glyphs continue to render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->