### PR TITLE
Core: own the font override struct so callers don't depend on fontique

### DIFF
--- a/.tegami/own-font-info-override.md
+++ b/.tegami/own-font-info-override.md
@@ -1,0 +1,12 @@
+---
+packages:
+  "cargo:takumi-core": minor
+  "cargo:takumi-css": minor
+---
+
+### Own the font override struct so callers don't depend on fontique
+
+`FontResource::override_info` took a `fontique::FontInfoOverride`. It now takes a
+takumi-owned `FontInfoOverride`, re-exported from the prelude, with `FontStretch`,
+`FontStyle`, and `FontWeight` fields. `takumi-css` gains `From<parley::FontStyle>
+for FontStyle` to support the conversion.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2358,9 +2358,8 @@ mod tests {
       style::{Color, ColorInput, Display, Style, StyleDeclaration, WhiteSpace},
       tree::RenderNode,
     },
-    resources::font::{FontResource, GenericFamily},
+    resources::font::{FontInfoOverride, FontResource, GenericFamily},
   };
-  use parley::fontique::FontInfoOverride;
   use takumi_css::SizingContext;
 
   fn create_test_context() -> Fonts {
@@ -2377,7 +2376,7 @@ mod tests {
       .register(
         FontResource::new(font_data)
           .override_info(FontInfoOverride {
-            family_name: Some("Geist"),
+            family_name: Some("Geist".to_string()),
             ..Default::default()
           })
           .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -11,8 +11,9 @@ use image::{Rgba, RgbaImage};
 use parley::{
   GenericFamily as ParleyGenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
   fontique::{
-    Attributes, Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, FontStyle,
-    QueryFamily, QueryStatus, Script, ScriptExt,
+    Attributes, Blob, Collection, CollectionOptions, FallbackKey,
+    FontInfoOverride as FontiqueFontInfoOverride, FontStyle, QueryFamily, QueryStatus, Script,
+    ScriptExt,
   },
 };
 use skrifa::{
@@ -24,8 +25,9 @@ use skrifa::{
   },
   instance::{LocationRef, Size},
   outline::{DrawSettings, OutlineGlyphCollection, OutlinePen},
-  raw::types::{BoundingBox, F2Dot14},
+  raw::types::{BoundingBox, F2Dot14, Tag},
 };
+use takumi_css::style::{FontStretch, FontStyle as CssFontStyle, FontWeight};
 use thiserror::Error;
 use tiny_skia::{IntSize, PathSegment as Command, Pixmap};
 
@@ -902,6 +904,17 @@ impl Fonts {
     } = font;
 
     let blob = source.into_blob()?;
+    let axes = info_override
+      .as_ref()
+      .map(FontInfoOverride::fontique_axes)
+      .unwrap_or_default();
+    let info_override = info_override.as_ref().map(|o| FontiqueFontInfoOverride {
+      family_name: o.family_name.as_deref(),
+      width: o.width.map(Into::into),
+      style: o.style.map(Into::into),
+      weight: o.weight.map(Into::into),
+      axes: (!axes.is_empty()).then_some(axes.as_slice()),
+    });
     let registered_fonts = self.inner.collection.register_fonts(blob, info_override);
 
     let mut families = Vec::with_capacity(registered_fonts.len());
@@ -1083,13 +1096,44 @@ impl From<GenericFamily> for ParleyGenericFamily {
   }
 }
 
+/// Overrides for a registered font's metadata, replacing the values declared by
+/// the font itself. Owned so callers need not depend on `parley`/`fontique`.
+#[derive(Debug, Default, Clone)]
+pub struct FontInfoOverride {
+  /// Family name to register the font under, instead of its own.
+  pub family_name: Option<String>,
+  /// Width/stretch to use instead of the font's own.
+  pub width: Option<FontStretch>,
+  /// Slant (italic/oblique) to use instead of the font's own.
+  pub style: Option<CssFontStyle>,
+  /// Weight to use instead of the font's own.
+  pub weight: Option<FontWeight>,
+  /// Default values for the font's variation axes, as `(tag, value)` pairs.
+  /// Tags must be four ASCII bytes (e.g. `"wght"`); invalid tags are ignored.
+  pub axes: Vec<(String, f32)>,
+}
+
+impl FontInfoOverride {
+  fn fontique_axes(&self) -> Vec<(Tag, f32)> {
+    self
+      .axes
+      .iter()
+      .filter_map(|(tag, value)| {
+        Tag::new_checked(tag.as_bytes())
+          .ok()
+          .map(|tag| (tag, *value))
+      })
+      .collect()
+  }
+}
+
 #[derive(Debug)]
 /// Information of a font resource
 pub struct FontResource<'a> {
   /// Font source
   source: FontSource<'a>,
   /// Font information for override
-  info_override: Option<FontInfoOverride<'a>>,
+  info_override: Option<FontInfoOverride>,
   /// Generic font family
   generic_family: Option<GenericFamily>,
   /// Logical family this font is a coverage subset of (see [`FontResource::subset_of`]).
@@ -1108,7 +1152,7 @@ impl<'a> FontResource<'a> {
   }
 
   /// Set font information for override
-  pub fn override_info(self, info_override: FontInfoOverride<'a>) -> Self {
+  pub fn override_info(self, info_override: FontInfoOverride) -> Self {
     Self {
       info_override: Some(info_override),
       ..self

--- a/takumi-css/src/style/properties/font_style.rs
+++ b/takumi-css/src/style/properties/font_style.rs
@@ -58,6 +58,12 @@ impl From<FontStyle> for ParleyFontStyle {
   }
 }
 
+impl From<ParleyFontStyle> for FontStyle {
+  fn from(value: ParleyFontStyle) -> Self {
+    Self(value)
+  }
+}
+
 impl ToCss for FontStyle {
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
     match &self.0 {

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -16,11 +16,11 @@ use std::{fmt::Display, ops::Deref};
 
 use napi::{De, Env, Error, bindgen_prelude::*};
 use napi_derive::napi;
-use parley::{FontStyle, FontWeight, fontique::FontInfoOverride};
+use parley::FontStyle;
 use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 use takumi_core::{
-  layout::style::{KeyframesRule, StyleSheet},
-  resources::font::FontResource,
+  layout::style::{FontWeight, KeyframesRule, StyleSheet},
+  resources::font::{FontInfoOverride, FontResource},
 };
 
 pub use renderer::Renderer;
@@ -118,11 +118,10 @@ pub(crate) fn resolve_font_resource<'a>(
   buffer: &'a [u8],
 ) -> Result<FontResource<'a>> {
   let resource = FontResource::new(buffer).override_info(FontInfoOverride {
-    family_name: font.name.as_deref(),
-    width: None,
-    style: font.style.map(|style| style.0),
-    weight: font.weight.map(|weight| FontWeight::new(weight as f32)),
-    axes: None,
+    family_name: font.name.clone(),
+    style: font.style.map(|style| style.0.into()),
+    weight: font.weight.map(|weight| FontWeight::from(weight as f32)),
+    ..Default::default()
   });
 
   let resource = match &font.subset_of {

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -7,13 +7,12 @@ use arc_swap::ArcSwap;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use parley::fontique::FontInfoOverride;
 use rayon::prelude::*;
 use takumi_core::{
   Fonts,
   layout::{node::Node, style::KeyframesRule as CoreKeyframesRule},
   resources::{
-    font::{FontResource, GenericFamily},
+    font::{FontInfoOverride, FontResource, GenericFamily},
     image::{ImageCache, ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource},
   },
 };
@@ -417,7 +416,7 @@ fn default_fonts() -> Result<Fonts> {
       .map(|(font, name, generic)| {
         FontResource::new(*font)
           .override_info(FontInfoOverride {
-            family_name: Some(*name),
+            family_name: Some((*name).to_string()),
             ..Default::default()
           })
           .generic_family(*generic)

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -2,7 +2,6 @@
 
 use crate::{helper::map_error, model::*};
 use base64::{Engine, prelude::BASE64_STANDARD};
-use parley::{FontWeight, fontique::FontInfoOverride};
 use serde_wasm_bindgen::{from_value, to_value};
 use std::{
   borrow::Cow,
@@ -14,10 +13,10 @@ use takumi_core::{
   layout::{
     DEFAULT_DEVICE_PIXEL_RATIO, Viewport,
     node::Node,
-    style::{KeyframesRule, StyleSheet},
+    style::{FontWeight, KeyframesRule, StyleSheet},
   },
   resources::{
-    font::{FontResource, GenericFamily, RegisteredFamily},
+    font::{FontInfoOverride, FontResource, GenericFamily, RegisteredFamily},
     image::{ImageCache, ImageSource as LoadedImageSource},
   },
 };
@@ -58,7 +57,7 @@ fn default_fonts() -> Result<Fonts, js_sys::Error> {
   for (font, family_name, generic_family) in EMBEDDED_FONTS {
     let resource = FontResource::new(*font)
       .override_info(FontInfoOverride {
-        family_name: Some(*family_name),
+        family_name: Some((*family_name).to_string()),
         ..Default::default()
       })
       .generic_family(*generic_family);
@@ -85,11 +84,10 @@ fn load_font_internal(
       .map_err(map_error),
     Font::Object(details) => {
       let resource = FontResource::new(details.data.into_vec()).override_info(FontInfoOverride {
-        family_name: details.name.as_deref(),
-        style: details.style.map(Into::into),
-        weight: details.weight.map(|weight| FontWeight::new(weight as f32)),
-        axes: None,
-        width: None,
+        family_name: details.name,
+        style: details.style.map(|style| style.0.into()),
+        weight: details.weight.map(|weight| FontWeight::from(weight as f32)),
+        ..Default::default()
       });
 
       let resource = match &details.subset_of {

--- a/takumi/examples/profile_many_runs.rs
+++ b/takumi/examples/profile_many_runs.rs
@@ -1,4 +1,3 @@
-use parley::fontique::FontInfoOverride;
 use std::hint::black_box;
 use takumi::{prelude::*, render};
 
@@ -18,7 +17,7 @@ fn load_global() -> Fonts {
   g.register(
     FontResource::new(regular.to_vec())
       .override_info(FontInfoOverride {
-        family_name: Some("Geist"),
+        family_name: Some("Geist".to_string()),
         ..Default::default()
       })
       .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi/examples/profile_mix.rs
+++ b/takumi/examples/profile_mix.rs
@@ -1,4 +1,3 @@
-use parley::fontique::FontInfoOverride;
 use std::{env, hint::black_box};
 use takumi::{prelude::*, render};
 
@@ -13,7 +12,7 @@ fn load_global() -> Fonts {
   g.register(
     FontResource::new(regular.to_vec())
       .override_info(FontInfoOverride {
-        family_name: Some("Geist"),
+        family_name: Some("Geist".to_string()),
         ..Default::default()
       })
       .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi/examples/profile_text.rs
+++ b/takumi/examples/profile_text.rs
@@ -1,4 +1,3 @@
-use parley::fontique::FontInfoOverride;
 use std::hint::black_box;
 use takumi::{prelude::*, render};
 
@@ -18,7 +17,7 @@ fn load_global() -> Fonts {
   g.register(
     FontResource::new(regular.to_vec())
       .override_info(FontInfoOverride {
-        family_name: Some("Geist"),
+        family_name: Some("Geist".to_string()),
         ..Default::default()
       })
       .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -74,7 +74,7 @@ pub mod prelude {
       style::*,
     },
     resources::{
-      font::{FontError, FontResource, GenericFamily, RegisteredFamily},
+      font::{FontError, FontInfoOverride, FontResource, GenericFamily, RegisteredFamily},
       image::{ImageCacheMode, ImageSource},
     },
   };

--- a/takumi/tests/font_tests.rs
+++ b/takumi/tests/font_tests.rs
@@ -5,7 +5,6 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use parley::fontique::FontInfoOverride;
 use takumi::{prelude::*, render};
 
 fn font_path(path: &str) -> PathBuf {
@@ -30,7 +29,7 @@ fn register_subset(fonts: &mut Fonts, path: &str, unique_name: &str, logical: &s
     .register(
       FontResource::new(read_font(path))
         .override_info(FontInfoOverride {
-          family_name: Some(unique_name),
+          family_name: Some(unique_name.to_string()),
           ..Default::default()
         })
         .generic_family(GenericFamily::SANS_SERIF)

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -7,7 +7,6 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use parley::fontique::FontInfoOverride;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use takumi::{
   encode_animated_gif, encode_animated_png, encode_animated_webp, prelude::*, render, write_image,
@@ -94,7 +93,7 @@ fn create_test_context() -> Fonts {
       .register(
         FontResource::new(font_data)
           .override_info(FontInfoOverride {
-            family_name: Some(name),
+            family_name: Some(name.to_string()),
             ..Default::default()
           })
           .generic_family(*generic),


### PR DESCRIPTION
## Why

`FontResource::override_info` took a `fontique::FontInfoOverride`, forcing every caller to depend on `parley`/`fontique` and construct a borrowed fontique struct just to rename a font or set its weight. This mirrors the parley leak that #875 closed for `GenericFamily`.

## What

- Add a takumi-owned `FontInfoOverride` in `takumi-core` with owned fields — `family_name: Option<String>`, `width: Option<FontStretch>`, `style: Option<FontStyle>`, `weight: Option<FontWeight>` (reusing the `takumi-css` owned types), and `axes: Vec<(String, f32)>` for variation tags. Converted to `fontique::FontInfoOverride` internally in `register`.
- `override_info` and the `FontResource` field now take the owned type; re-exported from the umbrella prelude alongside `FontResource`/`GenericFamily`.
- `takumi-css` gains the symmetric `From<parley::FontStyle> for FontStyle` so the napi/wasm bindings can feed the override from their parsed style without a fidelity loss.
- Migrate all call sites (napi, wasm, core inline test, umbrella tests, examples) off the parley/fontique imports.

Verified `cargo public-api -p takumi-core` shows zero `fontique` references; `override_info` names the owned `FontInfoOverride`. Clippy clean; core/raster/svg/umbrella tests green.

https://claude.ai/code/session_01Kf7C41WfiCS7q74LEsPmgw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Font overrides now use an owned, app-facing override type, making font registration and customization more consistent across platforms.
  * Font style values can now be converted more directly between styling systems.

* **Bug Fixes**
  * Improved handling of font override fields so default values are applied more reliably.
  * Font family names are now passed as owned strings, reducing mismatches during font loading and registration.

* **Documentation**
  * Added release notes covering the font override API update and version bump guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->