### PR TITLE
CSS: private internal resolving functions

### DIFF
--- a/takumi-css/src/style/properties/grid/grid_length.rs
+++ b/takumi-css/src/style/properties/grid/grid_length.rs
@@ -16,8 +16,7 @@ pub enum GridLength {
 }
 
 impl GridLength {
-  /// Converts the grid track size to a compact length representation.
-  pub fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
+  pub(crate) fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
     match self {
       GridLength::Fr(fr) => CompactLength::fr(fr),
       GridLength::Unit(unit) => unit.to_compact_length(sizing),

--- a/takumi-css/src/style/properties/grid/grid_track_size.rs
+++ b/takumi-css/src/style/properties/grid/grid_track_size.rs
@@ -35,8 +35,7 @@ pub enum GridTrackSize {
 }
 
 impl GridTrackSize {
-  /// Converts the grid track size to a non-repeated track sizing function.
-  pub fn to_min_max(self, sizing: &SizingContext) -> TrackSizingFunction {
+  pub(crate) fn to_min_max(self, sizing: &SizingContext) -> TrackSizingFunction {
     match self {
       // SAFETY: The compact length is a valid track sizing function.
       Self::Fixed(size) => unsafe {

--- a/takumi-css/src/style/properties/length.rs
+++ b/takumi-css/src/style/properties/length.rs
@@ -397,7 +397,7 @@ impl Length {
   }
 
   /// Resolves to a taffy `CompactLength`, keeping percent and calc unresolved.
-  pub fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
+  pub(crate) fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
     match self {
       Length::Auto => CompactLength::auto(),
       Length::Percentage(value) => CompactLength::percent(value / 100.0),
@@ -434,7 +434,7 @@ impl Length {
   }
 
   /// Resolves to a taffy `LengthPercentage`, treating auto as zero.
-  pub fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
+  pub(crate) fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
     let compact_length = self.to_compact_length(sizing);
 
     if compact_length.is_auto() {
@@ -465,12 +465,15 @@ impl Length {
   }
 
   /// Resolves to a taffy `LengthPercentageAuto`.
-  pub fn resolve_to_length_percentage_auto(self, sizing: &SizingContext) -> LengthPercentageAuto {
+  pub(crate) fn resolve_to_length_percentage_auto(
+    self,
+    sizing: &SizingContext,
+  ) -> LengthPercentageAuto {
     unsafe { LengthPercentageAuto::from_raw(self.to_compact_length(sizing)) }
   }
 
   /// Resolves to a taffy `Dimension`.
-  pub fn resolve_to_dimension(self, sizing: &SizingContext) -> Dimension {
+  pub(crate) fn resolve_to_dimension(self, sizing: &SizingContext) -> Dimension {
     self.resolve_to_length_percentage_auto(sizing).into()
   }
 }


### PR DESCRIPTION
## Why

The frozen 1.0 surface is the `takumi` umbrella prelude, which re-exports the
`takumi-css` value types (`Length`, `Display`, `Position`, `Overflow`,
`FlexDirection`, `LineHeight`, `TextAlign`, the grid types, …). Those types
carried conversion methods and `From` impls naming `taffy`/`parley`
(`Length::resolve_to_dimension -> taffy::Dimension`, `LineHeight::into_parley`,
`From<TextAlign> for parley::Alignment`, `From<Display> for taffy::Display`, …),
leaking the layout/text backends into the frozen value-type API.

## What

- `to_taffy_style`'s conversions (used only inside `takumi-css`) become
  crate-private: `Length`/`GridLength`/`GridTrackSize` resolve helpers are now
  `pub(crate)`, and the per-enum `From<Css> for taffy::*` impls become
  `pub(crate) fn to_taffy()` (`Display`, `Position`, `Overflow`, `FlexDirection`,
  `FlexWrap`, `Direction`, `BoxSizing`, `AlignItems`, `JustifyContent`,
  `GridAutoFlow`, `GridPlacement`, `GridRepetitionCount`, `GridTemplateAreas`).
- The text-engine bridges used outside `takumi-css` move into `takumi-core` as
  free functions: `LineHeight::into_parley` → `line_height_to_parley`,
  `From<TextAlign> for parley::Alignment` → `text_align_to_parley`.
- `takumi-css` non-brush `taffy|parley` public-API count: **114 → 44**. Cleared
  value types: `Length`, `Display`, `Position`, `Overflow`, `FlexDirection`,
  `FlexWrap`, `Direction`, `BoxSizing`, `AlignItems`, `JustifyContent`,
  `GridAutoFlow`, `GridPlacement`, `GridRepetitionCount`, `GridTemplateAreas`,
  `GridLength`, `GridTrackSize`, `LineHeight`, `TextAlign`.

### Deliberately left (scope control)

These remain on internal/geometry/transform types, not the marquee value types,
and are entangled (dual-use across `takumi-css` internals + all three backends,
or part of the `ComputedStyle`/`Affine` web that is no longer prelude-reachable):
`Affine::{transform_point,decompose_translation,from_transforms}`,
`Length::to_px`/`SpacePair::to_px` (taffy `Size` param, used pervasively),
`Float::resolve`/`Clear::resolve` (returning `taffy` for core's inline layout —
would require duplicating the resolution logic in core), `From<Viewport/Sides/
SpacePair> for taffy::*`, `BackgroundSize::resolve`, `OffsetAnchor::resolve`,
`PositionValue::to_point`, `ResolvedVerticalAlign::apply`, `sample_offset_path`,
`overlay_gradient_tile_fast_normal_unconstrained`, and the `ComputedStyle::*`
methods (already dropped from the prelude).

Gate: `cargo build/clippy --workspace` clean, crate + umbrella fixture tests
green, zero `.webp`/`.svg` golden changes (no render/layout behavior change).

https://claude.ai/code/session_01Kf7C41WfiCS7q74LEsPmgw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened access to several internal length and grid sizing helpers.
  * No user-facing behavior changed; layout calculations and results remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->