### PR TITLE
Core: own GenericFamily so callers don't depend on parley

### DIFF
--- a/.tegami/own-generic-family.md
+++ b/.tegami/own-generic-family.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Own `GenericFamily` so callers don't depend on `parley`
+
+`FontResource::generic_family` took a `parley::GenericFamily`, forcing callers
+to add `parley` as a dependency. It now takes a takumi-owned `GenericFamily`
+newtype exposing the families as named constants (`GenericFamily::SANS_SERIF`,
+etc.), re-exported from the prelude.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2358,9 +2358,9 @@ mod tests {
       style::{Color, ColorInput, Display, Style, StyleDeclaration, WhiteSpace},
       tree::RenderNode,
     },
-    resources::font::FontResource,
+    resources::font::{FontResource, GenericFamily},
   };
-  use parley::{GenericFamily, fontique::FontInfoOverride};
+  use parley::fontique::FontInfoOverride;
   use takumi_css::SizingContext;
 
   fn create_test_context() -> Fonts {
@@ -2380,7 +2380,7 @@ mod tests {
             family_name: Some("Geist"),
             ..Default::default()
           })
-          .generic_family(GenericFamily::SansSerif),
+          .generic_family(GenericFamily::SANS_SERIF),
       )
       .unwrap_or_else(|error| panic!("failed to load test font {}: {error}", path.display()));
     context

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -9,7 +9,7 @@ use std::{
 
 use image::{Rgba, RgbaImage};
 use parley::{
-  GenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
+  GenericFamily as ParleyGenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
   fontique::{
     Attributes, Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, FontStyle,
     QueryFamily, QueryStatus, Script, ScriptExt,
@@ -941,7 +941,7 @@ impl Fonts {
         self
           .inner
           .collection
-          .append_generic_families(generic_family, once(family));
+          .append_generic_families(generic_family.into(), once(family));
       }
     }
 
@@ -1039,6 +1039,47 @@ impl<'a> AsRef<[u8]> for FontSource<'a> {
       Self::Raw(raw) => raw,
       Self::Blob(blob) => blob.as_ref(),
     }
+  }
+}
+
+/// A CSS generic font family a registered font fulfills, exposed as named
+/// constants so callers need not depend on `parley`.
+/// https://drafts.csswg.org/css-fonts/#generic-font-families
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GenericFamily(ParleyGenericFamily);
+
+impl GenericFamily {
+  /// `serif`
+  pub const SERIF: Self = Self(ParleyGenericFamily::Serif);
+  /// `sans-serif`
+  pub const SANS_SERIF: Self = Self(ParleyGenericFamily::SansSerif);
+  /// `monospace`
+  pub const MONOSPACE: Self = Self(ParleyGenericFamily::Monospace);
+  /// `cursive`
+  pub const CURSIVE: Self = Self(ParleyGenericFamily::Cursive);
+  /// `fantasy`
+  pub const FANTASY: Self = Self(ParleyGenericFamily::Fantasy);
+  /// `system-ui`
+  pub const SYSTEM_UI: Self = Self(ParleyGenericFamily::SystemUi);
+  /// `ui-serif`
+  pub const UI_SERIF: Self = Self(ParleyGenericFamily::UiSerif);
+  /// `ui-sans-serif`
+  pub const UI_SANS_SERIF: Self = Self(ParleyGenericFamily::UiSansSerif);
+  /// `ui-monospace`
+  pub const UI_MONOSPACE: Self = Self(ParleyGenericFamily::UiMonospace);
+  /// `ui-rounded`
+  pub const UI_ROUNDED: Self = Self(ParleyGenericFamily::UiRounded);
+  /// `emoji`
+  pub const EMOJI: Self = Self(ParleyGenericFamily::Emoji);
+  /// `math`
+  pub const MATH: Self = Self(ParleyGenericFamily::Math);
+  /// `fangsong`
+  pub const FANG_SONG: Self = Self(ParleyGenericFamily::FangSong);
+}
+
+impl From<GenericFamily> for ParleyGenericFamily {
+  fn from(value: GenericFamily) -> Self {
+    value.0
   }
 }
 

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -7,13 +7,13 @@ use arc_swap::ArcSwap;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use parley::{GenericFamily, fontique::FontInfoOverride};
+use parley::fontique::FontInfoOverride;
 use rayon::prelude::*;
 use takumi_core::{
   Fonts,
   layout::{node::Node, style::KeyframesRule as CoreKeyframesRule},
   resources::{
-    font::FontResource,
+    font::{FontResource, GenericFamily},
     image::{ImageCache, ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource},
   },
 };
@@ -392,12 +392,12 @@ const EMBEDDED_FONTS: &[(&[u8], &str, GenericFamily)] = &[
   (
     include_bytes!("../../assets/fonts/geist/Geist[wght].woff2"),
     "Geist",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
   (
     include_bytes!("../../assets/fonts/geist/GeistMono[wght].woff2"),
     "Geist Mono",
-    GenericFamily::Monospace,
+    GenericFamily::MONOSPACE,
   ),
 ];
 

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -2,7 +2,7 @@
 
 use crate::{helper::map_error, model::*};
 use base64::{Engine, prelude::BASE64_STANDARD};
-use parley::{FontWeight, GenericFamily, fontique::FontInfoOverride};
+use parley::{FontWeight, fontique::FontInfoOverride};
 use serde_wasm_bindgen::{from_value, to_value};
 use std::{
   borrow::Cow,
@@ -17,7 +17,7 @@ use takumi_core::{
     style::{KeyframesRule, StyleSheet},
   },
   resources::{
-    font::{FontResource, RegisteredFamily},
+    font::{FontResource, GenericFamily, RegisteredFamily},
     image::{ImageCache, ImageSource as LoadedImageSource},
   },
 };
@@ -31,7 +31,7 @@ use wasm_bindgen::prelude::*;
 const EMBEDDED_FONTS: &[(&[u8], &str, GenericFamily)] = &[(
   include_bytes!("../../assets/fonts/manrope/manrope-latin-wght-normal.woff2"),
   "Manrope",
-  GenericFamily::SansSerif,
+  GenericFamily::SANS_SERIF,
 )];
 
 /// The main renderer for Takumi image rendering engine.

--- a/takumi/examples/profile_many_runs.rs
+++ b/takumi/examples/profile_many_runs.rs
@@ -1,4 +1,4 @@
-use parley::{GenericFamily, fontique::FontInfoOverride};
+use parley::fontique::FontInfoOverride;
 use std::hint::black_box;
 use takumi::{prelude::*, render};
 
@@ -21,7 +21,7 @@ fn load_global() -> Fonts {
         family_name: Some("Geist"),
         ..Default::default()
       })
-      .generic_family(GenericFamily::SansSerif),
+      .generic_family(GenericFamily::SANS_SERIF),
   )
   .unwrap();
   g

--- a/takumi/examples/profile_mix.rs
+++ b/takumi/examples/profile_mix.rs
@@ -1,4 +1,4 @@
-use parley::{GenericFamily, fontique::FontInfoOverride};
+use parley::fontique::FontInfoOverride;
 use std::{env, hint::black_box};
 use takumi::{prelude::*, render};
 
@@ -16,7 +16,7 @@ fn load_global() -> Fonts {
         family_name: Some("Geist"),
         ..Default::default()
       })
-      .generic_family(GenericFamily::SansSerif),
+      .generic_family(GenericFamily::SANS_SERIF),
   )
   .unwrap();
   g

--- a/takumi/examples/profile_text.rs
+++ b/takumi/examples/profile_text.rs
@@ -1,4 +1,4 @@
-use parley::{GenericFamily, fontique::FontInfoOverride};
+use parley::fontique::FontInfoOverride;
 use std::hint::black_box;
 use takumi::{prelude::*, render};
 
@@ -21,7 +21,7 @@ fn load_global() -> Fonts {
         family_name: Some("Geist"),
         ..Default::default()
       })
-      .generic_family(GenericFamily::SansSerif),
+      .generic_family(GenericFamily::SANS_SERIF),
   )
   .unwrap();
   g

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -74,7 +74,7 @@ pub mod prelude {
       style::*,
     },
     resources::{
-      font::{FontError, FontResource, RegisteredFamily},
+      font::{FontError, FontResource, GenericFamily, RegisteredFamily},
       image::{ImageCacheMode, ImageSource},
     },
   };

--- a/takumi/tests/font_tests.rs
+++ b/takumi/tests/font_tests.rs
@@ -5,7 +5,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use parley::{GenericFamily, fontique::FontInfoOverride};
+use parley::fontique::FontInfoOverride;
 use takumi::{prelude::*, render};
 
 fn font_path(path: &str) -> PathBuf {
@@ -33,7 +33,7 @@ fn register_subset(fonts: &mut Fonts, path: &str, unique_name: &str, logical: &s
           family_name: Some(unique_name),
           ..Default::default()
         })
-        .generic_family(GenericFamily::SansSerif)
+        .generic_family(GenericFamily::SANS_SERIF)
         .subset_of(logical),
     )
     .unwrap();

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -7,7 +7,7 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use parley::{GenericFamily, fontique::FontInfoOverride};
+use parley::fontique::FontInfoOverride;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use takumi::{
   encode_animated_gif, encode_animated_png, encode_animated_webp, prelude::*, render, write_image,
@@ -25,52 +25,52 @@ const TEST_FONTS: &[(&str, &str, GenericFamily)] = &[
   (
     "assets/fonts/geist/Geist[wght].woff2",
     "Geist",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
   (
     "assets/fonts/geist/GeistMono[wght].woff2",
     "Geist Mono",
-    GenericFamily::Monospace,
+    GenericFamily::MONOSPACE,
   ),
   (
     "assets/fonts/twemoji/TwemojiMozilla-colr.woff2",
     "Twemoji Mozilla",
-    GenericFamily::Emoji,
+    GenericFamily::EMOJI,
   ),
   (
     "assets/fonts/archivo/Archivo-VariableFont_wdth,wght.ttf",
     "Archivo",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
   (
     "assets/fonts/sil/scheherazade-new-v17-arabic-regular.woff2",
     "Scheherazade New Test",
-    GenericFamily::Serif,
+    GenericFamily::SERIF,
   ),
   (
     "assets/fonts/noto-sans/NotoSansTC-VariableFont_wght.woff2",
     "Noto Sans TC",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
   (
     "assets/fonts/cjk-locl-test/CJKLoclTest.woff2",
     "CJK Locl Test",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
   (
     "assets/fonts/noto-sans/noto-sans-devanagari-v30-devanagari-regular.woff2",
     "Noto Sans Devanagari",
-    GenericFamily::Serif,
+    GenericFamily::SERIF,
   ),
   (
     "assets/fonts/poppins/poppins-v24-devanagari_latin-regular.woff2",
     "Poppins",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
   (
     "assets/fonts/poppins/poppins-v24-devanagari_latin-700.woff2",
     "Poppins Bold",
-    GenericFamily::SansSerif,
+    GenericFamily::SANS_SERIF,
   ),
 ];
 


### PR DESCRIPTION
## Why

`FontResource::generic_family` took a `parley::GenericFamily`. Calling it forced users to add `parley` to their own `Cargo.toml` just to name a generic family — a confusing requirement that also semver-coupled the public API to `parley`.

## What

- Add a takumi-owned `GenericFamily` newtype exposing the 13 CSS generic families as named constants (`GenericFamily::SANS_SERIF`, `MONOSPACE`, …), modeled on parley's `FontWeight` constants. Convert to `parley` internally.
- `FontResource::generic_family` now takes the owned type; re-exported from `takumi::prelude`.
- napi/wasm embedded-font tables and tests/examples updated to the constants.

Verified: an external crate can call `r.generic_family(GenericFamily::SANS_SERIF)` via `takumi::prelude::*` with no `parley` dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in `GenericFamily` type with named constants for common CSS font families.
  * Made the generic font family type available from the main prelude for easier use.

* **Bug Fixes**
  * Updated font override and embedded font handling to use the new generic-family names consistently.
  * Aligned examples and tests with the revised font family constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->