### PR TITLE
Core: drop serde_bytes::ByteBuf from ImageSourceInput::Buffer

### DIFF
--- a/.tegami/own-imagesourceinput-buffer.md
+++ b/.tegami/own-imagesourceinput-buffer.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Drop `serde_bytes::ByteBuf` from `ImageSourceInput::Buffer`
+
+The `Buffer` variant exposed `serde_bytes::ByteBuf` in the public API. It now
+holds a `Vec<u8>` with `#[serde(with = "serde_bytes")]`, keeping the FFI
+bytes wire format while keeping `serde_bytes` out of the surface.

--- a/takumi-core/Cargo.toml
+++ b/takumi-core/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/kane50613/takumi"
 readme = "README.md"
 rust-version = "1.91"
 
+# `serde_bytes` is used via `#[serde(with = "serde_bytes")]`, which cargo-machete can't see.
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"]
+
 [dependencies]
 cssparser.workspace = true
 png.workspace = true

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -4,7 +4,6 @@ mod text;
 
 use crate::resources::image_buffer::ImageBuffer;
 use serde::Deserialize;
-use serde_bytes::ByteBuf;
 use std::{collections::BTreeMap, sync::Arc};
 use taffy::{AvailableSpace, Size};
 
@@ -71,10 +70,10 @@ pub struct TextData {
 pub enum ImageSourceInput {
   /// Source URL or path.
   Url(Arc<str>),
-  // `ByteBuf` (not `Vec<u8>`) so an FFI `Uint8Array`/`ArrayBuffer`, surfaced as a
-  // bytes value rather than a number array, deserializes here.
+  // `serde_bytes` so an FFI `Uint8Array`/`ArrayBuffer`, surfaced as a bytes value
+  // rather than a number array, deserializes here.
   /// Raw image bytes.
-  Buffer(ByteBuf),
+  Buffer(#[serde(with = "serde_bytes")] Vec<u8>),
   /// Pre-resolved image source.
   #[serde(skip_deserializing)]
   Loaded(ImageSource),
@@ -136,7 +135,7 @@ impl From<Arc<str>> for ImageData {
 impl From<Vec<u8>> for ImageData {
   fn from(data: Vec<u8>) -> Self {
     Self {
-      src: ImageSourceInput::Buffer(ByteBuf::from(data)),
+      src: ImageSourceInput::Buffer(data),
       width: None,
       height: None,
     }
@@ -146,7 +145,7 @@ impl From<Vec<u8>> for ImageData {
 impl From<&[u8]> for ImageData {
   fn from(data: &[u8]) -> Self {
     Self {
-      src: ImageSourceInput::Buffer(ByteBuf::from(data.to_vec())),
+      src: ImageSourceInput::Buffer(data.to_vec()),
       width: None,
       height: None,
     }


### PR DESCRIPTION
## Why

`ImageSourceInput::Buffer` — reachable through `takumi::prelude` and constructed by users — held a `serde_bytes::ByteBuf`, leaking the `serde_bytes` crate into the frozen surface.

## What

- `Buffer(ByteBuf)` → `Buffer(#[serde(with = "serde_bytes")] Vec<u8>)`. The FFI `Uint8Array`/`ArrayBuffer` JSON wire format is preserved (still deserialized as bytes, not a number array); only the Rust type changes. Verified `ByteBuf` no longer appears in the takumi-core public API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated image byte handling so `ImageSourceInput::Buffer` now stores raw bytes as a `Vec<u8>` while preserving the same serialized wire format.
  - Improved compatibility and reduced reliance on an internal byte wrapper type for image inputs.
- **Chores**
  - Updated package analysis configuration to ignore `serde_bytes` for static checks related to serde byte handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->