### PR TITLE
Core, CSS: harden the public API for the 2.0 release

### DIFF
--- a/.tegami/css-backend-paint-helpers.md
+++ b/.tegami/css-backend-paint-helpers.md
@@ -1,0 +1,11 @@
+---
+packages:
+  cargo:takumi-css: minor
+---
+
+### Move backend paint helpers into a dedicated `paint` module
+
+Gradient LUT, tile-position, and transfer-table helpers no longer glob into the
+`style` re-export (and thus `takumi::prelude`). Cross-crate helpers live in a
+dedicated `takumi_css::paint` module that the raster and SVG backends depend on
+directly; the rest are `pub(crate)`.

--- a/.tegami/css-from-css-str-list-aliases.md
+++ b/.tegami/css-from-css-str-list-aliases.md
@@ -1,0 +1,15 @@
+---
+packages:
+  cargo:takumi-css: minor
+---
+
+### Seal `cssparser` and parse values via `FromCssStr`
+
+`FromCss`, `ParseResult`, `CssToken`, `CssSyntaxKind`, and `CssExpectedMessage`
+are now `pub(crate)`, keeping `cssparser` off the public API. Parse CSS value
+types from strings through the new `FromCssStr` trait
+(`Length::from_css_str("12px")`), which returns an owned `ParseError`
+(`PartialEq`/`Eq`). The value-list types are plain aliases rather than newtypes:
+`Filters` = `Vec<Filter>`, `GridTemplateComponents` = `Vec<GridTemplateComponent>`,
+and `BackgroundImages`/`BackgroundSizes`/`BackgroundRepeats`/`PositionValues` =
+`Box<[_]>`.

--- a/.tegami/css-gradient-tiles-paint-module.md
+++ b/.tegami/css-gradient-tiles-paint-module.md
@@ -1,0 +1,11 @@
+---
+packages:
+  cargo:takumi-css: minor
+---
+
+### Move gradient tiles to the `paint` module and seal `tiny_skia`
+
+`LinearGradientTile`, `RadialGradientTile`, `ConicGradientTile`, their
+row-state and fast-path companions, and the `GradientOverlayTile` trait moved
+out of the prelude-globbed `style` surface into `paint`. Backends reach them
+via `paint`, keeping `tiny_skia` off the public API.

--- a/.tegami/css-seal-color-conversions.md
+++ b/.tegami/css-seal-color-conversions.md
@@ -1,0 +1,10 @@
+---
+packages:
+  cargo:takumi-css: minor
+---
+
+### Keep `image` and `tiny_skia` out of the `Color` API
+
+The public `From<Color>` conversions to `image::Rgba` and
+`tiny_skia::PremultipliedColorU8` (and back) are gone. The raster backend does
+the conversions internally instead.

--- a/.tegami/css-seal-smallvec-declaration-fields.md
+++ b/.tegami/css-seal-smallvec-declaration-fields.md
@@ -1,0 +1,12 @@
+---
+packages:
+  cargo:takumi-css: minor
+---
+
+### Keep `smallvec` and `image` out of the declaration-block API
+
+`StyleDeclarationBlock::declarations` and `DeclarationImportance::custom_properties`
+exposed `smallvec::SmallVec` as public fields; they are now `pub(crate)` with
+`len`/`is_empty` accessors alongside the existing `iter`. Dropped the unused
+`From<ImageScalingAlgorithm> for image::imageops::FilterType`, removing `image`
+from the value-enum surface.

--- a/.tegami/css-value-enums-non-exhaustive.md
+++ b/.tegami/css-value-enums-non-exhaustive.md
@@ -1,0 +1,10 @@
+---
+packages:
+  cargo:takumi-css: minor
+---
+
+### Mark spec-tracking CSS value enums `#[non_exhaustive]`
+
+`BlendMode`, `Filter`, `BasicShape`, `ContentValue`, `TextTransform`,
+`WhiteSpaceCollapse`, `OffsetPath`, `ImageScalingAlgorithm`, and `Position` can
+gain variants as their specs grow without a breaking change.

--- a/.tegami/distributive-omit-render-options.md
+++ b/.tegami/distributive-omit-render-options.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:takumi-js: patch
+---
+
+### Keep the format tagged union on `render` options
+
+`render`, `renderSvg`, and `renderAnimation` used a non-distributive `Omit` that
+collapsed the `format`/`quality`/`lossless` union, so `{ format: "webp", quality: 80 }`
+stopped type-checking. A distributive `Omit` restores it.

--- a/.tegami/own-font-override.md
+++ b/.tegami/own-font-override.md
@@ -1,0 +1,11 @@
+---
+packages:
+  cargo:takumi-core: minor
+---
+
+### Seal `parley` out of the font resource API
+
+`FontResource::override_info` now takes a takumi-owned `FontOverride` (owned
+family name, weight, style, width, axes) instead of `parley`'s
+`FontInfoOverride`. `FontSource` is an opaque struct over raw bytes rather than
+an enum exposing a `parley` blob. Callers no longer depend on `parley`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,6 @@ version = "0.1.0-rc.3"
 dependencies = [
  "bytemuck",
  "color",
- "cssparser",
  "data-url",
  "gif",
  "image",
@@ -1642,7 +1641,6 @@ dependencies = [
  "bytemuck",
  "color",
  "cssparser",
- "image",
  "kurbo",
  "parley",
  "paste",
@@ -1677,7 +1675,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "parley",
  "rayon",
  "serde",
  "takumi-core",
@@ -1729,7 +1726,6 @@ version = "0.0.0"
 dependencies = [
  "base64",
  "js-sys",
- "parley",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
  "svgtypes",
  "taffy",
  "takumi-core",
+ "takumi-css",
  "tiny-skia",
  "typed-builder",
 ]
@@ -1717,6 +1718,7 @@ dependencies = [
  "quick-xml",
  "taffy",
  "takumi-core",
+ "takumi-css",
  "tiny-skia",
  "typed-builder",
 ]

--- a/docs/content/docs/upgrade/v2.mdx
+++ b/docs/content/docs/upgrade/v2.mdx
@@ -37,7 +37,8 @@ Rust (takumi crate):
 - render_for_layout drops the current_color argument
 - style value types (unstable): LengthDefaultsToZero -> Length, ColorDefaultsToTransparent -> ColorInput
 - BackgroundPosition -> PositionValue, BackgroundPositions -> PositionValues; ObjectPosition/TransformOrigin removed -> PositionValue (PositionValue::center() for the 50% 50% default)
-- core enums (NodeKind, ImageSource, ImageSourceInput, ImageCacheMode, Length, ColorInput) and css PropertyId/StyleDeclaration are now #[non_exhaustive]: add a wildcard match arm; build via constructors, not struct literals
+- core enums (NodeKind, ImageSource, ImageSourceInput, ImageCacheMode, Length, ColorInput), css PropertyId/StyleDeclaration, and css value enums (BlendMode, Filter, BasicShape, ContentValue, TextTransform, WhiteSpaceCollapse, OffsetPath, ImageScalingAlgorithm, Position) are now #[non_exhaustive]: add a wildcard match arm; build via constructors, not struct literals
+- css value lists are plain aliases now (Filters = Vec<Filter>, BackgroundImages/Sizes/Repeats and PositionValues = Box<[_]>); drop any newtype wrapper and parse from strings with FromCssStr::from_css_str instead of parse()/from_str
 
 CSS defaults changed, verify visually: position relative -> static; border/outline width
 0 -> medium (3px); negative scale reflects; line-clamp is a shorthand; currentColor in SVG
@@ -321,7 +322,7 @@ let origin: PositionValue = PositionValue::center(); // [!code ++]
 
 ### Core enums are `#[non_exhaustive]`
 
-Several public enums gained `#[non_exhaustive]`: `NodeKind`, `ImageSource`, `ImageSourceInput`, `ImageCacheMode`, `Length`, and `ColorInput` (plus `PropertyId` and `StyleDeclaration` in `takumi-css`). You can no longer build these variants with a struct literal from outside the crate, and a `match` on them needs a wildcard arm.
+Several public enums gained `#[non_exhaustive]`: `NodeKind`, `ImageSource`, `ImageSourceInput`, `ImageCacheMode`, `Length`, and `ColorInput`, plus `PropertyId`, `StyleDeclaration`, and the spec-tracking CSS value enums (`BlendMode`, `Filter`, `BasicShape`, `ContentValue`, `TextTransform`, `WhiteSpaceCollapse`, `OffsetPath`, `ImageScalingAlgorithm`, `Position`) in `takumi-css`. You can no longer build these variants with a struct literal from outside the crate, and a `match` on them needs a wildcard arm.
 
 ```rust
 match node.kind {
@@ -329,6 +330,16 @@ match node.kind {
   NodeKind::Text(_) => {}
   _ => {} // [!code ++]
 }
+```
+
+### CSS value lists are type aliases
+
+The multi-value CSS lists are plain aliases instead of newtypes. `Filters` and `GridTemplateComponents` are `Vec<_>`; `BackgroundImages`, `BackgroundSizes`, `BackgroundRepeats`, and `PositionValues` are `Box<[_]>`. Drop the newtype wrapper when you build one. To parse a value from a string, use the `FromCssStr` trait, which returns an owned `ParseError` and keeps `cssparser` out of the public API.
+
+```rust
+let filters = Filters(vec![Filter::Blur(Length::Px(4.0))]); // [!code --]
+let filters = vec![Filter::Blur(Length::Px(4.0))];          // [!code ++]
+let sizes = BackgroundSizes::from_css_str("cover")?;
 ```
 
 ## More in Changelog!

--- a/takumi-core/Cargo.toml
+++ b/takumi-core/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.91"
 ignored = ["serde_bytes"]
 
 [dependencies]
-cssparser.workspace = true
 png.workspace = true
 gif.workspace = true
 data-url.workspace = true

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2358,9 +2358,8 @@ mod tests {
       style::{Color, ColorInput, Display, Style, StyleDeclaration, WhiteSpace},
       tree::RenderNode,
     },
-    resources::font::{FontResource, GenericFamily},
+    resources::font::{FontOverride, FontResource, GenericFamily},
   };
-  use parley::fontique::FontInfoOverride;
   use takumi_css::SizingContext;
 
   fn create_test_context() -> Fonts {
@@ -2376,8 +2375,8 @@ mod tests {
     context
       .register(
         FontResource::new(font_data)
-          .override_info(FontInfoOverride {
-            family_name: Some("Geist"),
+          .override_info(FontOverride {
+            family_name: Some("Geist".into()),
             ..Default::default()
           })
           .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -428,8 +428,8 @@ impl Node {
     }
     if let Some(dir) = &self.metadata.dir {
       let dir_str = match dir {
-        Direction::Ltr => "ltr",
         Direction::Rtl => "rtl",
+        _ => "ltr",
       };
       attrs.push(format!("dir=\"{}\"", dir_str));
     }
@@ -1012,10 +1012,10 @@ mod matching_tests {
     // Matched normal: should have width: 10px.
     // Matched important: should have height: 20px.
 
-    assert_eq!(matched[0].element().normal()[0].declarations.len(), 1);
+    assert_eq!(matched[0].element().normal()[0].len(), 1);
     assert!(matched[0].element().normal()[0].importance.is_empty());
 
-    assert_eq!(matched[0].element().important()[0].declarations.len(), 1);
+    assert_eq!(matched[0].element().important()[0].len(), 1);
     assert!(!matched[0].element().important()[0].importance.is_empty());
   }
 

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -429,7 +429,7 @@ impl Node {
     if let Some(dir) = &self.metadata.dir {
       let dir_str = match dir {
         Direction::Rtl => "rtl",
-        _ => "ltr",
+        Direction::Ltr => "ltr",
       };
       attrs.push(format!("dir=\"{}\"", dir_str));
     }

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -20,9 +20,9 @@ use crate::{
     },
     node::{Node, NodeStyleLayers},
     style::{
-      BackgroundImage, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem, ContentValue,
-      Display, Filters, Float, Isolation, Length, LineHeight, PercentageNumber, Position,
-      SizingContext, Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode,
+      BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem,
+      ContentValue, Display, Filters, Float, Isolation, Length, LineHeight, PercentageNumber,
+      Position, SizingContext, Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode,
       apply_stylesheet_animations,
     },
   },
@@ -411,9 +411,9 @@ fn push_layout_node<'r>(
     if let Some(parent) = stack.last_mut() {
       let render_index = parent.next_child_index - 1;
       let cb = match finished.position {
-        Position::Static | Position::Relative => None,
         Position::Absolute => Some(*cb_stack.last().unwrap_or(&root_id)),
         Position::Fixed => Some(root_id),
+        _ => None,
       };
       // Only re-parent when the containing block differs from the structural
       // parent; otherwise keep the node in place to preserve DOM order (and the
@@ -949,7 +949,7 @@ impl RenderNode {
       },
       gradient => {
         let mut context = Self::anonymous_box_context(parent_context);
-        context.style.background_image = Some(Box::from([gradient]));
+        context.style.background_image = Some(BackgroundImages::from([gradient]));
         Self {
           context,
           node: Some(Node::container([])),
@@ -1010,7 +1010,7 @@ impl RenderNode {
 
     let items = match std::mem::take(&mut style.content) {
       ContentValue::Items(items) => items,
-      ContentValue::None | ContentValue::Normal => return None,
+      _ => return None,
     };
 
     let pseudo_context = RenderContext::from_parent(parent_context, style, sizing, current_color);
@@ -1929,7 +1929,8 @@ fn drop_block_boundary_whitespace(input: Vec<RenderNode>) -> Vec<RenderNode> {
 
 #[cfg(test)]
 mod tests {
-  use cssparser::{Parser, ParserInput};
+  use std::str::FromStr;
+
   use taffy::NodeId;
 
   use super::{registered_custom_property_parent_style, sort_children_by_order};
@@ -2324,9 +2325,7 @@ mod tests {
     );
     let adjusted_parent =
       registered_custom_property_parent_style(&parent, &[stylesheet], Viewport::default());
-    let mut input = ParserInput::new("var(--box-size)");
-    let mut parser = Parser::new(&mut input);
-    let declarations = StyleDeclarationBlock::parse("width", &mut parser);
+    let declarations = StyleDeclarationBlock::from_str("width: var(--box-size)");
     assert!(
       declarations.is_ok(),
       "width declaration using registered custom property should parse: {declarations:?}"

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -12,7 +12,7 @@ use parley::{
   GenericFamily as ParleyGenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
   fontique::{
     Attributes, Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, FontStyle,
-    QueryFamily, QueryStatus, Script, ScriptExt,
+    FontWeight, FontWidth, QueryFamily, QueryStatus, Script, ScriptExt,
   },
 };
 use skrifa::{
@@ -24,10 +24,12 @@ use skrifa::{
   },
   instance::{LocationRef, Size},
   outline::{DrawSettings, OutlineGlyphCollection, OutlinePen},
-  raw::types::{BoundingBox, F2Dot14},
+  raw::types::{BoundingBox, F2Dot14, Tag},
 };
 use thiserror::Error;
 use tiny_skia::{IntSize, PathSegment as Command, Pixmap};
+
+use takumi_css::FontStyle as CssFontStyle;
 
 use crate::{
   context::RenderContext,
@@ -907,6 +909,11 @@ impl Fonts {
     } = font;
 
     let blob = source.into_blob()?;
+    let axes = info_override.as_ref().map(FontOverride::resolved_axes);
+    let info_override = info_override
+      .as_ref()
+      .zip(axes.as_deref())
+      .map(|(info, axes)| info.to_parley(axes));
     let registered_fonts = self.inner.collection.register_fonts(blob, info_override);
 
     let mut families = Vec::with_capacity(registered_fonts.len());
@@ -996,14 +1003,13 @@ impl RenderContext {
   }
 }
 
-/// Represents a font source buffer.
+/// A font source buffer. Construct from raw bytes via `From`; woff/woff2 are
+/// decompressed internally when the font is registered.
 #[derive(Debug)]
-pub enum FontSource<'a> {
-  /// Raw font buffer.
-  Raw(Cow<'a, [u8]>),
-  /// Recognized font blob.
-  /// Woff2 and Woff should be decompressed into raw buffer before passing to this.
-  Blob(Blob<u8>),
+pub struct FontSource<'a> {
+  bytes: Cow<'a, [u8]>,
+  /// Whether `bytes` is already decompressed (woff/woff2 expanded to raw sfnt).
+  is_decoded: bool,
 }
 
 impl<'a, T> From<T> for FontSource<'a>
@@ -1011,37 +1017,39 @@ where
   T: Into<Cow<'a, [u8]>>,
 {
   fn from(value: T) -> Self {
-    Self::Raw(value.into())
+    Self {
+      bytes: value.into(),
+      is_decoded: false,
+    }
   }
 }
 
 impl<'a> FontSource<'a> {
-  fn into_blob_variant(self) -> Result<Self, FontError> {
-    match self {
-      Self::Raw(raw) => Ok(Self::Blob(decode_font(raw)?)),
-      Self::Blob(_) => Ok(self),
+  fn into_decoded(self) -> Result<Self, FontError> {
+    if self.is_decoded {
+      return Ok(self);
     }
+
+    Ok(Self {
+      bytes: Cow::Owned(load_font(self.bytes, None)?),
+      is_decoded: true,
+    })
   }
 
   fn into_blob(self) -> Result<Blob<u8>, FontError> {
-    match self {
-      Self::Raw(raw) => decode_font(raw),
-      Self::Blob(blob) => Ok(blob),
-    }
-  }
-}
+    let decoded = if self.is_decoded {
+      self.bytes.into_owned()
+    } else {
+      load_font(self.bytes, None)?
+    };
 
-/// Decodes raw font bytes (decompressing woff2/woff) into a blob.
-fn decode_font(raw: Cow<'_, [u8]>) -> Result<Blob<u8>, FontError> {
-  Ok(Blob::new(Arc::new(load_font(raw, None)?)))
+    Ok(Blob::new(Arc::new(decoded)))
+  }
 }
 
 impl<'a> AsRef<[u8]> for FontSource<'a> {
   fn as_ref(&self) -> &[u8] {
-    match self {
-      Self::Raw(raw) => raw,
-      Self::Blob(blob) => blob.as_ref(),
-    }
+    &self.bytes
   }
 }
 
@@ -1086,14 +1094,54 @@ impl From<GenericFamily> for ParleyGenericFamily {
   }
 }
 
+/// Overrides for a registered font's metadata, letting callers rename its
+/// family or pin weight/style/width/axes regardless of what the font file
+/// itself declares.
+#[derive(Debug, Default, Clone)]
+pub struct FontOverride {
+  /// Family name to register the font under, instead of its embedded name.
+  pub family_name: Option<Arc<str>>,
+  /// Font weight (CSS numeric, e.g. `400.0`) to use instead of the embedded one.
+  pub weight: Option<f32>,
+  /// Font style (slant) to use instead of the embedded one.
+  pub style: Option<CssFontStyle>,
+  /// Font width as a percentage (e.g. `100.0` for normal) to use instead of the
+  /// embedded one.
+  pub width: Option<f32>,
+  /// Default values for named variation axes (four-byte OpenType tags). Axes not
+  /// present in the font are ignored, as are tags that are not valid.
+  pub axes: Vec<(String, f32)>,
+}
+
+impl FontOverride {
+  fn resolved_axes(&self) -> Vec<(Tag, f32)> {
+    self
+      .axes
+      .iter()
+      .filter_map(|(tag, value)| {
+        Tag::new_checked(tag.as_bytes())
+          .ok()
+          .map(|tag| (tag, *value))
+      })
+      .collect()
+  }
+
+  fn to_parley<'a>(&'a self, axes: &'a [(Tag, f32)]) -> FontInfoOverride<'a> {
+    FontInfoOverride {
+      family_name: self.family_name.as_deref(),
+      width: self.width.map(FontWidth::from_percentage),
+      style: self.style.map(Into::into),
+      weight: self.weight.map(FontWeight::new),
+      axes: (!axes.is_empty()).then_some(axes),
+    }
+  }
+}
+
 #[derive(Debug)]
 /// Information of a font resource
 pub struct FontResource<'a> {
-  /// Font source
   source: FontSource<'a>,
-  /// Font information for override
-  info_override: Option<FontInfoOverride<'a>>,
-  /// Generic font family
+  info_override: Option<FontOverride>,
   generic_family: Option<GenericFamily>,
   /// Logical family this font is a coverage subset of (see [`FontResource::subset_of`]).
   subset_of: Option<String>,
@@ -1110,8 +1158,8 @@ impl<'a> FontResource<'a> {
     }
   }
 
-  /// Set font information for override
-  pub fn override_info(self, info_override: FontInfoOverride<'a>) -> Self {
+  /// Set font metadata overrides
+  pub fn override_info(self, info_override: FontOverride) -> Self {
     Self {
       info_override: Some(info_override),
       ..self
@@ -1142,7 +1190,7 @@ impl<'a> FontResource<'a> {
 
   /// Convert to resolved font resource, decompressing woff2/woff into a raw buffer.
   pub fn into_resolved(self) -> Result<Self, FontError> {
-    let source = self.source.into_blob_variant()?;
+    let source = self.source.into_decoded()?;
     Ok(Self {
       source,
       info_override: self.info_override,

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -202,9 +202,9 @@ impl SvgRasterCacheKey {
       width,
       height,
       image_rendering: match image_rendering {
-        ImageScalingAlgorithm::Auto => 0,
         ImageScalingAlgorithm::Smooth => 1,
         ImageScalingAlgorithm::Pixelated => 2,
+        _ => 0,
       },
     }
   }

--- a/takumi-core/src/text_processing.rs
+++ b/takumi-core/src/text_processing.rs
@@ -45,6 +45,7 @@ pub(crate) fn apply_text_transform<'a>(input: &'a str, transform: TextTransform)
       }
       Cow::Owned(result)
     }
+    _ => Cow::Borrowed(input),
   }
 }
 
@@ -136,6 +137,11 @@ pub(crate) fn apply_white_space_collapse<'a>(
       *previous_collapsible_space = last_was_space;
       *previous_was_line_break = last_was_line_break;
       Cow::Owned(out)
+    }
+
+    _ => {
+      *previous_was_line_break = false;
+      Cow::Borrowed(input)
     }
   }
 }

--- a/takumi-css/Cargo.toml
+++ b/takumi-css/Cargo.toml
@@ -24,7 +24,6 @@ smallvec.workspace = true
 phf.workspace = true
 parley.workspace = true
 taffy.workspace = true
-image.workspace = true
 
 [dependencies.serde]
 workspace = true

--- a/takumi-css/src/lib.rs
+++ b/takumi-css/src/lib.rs
@@ -13,6 +13,29 @@ pub mod error;
 pub mod keyframes;
 /// Selector matching against an abstract node tree.
 pub mod matching;
+/// Backend painting helpers (gradient LUTs, tile positioning, transfer tables)
+/// shared with the raster and SVG renderers. Deliberately kept out of `style`
+/// (and thus `takumi`'s prelude) since they are rendering-backend internals, not
+/// part of the CSS value surface.
+pub mod paint {
+  pub use crate::style::properties::{
+    background_repeat::{
+      collect_repeat_tile_positions, collect_spaced_tile_positions,
+      collect_stretched_tile_positions,
+    },
+    conic_gradient::{ConicGradientRowState, ConicGradientTile},
+    filter::compose_transfer_table,
+    gradient_utils::{
+      GradientOverlayTile, build_color_lut_with_interpolation,
+      overlay_gradient_tile_fast_normal_unconstrained, resolve_stops_along_axis,
+    },
+    linear_gradient::{
+      LinearGradientFastPath, LinearGradientFastPathData, LinearGradientFastPathKind,
+      LinearGradientRowState, LinearGradientTile,
+    },
+    radial_gradient::{RadialGradientRowState, RadialGradientTile},
+  };
+}
 /// CSS value types, parsing, and the cascade.
 pub mod style;
 mod viewport;

--- a/takumi-css/src/style/mod.rs
+++ b/takumi-css/src/style/mod.rs
@@ -3,7 +3,7 @@ mod calc;
 mod css_input;
 mod math;
 mod media_query;
-mod properties;
+pub(crate) mod properties;
 pub(crate) mod selector;
 mod sizing;
 mod stylesheets;

--- a/takumi-css/src/style/properties/animation.rs
+++ b/takumi-css/src/style/properties/animation.rs
@@ -5,7 +5,7 @@ use cssparser::{BasicParseErrorKind, Parser, Token, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
-  CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult,
+  CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
   declare_enum_from_css_impl, next_is_comma, tw::TailwindPropertyParser,
 };
 
@@ -451,7 +451,7 @@ impl TailwindPropertyParser for Animations {
         Cow::Borrowed(value)
       };
 
-      return Self::from_str(&value).ok();
+      return Self::from_css_str(&value).ok();
     }
 
     Self::parse_tw(token)
@@ -697,11 +697,11 @@ mod tests {
   #[test]
   fn parse_animation_time() {
     assert_eq!(
-      AnimationTime::from_str("150ms"),
+      AnimationTime::from_css_str("150ms"),
       Ok(AnimationTime::from_milliseconds(150.0))
     );
     assert_eq!(
-      AnimationTime::from_str("2s"),
+      AnimationTime::from_css_str("2s"),
       Ok(AnimationTime::from_milliseconds(2000.0))
     );
   }
@@ -709,7 +709,7 @@ mod tests {
   #[test]
   fn parse_animation_names() {
     assert_matches!(
-      AnimationNames::from_str("fade, slide"),
+      AnimationNames::from_css_str("fade, slide"),
       Ok(names) if names.as_ref() == [Some("fade".to_string()), Some("slide".to_string())]
     );
   }
@@ -717,7 +717,7 @@ mod tests {
   #[test]
   fn parse_quoted_animation_names() {
     assert_matches!(
-      AnimationNames::from_str("\"fade\", slide"),
+      AnimationNames::from_css_str("\"fade\", slide"),
       Ok(names) if names.as_ref() == [Some("fade".to_string()), Some("slide".to_string())]
     );
   }
@@ -725,7 +725,7 @@ mod tests {
   #[test]
   fn parse_animation_names_with_none_entry() {
     assert_matches!(
-      AnimationNames::from_str("none, slide"),
+      AnimationNames::from_css_str("none, slide"),
       Ok(names) if names.as_ref() == [None, Some("slide".to_string())]
     );
   }
@@ -733,33 +733,33 @@ mod tests {
   #[test]
   fn parse_steps_timing_functions() {
     assert_eq!(
-      AnimationTimingFunction::from_str("step-start"),
+      AnimationTimingFunction::from_css_str("step-start"),
       Ok(AnimationTimingFunction::StepStart)
     );
     assert_eq!(
-      AnimationTimingFunction::from_str("step-end"),
+      AnimationTimingFunction::from_css_str("step-end"),
       Ok(AnimationTimingFunction::StepEnd)
     );
     assert_eq!(
-      AnimationTimingFunction::from_str("steps(4, end)"),
+      AnimationTimingFunction::from_css_str("steps(4, end)"),
       Ok(AnimationTimingFunction::Steps(4, StepPosition::End))
     );
   }
 
   #[test]
   fn reject_invalid_cubic_bezier_x_coordinates() {
-    assert!(AnimationTimingFunction::from_str("cubic-bezier(-0.1, 0, 0.2, 1)").is_err());
-    assert!(AnimationTimingFunction::from_str("cubic-bezier(0.1, 0, 1.2, 1)").is_err());
+    assert!(AnimationTimingFunction::from_css_str("cubic-bezier(-0.1, 0, 0.2, 1)").is_err());
+    assert!(AnimationTimingFunction::from_css_str("cubic-bezier(0.1, 0, 1.2, 1)").is_err());
   }
 
   #[test]
   fn reject_negative_animation_iteration_count() {
-    assert!(AnimationIterationCount::from_str("-1").is_err());
+    assert!(AnimationIterationCount::from_css_str("-1").is_err());
   }
 
   #[test]
   fn cubic_bezier_preserves_overshoot() {
-    let Ok(function) = AnimationTimingFunction::from_str("cubic-bezier(0.68, -0.6, 0.32, 1.6)")
+    let Ok(function) = AnimationTimingFunction::from_css_str("cubic-bezier(0.68, -0.6, 0.32, 1.6)")
     else {
       return;
     };
@@ -780,7 +780,7 @@ mod tests {
   #[test]
   fn parse_animation_shorthand() {
     assert_eq!(
-      Animations::from_str("fade 1s ease-in 200ms 2 alternate both paused"),
+      Animations::from_css_str("fade 1s ease-in 200ms 2 alternate both paused"),
       Ok(Box::from([Animation {
         duration: AnimationTime::from_milliseconds(1000.0),
         delay: AnimationTime::from_milliseconds(200.0),
@@ -797,7 +797,7 @@ mod tests {
   #[test]
   fn parse_animation_shorthand_with_quoted_name() {
     assert_eq!(
-      Animations::from_str("\"fade\" 1s linear"),
+      Animations::from_css_str("\"fade\" 1s linear"),
       Ok(Box::from([Animation {
         duration: AnimationTime::from_milliseconds(1000.0),
         timing_function: AnimationTimingFunction::Linear,
@@ -810,7 +810,7 @@ mod tests {
   #[test]
   fn parse_multiple_animation_shorthand_values() {
     assert_eq!(
-      Animations::from_str("fade 1s linear, 2s slide"),
+      Animations::from_css_str("fade 1s linear, 2s slide"),
       Ok(Box::from([
         Animation {
           duration: AnimationTime::from_milliseconds(1000.0),

--- a/takumi-css/src/style/properties/aspect_ratio.rs
+++ b/takumi-css/src/style/properties/aspect_ratio.rs
@@ -2,8 +2,8 @@ use cssparser::Parser;
 use std::fmt;
 
 use crate::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
-  ToCss, lerp, tw::TailwindPropertyParser,
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
+  SizingContext, ToCss, lerp, tw::TailwindPropertyParser,
 };
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -45,7 +45,7 @@ impl Animatable for AspectRatio {
 
 impl TailwindPropertyParser for AspectRatio {
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 
@@ -98,18 +98,21 @@ mod tests {
 
   #[test]
   fn parses_auto_keyword() {
-    assert_eq!(AspectRatio::from_str("auto"), Ok(AspectRatio::Auto));
+    assert_eq!(AspectRatio::from_css_str("auto"), Ok(AspectRatio::Auto));
   }
 
   #[test]
   fn parses_single_number_as_ratio() {
-    assert_eq!(AspectRatio::from_str("1.5"), Ok(AspectRatio::Ratio(1.5)));
+    assert_eq!(
+      AspectRatio::from_css_str("1.5"),
+      Ok(AspectRatio::Ratio(1.5))
+    );
   }
 
   #[test]
   fn parses_ratio_with_slash() {
     assert_eq!(
-      AspectRatio::from_str("16/9"),
+      AspectRatio::from_css_str("16/9"),
       Ok(AspectRatio::Ratio(16.0 / 9.0))
     );
   }
@@ -117,18 +120,18 @@ mod tests {
   #[test]
   fn parses_ratio_with_decimal_values() {
     assert_eq!(
-      AspectRatio::from_str("1.777/1"),
+      AspectRatio::from_css_str("1.777/1"),
       Ok(AspectRatio::Ratio(1.777))
     );
   }
 
   #[test]
   fn errors_on_invalid_input() {
-    assert!(AspectRatio::from_str("invalid").is_err());
+    assert!(AspectRatio::from_css_str("invalid").is_err());
   }
 
   #[test]
   fn errors_on_empty_slash() {
-    assert!(AspectRatio::from_str("16/").is_err());
+    assert!(AspectRatio::from_css_str("16/").is_err());
   }
 }

--- a/takumi-css/src/style/properties/background.rs
+++ b/takumi-css/src/style/properties/background.rs
@@ -157,7 +157,7 @@ mod tests {
   #[test]
   fn test_parse_background_color_only() {
     assert_eq!(
-      Background::from_str("red"),
+      Background::from_css_str("red"),
       Ok(Background {
         color: Some(ColorInput::Value(Color([255, 0, 0, 255]))),
         ..Default::default()
@@ -169,7 +169,7 @@ mod tests {
   fn test_parse_background_color_and_clip() {
     // A single `<box>` sets both origin and clip.
     assert_eq!(
-      Background::from_str("red border-box"),
+      Background::from_css_str("red border-box"),
       Ok(Background {
         color: Some(ColorInput::Value(Color([255, 0, 0, 255]))),
         clip: BackgroundClip::BorderBox,
@@ -182,7 +182,7 @@ mod tests {
   #[test]
   fn test_parse_background_two_boxes_origin_then_clip() {
     assert_eq!(
-      Background::from_str("content-box border-box"),
+      Background::from_css_str("content-box border-box"),
       Ok(Background {
         origin: BackgroundOrigin::ContentBox,
         clip: BackgroundClip::BorderBox,
@@ -195,7 +195,7 @@ mod tests {
   fn test_parse_background_default_origin_is_padding_box() {
     assert_eq!(Background::default().origin, BackgroundOrigin::PaddingBox);
     assert_eq!(
-      Background::from_str("red").unwrap().origin,
+      Background::from_css_str("red").unwrap().origin,
       BackgroundOrigin::PaddingBox
     );
   }
@@ -203,7 +203,7 @@ mod tests {
   #[test]
   fn test_parse_background_with_position_and_size() {
     assert_eq!(
-      Background::from_str("center/cover"),
+      Background::from_css_str("center/cover"),
       Ok(Background {
         position: PositionValue(SpacePair::from_pair(
           PositionComponent::KeywordX(PositionKeywordX::Center),
@@ -218,7 +218,7 @@ mod tests {
   #[test]
   fn test_parse_background_full() {
     assert_eq!(
-      Background::from_str("no-repeat center/80% url(../img/image.png)"),
+      Background::from_css_str("no-repeat center/80% url(../img/image.png)"),
       Ok(Background {
         image: BackgroundImage::Url("../img/image.png".into()),
         position: PositionValue(SpacePair::from_pair(
@@ -237,18 +237,18 @@ mod tests {
 
   #[test]
   fn test_parse_background_empty() {
-    assert_eq!(Background::from_str(""), Ok(Background::default()));
+    assert_eq!(Background::from_css_str(""), Ok(Background::default()));
   }
 
   #[test]
   fn test_parse_background_invalid() {
-    assert!(Background::from_str("invalid-value").is_err());
+    assert!(Background::from_css_str("invalid-value").is_err());
   }
 
   #[test]
   fn test_parse_backgrounds_multiple_gradients() {
     assert_eq!(
-      Backgrounds::from_str(
+      Backgrounds::from_css_str(
         "radial-gradient(circle at 80% 20%, #FF3D00 0%, transparent 40%), radial-gradient(circle at 20% 80%, #00E5FF 0%, transparent 40%)",
       ),
       Ok(

--- a/takumi-css/src/style/properties/background_image.rs
+++ b/takumi-css/src/style/properties/background_image.rs
@@ -103,7 +103,7 @@ pub(crate) fn parse_comma_list<'i, T>(
   Ok(items.into_boxed_slice())
 }
 
-/// A collection of background images.
+/// An ordered list of [`BackgroundImage`] values.
 pub type BackgroundImages = Box<[BackgroundImage]>;
 
 impl<'i> FromCss<'i> for BackgroundImages {

--- a/takumi-css/src/style/properties/background_image.rs
+++ b/takumi-css/src/style/properties/background_image.rs
@@ -137,6 +137,7 @@ mod tests {
   };
 
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_tailwind_none() {
@@ -156,7 +157,7 @@ mod tests {
 
   #[test]
   fn test_parse_background_images_radial_explicit_radii() {
-    let images = BackgroundImages::from_str(
+    let images = BackgroundImages::from_css_str(
       "radial-gradient(ellipse 60% 60% at 50% 50%, rgba(255, 53, 53, 0.10) 0%, transparent 70%), radial-gradient(ellipse 30% 30% at 50% 50%, rgba(255, 53, 53, 0.06) 0%, transparent 55%)",
     );
 
@@ -216,7 +217,7 @@ mod tests {
 
   #[test]
   fn test_parse_repeating_gradients_in_background_images() {
-    let images = BackgroundImages::from_str(
+    let images = BackgroundImages::from_css_str(
       "repeating-linear-gradient(90deg, red 0px 5px, blue 5px 10px), repeating-radial-gradient(circle 20px, red 0px 5px, blue 5px 10px), repeating-conic-gradient(from 0deg, red 0deg 90deg, blue 90deg 180deg)",
     );
 

--- a/takumi-css/src/style/properties/background_position.rs
+++ b/takumi-css/src/style/properties/background_position.rs
@@ -252,7 +252,7 @@ impl<'i> FromCss<'i> for PositionComponent {
   ];
 }
 
-/// A list of `background-position` values (one per layer).
+/// An ordered list of [`PositionValue`] values.
 pub type PositionValues = Box<[PositionValue]>;
 
 impl<'i> FromCss<'i> for PositionValues {

--- a/takumi-css/src/style/properties/background_repeat.rs
+++ b/takumi-css/src/style/properties/background_repeat.rs
@@ -159,7 +159,7 @@ impl<'i> FromCss<'i> for BackgroundRepeat {
   ];
 }
 
-/// A list of background-repeat values (one per layer).
+/// An ordered list of [`BackgroundRepeat`] values.
 pub type BackgroundRepeats = Box<[BackgroundRepeat]>;
 
 impl<'i> FromCss<'i> for BackgroundRepeats {

--- a/takumi-css/src/style/properties/background_size.rs
+++ b/takumi-css/src/style/properties/background_size.rs
@@ -183,7 +183,7 @@ impl BackgroundSize {
   }
 }
 
-/// A list of `background-size` values (one per layer).
+/// An ordered list of [`BackgroundSize`] values.
 pub type BackgroundSizes = Box<[BackgroundSize]>;
 
 impl<'i> FromCss<'i> for BackgroundSizes {

--- a/takumi-css/src/style/properties/background_size.rs
+++ b/takumi-css/src/style/properties/background_size.rs
@@ -214,16 +214,20 @@ impl ToCss for BackgroundSize {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn parses_cover_keyword() {
-    assert_eq!(BackgroundSize::from_str("cover"), Ok(BackgroundSize::Cover));
+    assert_eq!(
+      BackgroundSize::from_css_str("cover"),
+      Ok(BackgroundSize::Cover)
+    );
   }
 
   #[test]
   fn parses_contain_keyword() {
     assert_eq!(
-      BackgroundSize::from_str("contain"),
+      BackgroundSize::from_css_str("contain"),
       Ok(BackgroundSize::Contain)
     );
   }
@@ -231,7 +235,7 @@ mod tests {
   #[test]
   fn parses_single_percentage_value_as_both_dimensions() {
     assert_eq!(
-      BackgroundSize::from_str("50%\t"),
+      BackgroundSize::from_css_str("50%\t"),
       Ok(BackgroundSize::Explicit {
         width: Length::Percentage(50.0),
         height: Length::Auto,
@@ -242,7 +246,7 @@ mod tests {
   #[test]
   fn parses_single_auto_value_as_both_dimensions() {
     assert_eq!(
-      BackgroundSize::from_str("auto"),
+      BackgroundSize::from_css_str("auto"),
       Ok(BackgroundSize::Explicit {
         width: Length::Auto,
         height: Length::Auto,
@@ -253,7 +257,7 @@ mod tests {
   #[test]
   fn parses_two_values_mixed_units() {
     assert_eq!(
-      BackgroundSize::from_str("100px auto"),
+      BackgroundSize::from_css_str("100px auto"),
       Ok(BackgroundSize::Explicit {
         width: Length::Px(100.0),
         height: Length::Auto,
@@ -263,13 +267,13 @@ mod tests {
 
   #[test]
   fn errors_on_unknown_identifier() {
-    assert!(BackgroundSize::from_str("bogus").is_err());
+    assert!(BackgroundSize::from_css_str("bogus").is_err());
   }
 
   #[test]
   fn parses_multiple_layers_with_keywords_and_values() {
     assert_eq!(
-      BackgroundSizes::from_str("cover, 50% auto"),
+      BackgroundSizes::from_css_str("cover, 50% auto"),
       Ok(
         [
           BackgroundSize::Cover,
@@ -286,7 +290,7 @@ mod tests {
   #[test]
   fn parses_multiple_layers_with_single_value_duplication() {
     assert_eq!(
-      BackgroundSizes::from_str("25%, contain"),
+      BackgroundSizes::from_css_str("25%, contain"),
       Ok(
         [
           BackgroundSize::Explicit {
@@ -302,6 +306,6 @@ mod tests {
 
   #[test]
   fn errors_on_invalid_first_layer() {
-    assert!(BackgroundSizes::from_str("nope").is_err());
+    assert!(BackgroundSizes::from_css_str("nope").is_err());
   }
 }

--- a/takumi-css/src/style/properties/blend_mode.rs
+++ b/takumi-css/src/style/properties/blend_mode.rs
@@ -19,6 +19,7 @@ impl<'i> FromCss<'i> for BlendModes {
 
 /// Defines the blending mode for an element.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub enum BlendMode {
   /// The final color is the top color, regardless of what the bottom color is.
   #[default]

--- a/takumi-css/src/style/properties/blend_mode.rs
+++ b/takumi-css/src/style/properties/blend_mode.rs
@@ -2,7 +2,7 @@ use cssparser::Parser;
 
 use super::background_image::parse_comma_list;
 use crate::style::{
-  Animatable, CssToken, FromCss, ListInterpolationStrategy, ParseResult,
+  Animatable, CssToken, FromCss, FromCssStr, ListInterpolationStrategy, ParseResult,
   declare_enum_from_css_impl, tw::TailwindPropertyParser,
 };
 
@@ -84,7 +84,7 @@ declare_enum_from_css_impl!(
 
 impl TailwindPropertyParser for BlendMode {
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 

--- a/takumi-css/src/style/properties/border.rs
+++ b/takumi-css/src/style/properties/border.rs
@@ -201,21 +201,22 @@ mod tests {
   use crate::style::Color;
 
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_border_style_solid() {
-    assert_eq!(BorderStyle::from_str("solid"), Ok(BorderStyle::Solid));
+    assert_eq!(BorderStyle::from_css_str("solid"), Ok(BorderStyle::Solid));
   }
 
   #[test]
   fn test_parse_border_style_dashed() {
-    assert_eq!(BorderStyle::from_str("dashed"), Ok(BorderStyle::Dashed));
+    assert_eq!(BorderStyle::from_css_str("dashed"), Ok(BorderStyle::Dashed));
   }
 
   #[test]
   fn test_parse_border_width_only() {
     assert_eq!(
-      Border::from_str("10px"),
+      Border::from_css_str("10px"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(10.0)),
         style: BorderStyle::None,
@@ -227,7 +228,7 @@ mod tests {
   #[test]
   fn test_parse_border_style_only() {
     assert_eq!(
-      Border::from_str("solid"),
+      Border::from_css_str("solid"),
       Ok(Border {
         width: LineWidth::default(),
         style: BorderStyle::Solid,
@@ -239,7 +240,7 @@ mod tests {
   #[test]
   fn test_parse_border_color_only() {
     assert_eq!(
-      Border::from_str("red"),
+      Border::from_css_str("red"),
       Ok(Border {
         width: LineWidth::default(),
         style: BorderStyle::None,
@@ -251,7 +252,7 @@ mod tests {
   #[test]
   fn test_parse_border_width_and_style() {
     assert_eq!(
-      Border::from_str("2px solid"),
+      Border::from_css_str("2px solid"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
@@ -263,7 +264,7 @@ mod tests {
   #[test]
   fn test_parse_border_width_style_color() {
     assert_eq!(
-      Border::from_str("2px solid red"),
+      Border::from_css_str("2px solid red"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
@@ -275,7 +276,7 @@ mod tests {
   #[test]
   fn test_parse_border_style_width_color() {
     assert_eq!(
-      Border::from_str("solid 2px red"),
+      Border::from_css_str("solid 2px red"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
@@ -287,7 +288,7 @@ mod tests {
   #[test]
   fn test_parse_border_color_style_width() {
     assert_eq!(
-      Border::from_str("red solid 2px"),
+      Border::from_css_str("red solid 2px"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Solid,
@@ -299,7 +300,7 @@ mod tests {
   #[test]
   fn test_parse_border_rem_units() {
     assert_eq!(
-      Border::from_str("1.5rem solid blue"),
+      Border::from_css_str("1.5rem solid blue"),
       Ok(Border {
         width: LineWidth::Length(Length::Rem(1.5)),
         style: BorderStyle::Solid,
@@ -311,7 +312,7 @@ mod tests {
   #[test]
   fn test_parse_border_hex_color() {
     assert_eq!(
-      Border::from_str("3px solid #ff0000"),
+      Border::from_css_str("3px solid #ff0000"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(3.0)),
         style: BorderStyle::Solid,
@@ -323,7 +324,7 @@ mod tests {
   #[test]
   fn test_parse_border_rgb_color() {
     assert_eq!(
-      Border::from_str("4px solid rgb(0, 255, 0)"),
+      Border::from_css_str("4px solid rgb(0, 255, 0)"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(4.0)),
         style: BorderStyle::Solid,
@@ -335,7 +336,7 @@ mod tests {
   #[test]
   fn test_parse_border_dashed() {
     assert_eq!(
-      Border::from_str("2px dashed red"),
+      Border::from_css_str("2px dashed red"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(2.0)),
         style: BorderStyle::Dashed,
@@ -346,18 +347,18 @@ mod tests {
 
   #[test]
   fn test_parse_border_invalid_color() {
-    assert!(Border::from_str("2px solid invalid-color").is_err());
+    assert!(Border::from_css_str("2px solid invalid-color").is_err());
   }
 
   #[test]
   fn test_parse_border_empty() {
-    assert_eq!(Border::from_str(""), Ok(Border::default()));
+    assert_eq!(Border::from_css_str(""), Ok(Border::default()));
   }
 
   #[test]
   fn test_border_value_from_css() {
     assert_eq!(
-      Border::from_str("3px solid blue"),
+      Border::from_css_str("3px solid blue"),
       Ok(Border {
         width: LineWidth::Length(Length::Px(3.0)),
         style: BorderStyle::Solid,
@@ -368,7 +369,7 @@ mod tests {
 
   #[test]
   fn test_border_value_from_invalid_css() {
-    assert!(Border::from_str("invalid border").is_err());
+    assert!(Border::from_css_str("invalid border").is_err());
   }
 
   #[test]
@@ -385,19 +386,19 @@ mod tests {
   #[test]
   fn test_line_width_keywords() {
     assert_eq!(
-      LineWidth::from_str("thin"),
+      LineWidth::from_css_str("thin"),
       Ok(LineWidth::Keyword(LineWidthKeyword::Thin))
     );
     assert_eq!(
-      LineWidth::from_str("medium"),
+      LineWidth::from_css_str("medium"),
       Ok(LineWidth::Keyword(LineWidthKeyword::Medium))
     );
     assert_eq!(
-      LineWidth::from_str("thick"),
+      LineWidth::from_css_str("thick"),
       Ok(LineWidth::Keyword(LineWidthKeyword::Thick))
     );
     assert_eq!(
-      LineWidth::from_str("2px"),
+      LineWidth::from_css_str("2px"),
       Ok(LineWidth::Length(Length::Px(2.0)))
     );
   }
@@ -405,7 +406,7 @@ mod tests {
   #[test]
   fn test_border_keyword_width() {
     assert_eq!(
-      Border::from_str("thick solid"),
+      Border::from_css_str("thick solid"),
       Ok(Border {
         width: LineWidth::Keyword(LineWidthKeyword::Thick),
         style: BorderStyle::Solid,

--- a/takumi-css/src/style/properties/box_shadow.rs
+++ b/takumi-css/src/style/properties/box_shadow.rs
@@ -4,7 +4,7 @@ use cssparser::{BasicParseErrorKind, ParseError, Parser};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
-  Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, Length,
+  Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length,
   ListInterpolationStrategy, MakeComputed, ParseResult, SizingContext, ToCss, next_is_comma,
 };
 
@@ -157,7 +157,7 @@ impl<'i> FromCss<'i> for BoxShadow {
 
 impl crate::style::tw::TailwindPropertyParser for BoxShadow {
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 
@@ -367,14 +367,14 @@ mod tests {
     ];
 
     for (css, expected) in cases {
-      assert_eq!(BoxShadow::from_str(css), Ok(*expected), "css: {css}");
+      assert_eq!(BoxShadow::from_css_str(css), Ok(*expected), "css: {css}");
     }
   }
 
   #[test]
   fn test_parse_box_shadow_invalid() {
-    assert!(BoxShadow::from_str("2px").is_err());
-    assert!(BoxShadow::from_str("").is_err());
+    assert!(BoxShadow::from_css_str("2px").is_err());
+    assert!(BoxShadow::from_css_str("").is_err());
   }
 
   #[test]
@@ -382,7 +382,7 @@ mod tests {
     // Percentages are not valid <length> for blur/spread; loose parsing ignores
     // the trailing token rather than capturing it as a Percentage length.
     assert_eq!(
-      BoxShadow::from_str("2px 4px 50%"),
+      BoxShadow::from_css_str("2px 4px 50%"),
       Ok(BoxShadow {
         offset_x: Px(2.0),
         offset_y: Px(4.0),
@@ -391,7 +391,7 @@ mod tests {
       })
     );
     assert_eq!(
-      BoxShadow::from_str("2px 4px 6px 50%"),
+      BoxShadow::from_css_str("2px 4px 6px 50%"),
       Ok(BoxShadow {
         offset_x: Px(2.0),
         offset_y: Px(4.0),
@@ -405,7 +405,7 @@ mod tests {
   #[test]
   fn test_parse_multiple_box_shadows_with_rgba() {
     assert_eq!(
-      BoxShadows::from_str("2px 4px rgba(0, 0, 0, 0.5), 1px 2px 3px rgba(255, 0, 0, 0.25)"),
+      BoxShadows::from_css_str("2px 4px rgba(0, 0, 0, 0.5), 1px 2px 3px rgba(255, 0, 0, 0.25)"),
       Ok(
         [
           BoxShadow {

--- a/takumi-css/src/style/properties/clip_path.rs
+++ b/takumi-css/src/style/properties/clip_path.rs
@@ -128,6 +128,7 @@ pub struct PathShape {
 
 /// Represents a basic shape function for clip-path.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum BasicShape {
   /// inset() function
   Inset(Box<InsetShape>),

--- a/takumi-css/src/style/properties/clip_path.rs
+++ b/takumi-css/src/style/properties/clip_path.rs
@@ -386,12 +386,13 @@ mod tests {
   use std::assert_matches;
 
   use super::*;
+  use crate::style::FromCssStr;
   use Length::*;
 
   #[test]
   fn test_parse_inset_simple() {
     assert_eq!(
-      BasicShape::from_str("inset(10px)"),
+      BasicShape::from_css_str("inset(10px)"),
       Ok(BasicShape::Inset(Box::new(InsetShape {
         inset: Sides([Px(10.0); 4]),
         border_radius: None,
@@ -402,7 +403,7 @@ mod tests {
   #[test]
   fn test_parse_inset_four_values() {
     assert_eq!(
-      BasicShape::from_str("inset(10px 20px 30px 40px)"),
+      BasicShape::from_css_str("inset(10px 20px 30px 40px)"),
       Ok(BasicShape::Inset(Box::new(InsetShape {
         inset: Sides([Px(10.0), Px(20.0), Px(30.0), Px(40.0)]),
         border_radius: None,
@@ -413,7 +414,7 @@ mod tests {
   #[test]
   fn test_parse_inset_with_border_radius() {
     assert_eq!(
-      BasicShape::from_str("inset(10px round 5px)"),
+      BasicShape::from_css_str("inset(10px round 5px)"),
       Ok(BasicShape::Inset(Box::new(InsetShape {
         inset: Sides::from(Px(10.0)),
         border_radius: Some(Sides::from(Px(5.0))),
@@ -424,7 +425,7 @@ mod tests {
   #[test]
   fn test_parse_inset_with_complex_border_radius() {
     assert_eq!(
-      BasicShape::from_str("inset(10px 20px 30px 40px round 5px 10px 15px 20px)"),
+      BasicShape::from_css_str("inset(10px 20px 30px 40px round 5px 10px 15px 20px)"),
       Ok(BasicShape::Inset(Box::new(InsetShape {
         inset: Sides([Px(10.0), Px(20.0), Px(30.0), Px(40.0)]),
         border_radius: Some(Sides([Px(5.0), Px(10.0), Px(15.0), Px(20.0)])),
@@ -435,7 +436,7 @@ mod tests {
   #[test]
   fn test_parse_circle_simple() {
     assert_eq!(
-      BasicShape::from_str("circle(50px)"),
+      BasicShape::from_css_str("circle(50px)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::Length(Px(50.0)),
         radius_y: ShapeRadius::Length(Px(50.0)),
@@ -447,7 +448,7 @@ mod tests {
   #[test]
   fn test_parse_circle_with_position() {
     assert_eq!(
-      BasicShape::from_str("circle(50px at 25% 75%)"),
+      BasicShape::from_css_str("circle(50px at 25% 75%)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::Length(Px(50.0)),
         radius_y: ShapeRadius::Length(Px(50.0)),
@@ -462,7 +463,7 @@ mod tests {
   #[test]
   fn test_parse_circle_default_radius() {
     assert_eq!(
-      BasicShape::from_str("circle(at 25% 75%)"),
+      BasicShape::from_css_str("circle(at 25% 75%)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::ClosestSide,
         radius_y: ShapeRadius::ClosestSide,
@@ -477,7 +478,7 @@ mod tests {
   #[test]
   fn test_parse_ellipse_simple() {
     assert_eq!(
-      BasicShape::from_str("ellipse(50px 30px)"),
+      BasicShape::from_css_str("ellipse(50px 30px)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::Length(Px(50.0)),
         radius_y: ShapeRadius::Length(Px(30.0)),
@@ -489,7 +490,7 @@ mod tests {
   #[test]
   fn test_parse_ellipse_with_position() {
     assert_eq!(
-      BasicShape::from_str("ellipse(50px 30px at 25% 75%)"),
+      BasicShape::from_css_str("ellipse(50px 30px at 25% 75%)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::Length(Px(50.0)),
         radius_y: ShapeRadius::Length(Px(30.0)),
@@ -504,7 +505,7 @@ mod tests {
   #[test]
   fn test_parse_polygon_triangle() {
     assert_matches!(
-      BasicShape::from_str("polygon(50% 0%, 0% 100%, 100% 100%)"),
+      BasicShape::from_css_str("polygon(50% 0%, 0% 100%, 100% 100%)"),
       Ok(BasicShape::Polygon(PolygonShape {
         fill_rule: None,
         coordinates: coords,
@@ -518,7 +519,7 @@ mod tests {
   #[test]
   fn test_parse_polygon_with_fill_rule() {
     assert_matches!(
-      BasicShape::from_str("polygon(evenodd, 50% 0%, 0% 100%, 100% 100%)"),
+      BasicShape::from_css_str("polygon(evenodd, 50% 0%, 0% 100%, 100% 100%)"),
       Ok(BasicShape::Polygon(PolygonShape {
         fill_rule: Some(FillRule::EvenOdd),
         coordinates: coords,
@@ -529,7 +530,7 @@ mod tests {
   #[test]
   fn test_parse_path() {
     assert_eq!(
-      BasicShape::from_str("path('M 10 10 L 90 90')"),
+      BasicShape::from_css_str("path('M 10 10 L 90 90')"),
       Ok(BasicShape::Path(PathShape {
         fill_rule: None,
         path: "M 10 10 L 90 90".into(),
@@ -540,7 +541,7 @@ mod tests {
   #[test]
   fn test_parse_path_with_fill_rule() {
     assert_eq!(
-      BasicShape::from_str("path(evenodd, 'M 10 10 L 90 90')"),
+      BasicShape::from_css_str("path(evenodd, 'M 10 10 L 90 90')"),
       Ok(BasicShape::Path(PathShape {
         fill_rule: Some(FillRule::EvenOdd),
         path: "M 10 10 L 90 90".into(),
@@ -551,7 +552,7 @@ mod tests {
   #[test]
   fn test_parse_circle_percentage_radius() {
     assert_eq!(
-      BasicShape::from_str("circle(50%)"),
+      BasicShape::from_css_str("circle(50%)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::Length(Length::Percentage(50.0)),
         radius_y: ShapeRadius::Length(Length::Percentage(50.0)),
@@ -563,7 +564,7 @@ mod tests {
   #[test]
   fn test_parse_circle_closest_side() {
     assert_eq!(
-      BasicShape::from_str("circle(closest-side)"),
+      BasicShape::from_css_str("circle(closest-side)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::ClosestSide,
         radius_y: ShapeRadius::ClosestSide,
@@ -575,7 +576,7 @@ mod tests {
   #[test]
   fn test_parse_circle_farthest_side() {
     assert_eq!(
-      BasicShape::from_str("circle(farthest-side)"),
+      BasicShape::from_css_str("circle(farthest-side)"),
       Ok(BasicShape::Ellipse(Box::new(EllipseShape {
         radius_x: ShapeRadius::FarthestSide,
         radius_y: ShapeRadius::FarthestSide,

--- a/takumi-css/src/style/properties/color.rs
+++ b/takumi-css/src/style/properties/color.rs
@@ -1,19 +1,16 @@
 use crate::style::{ToCss, unexpected_token};
 use std::fmt::{self, Display};
 
+use crate::style::{
+  Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
+  MakeComputed, ParseResult, PercentageNumber, SizingContext, fast_div_255,
+  properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
+};
 use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Srgb, parse_color};
 use cssparser::{
   Parser, Token,
   color::{parse_hash_color, parse_named_color},
   match_ignore_ascii_case,
-};
-use image::Rgba;
-use tiny_skia::{ColorU8, PremultipliedColorU8};
-
-use crate::style::{
-  Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-  MakeComputed, ParseResult, PercentageNumber, SizingContext, fast_div_255,
-  properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
 };
 
 fn is_cylindrical_color_space(color_space: ColorSpaceTag) -> bool {
@@ -430,30 +427,6 @@ impl TailwindPropertyParser for Color {
 impl From<Color> for ColorInput {
   fn from(color: Color) -> Self {
     ColorInput::Value(color)
-  }
-}
-
-impl From<Color> for Rgba<u8> {
-  fn from(color: Color) -> Self {
-    Rgba(color.0)
-  }
-}
-
-impl From<Color> for PremultipliedColorU8 {
-  fn from(color: Color) -> Self {
-    let [r, g, b, a] = color.0;
-    let premul_r = fast_div_255(r as u32 * a as u32);
-    let premul_g = fast_div_255(g as u32 * a as u32);
-    let premul_b = fast_div_255(b as u32 * a as u32);
-
-    PremultipliedColorU8::from_rgba(premul_r, premul_g, premul_b, a)
-      .unwrap_or(PremultipliedColorU8::TRANSPARENT)
-  }
-}
-
-impl From<ColorU8> for Color {
-  fn from(color: ColorU8) -> Self {
-    Self([color.red(), color.green(), color.blue(), color.alpha()])
   }
 }
 

--- a/takumi-css/src/style/properties/color.rs
+++ b/takumi-css/src/style/properties/color.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 use crate::style::{
   Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-  MakeComputed, ParseResult, PercentageNumber, SizingContext, fast_div_255,
+  FromCssStr, MakeComputed, ParseResult, PercentageNumber, SizingContext, fast_div_255,
   properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
 };
 use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Srgb, parse_color};
@@ -742,7 +742,7 @@ fn parse_relative_color<'i>(
   }
 
   let scale = channel_keyword_scale(target_cs);
-  let origin_color = Color::from_str(input.slice_from(origin_start).trim())
+  let origin_color = Color::from_css_str(input.slice_from(origin_start).trim())
     .map_err(|_| unexpected_token!(Color, origin_location, &origin_token))?;
   let [r, g, b, a] = origin_color.0;
   let converted =
@@ -858,7 +858,7 @@ mod tests {
       ("deepskyblue", Color([0, 191, 255, 255])),
     ] {
       assert_eq!(
-        ColorInput::from_str(css),
+        ColorInput::from_css_str(css),
         Ok(ColorInput::Value(expected)),
         "failed for {css}",
       );
@@ -872,7 +872,7 @@ mod tests {
       ("rgb(255 0 153 / 0.5)", Color([255, 0, 153, 128])),
     ] {
       assert_eq!(
-        ColorInput::from_str(css),
+        ColorInput::from_css_str(css),
         Ok(ColorInput::Value(expected)),
         "failed for {css}",
       );
@@ -881,100 +881,100 @@ mod tests {
 
   #[test]
   fn test_parse_color_invalid_function() {
-    assert!(ColorInput::from_str("invalid(255, 0, 153)").is_err());
+    assert!(ColorInput::from_css_str("invalid(255, 0, 153)").is_err());
   }
 
   #[test]
   fn test_parse_color_mix_srgb_default_percentages() {
     assert_eq!(
-      ColorInput::from_str("color-mix(in srgb, red, blue)"),
+      ColorInput::from_css_str("color-mix(in srgb, red, blue)"),
       Ok(ColorInput::Value(Color([128, 0, 128, 255])))
     );
   }
 
   #[test]
   fn test_parse_color_mix_equivalent_percentage_syntaxes() {
-    let canonical = ColorInput::from_str("color-mix(in srgb, red 25%, blue 75%)");
+    let canonical = ColorInput::from_css_str("color-mix(in srgb, red 25%, blue 75%)");
 
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in srgb, 25% red, 75% blue)")
+      ColorInput::from_css_str("color-mix(in srgb, 25% red, 75% blue)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in srgb, red 25%, 75% blue)")
+      ColorInput::from_css_str("color-mix(in srgb, red 25%, 75% blue)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in srgb, red 25%, blue)")
+      ColorInput::from_css_str("color-mix(in srgb, red 25%, blue)")
     );
     assert_eq!(canonical, Ok(ColorInput::Value(Color([64, 0, 191, 255]))));
   }
 
   #[test]
   fn test_parse_color_mix_lch_missing_percentage_equivalence() {
-    let canonical = ColorInput::from_str("color-mix(in lch, purple 50%, plum 50%)");
+    let canonical = ColorInput::from_css_str("color-mix(in lch, purple 50%, plum 50%)");
 
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple 50%, plum)")
+      ColorInput::from_css_str("color-mix(in lch, purple 50%, plum)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple, plum 50%)")
+      ColorInput::from_css_str("color-mix(in lch, purple, plum 50%)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple, plum)")
+      ColorInput::from_css_str("color-mix(in lch, purple, plum)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, plum, purple)")
+      ColorInput::from_css_str("color-mix(in lch, plum, purple)")
     );
   }
 
   #[test]
   fn test_parse_color_mix_lch_normalizes_equal_opaque_percentages() {
-    let canonical = ColorInput::from_str("color-mix(in lch, purple 50%, plum 50%)");
+    let canonical = ColorInput::from_css_str("color-mix(in lch, purple 50%, plum 50%)");
 
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple 55%, plum 55%)")
+      ColorInput::from_css_str("color-mix(in lch, purple 55%, plum 55%)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple 70%, plum 70%)")
+      ColorInput::from_css_str("color-mix(in lch, purple 70%, plum 70%)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple 95%, plum 95%)")
+      ColorInput::from_css_str("color-mix(in lch, purple 95%, plum 95%)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple 125%, plum 125%)")
+      ColorInput::from_css_str("color-mix(in lch, purple 125%, plum 125%)")
     );
     assert_eq!(
       canonical,
-      ColorInput::from_str("color-mix(in lch, purple 9999%, plum 9999%)")
+      ColorInput::from_css_str("color-mix(in lch, purple 9999%, plum 9999%)")
     );
   }
 
   #[test]
   fn test_parse_color_mix_endpoint_percentages_return_endpoint_colors() {
     assert_eq!(
-      ColorInput::from_str("color-mix(in srgb, red 100%, blue 0%)"),
-      ColorInput::from_str("red")
+      ColorInput::from_css_str("color-mix(in srgb, red 100%, blue 0%)"),
+      ColorInput::from_css_str("red")
     );
     assert_eq!(
-      ColorInput::from_str("color-mix(in srgb, red 0%, blue 100%)"),
-      ColorInput::from_str("blue")
+      ColorInput::from_css_str("color-mix(in srgb, red 0%, blue 100%)"),
+      ColorInput::from_css_str("blue")
     );
   }
 
   #[test]
   fn test_parse_color_mix_alpha_multiplier_under_100_percent() {
     assert_eq!(
-      ColorInput::from_str("color-mix(in srgb, red 30%, blue 30%)"),
+      ColorInput::from_css_str("color-mix(in srgb, red 30%, blue 30%)"),
       Ok(ColorInput::Value(Color([128, 0, 128, 153])))
     );
   }
@@ -982,23 +982,25 @@ mod tests {
   #[test]
   fn test_parse_color_mix_hue_directions_change_result() {
     assert_eq!(
-      ColorInput::from_str(
+      ColorInput::from_css_str(
         "color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))",
       ),
       Ok(ColorInput::Value(Color([191, 86, 64, 255])))
     );
     assert_eq!(
-      ColorInput::from_str(
+      ColorInput::from_css_str(
         "color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))",
       ),
       Ok(ColorInput::Value(Color([191, 86, 64, 255])))
     );
     assert_eq!(
-      ColorInput::from_str("color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))",),
+      ColorInput::from_css_str(
+        "color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))",
+      ),
       Ok(ColorInput::Value(Color([64, 169, 191, 255])))
     );
     assert_eq!(
-      ColorInput::from_str(
+      ColorInput::from_css_str(
         "color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))",
       ),
       Ok(ColorInput::Value(Color([64, 169, 191, 255])))
@@ -1008,35 +1010,35 @@ mod tests {
   #[test]
   fn test_parse_color_mix_over_100_percent_normalizes_weights() {
     assert_eq!(
-      ColorInput::from_str("color-mix(in srgb, red 120%, blue 80%)"),
+      ColorInput::from_css_str("color-mix(in srgb, red 120%, blue 80%)"),
       Ok(ColorInput::Value(Color([153, 0, 102, 255])))
     );
   }
 
   #[test]
   fn test_parse_color_mix_unknown_color_space() {
-    assert!(ColorInput::from_str("color-mix(in unknown, red, blue)").is_err());
+    assert!(ColorInput::from_css_str("color-mix(in unknown, red, blue)").is_err());
   }
 
   #[test]
   fn test_parse_color_mix_hue_method_with_non_cylindrical_space_errors() {
-    assert!(ColorInput::from_str("color-mix(in srgb longer hue, red, blue)").is_err());
+    assert!(ColorInput::from_css_str("color-mix(in srgb longer hue, red, blue)").is_err());
   }
 
   #[test]
   fn test_parse_color_mix_malformed_missing_comma_errors() {
-    assert!(ColorInput::from_str("color-mix(in srgb, red blue)").is_err());
+    assert!(ColorInput::from_css_str("color-mix(in srgb, red blue)").is_err());
   }
 
   #[test]
   fn test_parse_color_mix_zero_sum_percentages_errors() {
-    assert!(ColorInput::from_str("color-mix(in srgb, red 0%, blue 0%)").is_err());
+    assert!(ColorInput::from_css_str("color-mix(in srgb, red 0%, blue 0%)").is_err());
   }
 
   #[test]
   fn test_parse_color_mix_accepts_number_as_percentage() {
     assert_eq!(
-      ColorInput::from_str("color-mix(in srgb, red 0.5, blue 0.5)"),
+      ColorInput::from_css_str("color-mix(in srgb, red 0.5, blue 0.5)"),
       Ok(ColorInput::Value(Color([128, 0, 128, 255])))
     );
   }
@@ -1044,54 +1046,54 @@ mod tests {
   #[test]
   fn test_parse_color_mix_nested_color_mix() {
     assert!(
-      ColorInput::from_str("color-mix(in srgb, color-mix(in srgb, red, blue), white)").is_ok()
+      ColorInput::from_css_str("color-mix(in srgb, color-mix(in srgb, red, blue), white)").is_ok()
     );
   }
 
   #[test]
   fn test_parse_relative_oklch_keywords_only() {
-    let relative = ColorInput::from_str("oklch(from oklch(0.7 0.15 30) l c h / 0.5)");
-    let direct = ColorInput::from_str("oklch(0.7 0.15 30 / 0.5)");
+    let relative = ColorInput::from_css_str("oklch(from oklch(0.7 0.15 30) l c h / 0.5)");
+    let direct = ColorInput::from_css_str("oklch(0.7 0.15 30 / 0.5)");
     assert_eq!(relative, direct);
   }
 
   #[test]
   fn test_parse_relative_oklch_keywords_only_from_named_color() {
-    assert!(ColorInput::from_str("oklch(from red l c h)").is_ok());
+    assert!(ColorInput::from_css_str("oklch(from red l c h)").is_ok());
   }
 
   #[test]
   fn test_parse_relative_rgb_keywords_only_scales_to_255() {
     assert_eq!(
-      ColorInput::from_str("rgb(from #336699 r g b)"),
-      ColorInput::from_str("rgb(51 102 153)"),
+      ColorInput::from_css_str("rgb(from #336699 r g b)"),
+      ColorInput::from_css_str("rgb(51 102 153)"),
     );
   }
 
   #[test]
   fn test_parse_relative_rgb_drops_origin_alpha_when_alpha_omitted() {
     assert_eq!(
-      ColorInput::from_str("rgb(from rgb(10 20 30 / 0.5) r g b / 0.25)"),
-      ColorInput::from_str("rgba(10, 20, 30, 0.25)"),
+      ColorInput::from_css_str("rgb(from rgb(10 20 30 / 0.5) r g b / 0.25)"),
+      ColorInput::from_css_str("rgba(10, 20, 30, 0.25)"),
     );
   }
 
   #[test]
   fn test_parse_relative_hsl_with_dimension_hue() {
-    assert!(ColorInput::from_str("hsl(from red 120deg s l)").is_ok());
+    assert!(ColorInput::from_css_str("hsl(from red 120deg s l)").is_ok());
   }
 
   #[test]
   fn test_parse_relative_oklch_substitutes_origin_alpha() {
     assert_eq!(
-      ColorInput::from_str("oklch(from oklch(0.5 0.1 200 / 0.4) l c h / alpha)",),
-      ColorInput::from_str("oklch(0.5 0.1 200 / 0.4)"),
+      ColorInput::from_css_str("oklch(from oklch(0.5 0.1 200 / 0.4) l c h / alpha)",),
+      ColorInput::from_css_str("oklch(0.5 0.1 200 / 0.4)"),
     );
   }
 
   #[test]
   fn test_parse_relative_color_with_color_mix_origin() {
-    assert!(ColorInput::from_str("lch(from color-mix(in srgb, red, blue) l c h)").is_ok());
+    assert!(ColorInput::from_css_str("lch(from color-mix(in srgb, red, blue) l c h)").is_ok());
   }
 
   #[test]
@@ -1099,7 +1101,7 @@ mod tests {
     use crate::style::properties::linear_gradient::LinearGradient;
 
     assert!(
-      LinearGradient::from_str(
+      LinearGradient::from_css_str(
         "linear-gradient(to right, oklch(from oklch(0.7 0.15 30) l c h / 0.5), white)",
       )
       .is_ok()
@@ -1111,8 +1113,10 @@ mod tests {
     use crate::style::properties::linear_gradient::LinearGradient;
 
     assert!(
-      LinearGradient::from_str("linear-gradient(to right, color-mix(in srgb, red, blue), white)")
-        .is_ok()
+      LinearGradient::from_css_str(
+        "linear-gradient(to right, color-mix(in srgb, red, blue), white)"
+      )
+      .is_ok()
     );
   }
 }

--- a/takumi-css/src/style/properties/conic_gradient.rs
+++ b/takumi-css/src/style/properties/conic_gradient.rs
@@ -374,6 +374,7 @@ mod tests {
   use tiny_skia::ColorU8;
 
   use super::*;
+  use crate::style::FromCssStr;
   use crate::{
     Viewport,
     style::{Color, Length, SpacePair, StopPosition, properties::gradient_utils::red_blue_stops},
@@ -429,7 +430,7 @@ mod tests {
       ),
     ] {
       assert_eq!(
-        ConicGradient::from_str(input),
+        ConicGradient::from_css_str(input),
         Ok(ConicGradient {
           repeating: false,
           from_angle: Angle::zero(),
@@ -445,7 +446,7 @@ mod tests {
   #[test]
   fn test_parse_conic_gradient_with_interpolation_color_space() {
     assert_eq!(
-      ConicGradient::from_str("conic-gradient(in oklab, red, blue)"),
+      ConicGradient::from_css_str("conic-gradient(in oklab, red, blue)"),
       Ok(ConicGradient {
         repeating: false,
         from_angle: Angle::zero(),
@@ -471,7 +472,7 @@ mod tests {
 
   #[test]
   fn test_parse_conic_gradient_complex() {
-    let gradient = ConicGradient::from_str("conic-gradient(from 90deg at 25% 75%, red, blue)");
+    let gradient = ConicGradient::from_css_str("conic-gradient(from 90deg at 25% 75%, red, blue)");
 
     assert_eq!(
       gradient,

--- a/takumi-css/src/style/properties/content.rs
+++ b/takumi-css/src/style/properties/content.rs
@@ -8,6 +8,7 @@ use crate::style::{
 
 /// CSS `content` property value for `::before` / `::after` pseudo-elements.
 #[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub enum ContentValue {
   /// `content: normal`. For `::before` / `::after` this behaves as `None`.
   #[default]

--- a/takumi-css/src/style/properties/content.rs
+++ b/takumi-css/src/style/properties/content.rs
@@ -190,9 +190,10 @@ mod tests {
   use std::assert_matches;
 
   use super::*;
+  use crate::style::FromCssStr;
 
   fn parse(input: &str) -> ContentValue {
-    ContentValue::from_str(input).expect("parse")
+    ContentValue::from_css_str(input).expect("parse")
   }
 
   #[test]
@@ -262,13 +263,13 @@ mod tests {
 
   #[test]
   fn unsupported_function_is_rejected() {
-    assert!(ContentValue::from_str("counter(foo)").is_err());
-    assert!(ContentValue::from_str("\"prefix\" counter(foo)").is_err());
+    assert!(ContentValue::from_css_str("counter(foo)").is_err());
+    assert!(ContentValue::from_css_str("\"prefix\" counter(foo)").is_err());
   }
 
   #[test]
   fn unsupported_keyword_is_rejected() {
-    assert!(ContentValue::from_str("open-quote").is_err());
-    assert!(ContentValue::from_str("\"x\" close-quote").is_err());
+    assert!(ContentValue::from_css_str("open-quote").is_err());
+    assert!(ContentValue::from_css_str("\"x\" close-quote").is_err());
   }
 }

--- a/takumi-css/src/style/properties/filter.rs
+++ b/takumi-css/src/style/properties/filter.rs
@@ -38,6 +38,7 @@ pub(crate) fn build_transfer_table<F: Fn(usize) -> f32>(f: F) -> TransferTable {
 
 /// Represents a single CSS filter operation
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum Filter {
   /// Brightness multiplier (1 = unchanged). Accepts number or percentage
   Brightness(PercentageNumber),
@@ -110,7 +111,7 @@ impl Filter {
   }
 }
 
-/// A list of filter operations
+/// An ordered list of [`Filter`] values.
 pub type Filters = Vec<Filter>;
 
 impl MakeComputed for Filter {
@@ -409,7 +410,7 @@ mod tests {
 
   #[test]
   fn test_parse_none_clears_filters() {
-    assert_eq!(Filters::from_str("none"), Ok(Filters::default()));
+    assert_eq!(Filters::from_str("none").unwrap(), Filters::default());
   }
 
   #[test]

--- a/takumi-css/src/style/properties/filter.rs
+++ b/takumi-css/src/style/properties/filter.rs
@@ -401,45 +401,55 @@ impl ToCss for Filter {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
   use crate::style::{Color, ColorInput, Length::Px};
 
   #[test]
   fn test_parse_blur_filter() {
-    assert_eq!(Filter::from_str("blur(5px)"), Ok(Filter::Blur(Px(5.0))));
+    assert_eq!(Filter::from_css_str("blur(5px)"), Ok(Filter::Blur(Px(5.0))));
   }
 
   #[test]
   fn test_parse_none_clears_filters() {
-    assert_eq!(Filters::from_str("none").unwrap(), Filters::default());
+    assert_eq!(Filters::from_css_str("none").unwrap(), Filters::default());
   }
 
   #[test]
   fn filters_serialize_space_separated() {
-    let filters = Filters::from_str("blur(3px) grayscale(0.5)").unwrap();
+    let filters = Filters::from_css_str("blur(3px) grayscale(0.5)").unwrap();
     assert_eq!(filters.to_css_string(), "blur(3px) grayscale(0.5)");
   }
 
   #[test]
   fn empty_filters_serialize_as_none() {
     assert_eq!(Filters::default().to_css_string(), "none");
-    assert_eq!(Filters::from_str("none").unwrap().to_css_string(), "none");
+    assert_eq!(
+      Filters::from_css_str("none").unwrap().to_css_string(),
+      "none"
+    );
   }
 
   #[test]
   fn test_parse_blur_rejects_invalid_argument() {
-    assert_eq!(Filter::from_str("blur()"), Ok(Filter::Blur(Length::zero())));
-    assert!(Filter::from_str("blur(red)").is_err());
+    assert_eq!(
+      Filter::from_css_str("blur()"),
+      Ok(Filter::Blur(Length::zero()))
+    );
+    assert!(Filter::from_css_str("blur(red)").is_err());
   }
 
   #[test]
   fn test_parse_blur_filter_zero() {
-    assert_eq!(Filter::from_str("blur()"), Ok(Filter::Blur(Length::zero())));
+    assert_eq!(
+      Filter::from_css_str("blur()"),
+      Ok(Filter::Blur(Length::zero()))
+    );
   }
 
   #[test]
   fn test_parse_drop_shadow_filter() {
     assert_eq!(
-      Filter::from_str("drop-shadow(2px 4px 6px red)"),
+      Filter::from_css_str("drop-shadow(2px 4px 6px red)"),
       Ok(Filter::DropShadow(TextShadow {
         offset_x: Px(2.0),
         offset_y: Px(4.0),
@@ -452,7 +462,7 @@ mod tests {
   #[test]
   fn test_parse_drop_shadow_color_first() {
     assert_eq!(
-      Filter::from_str("drop-shadow(red 2px 4px)"),
+      Filter::from_css_str("drop-shadow(red 2px 4px)"),
       Ok(Filter::DropShadow(TextShadow {
         offset_x: Px(2.0),
         offset_y: Px(4.0),
@@ -465,7 +475,7 @@ mod tests {
   #[test]
   fn test_parse_drop_shadow_no_blur() {
     assert_eq!(
-      Filter::from_str("drop-shadow(2px 4px)"),
+      Filter::from_css_str("drop-shadow(2px 4px)"),
       Ok(Filter::DropShadow(TextShadow {
         offset_x: Px(2.0),
         offset_y: Px(4.0),

--- a/takumi-css/src/style/properties/flex.rs
+++ b/takumi-css/src/style/properties/flex.rs
@@ -2,8 +2,8 @@ use crate::style::unexpected_token;
 use cssparser::{Parser, match_ignore_ascii_case};
 
 use crate::style::{
-  AspectRatio, CssSyntaxKind, CssToken, FlexDirection, FlexWrap, FromCss, Length, MakeComputed,
-  ParseResult, SizingContext, tw::TailwindPropertyParser,
+  AspectRatio, CssSyntaxKind, CssToken, FlexDirection, FlexWrap, FromCss, FromCssStr, Length,
+  MakeComputed, ParseResult, SizingContext, tw::TailwindPropertyParser,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -26,7 +26,7 @@ impl TailwindPropertyParser for Flex {
       _ => {}
     }
 
-    let Ok(AspectRatio::Ratio(ratio)) = AspectRatio::from_str(token) else {
+    let Ok(AspectRatio::Ratio(ratio)) = AspectRatio::from_css_str(token) else {
       return None;
     };
 
@@ -193,7 +193,7 @@ mod tests {
   #[test]
   fn test_flex_three_values() {
     assert_eq!(
-      Flex::from_str("1 1 auto"),
+      Flex::from_css_str("1 1 auto"),
       Ok(Flex {
         grow: 1.0,
         shrink: 1.0,
@@ -205,7 +205,7 @@ mod tests {
   #[test]
   fn test_flex_single_number() {
     assert_eq!(
-      Flex::from_str("2"),
+      Flex::from_css_str("2"),
       Ok(Flex {
         grow: 2.0,
         shrink: 1.0,
@@ -217,7 +217,7 @@ mod tests {
   #[test]
   fn test_flex_number_and_length() {
     assert_eq!(
-      Flex::from_str("1 30px"),
+      Flex::from_css_str("1 30px"),
       Ok(Flex {
         grow: 1.0,
         shrink: 1.0,
@@ -229,7 +229,7 @@ mod tests {
   #[test]
   fn test_flex_two_numbers() {
     assert_eq!(
-      Flex::from_str("2 2"),
+      Flex::from_css_str("2 2"),
       Ok(Flex {
         grow: 2.0,
         shrink: 2.0,

--- a/takumi-css/src/style/properties/font_family.rs
+++ b/takumi-css/src/style/properties/font_family.rs
@@ -184,12 +184,12 @@ mod tests {
   use parley::GenericFamily;
 
   use super::{FontFamily, FontFamilyToken};
-  use crate::style::{FromCss, tw::TailwindPropertyParser};
+  use crate::style::{FromCssStr, tw::TailwindPropertyParser};
 
   #[test]
   fn parses_single_generic_family() {
     assert_eq!(
-      FontFamily::from_str("serif"),
+      FontFamily::from_css_str("serif"),
       Ok(FontFamily(Box::new([FontFamilyToken::Generic(
         GenericFamily::Serif,
       )])))
@@ -199,7 +199,7 @@ mod tests {
   #[test]
   fn parses_fallback_family_list() {
     assert_eq!(
-      FontFamily::from_str("\"Inter\", Arial, serif"),
+      FontFamily::from_css_str("\"Inter\", Arial, serif"),
       Ok(FontFamily(Box::new([
         FontFamilyToken::Owned(String::from("Inter")),
         FontFamilyToken::Owned(String::from("Arial")),
@@ -211,7 +211,7 @@ mod tests {
   #[test]
   fn parses_unquoted_multi_word_family_name() {
     assert_eq!(
-      FontFamily::from_str("Noto Sans TC"),
+      FontFamily::from_css_str("Noto Sans TC"),
       Ok(FontFamily(Box::new([FontFamilyToken::Owned(
         "Noto Sans TC".to_string()
       )])))

--- a/takumi-css/src/style/properties/font_feature_settings.rs
+++ b/takumi-css/src/style/properties/font_feature_settings.rs
@@ -80,12 +80,13 @@ impl ToCss for parley::FontFeature {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn empty_settings_serialize_as_normal() {
     assert_eq!(FontFeatureSettings::default().to_css_string(), "normal");
     assert_eq!(
-      FontFeatureSettings::from_str("normal")
+      FontFeatureSettings::from_css_str("normal")
         .unwrap()
         .to_css_string(),
       "normal"

--- a/takumi-css/src/style/properties/font_size.rs
+++ b/takumi-css/src/style/properties/font_size.rs
@@ -194,6 +194,7 @@ mod tests {
   use taffy::Size;
 
   use super::*;
+  use crate::style::FromCssStr;
   use crate::{
     style::{CalcArena, SizingContext},
     viewport::Viewport,
@@ -211,8 +212,8 @@ mod tests {
       calc_arena: Rc::new(CalcArena::default()),
     };
 
-    assert_eq!(FontSize::from_str("larger"), Ok(FontSize::Larger));
-    assert_eq!(FontSize::from_str("smaller"), Ok(FontSize::Smaller));
+    assert_eq!(FontSize::from_css_str("larger"), Ok(FontSize::Larger));
+    assert_eq!(FontSize::from_css_str("smaller"), Ok(FontSize::Smaller));
     assert_eq!(FontSize::Larger.to_px(&sizing, 20.0), 24.0);
     assert_eq!(FontSize::Smaller.to_px(&sizing, 20.0), 20.0 / 1.2);
   }

--- a/takumi-css/src/style/properties/font_stretch.rs
+++ b/takumi-css/src/style/properties/font_stretch.rs
@@ -5,8 +5,8 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::FontWidth;
 
 use crate::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
-  lerp, tw::TailwindPropertyParser,
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
+  SizingContext, lerp, tw::TailwindPropertyParser,
 };
 
 /// Controls the width/stretch of text rendering.
@@ -67,7 +67,7 @@ impl<'i> FromCss<'i> for FontStretch {
 
 impl TailwindPropertyParser for FontStretch {
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 
@@ -109,20 +109,19 @@ impl ToCss for FontStretch {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::style::FromCss;
 
   #[test]
   fn test_parse_font_stretch_keywords() {
     assert_eq!(
-      FontStretch::from_str("condensed"),
+      FontStretch::from_css_str("condensed"),
       Ok(FontStretch(FontWidth::CONDENSED))
     );
     assert_eq!(
-      FontStretch::from_str("expanded"),
+      FontStretch::from_css_str("expanded"),
       Ok(FontStretch(FontWidth::EXPANDED))
     );
     assert_eq!(
-      FontStretch::from_str("normal"),
+      FontStretch::from_css_str("normal"),
       Ok(FontStretch(FontWidth::NORMAL))
     );
   }
@@ -130,7 +129,7 @@ mod tests {
   #[test]
   fn test_parse_font_stretch_percentage() {
     assert_eq!(
-      FontStretch::from_str("75%"),
+      FontStretch::from_css_str("75%"),
       Ok(FontStretch(FontWidth::CONDENSED))
     );
   }

--- a/takumi-css/src/style/properties/font_variant.rs
+++ b/takumi-css/src/style/properties/font_variant.rs
@@ -571,7 +571,7 @@ impl ToCss for FontVariantPosition {
 
 /// Appends every resolved `font-variant-*` feature to `out`, in property order. The caller
 /// appends `font-feature-settings` afterwards so explicit settings win on tag conflicts.
-pub fn append_variant_features(
+pub(crate) fn append_variant_features(
   ligatures: &FontVariantLigatures,
   numeric: &FontVariantNumeric,
   east_asian: &FontVariantEastAsian,

--- a/takumi-css/src/style/properties/font_weight.rs
+++ b/takumi-css/src/style/properties/font_weight.rs
@@ -162,16 +162,17 @@ impl ToCss for FontWeight {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn parses_numeric_font_weight() {
-    assert_eq!(FontWeight::from_str("700"), Ok(700.0.into()));
+    assert_eq!(FontWeight::from_css_str("700"), Ok(700.0.into()));
   }
 
   #[test]
   fn resolves_relative_keywords_against_parent() {
-    assert_eq!(FontWeight::from_str("bolder"), Ok(FontWeight::Bolder));
-    assert_eq!(FontWeight::from_str("lighter"), Ok(FontWeight::Lighter));
+    assert_eq!(FontWeight::from_css_str("bolder"), Ok(FontWeight::Bolder));
+    assert_eq!(FontWeight::from_css_str("lighter"), Ok(FontWeight::Lighter));
 
     assert_eq!(FontWeight::Bolder.resolve_against(400.0).value(), 700.0);
     assert_eq!(FontWeight::Bolder.resolve_against(700.0).value(), 900.0);

--- a/takumi-css/src/style/properties/gradient_utils.rs
+++ b/takumi-css/src/style/properties/gradient_utils.rs
@@ -172,8 +172,19 @@ pub(crate) fn write_gradient_css<W: fmt::Write>(
   dest.write_char(')')
 }
 
-/// Interpolates between two colors in RGBA space, if t is 0.0 or 1.0, returns the first or second color.
-pub fn interpolate_rgba(c1: Color, c2: Color, t: f32) -> Color {
+/// Premultiplies a straight-alpha [`Color`] into a `tiny_skia`
+/// [`PremultipliedColorU8`].
+pub(crate) fn color_to_premultiplied(color: Color) -> PremultipliedColorU8 {
+  let [r, g, b, a] = color.0;
+  let premul_r = fast_div_255(r as u32 * a as u32);
+  let premul_g = fast_div_255(g as u32 * a as u32);
+  let premul_b = fast_div_255(b as u32 * a as u32);
+
+  PremultipliedColorU8::from_rgba(premul_r, premul_g, premul_b, a)
+    .unwrap_or(PremultipliedColorU8::TRANSPARENT)
+}
+
+pub(crate) fn interpolate_rgba(c1: Color, c2: Color, t: f32) -> Color {
   if t <= f32::EPSILON {
     return c1;
   }
@@ -253,7 +264,7 @@ pub(crate) fn interpolate_with_color_space(
 }
 
 /// Interpolates two premultiplied colors directly in premultiplied RGBA space.
-pub fn interpolate_rgba_premultiplied(
+pub(crate) fn interpolate_rgba_premultiplied(
   c1: PremultipliedColorU8,
   c2: PremultipliedColorU8,
   t: f32,
@@ -485,7 +496,7 @@ fn snap_stop_samples(
 
   let stop_indices = assign_stop_sample_indices(resolved_stops, axis_length, typed_lut.len());
   for (stop, &sample_index) in resolved_stops.iter().zip(&stop_indices) {
-    typed_lut[sample_index] = stop.color.into();
+    typed_lut[sample_index] = color_to_premultiplied(stop.color);
   }
 }
 
@@ -520,7 +531,7 @@ pub fn build_color_lut_with_interpolation(
       .map(|s| s.color)
       .unwrap_or(crate::style::Color::transparent());
 
-    return vec![color.into()];
+    return vec![color_to_premultiplied(color)];
   }
 
   let mut left_index = 0usize;
@@ -546,12 +557,16 @@ pub fn build_color_lut_with_interpolation(
       let left_stop = &resolved_stops[left_index];
       let right_stop = &resolved_stops[right_index];
       if left_stop.color == right_stop.color {
-        return left_stop.color.into();
+        return color_to_premultiplied(left_stop.color);
       }
 
       let t = interpolation_position(left_stop.position, right_stop.position, position_px);
       if color_space == ColorSpaceTag::Srgb && hue_direction == HueDirection::Shorter {
-        return interpolate_rgba_premultiplied(left_stop.color.into(), right_stop.color.into(), t);
+        return interpolate_rgba_premultiplied(
+          color_to_premultiplied(left_stop.color),
+          color_to_premultiplied(right_stop.color),
+          t,
+        );
       }
 
       interpolate_with_color_space(
@@ -563,7 +578,7 @@ pub fn build_color_lut_with_interpolation(
       )
     };
 
-    color.into()
+    color_to_premultiplied(color)
   };
 
   let mut typed_lut = vec![PremultipliedColorU8::TRANSPARENT; lut_size];
@@ -575,7 +590,10 @@ pub fn build_color_lut_with_interpolation(
 }
 
 /// Calculates an adaptive LUT size based on the gradient axis length.
-pub fn adaptive_lut_size(axis_length: f32, resolved_stops: &[ResolvedGradientStop]) -> usize {
+pub(crate) fn adaptive_lut_size(
+  axis_length: f32,
+  resolved_stops: &[ResolvedGradientStop],
+) -> usize {
   adaptive_lut_size_with_visible_samples(
     (axis_length.ceil() as usize)
       .saturating_add(1)
@@ -586,7 +604,7 @@ pub fn adaptive_lut_size(axis_length: f32, resolved_stops: &[ResolvedGradientSto
 }
 
 /// LUT size that covers `visible_samples` and the tightest stop interval.
-pub fn adaptive_lut_size_with_visible_samples(
+pub(crate) fn adaptive_lut_size_with_visible_samples(
   visible_samples: usize,
   axis_length: f32,
   resolved_stops: &[ResolvedGradientStop],
@@ -958,8 +976,8 @@ mod tests {
       },
     );
 
-    assert_eq!(lut[7], Color([255, 0, 0, 255]).into());
-    assert_eq!(lut[8], Color([0, 0, 255, 255]).into());
+    assert_eq!(lut[7], color_to_premultiplied(Color([255, 0, 0, 255])));
+    assert_eq!(lut[8], color_to_premultiplied(Color([0, 0, 255, 255])));
   }
 
   #[test]
@@ -992,8 +1010,14 @@ mod tests {
     let stop_indices = assign_stop_sample_indices(&resolved, 32.0, lut.len());
 
     assert!(stop_indices[0] < stop_indices[1]);
-    assert_eq!(lut[stop_indices[0]], resolved[0].color.into());
-    assert_eq!(lut[stop_indices[1]], resolved[1].color.into());
+    assert_eq!(
+      lut[stop_indices[0]],
+      color_to_premultiplied(resolved[0].color)
+    );
+    assert_eq!(
+      lut[stop_indices[1]],
+      color_to_premultiplied(resolved[1].color)
+    );
   }
 
   #[test]

--- a/takumi-css/src/style/properties/grid/grid_length.rs
+++ b/takumi-css/src/style/properties/grid/grid_length.rs
@@ -68,13 +68,14 @@ impl ToCss for GridLength {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_fr_and_unit() {
-    assert_eq!(GridLength::from_str("1fr"), Ok(GridLength::Fr(1.0)));
+    assert_eq!(GridLength::from_css_str("1fr"), Ok(GridLength::Fr(1.0)));
 
     assert_eq!(
-      GridLength::from_str("10px"),
+      GridLength::from_css_str("10px"),
       Ok(GridLength::Unit(Length::Px(10.0)))
     );
   }

--- a/takumi-css/src/style/properties/grid/grid_line.rs
+++ b/takumi-css/src/style/properties/grid/grid_line.rs
@@ -87,11 +87,12 @@ impl TailwindPropertyParser for GridLine {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_line() {
     assert_eq!(
-      GridLine::from_str("span 2 / 3"),
+      GridLine::from_css_str("span 2 / 3"),
       Ok(GridLine {
         start: GridPlacement::span(2),
         end: GridPlacement::Line(3),

--- a/takumi-css/src/style/properties/grid/grid_placement.rs
+++ b/takumi-css/src/style/properties/grid/grid_placement.rs
@@ -167,27 +167,34 @@ impl ToCss for GridPlacement {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_placement() {
-    assert_eq!(GridPlacement::from_str("auto"), Ok(GridPlacement::auto()));
+    assert_eq!(
+      GridPlacement::from_css_str("auto"),
+      Ok(GridPlacement::auto())
+    );
 
     assert_eq!(
-      GridPlacement::from_str("span 2"),
+      GridPlacement::from_css_str("span 2"),
       Ok(GridPlacement::span(2))
     );
 
     assert_eq!(
-      GridPlacement::from_str("span name"),
+      GridPlacement::from_css_str("span name"),
       Ok(GridPlacement::span(1))
     );
 
-    assert_eq!(GridPlacement::from_str("3"), Ok(GridPlacement::Line(3)));
-
-    assert_eq!(GridPlacement::from_str("-1"), Ok(GridPlacement::Line(-1)));
+    assert_eq!(GridPlacement::from_css_str("3"), Ok(GridPlacement::Line(3)));
 
     assert_eq!(
-      GridPlacement::from_str("header"),
+      GridPlacement::from_css_str("-1"),
+      Ok(GridPlacement::Line(-1))
+    );
+
+    assert_eq!(
+      GridPlacement::from_css_str("header"),
       Ok(GridPlacement::Named("header".to_string()))
     );
   }

--- a/takumi-css/src/style/properties/grid/grid_repetition_count.rs
+++ b/takumi-css/src/style/properties/grid/grid_repetition_count.rs
@@ -105,23 +105,24 @@ impl ToCss for GridRepetitionCount {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_repetition_count() {
     assert_eq!(
-      GridRepetitionCount::from_str("auto-fill"),
+      GridRepetitionCount::from_css_str("auto-fill"),
       Ok(GridRepetitionCount::Keyword(
         GridRepetitionKeyword::AutoFill
       ))
     );
 
     assert_eq!(
-      GridRepetitionCount::from_str("auto-fit"),
+      GridRepetitionCount::from_css_str("auto-fit"),
       Ok(GridRepetitionCount::Keyword(GridRepetitionKeyword::AutoFit))
     );
 
     assert_eq!(
-      GridRepetitionCount::from_str("3"),
+      GridRepetitionCount::from_css_str("3"),
       Ok(GridRepetitionCount::Count(3))
     );
   }

--- a/takumi-css/src/style/properties/grid/grid_template_component.rs
+++ b/takumi-css/src/style/properties/grid/grid_template_component.rs
@@ -8,7 +8,7 @@ use crate::style::{
   GridTrackSize, MakeComputed, ParseResult, SizingContext, ToCss,
 };
 
-/// An ordered list of grid-template track components and line names.
+/// An ordered list of [`GridTemplateComponent`] values.
 pub type GridTemplateComponents = Vec<GridTemplateComponent>;
 
 /// Parses a `[name1 name2 ...]` line-name block's body; caller consumes the opening bracket.

--- a/takumi-css/src/style/properties/grid/grid_template_component.rs
+++ b/takumi-css/src/style/properties/grid/grid_template_component.rs
@@ -227,10 +227,11 @@ mod tests {
   use crate::style::{GridLength, GridRepetitionKeyword};
 
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn components_serialize_space_separated() {
-    let components = GridTemplateComponents::from_str("50px 100px").unwrap();
+    let components = GridTemplateComponents::from_css_str("50px 100px").unwrap();
     assert_eq!(components.to_css_string(), "50px 100px");
   }
 
@@ -242,7 +243,7 @@ mod tests {
   #[test]
   fn test_parse_template_component_repeat() {
     assert_eq!(
-      GridTemplateComponent::from_str("repeat(auto-fill, [a] 1fr [b] 2fr)"),
+      GridTemplateComponent::from_css_str("repeat(auto-fill, [a] 1fr [b] 2fr)"),
       Ok(GridTemplateComponent::Repeat(
         GridRepetitionCount::Keyword(GridRepetitionKeyword::AutoFill),
         vec![
@@ -263,6 +264,6 @@ mod tests {
 
   #[test]
   fn test_parse_repeat_without_track_size_is_error() {
-    assert!(GridTemplateComponent::from_str("repeat(2, [a])").is_err());
+    assert!(GridTemplateComponent::from_css_str("repeat(2, [a])").is_err());
   }
 }

--- a/takumi-css/src/style/properties/grid/grid_track_size.rs
+++ b/takumi-css/src/style/properties/grid/grid_track_size.rs
@@ -112,11 +112,12 @@ mod tests {
   use crate::style::Length;
 
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_minmax_and_track_size() {
     assert_eq!(
-      GridTrackSize::from_str("minmax(10px, 1fr)"),
+      GridTrackSize::from_css_str("minmax(10px, 1fr)"),
       Ok(GridTrackSize::MinMax(GridMinMaxSize {
         min: GridLength::Unit(Length::Px(10.0)),
         max: GridLength::Fr(1.0)
@@ -124,7 +125,7 @@ mod tests {
     );
 
     assert_eq!(
-      GridTrackSize::from_str("2fr"),
+      GridTrackSize::from_css_str("2fr"),
       Ok(GridTrackSize::Fixed(GridLength::Fr(2.0)))
     );
   }

--- a/takumi-css/src/style/properties/length.rs
+++ b/takumi-css/src/style/properties/length.rs
@@ -9,7 +9,8 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use taffy::{CompactLength, Dimension, LengthPercentage, LengthPercentageAuto};
 
 use crate::style::{
-  AspectRatio, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
+  AspectRatio, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
+  SizingContext,
   tw::{TW_VAR_SPACING, TailwindPropertyParser},
 };
 
@@ -144,7 +145,7 @@ impl TailwindPropertyParser for Length {
       return Some(Length::from_spacing(value));
     }
 
-    match AspectRatio::from_str(token) {
+    match AspectRatio::from_css_str(token) {
       Ok(AspectRatio::Ratio(ratio)) => return Some(Length::Percentage(ratio * 100.0)),
       Ok(AspectRatio::Auto) => return Some(Length::Auto),
       _ => {}
@@ -543,7 +544,7 @@ mod tests {
   #[test]
   fn parse_calc_mixed_returns_formula() {
     assert_eq!(
-      Length::from_str("calc(100% - 12px)"),
+      Length::from_css_str("calc(100% - 12px)"),
       Ok(Length::Calc(CalcFormula {
         percent: 1.0,
         px: -12.0,
@@ -554,19 +555,19 @@ mod tests {
 
   #[test]
   fn parse_calc_number_expression_becomes_px() {
-    let parsed = Length::from_str("calc(1 + 2)");
+    let parsed = Length::from_css_str("calc(1 + 2)");
     assert_eq!(parsed, Ok(Length::Px(3.0)));
   }
 
   #[test]
   fn parse_calc_rejects_number_plus_length() {
-    let parsed = Length::from_str("calc(1 + 2px)");
+    let parsed = Length::from_css_str("calc(1 + 2px)");
     assert!(parsed.is_err());
   }
 
   #[test]
   fn parse_calc_rejects_division_by_zero() {
-    let parsed = Length::from_str("calc(10px / 0)");
+    let parsed = Length::from_css_str("calc(10px / 0)");
     assert!(parsed.is_err());
   }
 
@@ -747,28 +748,28 @@ mod tests {
 
   #[test]
   fn parse_supports_modern_viewport_and_container_units() {
-    assert_eq!(Length::from_str("12dvw"), Ok(Length::Vw(12.0)));
-    assert_eq!(Length::from_str("12svw"), Ok(Length::Vw(12.0)));
-    assert_eq!(Length::from_str("12lvw"), Ok(Length::Vw(12.0)));
-    assert_eq!(Length::from_str("12cqw"), Ok(Length::CqW(12.0)));
-    assert_eq!(Length::from_str("12cqi"), Ok(Length::CqW(12.0)));
-    assert_eq!(Length::from_str("12vi"), Ok(Length::Vw(12.0)));
-    assert_eq!(Length::from_str("12dvh"), Ok(Length::Vh(12.0)));
-    assert_eq!(Length::from_str("12svh"), Ok(Length::Vh(12.0)));
-    assert_eq!(Length::from_str("12lvh"), Ok(Length::Vh(12.0)));
-    assert_eq!(Length::from_str("12cqh"), Ok(Length::CqH(12.0)));
-    assert_eq!(Length::from_str("12cqb"), Ok(Length::CqH(12.0)));
-    assert_eq!(Length::from_str("12vb"), Ok(Length::Vh(12.0)));
-    assert_eq!(Length::from_str("12vmin"), Ok(Length::VMin(12.0)));
-    assert_eq!(Length::from_str("12cqmin"), Ok(Length::CqMin(12.0)));
-    assert_eq!(Length::from_str("12vmax"), Ok(Length::VMax(12.0)));
-    assert_eq!(Length::from_str("12cqmax"), Ok(Length::CqMax(12.0)));
+    assert_eq!(Length::from_css_str("12dvw"), Ok(Length::Vw(12.0)));
+    assert_eq!(Length::from_css_str("12svw"), Ok(Length::Vw(12.0)));
+    assert_eq!(Length::from_css_str("12lvw"), Ok(Length::Vw(12.0)));
+    assert_eq!(Length::from_css_str("12cqw"), Ok(Length::CqW(12.0)));
+    assert_eq!(Length::from_css_str("12cqi"), Ok(Length::CqW(12.0)));
+    assert_eq!(Length::from_css_str("12vi"), Ok(Length::Vw(12.0)));
+    assert_eq!(Length::from_css_str("12dvh"), Ok(Length::Vh(12.0)));
+    assert_eq!(Length::from_css_str("12svh"), Ok(Length::Vh(12.0)));
+    assert_eq!(Length::from_css_str("12lvh"), Ok(Length::Vh(12.0)));
+    assert_eq!(Length::from_css_str("12cqh"), Ok(Length::CqH(12.0)));
+    assert_eq!(Length::from_css_str("12cqb"), Ok(Length::CqH(12.0)));
+    assert_eq!(Length::from_css_str("12vb"), Ok(Length::Vh(12.0)));
+    assert_eq!(Length::from_css_str("12vmin"), Ok(Length::VMin(12.0)));
+    assert_eq!(Length::from_css_str("12cqmin"), Ok(Length::CqMin(12.0)));
+    assert_eq!(Length::from_css_str("12vmax"), Ok(Length::VMax(12.0)));
+    assert_eq!(Length::from_css_str("12cqmax"), Ok(Length::CqMax(12.0)));
   }
 
   #[test]
   fn parse_supports_lh_and_rlh_units() {
-    assert_eq!(Length::from_str("1.5lh"), Ok(Length::Lh(1.5)));
-    assert_eq!(Length::from_str("2rlh"), Ok(Length::Rlh(2.0)));
+    assert_eq!(Length::from_css_str("1.5lh"), Ok(Length::Lh(1.5)));
+    assert_eq!(Length::from_css_str("2rlh"), Ok(Length::Rlh(2.0)));
   }
 
   #[test]
@@ -789,7 +790,7 @@ mod tests {
 
   #[test]
   fn parse_calc_supports_lh_and_rlh() {
-    let parsed = Length::from_str("calc(1lh + 2rlh - 3px)");
+    let parsed = Length::from_css_str("calc(1lh + 2rlh - 3px)");
     assert_eq!(
       parsed,
       Ok(Length::Calc(CalcFormula {
@@ -804,7 +805,7 @@ mod tests {
   #[test]
   fn calc_lh_resolves_through_line_height_basis() {
     let sizing = sizing();
-    let parsed = Length::from_str("calc(1lh + 2px)");
+    let parsed = Length::from_css_str("calc(1lh + 2px)");
     assert_eq!(
       parsed,
       Ok(Length::Calc(CalcFormula {
@@ -829,7 +830,7 @@ mod tests {
 
   #[test]
   fn parse_calc_supports_modern_viewport_and_container_units() {
-    let parsed = Length::from_str("calc(20cqmax + 5px - 2cqb)");
+    let parsed = Length::from_css_str("calc(20cqmax + 5px - 2cqb)");
     assert_eq!(
       parsed,
       Ok(Length::Calc(CalcFormula {
@@ -864,27 +865,27 @@ mod tests {
   #[test]
   fn parse_calc_supports_constants() {
     assert_eq!(
-      Length::from_str("calc(pi)").as_ref(),
+      Length::from_css_str("calc(pi)").as_ref(),
       Ok(&Length::Px(std::f32::consts::PI))
     );
     assert_eq!(
-      Length::from_str("calc(e)").as_ref(),
+      Length::from_css_str("calc(e)").as_ref(),
       Ok(&Length::Px(std::f32::consts::E))
     );
 
-    let inf = Length::from_str("calc(infinity)");
+    let inf = Length::from_css_str("calc(infinity)");
     assert_matches!(inf, Ok(Length::Px(v)) if v.is_infinite() && v.is_sign_positive());
 
-    let neg_inf = Length::from_str("calc(-infinity)");
+    let neg_inf = Length::from_css_str("calc(-infinity)");
     assert_matches!(neg_inf, Ok(Length::Px(v)) if v.is_infinite() && v.is_sign_negative());
 
-    let nan = Length::from_str("calc(nan)");
+    let nan = Length::from_css_str("calc(nan)");
     assert_matches!(nan, Ok(Length::Px(v)) if v.is_nan());
   }
 
   #[test]
   fn parse_calc_infinity_times_length_clamps_in_to_px() {
-    let parsed = Length::from_str("calc(infinity * 1px)");
+    let parsed = Length::from_css_str("calc(infinity * 1px)");
     let sizing = sizing();
     assert!(parsed.is_ok(), "expected successful parse, got {parsed:?}");
     let Ok(length) = parsed else {

--- a/takumi-css/src/style/properties/line_height.rs
+++ b/takumi-css/src/style/properties/line_height.rs
@@ -128,12 +128,12 @@ impl ToCss for LineHeight {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::{FromCss, Length, LineHeight, tw::TailwindPropertyParser};
+  use crate::style::{FromCssStr, Length, LineHeight, tw::TailwindPropertyParser};
 
   #[test]
   fn parses_unitless_calc_expression() {
     assert_eq!(
-      LineHeight::from_str("calc(1.75 / 1.125)"),
+      LineHeight::from_css_str("calc(1.75 / 1.125)"),
       Ok(LineHeight::Unitless(1.75 / 1.125))
     );
   }
@@ -141,7 +141,7 @@ mod tests {
   #[test]
   fn parses_percentage_as_font_size_relative() {
     assert_eq!(
-      LineHeight::from_str("90%"),
+      LineHeight::from_css_str("90%"),
       Ok(LineHeight::Length(Length::Percentage(90.0)))
     );
   }

--- a/takumi-css/src/style/properties/linear_gradient.rs
+++ b/takumi-css/src/style/properties/linear_gradient.rs
@@ -833,6 +833,7 @@ mod tests {
   };
 
   use super::*;
+  use crate::style::FromCssStr;
   fn sizing() -> SizingContext {
     SizingContext {
       viewport: Viewport::new((200, 100)),
@@ -848,7 +849,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(to top right, #ff0000, #0000ff)"),
+      LinearGradient::from_css_str("linear-gradient(to top right, #ff0000, #0000ff)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Keyword(GradientKeywordDirection {
@@ -869,10 +870,10 @@ mod tests {
       ("0.5turn", Angle::new(180.0)),
       ("90", Angle::new(90.0)),
     ] {
-      assert_eq!(Angle::from_str(input), Ok(expected), "input: {input}");
+      assert_eq!(Angle::from_css_str(input), Ok(expected), "input: {input}");
     }
     // rad requires approximate comparison
-    assert!(Angle::from_str("3.14159rad").is_ok_and(|a| (a.0 - 180.0).abs() < 0.001));
+    assert!(Angle::from_css_str("3.14159rad").is_ok_and(|a| (a.0 - 180.0).abs() < 0.001));
   }
 
   #[test]
@@ -938,7 +939,7 @@ mod tests {
       ),
     ] {
       assert_eq!(
-        GradientKeywordDirection::from_str(input),
+        GradientKeywordDirection::from_css_str(input),
         Ok(expected),
         "input: {input}"
       );
@@ -970,7 +971,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_with_angle() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(45deg, #ff0000, #0000ff)"),
+      LinearGradient::from_css_str("linear-gradient(45deg, #ff0000, #0000ff)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Angle(Angle::new(45.0)),
@@ -983,7 +984,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_with_interpolation_color_space() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(in oklab, #ff0000, #0000ff)"),
+      LinearGradient::from_css_str("linear-gradient(in oklab, #ff0000, #0000ff)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::default(),
@@ -1001,8 +1002,8 @@ mod tests {
     // The serialized form must stay valid CSS (direction and color space in one
     // clause), so re-parsing keeps the interpolation instead of dropping it.
     let gradient =
-      LinearGradient::from_str("linear-gradient(to right in oklab, #ff0000, #0000ff)").unwrap();
-    let reparsed = LinearGradient::from_str(&gradient.to_css_string()).unwrap();
+      LinearGradient::from_css_str("linear-gradient(to right in oklab, #ff0000, #0000ff)").unwrap();
+    let reparsed = LinearGradient::from_css_str(&gradient.to_css_string()).unwrap();
     assert_eq!(gradient, reparsed);
     assert_eq!(reparsed.interpolation.color_space, ColorSpaceTag::Oklab);
   }
@@ -1010,7 +1011,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_with_interpolation_hue_direction() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(to right in oklch longer hue, red, blue)"),
+      LinearGradient::from_css_str("linear-gradient(to right in oklch longer hue, red, blue)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Keyword(GradientKeywordDirection {
@@ -1038,14 +1039,14 @@ mod tests {
 
   #[test]
   fn test_parse_linear_gradient_rejects_multiple_directions() {
-    assert!(LinearGradient::from_str("linear-gradient(to right 45deg, red, blue)").is_err());
-    assert!(LinearGradient::from_str("linear-gradient(45deg to right, red, blue)").is_err());
+    assert!(LinearGradient::from_css_str("linear-gradient(to right 45deg, red, blue)").is_err());
+    assert!(LinearGradient::from_css_str("linear-gradient(45deg to right, red, blue)").is_err());
   }
 
   #[test]
   fn test_parse_linear_gradient_with_stops() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(to right, #ff0000 0%, #0000ff 100%)"),
+      LinearGradient::from_css_str("linear-gradient(to right, #ff0000 0%, #0000ff 100%)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Keyword(GradientKeywordDirection {
@@ -1065,7 +1066,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_with_double_position_color_stop() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(to right, red 10% 20%, blue)"),
+      LinearGradient::from_css_str("linear-gradient(to right, red 10% 20%, blue)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Keyword(GradientKeywordDirection {
@@ -1095,7 +1096,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_with_hint() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(to right, #ff0000, 50%, #0000ff)"),
+      LinearGradient::from_css_str("linear-gradient(to right, #ff0000, 50%, #0000ff)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Keyword(GradientKeywordDirection {
@@ -1122,7 +1123,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_single_color() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(to bottom, #ff0000)"),
+      LinearGradient::from_css_str("linear-gradient(to bottom, #ff0000)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Keyword(GradientKeywordDirection {
@@ -1143,7 +1144,7 @@ mod tests {
   fn test_parse_linear_gradient_default_angle() {
     // Default angle is 180 degrees (to bottom)
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(#ff0000, #0000ff)"),
+      LinearGradient::from_css_str("linear-gradient(#ff0000, #0000ff)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::default(),
@@ -1166,7 +1167,7 @@ mod tests {
   #[test]
   fn test_parse_gradient_hint_color() {
     assert_eq!(
-      GradientStop::from_str("#ff0000"),
+      GradientStop::from_css_str("#ff0000"),
       Ok(GradientStop::ColorHint {
         color: ColorInput::Value(Color([255, 0, 0, 255])),
         hint: None,
@@ -1177,7 +1178,7 @@ mod tests {
   #[test]
   fn test_parse_gradient_hint_numeric() {
     assert_eq!(
-      GradientStop::from_str("50%"),
+      GradientStop::from_css_str("50%"),
       Ok(GradientStop::Hint(StopPosition(Length::Percentage(50.0))))
     );
   }
@@ -1232,7 +1233,7 @@ mod tests {
   #[test]
   fn test_parse_linear_gradient_mixed_hints_and_colors() {
     assert_eq!(
-      LinearGradient::from_str("linear-gradient(45deg, #ff0000, 25%, #00ff00, 75%, #0000ff)"),
+      LinearGradient::from_css_str("linear-gradient(45deg, #ff0000, 25%, #00ff00, 75%, #0000ff)"),
       Ok(LinearGradient {
         repeating: false,
         direction: LinearGradientDirection::Angle(Angle::new(45.0)),
@@ -1428,9 +1429,9 @@ mod tests {
   }
 
   #[test]
-  fn test_linear_gradient_px_stops_crisp_line() -> ParseResult<'static, ()> {
+  fn test_linear_gradient_px_stops_crisp_line() {
     let gradient =
-      LinearGradient::from_str("linear-gradient(to right, grey 1px, transparent 1px)")?;
+      LinearGradient::from_css_str("linear-gradient(to right, grey 1px, transparent 1px)").unwrap();
 
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((40, 40)))
@@ -1448,14 +1449,13 @@ mod tests {
     // transparent till the end
     let c2 = tile.sample_pixel(40, 0).demultiply();
     assert_eq!(c2, ColorU8::from_rgba(0, 0, 0, 0));
-
-    Ok(())
   }
 
   #[test]
-  fn test_linear_gradient_vertical_px_stops_top_pixel() -> ParseResult<'static, ()> {
+  fn test_linear_gradient_vertical_px_stops_top_pixel() {
     let gradient =
-      LinearGradient::from_str("linear-gradient(to bottom, grey 1px, transparent 1px)")?;
+      LinearGradient::from_css_str("linear-gradient(to bottom, grey 1px, transparent 1px)")
+        .unwrap();
 
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((40, 40)))
@@ -1467,8 +1467,6 @@ mod tests {
       tile.sample_pixel(0, 0).demultiply(),
       ColorU8::from_rgba(128, 128, 128, 255)
     );
-
-    Ok(())
   }
 
   #[test]
@@ -1481,7 +1479,7 @@ mod tests {
       ("8px", StopPosition(Length::Px(8.0))),
     ] {
       assert_eq!(
-        StopPosition::from_str(input),
+        StopPosition::from_css_str(input),
         Ok(expected),
         "input: {input}"
       );

--- a/takumi-css/src/style/properties/mod.rs
+++ b/takumi-css/src/style/properties/mod.rs
@@ -8,7 +8,7 @@ mod aspect_ratio;
 mod background;
 mod background_image;
 mod background_position;
-mod background_repeat;
+pub(crate) mod background_repeat;
 mod background_size;
 mod background_size_resolve;
 mod blend_mode;
@@ -17,9 +17,9 @@ mod box_alignment;
 mod box_shadow;
 mod clip_path;
 mod color;
-mod conic_gradient;
+pub(crate) mod conic_gradient;
 mod content;
-mod filter;
+pub(crate) mod filter;
 mod flex;
 mod flex_grow;
 mod font_family;
@@ -31,18 +31,18 @@ mod font_synthesis;
 mod font_variant;
 mod font_variation_settings;
 mod font_weight;
-mod gradient_utils;
+pub(crate) mod gradient_utils;
 mod grid;
 mod length;
 mod line_clamp;
 mod line_height;
-mod linear_gradient;
+pub(crate) mod linear_gradient;
 mod offset_path;
 mod order;
 mod overflow;
 mod overflow_wrap;
 mod percentage_number;
-mod radial_gradient;
+pub(crate) mod radial_gradient;
 mod sides;
 mod space_pair;
 mod text_decoration;
@@ -64,7 +64,7 @@ pub use aspect_ratio::*;
 pub use background::*;
 pub use background_image::*;
 pub use background_position::*;
-pub use background_repeat::*;
+pub use background_repeat::{BackgroundRepeat, BackgroundRepeatStyle, BackgroundRepeats};
 pub use background_size::*;
 pub use background_size_resolve::*;
 pub use blend_mode::*;
@@ -73,9 +73,12 @@ pub use box_alignment::*;
 pub use box_shadow::*;
 pub use clip_path::*;
 pub use color::*;
-pub use conic_gradient::*;
+pub use conic_gradient::ConicGradient;
 pub use content::*;
-pub use filter::*;
+pub use filter::{
+  BlurType, Filter, FilterCategory, Filters, LUMA_WEIGHTS, SEPIA_WEIGHTS, TransferChannel,
+  TransferTable,
+};
 pub use flex::*;
 pub use flex_grow::*;
 pub use font_family::*;
@@ -87,21 +90,20 @@ pub use font_synthesis::*;
 pub use font_variant::*;
 pub use font_variation_settings::*;
 pub use font_weight::*;
-pub use gradient_utils::{
-  GradientOverlayTile, build_color_lut_with_interpolation,
-  overlay_gradient_tile_fast_normal_unconstrained, resolve_stops_along_axis,
-};
 pub use grid::*;
 pub use length::*;
 pub use line_clamp::*;
 pub use line_height::*;
-pub use linear_gradient::*;
+pub use linear_gradient::{
+  Angle, GradientKeywordDirection, GradientStop, GradientStops, HorizontalKeyword, LinearGradient,
+  LinearGradientDirection, ResolvedGradientStop, StopPosition, VerticalKeyword,
+};
 pub use offset_path::*;
 pub use order::*;
 pub use overflow::*;
 pub use overflow_wrap::*;
 pub use percentage_number::*;
-pub use radial_gradient::*;
+pub use radial_gradient::{RadialGradient, RadialShape, RadialSize};
 use serde::Deserialize;
 pub use sides::*;
 pub use space_pair::*;
@@ -123,7 +125,6 @@ pub use word_break::*;
 pub use z_index::*;
 
 use cssparser::{Parser, match_ignore_ascii_case};
-use image::imageops::FilterType;
 use parley::Alignment;
 use std::fmt;
 
@@ -136,20 +137,12 @@ pub(crate) fn next_is_comma<'i>(input: &mut Parser<'i, '_>) -> bool {
   is_comma
 }
 
-/// Implements `TailwindPropertyParser` by delegating to each type's `FromStr`.
-macro_rules! impl_tw_from_str {
-  ($($ty:ty),+ $(,)?) => {
-    $(
-      impl TailwindPropertyParser for $ty {
-        fn parse_tw(token: &str) -> Option<Self> {
-          Self::from_str(token).ok()
-        }
-      }
-    )+
-  };
-}
-
-impl_tw_from_str!(ObjectFit, TextAlign, LineJoin, AlignItems, BorderStyle);
+// These parse Tailwind tokens straight through their `FromCss` value parser.
+impl TailwindPropertyParser for ObjectFit {}
+impl TailwindPropertyParser for TextAlign {}
+impl TailwindPropertyParser for LineJoin {}
+impl TailwindPropertyParser for AlignItems {}
+impl TailwindPropertyParser for BorderStyle {}
 
 impl<T: Animatable + Copy> Animatable for SpacePair<T> {
   fn interpolate(
@@ -539,6 +532,7 @@ declare_enum_from_css_impl!(
 ///
 /// This enum determines how an element is positioned within its containing element.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum Position {
   /// The element is laid out in the normal flow and is not a containing block.
   /// Offsets (top, right, bottom, left) have no effect.
@@ -1024,6 +1018,7 @@ impl_from_taffy_enum!(FlexWrap, taffy::FlexWrap, NoWrap, Wrap, WrapReverse);
 
 /// Controls text case transformation when rendering.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub enum TextTransform {
   /// Do not transform text
   #[default]
@@ -1063,6 +1058,7 @@ declare_enum_from_css_impl!(
 
 /// Controls how whitespace should be collapsed.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub enum WhiteSpaceCollapse {
   /// Preserve whitespace as is—spaces and tabs are not collapsed.
   Preserve,
@@ -1085,6 +1081,7 @@ declare_enum_from_css_impl!(
 
 /// Defines how images should be scaled when rendered.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub enum ImageScalingAlgorithm {
   /// The image is scaled using Catmull-Rom interpolation.
   /// This is balanced for speed and quality.
@@ -1151,13 +1148,3 @@ declare_enum_from_css_impl!(
   "inset" => BorderStyle::Inset,
   "outset" => BorderStyle::Outset,
 );
-
-impl From<ImageScalingAlgorithm> for FilterType {
-  fn from(algorithm: ImageScalingAlgorithm) -> Self {
-    match algorithm {
-      ImageScalingAlgorithm::Auto => FilterType::CatmullRom,
-      ImageScalingAlgorithm::Smooth => FilterType::Lanczos3,
-      ImageScalingAlgorithm::Pixelated => FilterType::Nearest,
-    }
-  }
-}

--- a/takumi-css/src/style/properties/mod.rs
+++ b/takumi-css/src/style/properties/mod.rs
@@ -808,7 +808,7 @@ impl TailwindPropertyParser for JustifyContent {
       "between" => Some(JustifyContent::SpaceBetween),
       "around" => Some(JustifyContent::SpaceAround),
       "evenly" => Some(JustifyContent::SpaceEvenly),
-      _ => Self::from_str(token).ok(),
+      _ => Self::from_css_str(token).ok(),
     }
   }
 }

--- a/takumi-css/src/style/properties/offset_path.rs
+++ b/takumi-css/src/style/properties/offset_path.rs
@@ -766,6 +766,7 @@ pub(crate) fn sample_offset_path(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   fn test_sizing() -> SizingContext {
     SizingContext::builder()
@@ -776,23 +777,23 @@ mod tests {
   #[test]
   fn parses_keywords_and_angles() {
     assert_eq!(
-      OffsetRotate::from_str("auto"),
+      OffsetRotate::from_css_str("auto"),
       Ok(OffsetRotate::Auto(Angle::zero()))
     );
     assert_eq!(
-      OffsetRotate::from_str("reverse"),
+      OffsetRotate::from_css_str("reverse"),
       Ok(OffsetRotate::Reverse(Angle::zero()))
     );
     assert_eq!(
-      OffsetRotate::from_str("45deg"),
+      OffsetRotate::from_css_str("45deg"),
       Ok(OffsetRotate::Fixed(Angle::new(45.0)))
     );
     assert_eq!(
-      OffsetRotate::from_str("auto 90deg"),
+      OffsetRotate::from_css_str("auto 90deg"),
       Ok(OffsetRotate::Auto(Angle::new(90.0)))
     );
     assert_eq!(
-      OffsetRotate::from_str("90deg auto"),
+      OffsetRotate::from_css_str("90deg auto"),
       Ok(OffsetRotate::Auto(Angle::new(90.0)))
     );
   }
@@ -805,7 +806,7 @@ mod tests {
 
   #[test]
   fn samples_horizontal_line_midpoint() {
-    let path = OffsetPath::from_str("path('M 0 0 L 100 0')").unwrap();
+    let path = OffsetPath::from_css_str("path('M 0 0 L 100 0')").unwrap();
     let size = Size {
       width: 200.0,
       height: 200.0,
@@ -827,7 +828,7 @@ mod tests {
 
   #[test]
   fn open_path_clamps_distance() {
-    let path = OffsetPath::from_str("path('M 0 0 L 100 0')").unwrap();
+    let path = OffsetPath::from_css_str("path('M 0 0 L 100 0')").unwrap();
     let size = Size {
       width: 200.0,
       height: 200.0,
@@ -846,7 +847,7 @@ mod tests {
 
   #[test]
   fn path_coordinates_scale_with_device_pixel_ratio() {
-    let path = OffsetPath::from_str("path('M 0 0 L 100 0')").unwrap();
+    let path = OffsetPath::from_css_str("path('M 0 0 L 100 0')").unwrap();
     let size = Size {
       width: 400.0,
       height: 400.0,
@@ -870,7 +871,7 @@ mod tests {
 
   #[test]
   fn ray_points_up_at_zero_degrees() {
-    let path = OffsetPath::from_str("ray(0deg)").unwrap();
+    let path = OffsetPath::from_css_str("ray(0deg)").unwrap();
     let size = Size {
       width: 200.0,
       height: 200.0,
@@ -892,7 +893,7 @@ mod tests {
 
   #[test]
   fn ray_at_position_overrides_start() {
-    let path = OffsetPath::from_str("ray(90deg at 0% 0%)").unwrap();
+    let path = OffsetPath::from_css_str("ray(90deg at 0% 0%)").unwrap();
     let size = Size {
       width: 200.0,
       height: 200.0,

--- a/takumi-css/src/style/properties/offset_path.rs
+++ b/takumi-css/src/style/properties/offset_path.rs
@@ -140,6 +140,7 @@ declare_enum_from_css_impl!(
 
 /// The non-`none` value of the CSS `offset-path` property.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum OffsetPath {
   /// `ray()`
   Ray(RayShape),
@@ -729,7 +730,7 @@ fn sample_ray(
 
 /// Samples an `offset-path` at `distance`, returning the point (box-local px)
 /// and tangent direction (radians).
-pub fn sample_offset_path(
+pub(crate) fn sample_offset_path(
   path: &OffsetPath,
   distance: Length,
   offset_position: &OffsetPosition,

--- a/takumi-css/src/style/properties/overflow.rs
+++ b/takumi-css/src/style/properties/overflow.rs
@@ -50,11 +50,11 @@ impl From<Overflow> for TaffyOverflow {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::style::FromCss;
+  use crate::style::FromCssStr;
 
   #[test]
   fn parses_css_clip() {
-    assert_eq!(Overflow::from_str("clip"), Ok(Overflow::Clip));
+    assert_eq!(Overflow::from_css_str("clip"), Ok(Overflow::Clip));
   }
 
   #[test]

--- a/takumi-css/src/style/properties/overflow_wrap.rs
+++ b/takumi-css/src/style/properties/overflow_wrap.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
-  CssToken, FromCss, MakeComputed, ParseResult, ToCss, tw::TailwindPropertyParser, unexpected_token,
+  CssToken, FromCss, FromCssStr, MakeComputed, ParseResult, ToCss, tw::TailwindPropertyParser,
+  unexpected_token,
 };
 
 /// Controls how text should be overflowed.
@@ -12,7 +13,7 @@ pub struct OverflowWrap(parley::OverflowWrap);
 
 impl TailwindPropertyParser for OverflowWrap {
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 

--- a/takumi-css/src/style/properties/radial_gradient.rs
+++ b/takumi-css/src/style/properties/radial_gradient.rs
@@ -525,6 +525,7 @@ mod tests {
   use tiny_skia::ColorU8;
 
   use super::*;
+  use crate::style::FromCssStr;
   use crate::{
     Viewport,
     style::{
@@ -534,7 +535,7 @@ mod tests {
   };
   #[test]
   fn test_parse_radial_gradient_basic() {
-    let gradient = RadialGradient::from_str("radial-gradient(#ff0000, #0000ff)");
+    let gradient = RadialGradient::from_css_str("radial-gradient(#ff0000, #0000ff)");
 
     assert_eq!(
       gradient,
@@ -549,7 +550,7 @@ mod tests {
   #[test]
   fn test_parse_radial_gradient_with_interpolation_color_space() {
     assert_eq!(
-      RadialGradient::from_str("radial-gradient(in oklab, red, blue)"),
+      RadialGradient::from_css_str("radial-gradient(in oklab, red, blue)"),
       Ok(
         RadialGradient::builder()
           .interpolation(ColorInterpolationMethod {
@@ -574,7 +575,7 @@ mod tests {
   #[test]
   fn test_parse_radial_gradient_circle_farthest_side() {
     let gradient =
-      RadialGradient::from_str("radial-gradient(circle farthest-side, #ff0000, #0000ff)");
+      RadialGradient::from_css_str("radial-gradient(circle farthest-side, #ff0000, #0000ff)");
 
     assert_eq!(
       gradient,
@@ -591,7 +592,7 @@ mod tests {
   #[test]
   fn test_parse_radial_gradient_ellipse_at_left_top() {
     let gradient =
-      RadialGradient::from_str("radial-gradient(ellipse at left top, #ff0000, #0000ff)");
+      RadialGradient::from_css_str("radial-gradient(ellipse at left top, #ff0000, #0000ff)");
 
     assert_eq!(
       gradient,
@@ -610,7 +611,7 @@ mod tests {
   #[test]
   fn test_parse_radial_gradient_size_then_position() {
     let gradient =
-      RadialGradient::from_str("radial-gradient(farthest-corner at 25% 70%, #ffffff, #000000)");
+      RadialGradient::from_css_str("radial-gradient(farthest-corner at 25% 70%, #ffffff, #000000)");
 
     assert_eq!(
       gradient,
@@ -637,7 +638,7 @@ mod tests {
 
   #[test]
   fn test_parse_radial_gradient_circle_farthest_side_with_stops() {
-    let gradient = RadialGradient::from_str(
+    let gradient = RadialGradient::from_css_str(
       "radial-gradient(circle at 25px 25px, lightgray 2%, transparent 0%)",
     );
 
@@ -703,7 +704,7 @@ mod tests {
       ),
     ] {
       assert_eq!(
-        RadialGradient::from_str(input),
+        RadialGradient::from_css_str(input),
         Ok(
           RadialGradient::builder()
             .shape(RadialShape::Circle)
@@ -717,7 +718,7 @@ mod tests {
 
   #[test]
   fn test_parse_radial_gradient_with_explicit_ellipse_radii() {
-    let gradient = RadialGradient::from_str(
+    let gradient = RadialGradient::from_css_str(
       "radial-gradient(ellipse 60% 60% at 50% 50%, rgba(255, 53, 53, 0.10) 0%, transparent 70%)",
     );
 

--- a/takumi-css/src/style/properties/sides.rs
+++ b/takumi-css/src/style/properties/sides.rs
@@ -130,12 +130,13 @@ impl<T: Copy + ToCss> ToCss for Sides<T> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
   use crate::style::Length;
 
   #[test]
   fn deserialize_single_number() {
     assert_eq!(
-      Sides::<Length>::from_str("5"),
+      Sides::<Length>::from_css_str("5"),
       Ok(Sides([Length::Px(5.0); 4]))
     );
   }
@@ -143,7 +144,7 @@ mod tests {
   #[test]
   fn deserialize_axis_pair_numbers() {
     assert_eq!(
-      Sides::<Length>::from_str("10 20"),
+      Sides::<Length>::from_css_str("10 20"),
       Ok(Sides([
         Length::Px(10.0),
         Length::Px(20.0),
@@ -156,7 +157,7 @@ mod tests {
   #[test]
   fn deserialize_css_single_value() {
     assert_eq!(
-      Sides::<Length>::from_str("10px"),
+      Sides::<Length>::from_css_str("10px"),
       Ok(Sides([Length::Px(10.0); 4]))
     );
   }
@@ -164,7 +165,7 @@ mod tests {
   #[test]
   fn deserialize_css_multi_values() {
     assert_eq!(
-      Sides::<Length>::from_str("1px 2px 3px 4px"),
+      Sides::<Length>::from_css_str("1px 2px 3px 4px"),
       Ok(Sides([
         Length::Px(1.0),
         Length::Px(2.0),

--- a/takumi-css/src/style/properties/text_decoration.rs
+++ b/takumi-css/src/style/properties/text_decoration.rs
@@ -6,8 +6,9 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
-  SizingContext, declare_enum_from_css_impl, properties::ColorInput, tw::TailwindPropertyParser,
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length, MakeComputed,
+  ParseResult, SizingContext, declare_enum_from_css_impl, properties::ColorInput,
+  tw::TailwindPropertyParser,
 };
 
 bitflags! {
@@ -152,7 +153,7 @@ impl TailwindPropertyParser for TextDecorationThickness {
       return Some(Self::Length(Length::Px(number)));
     }
 
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 
@@ -373,7 +374,7 @@ mod tests {
   #[test]
   fn test_parse_text_decoration_underline() {
     assert_eq!(
-      TextDecoration::from_str("underline"),
+      TextDecoration::from_css_str("underline"),
       Ok(
         TextDecoration::builder()
           .line(TextDecorationLines::UNDERLINE)
@@ -385,7 +386,7 @@ mod tests {
   #[test]
   fn test_parse_text_decoration_line_through() {
     assert_eq!(
-      TextDecoration::from_str("line-through"),
+      TextDecoration::from_css_str("line-through"),
       Ok(
         TextDecoration::builder()
           .line(TextDecorationLines::LINE_THROUGH)
@@ -397,7 +398,7 @@ mod tests {
   #[test]
   fn test_parse_text_decoration_underline_solid() {
     assert_eq!(
-      TextDecoration::from_str("underline solid"),
+      TextDecoration::from_css_str("underline solid"),
       Ok(
         TextDecoration::builder()
           .line(TextDecorationLines::UNDERLINE)
@@ -410,7 +411,7 @@ mod tests {
   #[test]
   fn test_parse_text_decoration_line_through_solid_red() {
     assert_eq!(
-      TextDecoration::from_str("line-through solid red"),
+      TextDecoration::from_css_str("line-through solid red"),
       Ok(
         TextDecoration::builder()
           .line(TextDecorationLines::LINE_THROUGH)
@@ -424,7 +425,7 @@ mod tests {
   #[test]
   fn test_parse_text_decoration_multiple_lines() {
     assert_eq!(
-      TextDecoration::from_str("underline line-through solid red"),
+      TextDecoration::from_css_str("underline line-through solid red"),
       Ok(
         TextDecoration::builder()
           .line(TextDecorationLines::UNDERLINE | TextDecorationLines::LINE_THROUGH)
@@ -437,14 +438,14 @@ mod tests {
 
   #[test]
   fn test_parse_text_decoration_invalid() {
-    let result = TextDecoration::from_str("invalid");
+    let result = TextDecoration::from_css_str("invalid");
     assert!(result.is_err());
   }
 
   #[test]
   fn test_parse_text_underline_offset_auto() {
     assert_eq!(
-      TextUnderlineOffset::from_str("auto"),
+      TextUnderlineOffset::from_css_str("auto"),
       Ok(TextUnderlineOffset::Auto)
     );
   }
@@ -452,13 +453,13 @@ mod tests {
   #[test]
   fn test_parse_text_underline_offset_length() {
     assert_eq!(
-      TextUnderlineOffset::from_str("3px"),
+      TextUnderlineOffset::from_css_str("3px"),
       Ok(TextUnderlineOffset::Length(Length::Px(3.0)))
     );
   }
 
   #[test]
   fn test_parse_text_underline_offset_invalid() {
-    assert!(TextUnderlineOffset::from_str("solid").is_err());
+    assert!(TextUnderlineOffset::from_css_str("solid").is_err());
   }
 }

--- a/takumi-css/src/style/properties/text_indent.rs
+++ b/takumi-css/src/style/properties/text_indent.rs
@@ -134,12 +134,12 @@ impl ToCss for TextIndent {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::{FromCss, Length, TextIndent};
+  use crate::style::{FromCssStr, Length, TextIndent};
 
   #[test]
   fn parses_indent_keywords_in_any_order() {
     assert_eq!(
-      TextIndent::from_str("hanging 2em each-line"),
+      TextIndent::from_css_str("hanging 2em each-line"),
       Ok(TextIndent {
         amount: Length::Em(2.0),
         each_line: true,
@@ -156,7 +156,7 @@ mod tests {
   #[test]
   fn keyword_only_keeps_zero_amount() {
     assert_eq!(
-      TextIndent::from_str("hanging"),
+      TextIndent::from_css_str("hanging"),
       Ok(TextIndent {
         amount: Length::Px(0.0),
         each_line: false,

--- a/takumi-css/src/style/properties/text_shadow.rs
+++ b/takumi-css/src/style/properties/text_shadow.rs
@@ -5,7 +5,7 @@ use typed_builder::TypedBuilder;
 
 use super::box_shadow::parse_offsets_blur;
 use crate::style::{
-  Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, Length,
+  Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length,
   ListInterpolationStrategy, MakeComputed, ParseResult, SizingContext, ToCss, next_is_comma,
 };
 
@@ -107,7 +107,7 @@ impl<'i> FromCss<'i> for TextShadow {
 
 impl crate::style::tw::TailwindPropertyParser for TextShadow {
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 }
 
@@ -194,7 +194,7 @@ mod tests {
   #[test]
   fn test_parse_text_shadow_no_blur_radius() {
     assert_eq!(
-      TextShadows::from_str("5px 5px #558abb"),
+      TextShadows::from_css_str("5px 5px #558abb"),
       Ok(
         [TextShadow {
           offset_x: Px(5.0),
@@ -210,7 +210,7 @@ mod tests {
   #[test]
   fn test_parse_text_shadow_multiple_values() {
     assert_eq!(
-      TextShadows::from_str("5px 5px #558abb, 10px 10px #558abb"),
+      TextShadows::from_css_str("5px 5px #558abb, 10px 10px #558abb"),
       Ok(
         [
           TextShadow {
@@ -234,7 +234,7 @@ mod tests {
   #[test]
   fn test_parse_text_shadow_multiple_rgba_values() {
     assert_eq!(
-      TextShadows::from_str("5px 5px rgba(0, 0, 0, 0.5), 10px 10px rgba(255, 0, 0, 0.25)"),
+      TextShadows::from_css_str("5px 5px rgba(0, 0, 0, 0.5), 10px 10px rgba(255, 0, 0, 0.25)"),
       Ok(
         [
           TextShadow {

--- a/takumi-css/src/style/properties/traits.rs
+++ b/takumi-css/src/style/properties/traits.rs
@@ -347,18 +347,6 @@ pub(crate) trait FromCss<'i> {
   where
     Self: Sized;
 
-  /// Parses the type from a string. Internal, borrowed-error convenience over
-  /// [`FromCss::from_css`]; the public owned-error entry point is `FromCssStr`.
-  fn from_str(source: &'i str) -> ParseResult<'i, Self>
-  where
-    Self: Sized,
-  {
-    let mut input = ParserInput::new(source);
-    let mut parser = Parser::new(&mut input);
-
-    Self::from_css(&mut parser)
-  }
-
   /// Returns the list of valid CSS tokens for this type.
   const VALID_TOKENS: &'static [CssToken];
 

--- a/takumi-css/src/style/properties/traits.rs
+++ b/takumi-css/src/style/properties/traits.rs
@@ -1,15 +1,74 @@
-use cssparser::{ParseError, Parser, ParserInput};
+use cssparser::{Parser, ParserInput};
 use std::{borrow::Cow, fmt, sync::Arc};
 
 use crate::style::{Color, SizingContext, math::lcm};
 
 /// Parser result type alias for CSS property parsers.
-pub type ParseResult<'i, T> = Result<T, ParseError<'i, Cow<'i, str>>>;
+pub(crate) type ParseResult<'i, T> = Result<T, cssparser::ParseError<'i, Cow<'i, str>>>;
+
+/// Owned error returned by [`FromCssStr::from_css_str`]. Carries a
+/// human-readable message and borrows nothing from the parser, keeping
+/// `cssparser` out of the public API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+  message: String,
+}
+
+impl fmt::Display for ParseError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.message)
+  }
+}
+
+impl std::error::Error for ParseError {}
+
+impl ParseError {
+  /// Stringifies an internal `cssparser` error into an owned [`ParseError`].
+  pub(crate) fn from_css_error(error: &cssparser::ParseError<'_, Cow<'_, str>>) -> Self {
+    let message = match &error.kind {
+      cssparser::ParseErrorKind::Custom(message) => message.to_string(),
+      basic => format!("{basic:?}"),
+    };
+
+    Self { message }
+  }
+}
+
+/// Runs the internal `FromCss` parser over `source`, mapping the borrowed
+/// `cssparser` error into the owned public [`ParseError`].
+pub(crate) fn parse_css_str<T>(source: &str) -> Result<T, ParseError>
+where
+  T: for<'i> FromCss<'i>,
+{
+  let mut input = ParserInput::new(source);
+  let mut parser = Parser::new(&mut input);
+
+  T::from_css(&mut parser).map_err(|error| ParseError::from_css_error(&error))
+}
+
+/// Parses a CSS value type from a string, delegating to its internal [`FromCss`].
+///
+/// Blanket-implemented over every `FromCss` type, so it also covers the bare
+/// `Vec<_>`/`Box<[_]>` list aliases that orphan rules bar from carrying a
+/// [`std::str::FromStr`].
+pub trait FromCssStr: Sized {
+  /// Parses `source` into this value type.
+  fn from_css_str(source: &str) -> Result<Self, ParseError>;
+}
+
+impl<T> FromCssStr for T
+where
+  T: for<'i> FromCss<'i>,
+{
+  fn from_css_str(source: &str) -> Result<Self, ParseError> {
+    parse_css_str::<Self>(source)
+  }
+}
 
 /// Compact identifiers for frequently reused CSS syntax tokens.
 #[derive(Clone, Copy)]
 #[non_exhaustive]
-pub enum CssSyntaxKind {
+pub(crate) enum CssSyntaxKind {
   /// `<angle>`
   Angle,
   /// `<border-style>`
@@ -84,7 +143,7 @@ impl CssSyntaxKind {
 
 /// Compact identifiers for reusable CSS descriptor and function labels.
 #[derive(Clone, Copy)]
-pub enum CssDescriptorKind {
+pub(crate) enum CssDescriptorKind {
   /// `<blur()>`
   BlurFn,
   /// `<blend-mode>`
@@ -196,7 +255,7 @@ impl CssDescriptorKind {
 /// Enum representing CSS tokens.
 #[derive(Clone, Copy)]
 #[non_exhaustive]
-pub enum CssToken {
+pub(crate) enum CssToken {
   /// A CSS keyword.
   Keyword(&'static str),
   /// A common CSS syntax token backed by a compact enum table.
@@ -247,7 +306,7 @@ impl std::fmt::Display for CssToken {
 
 /// Defines reusable message templates for CSS parse errors.
 #[non_exhaustive]
-pub enum CssExpectedMessage {
+pub(crate) enum CssExpectedMessage {
   /// Expects a value or the `none` keyword.
   ValueOrNone,
   /// Expects exactly one value.
@@ -282,13 +341,14 @@ impl CssExpectedMessage {
 }
 
 /// Trait for types that can be parsed from CSS.
-pub trait FromCss<'i> {
+pub(crate) trait FromCss<'i> {
   /// Parses the type from a [`Parser`] instance.
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self>
   where
     Self: Sized;
 
-  /// Helper function to parse the type from a string.
+  /// Parses the type from a string. Internal, borrowed-error convenience over
+  /// [`FromCss::from_css`]; the public owned-error entry point is `FromCssStr`.
   fn from_str(source: &'i str) -> ParseResult<'i, Self>
   where
     Self: Sized,
@@ -761,6 +821,7 @@ macro_rules! declare_enum_from_css_impl {
         }
       }
     }
+
   };
 }
 
@@ -822,6 +883,7 @@ macro_rules! declare_box_alignment_enum_impl {
         }
       }
     }
+
   };
 }
 

--- a/takumi-css/src/style/properties/transform.rs
+++ b/takumi-css/src/style/properties/transform.rs
@@ -587,11 +587,12 @@ impl<'i> FromCss<'i> for Transform {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_transform_from_str() {
     assert_eq!(
-      Transform::from_str("translate(10, 20px)"),
+      Transform::from_css_str("translate(10, 20px)"),
       Ok(Transform::Translate(Length::Px(10.0), Length::Px(20.0)))
     );
   }
@@ -599,7 +600,7 @@ mod tests {
   #[test]
   fn test_transform_scale_from_str() {
     assert_eq!(
-      Transform::from_str("scale(10)"),
+      Transform::from_css_str("scale(10)"),
       Ok(Transform::Scale(10.0, 10.0))
     );
   }
@@ -607,15 +608,15 @@ mod tests {
   #[test]
   fn test_transform_negative_scale_reflects() {
     assert_eq!(
-      Transform::from_str("scale(-1)"),
+      Transform::from_css_str("scale(-1)"),
       Ok(Transform::Scale(-1.0, -1.0))
     );
     assert_eq!(
-      Transform::from_str("scaleX(-1)"),
+      Transform::from_css_str("scaleX(-1)"),
       Ok(Transform::Scale(-1.0, DEFAULT_SCALE))
     );
     assert_eq!(
-      Transform::from_str("scaleY(-2)"),
+      Transform::from_css_str("scaleY(-2)"),
       Ok(Transform::Scale(DEFAULT_SCALE, -2.0))
     );
   }

--- a/takumi-css/src/style/properties/vertical_align.rs
+++ b/takumi-css/src/style/properties/vertical_align.rs
@@ -221,7 +221,7 @@ impl ResolvedVerticalAlign {
 
 impl TailwindPropertyParser for VerticalAlign {
   fn parse_tw(token: &str) -> Option<Self> {
-    VerticalAlignKeyword::from_str(token)
+    VerticalAlignKeyword::from_css_str(token)
       .ok()
       .map(Self::Keyword)
   }
@@ -273,19 +273,19 @@ mod tests {
   #[test]
   fn parse_keywords_and_length_percentage() {
     assert_eq!(
-      VerticalAlign::from_str("baseline"),
+      VerticalAlign::from_css_str("baseline"),
       Ok(VerticalAlign::Keyword(VerticalAlignKeyword::Baseline))
     );
     assert_eq!(
-      VerticalAlign::from_str("10px"),
+      VerticalAlign::from_css_str("10px"),
       Ok(VerticalAlign::Length(Length::Px(10.0)))
     );
     assert_eq!(
-      VerticalAlign::from_str("25%"),
+      VerticalAlign::from_css_str("25%"),
       Ok(VerticalAlign::Length(Length::Percentage(25.0)))
     );
     assert_eq!(
-      VerticalAlign::from_str("-0.5em"),
+      VerticalAlign::from_css_str("-0.5em"),
       Ok(VerticalAlign::Length(Length::Em(-0.5)))
     );
   }
@@ -405,7 +405,7 @@ mod tests {
 
   #[test]
   fn resolve_normal_calc_percentage_uses_metrics_relative_px() {
-    let Ok(length) = Length::from_str("calc(50% + 4px)") else {
+    let Ok(length) = Length::from_css_str("calc(50% + 4px)") else {
       return;
     };
     let resolved = VerticalAlign::Length(length).resolve(&sizing(), 12.0, LineHeight::Normal);

--- a/takumi-css/src/style/properties/white_space.rs
+++ b/takumi-css/src/style/properties/white_space.rs
@@ -129,9 +129,13 @@ impl<'i> FromCss<'i> for WhiteSpace {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::FromCssStr;
 
   #[test]
   fn test_parse_white_space_no_wrap() {
-    assert_eq!(WhiteSpace::from_str("nowrap"), Ok(WhiteSpace::no_wrap()));
+    assert_eq!(
+      WhiteSpace::from_css_str("nowrap"),
+      Ok(WhiteSpace::no_wrap())
+    );
   }
 }

--- a/takumi-css/src/style/properties/z_index.rs
+++ b/takumi-css/src/style/properties/z_index.rs
@@ -55,15 +55,15 @@ impl ToCss for ZIndex {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::{FromCss, ZIndex};
+  use crate::style::{FromCssStr, ZIndex};
 
   #[test]
   fn parses_auto() {
-    assert_eq!(ZIndex::from_str("auto"), Ok(ZIndex::Auto));
+    assert_eq!(ZIndex::from_css_str("auto"), Ok(ZIndex::Auto));
   }
 
   #[test]
   fn parses_integer() {
-    assert_eq!(ZIndex::from_str("-3"), Ok(ZIndex::Integer(-3)));
+    assert_eq!(ZIndex::from_css_str("-3"), Ok(ZIndex::Integer(-3)));
   }
 }

--- a/takumi-css/src/style/stylesheets.rs
+++ b/takumi-css/src/style/stylesheets.rs
@@ -1479,7 +1479,7 @@ impl<'i> FromCss<'i> for CssWideKeyword {
 pub struct DeclarationImportance {
   pub(crate) longhands: PropertyMask,
   /// Custom property names marked important.
-  pub custom_properties: SmallVec<[Box<str>; 1]>,
+  pub(crate) custom_properties: SmallVec<[Box<str>; 1]>,
 }
 
 impl DeclarationImportance {
@@ -1541,7 +1541,7 @@ where
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct StyleDeclarationBlock {
   /// Ordered declarations in source order.
-  pub declarations: SmallVec<[StyleDeclaration; 8]>,
+  pub(crate) declarations: SmallVec<[StyleDeclaration; 8]>,
   /// Properties that were marked with `!important`.
   pub importance: DeclarationImportance,
 }
@@ -1578,6 +1578,16 @@ impl StyleDeclarationBlock {
     self.declarations.iter()
   }
 
+  /// The number of declarations in this block.
+  pub fn len(&self) -> usize {
+    self.declarations.len()
+  }
+
+  /// Whether this block has no declarations.
+  pub fn is_empty(&self) -> bool {
+    self.declarations.is_empty()
+  }
+
   /// Collects resource URLs referenced by declarations in this block.
   pub fn resource_urls(&self) -> impl Iterator<Item = &str> {
     fn background_image_url(image: &BackgroundImage) -> Option<&str> {
@@ -1608,7 +1618,7 @@ impl StyleDeclarationBlock {
   }
 
   /// Parses one declaration block for the given property name.
-  pub fn parse<'i>(name: &str, input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+  pub(crate) fn parse<'i>(name: &str, input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     parse_style_declaration(name, input)
   }
 }
@@ -1636,6 +1646,14 @@ impl FromStr for StyleDeclarationBlock {
     }
 
     Ok(block)
+  }
+}
+
+impl FromStr for Style {
+  type Err = StyleDeclarationBlockParseError;
+
+  fn from_str(input: &str) -> Result<Self, Self::Err> {
+    StyleDeclarationBlock::from_str(input).map(Into::into)
   }
 }
 

--- a/takumi-css/src/style/stylesheets_helpers.rs
+++ b/takumi-css/src/style/stylesheets_helpers.rs
@@ -113,7 +113,9 @@ where
   match css_input {
     CssInput::Str(value) => {
       let source = value.to_string();
-      let failure = match T::from_str(source.as_str()) {
+      let mut parser_input = ParserInput::new(source.as_str());
+      let mut parser = Parser::new(&mut parser_input);
+      let failure = match T::from_css(&mut parser) {
         Ok(parsed_value) => return Ok(parsed_value),
         Err(error) => css_input_parse_failure(source.as_str(), error),
       };
@@ -128,8 +130,10 @@ where
     }
     CssInput::Number(number) => {
       let source = number.to_string();
+      let mut parser_input = ParserInput::new(&source);
+      let mut parser = Parser::new(&mut parser_input);
 
-      T::from_str(&source).map_err(|_| CssInputParseError::NumberType {
+      T::from_css(&mut parser).map_err(|_| CssInputParseError::NumberType {
         number,
         expected: T::EXPECT_MESSAGE
           .build_message(&source, merge_enum_values(T::VALID_TOKENS))

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -11,7 +11,9 @@ use super::{
 };
 use crate::{
   Viewport,
-  style::{CalcArena, ComputedStyle, SizingContext, Style, StyleDeclaration, properties::*},
+  style::{
+    CalcArena, ComputedStyle, FromCss, SizingContext, Style, StyleDeclaration, properties::*,
+  },
 };
 
 fn style_with(declarations: impl IntoIterator<Item = StyleDeclaration>) -> Style {
@@ -762,7 +764,7 @@ fn test_needs_offscreen_compositing_for_clip_path_and_mask_image() {
   let mut style = ComputedStyle::default();
   assert!(!style.needs_offscreen_compositing());
 
-  style.clip_path = BasicShape::from_str("inset(10px)").ok();
+  style.clip_path = <BasicShape as FromCss>::from_str("inset(10px)").ok();
   assert!(style.needs_offscreen_compositing());
 
   style.clip_path = None;
@@ -865,7 +867,7 @@ fn test_offset_path_moves_element_onto_path_and_creates_stacking_context() {
     height: 40.0,
   };
 
-  style.offset_path = OffsetPath::from_str("path('M 0 0 L 100 0')").ok();
+  style.offset_path = <OffsetPath as FromCss>::from_str("path('M 0 0 L 100 0')").ok();
   style.offset_distance = Length::Percentage(50.0);
 
   assert!(style.creates_stacking_context(border_box, &sizing, false));

--- a/takumi-css/src/style/stylesheets_tests.rs
+++ b/takumi-css/src/style/stylesheets_tests.rs
@@ -11,9 +11,7 @@ use super::{
 };
 use crate::{
   Viewport,
-  style::{
-    CalcArena, ComputedStyle, FromCss, SizingContext, Style, StyleDeclaration, properties::*,
-  },
+  style::{CalcArena, ComputedStyle, SizingContext, Style, StyleDeclaration, properties::*},
 };
 
 fn style_with(declarations: impl IntoIterator<Item = StyleDeclaration>) -> Style {
@@ -764,7 +762,7 @@ fn test_needs_offscreen_compositing_for_clip_path_and_mask_image() {
   let mut style = ComputedStyle::default();
   assert!(!style.needs_offscreen_compositing());
 
-  style.clip_path = <BasicShape as FromCss>::from_str("inset(10px)").ok();
+  style.clip_path = BasicShape::from_css_str("inset(10px)").ok();
   assert!(style.needs_offscreen_compositing());
 
   style.clip_path = None;
@@ -867,7 +865,7 @@ fn test_offset_path_moves_element_onto_path_and_creates_stacking_context() {
     height: 40.0,
   };
 
-  style.offset_path = <OffsetPath as FromCss>::from_str("path('M 0 0 L 100 0')").ok();
+  style.offset_path = OffsetPath::from_css_str("path('M 0 0 L 100 0')").ok();
   style.offset_distance = Length::Percentage(50.0);
 
   assert!(style.creates_stacking_context(border_box, &sizing, false));

--- a/takumi-css/src/style/tw/builder.rs
+++ b/takumi-css/src/style/tw/builder.rs
@@ -131,14 +131,17 @@ impl TailwindDeclarationBuilder {
   }
 
   pub(super) fn push_filter(&mut self, filter: Filter, important: bool) {
-    self.filter.get_or_insert_with(Vec::new).push(filter);
+    self
+      .filter
+      .get_or_insert_with(Filters::default)
+      .push(filter);
     self.filter_important = important;
   }
 
   pub(super) fn push_backdrop_filter(&mut self, filter: Filter, important: bool) {
     self
       .backdrop_filter
-      .get_or_insert_with(Vec::new)
+      .get_or_insert_with(Filters::default)
       .push(filter);
     self.backdrop_filter_important = important;
   }

--- a/takumi-css/src/style/tw/mod.rs
+++ b/takumi-css/src/style/tw/mod.rs
@@ -668,9 +668,12 @@ fn decode_arbitrary_value(value: &str) -> Cow<'_, str> {
 }
 
 /// A trait for parsing tailwind properties.
-pub trait TailwindPropertyParser: Sized + for<'i> FromCss<'i> {
-  /// Parse a tailwind property from a token.
-  fn parse_tw(token: &str) -> Option<Self>;
+pub(crate) trait TailwindPropertyParser: Sized + for<'i> FromCss<'i> {
+  /// Parse a tailwind property from a token. Defaults to the type's `FromCss`
+  /// parser; override for keywords Tailwind spells differently from CSS.
+  fn parse_tw(token: &str) -> Option<Self> {
+    Self::from_str(token).ok()
+  }
 
   /// Parse a tailwind property from a token, with support for arbitrary values.
   fn parse_tw_with_arbitrary(token: &str) -> Option<Self> {

--- a/takumi-css/src/style/tw/mod.rs
+++ b/takumi-css/src/style/tw/mod.rs
@@ -672,13 +672,13 @@ pub(crate) trait TailwindPropertyParser: Sized + for<'i> FromCss<'i> {
   /// Parse a tailwind property from a token. Defaults to the type's `FromCss`
   /// parser; override for keywords Tailwind spells differently from CSS.
   fn parse_tw(token: &str) -> Option<Self> {
-    Self::from_str(token).ok()
+    Self::from_css_str(token).ok()
   }
 
   /// Parse a tailwind property from a token, with support for arbitrary values.
   fn parse_tw_with_arbitrary(token: &str) -> Option<Self> {
     if let Some(value) = extract_arbitrary_value(token) {
-      return Self::from_str(&value).ok();
+      return Self::from_css_str(&value).ok();
     }
 
     Self::parse_tw(token)

--- a/takumi-css/src/style/tw/tests.rs
+++ b/takumi-css/src/style/tw/tests.rs
@@ -934,7 +934,7 @@ fn test_grid_cols_none() {
   assert_eq!(
     TailwindProperty::parse("grid-cols-none"),
     Some(TailwindProperty::GridTemplateColumns(TwGridTemplate(
-      Vec::new()
+      GridTemplateComponents::default()
     )))
   );
 }

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -20,7 +20,7 @@ use typed_builder::TypedBuilder;
 
 use takumi_core::layout::{
   node::{ImageData, ImageSourceInput, Node, NodeKind},
-  style::{Direction, FromCss, Style, StyleDeclarationBlock, tw::TailwindValues},
+  style::{Direction, FromCssStr, Style, StyleDeclarationBlock, tw::TailwindValues},
 };
 
 /// Tags whose entire subtree is dropped, matching the JS `isHtmlVoidElement`
@@ -513,7 +513,7 @@ fn dimension(handle: &Handle, name: &str) -> Option<f32> {
 }
 
 fn parse_direction(value: &str) -> Option<Direction> {
-  Direction::from_str(value).ok()
+  Direction::from_css_str(value).ok()
 }
 
 /// Serialize an element including its own tag (outer HTML), used to round-trip
@@ -553,7 +553,7 @@ mod tests {
     for (tag, _) in DEFAULT_PRESETS {
       let style = presets.get(tag).expect("preset present");
       assert!(
-        !style.declarations.declarations.is_empty(),
+        !style.declarations.is_empty(),
         "preset `{tag}` produced no declarations",
       );
     }

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -55,9 +55,18 @@ type Managed<TInner> =
   | (TInner & SharedRenderExtras)
   | (TInner & Omit<SharedRenderExtras, "renderer"> & ManagedRendererOptions);
 
-type InnerRenderOptions = Omit<napi.RenderOptions | wasm.RenderOptions, "images">;
-type InnerSvgRenderOptions = Omit<napi.SvgRenderOptions | wasm.SvgRenderOptions, "images">;
-type InnerRenderAnimationOptions = Omit<
+/**
+ * `Omit` that distributes over unions, so the backends' `format`/`quality`/`lossless`
+ * tagged union survives instead of collapsing into one flat member.
+ */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+type InnerRenderOptions = DistributiveOmit<napi.RenderOptions | wasm.RenderOptions, "images">;
+type InnerSvgRenderOptions = DistributiveOmit<
+  napi.SvgRenderOptions | wasm.SvgRenderOptions,
+  "images"
+>;
+type InnerRenderAnimationOptions = DistributiveOmit<
   napi.RenderAnimationOptions | wasm.RenderAnimationOptions,
   "images"
 >;
@@ -72,7 +81,7 @@ export type AnimationScene = Omit<napi.AnimationScene, "node"> & {
 };
 
 export type RenderAnimationOptions = Managed<
-  Omit<InnerRenderAnimationOptions, "scenes"> & {
+  DistributiveOmit<InnerRenderAnimationOptions, "scenes"> & {
     /** The scenes to render sequentially. */
     scenes: AnimationScene[];
   }

--- a/takumi-napi/Cargo.toml
+++ b/takumi-napi/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 serde.workspace = true
 rayon.workspace = true
-parley.workspace = true
 napi.workspace = true
 napi-derive.workspace = true
 arc-swap.workspace = true

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -15,7 +15,7 @@ use std::{fmt::Display, ops::Deref};
 
 use napi::{De, Env, Error, bindgen_prelude::*};
 use napi_derive::napi;
-use serde::{Deserialize, Deserializer, de::DeserializeOwned};
+use serde::{Deserialize, Deserializer, de::DeserializeOwned, de::Error as DeError};
 use takumi_core::{
   layout::style::{FontStyle, FromCssStr, KeyframesRule, StyleSheet},
   resources::font::{FontOverride, FontResource},
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for FontStyleInput {
   {
     let s = String::deserialize(deserializer)?;
     Ok(FontStyleInput(
-      FontStyle::from_css_str(&s).unwrap_or_default(),
+      FontStyle::from_css_str(&s).map_err(D::Error::custom)?,
     ))
   }
 }

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -15,11 +15,10 @@ use std::{fmt::Display, ops::Deref};
 
 use napi::{De, Env, Error, bindgen_prelude::*};
 use napi_derive::napi;
-use parley::{FontStyle, FontWeight, fontique::FontInfoOverride};
 use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 use takumi_core::{
-  layout::style::{KeyframesRule, StyleSheet},
-  resources::font::FontResource,
+  layout::style::{FontStyle, FromCssStr, KeyframesRule, StyleSheet},
+  resources::font::{FontOverride, FontResource},
 };
 
 pub use renderer::Renderer;
@@ -85,7 +84,9 @@ impl<'de> Deserialize<'de> for FontStyleInput {
     D: Deserializer<'de>,
   {
     let s = String::deserialize(deserializer)?;
-    Ok(FontStyleInput(FontStyle::parse_css(&s).unwrap_or_default()))
+    Ok(FontStyleInput(
+      FontStyle::from_css_str(&s).unwrap_or_default(),
+    ))
   }
 }
 
@@ -116,12 +117,11 @@ pub(crate) fn resolve_font_resource<'a>(
   font: &'a FontInput,
   buffer: &'a [u8],
 ) -> Result<FontResource<'a>> {
-  let resource = FontResource::new(buffer).override_info(FontInfoOverride {
-    family_name: font.name.as_deref(),
-    width: None,
+  let resource = FontResource::new(buffer).override_info(FontOverride {
+    family_name: font.name.clone().map(Into::into),
     style: font.style.map(|style| style.0),
-    weight: font.weight.map(|weight| FontWeight::new(weight as f32)),
-    axes: None,
+    weight: font.weight.map(|weight| weight as f32),
+    ..Default::default()
   });
 
   let resource = match &font.subset_of {

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -7,13 +7,12 @@ use arc_swap::ArcSwap;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use parley::fontique::FontInfoOverride;
 use rayon::prelude::*;
 use takumi_core::{
   Fonts,
   layout::{node::Node, style::KeyframesRule as CoreKeyframesRule},
   resources::{
-    font::{FontResource, GenericFamily},
+    font::{FontOverride, FontResource, GenericFamily},
     image::{ImageCache, ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource},
   },
 };
@@ -374,8 +373,8 @@ fn default_fonts() -> Result<Fonts> {
       .par_iter()
       .map(|(font, name, generic)| {
         FontResource::new(*font)
-          .override_info(FontInfoOverride {
-            family_name: Some(*name),
+          .override_info(FontOverride {
+            family_name: Some((*name).to_string().into()),
             ..Default::default()
           })
           .generic_family(*generic)

--- a/takumi-raster/Cargo.toml
+++ b/takumi-raster/Cargo.toml
@@ -39,6 +39,10 @@ path = "../takumi-core"
 version = "0.1.0-rc.3"
 default-features = false
 
+[dependencies.takumi-css]
+path = "../takumi-css"
+version = "0.2.0-rc.2"
+
 [dependencies.serde]
 workspace = true
 features = ["rc"]

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -9,11 +9,15 @@ use tiny_skia::{IntSize, Pixmap, PixmapMut, PremultipliedColorU8};
 use crate::resources::image::RenderedImage;
 use crate::{
   BorderProperties, BufferPool, OverlayOptions, PaintSource, RenderContext, Result,
-  SamplingFootprint, fast_div_255, interpolate_with_footprint,
+  SamplingFootprint, color_to_premultiplied, interpolate_with_footprint,
   layout::{node::resolve_image, style::*},
   overlay_gradient_tile, overlay_image, overlay_linear_gradient_tile, overlay_radial_gradient_tile,
   pixmap_from_buffer, pixmap_ref_from_buffer,
   resources::{image::ImageSource, image_buffer::ImageBuffer},
+};
+use takumi_css::paint::{
+  ConicGradientTile, GradientOverlayTile, LinearGradientTile, RadialGradientTile,
+  collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
 };
 
 pub(crate) struct TileLayer {
@@ -212,18 +216,10 @@ pub(crate) struct ColorTile {
 }
 
 impl ColorTile {
-  pub(crate) fn new(color: Rgba<u8>, width: u32, height: u32) -> Self {
-    let alpha = color.0[3] as u32;
-    let premultiplied = PremultipliedColorU8::from_rgba(
-      fast_div_255(color.0[0] as u32 * alpha),
-      fast_div_255(color.0[1] as u32 * alpha),
-      fast_div_255(color.0[2] as u32 * alpha),
-      color.0[3],
-    )
-    .unwrap_or(PremultipliedColorU8::TRANSPARENT);
+  pub(crate) fn new(color: Color, width: u32, height: u32) -> Self {
     Self {
-      color: color.0.into(),
-      premultiplied,
+      color,
+      premultiplied: color_to_premultiplied(Rgba(color.0)),
       width,
       height,
     }
@@ -861,7 +857,7 @@ pub(crate) fn collect_background_layers(
       0,
       TileLayer {
         tile: BackgroundTile::Color(ColorTile::new(
-          background_color.into(),
+          background_color,
           border_box.width as u32,
           border_box.height as u32,
         )),

--- a/takumi-raster/src/blend.rs
+++ b/takumi-raster/src/blend.rs
@@ -444,6 +444,14 @@ pub(crate) fn premultiply_rgba(color: Rgba<u8>) -> [u8; 4] {
   premultiply_rgba_pixel(red, green, blue, alpha)
 }
 
+/// Premultiplies a straight-alpha pixel into a `tiny_skia`
+/// [`PremultipliedColorU8`].
+pub(crate) fn color_to_premultiplied(color: Rgba<u8>) -> PremultipliedColorU8 {
+  let [red, green, blue, alpha] = premultiply_rgba(color);
+  PremultipliedColorU8::from_rgba(red, green, blue, alpha)
+    .unwrap_or(PremultipliedColorU8::TRANSPARENT)
+}
+
 #[inline(always)]
 pub(crate) fn premultiplied_from_pixel(pixel: PremultipliedColorU8) -> [u8; 4] {
   [pixel.red(), pixel.green(), pixel.blue(), pixel.alpha()]

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -30,11 +30,12 @@ use crate::{
   blend::*,
   build_path,
   error::Error,
-  layout::style::{
-    Affine, BlendMode, GradientOverlayTile, ImageScalingAlgorithm, LinearGradientFastPathKind,
-    LinearGradientTile, RadialGradientTile, overlay_gradient_tile_fast_normal_unconstrained,
-  },
+  layout::style::{Affine, BlendMode, Color, ImageScalingAlgorithm},
   stacking_context::blend_pixmap_software,
+};
+use takumi_css::paint::{
+  GradientOverlayTile, LinearGradientFastPathKind, LinearGradientTile, RadialGradientTile,
+  overlay_gradient_tile_fast_normal_unconstrained,
 };
 
 pub(crate) use buffer_pool::BufferPool;
@@ -360,16 +361,16 @@ impl Canvas {
     f(&self.image, &mut self.buffer_pool)
   }
 
-  pub(crate) fn draw_mask<C: Into<Rgba<u8>>>(
+  pub(crate) fn draw_mask(
     &mut self,
     mask: &[u8],
     placement: Placement,
-    color: C,
+    color: Color,
     mode: BlendMode,
   ) {
     let placement = self.localize_placement(placement);
     self.with_overlay_state(|pixmap, combined_mask, _| {
-      draw_mask(pixmap, mask, placement, color.into(), mode, combined_mask);
+      draw_mask(pixmap, mask, placement, Rgba(color.0), mode, combined_mask);
     });
   }
   pub(crate) fn composite_mask_source(
@@ -397,12 +398,12 @@ impl Canvas {
       );
     });
   }
-  pub(crate) fn composite_mask_source_over_color<C: Into<Rgba<u8>>>(
+  pub(crate) fn composite_mask_source_over_color(
     &mut self,
     mask: &[u8],
     placement: Placement,
     source: PaintSource<'_>,
-    color: C,
+    color: Color,
     sampling: MaskSamplingOptions,
     mode: BlendMode,
   ) {
@@ -416,19 +417,19 @@ impl Canvas {
         composite::Options {
           placement,
           sampling,
-          color_mode: MaskCompositeColor::SourceOverColor(premultiply_rgba(color.into())),
+          color_mode: MaskCompositeColor::SourceOverColor(premultiply_rgba(Rgba(color.0))),
           mode,
           combined_mask,
         },
       );
     });
   }
-  pub(crate) fn composite_mask_color_over_source<C: Into<Rgba<u8>>>(
+  pub(crate) fn composite_mask_color_over_source(
     &mut self,
     mask: &[u8],
     placement: Placement,
     source: PaintSource<'_>,
-    color: C,
+    color: Color,
     sampling: MaskSamplingOptions,
     mode: BlendMode,
   ) {
@@ -442,7 +443,7 @@ impl Canvas {
         composite::Options {
           placement,
           sampling,
-          color_mode: MaskCompositeColor::ColorOverSource(premultiply_rgba(color.into())),
+          color_mode: MaskCompositeColor::ColorOverSource(premultiply_rgba(Rgba(color.0))),
           mode,
           combined_mask,
         },
@@ -724,13 +725,14 @@ fn to_tiny_blend_mode(mode: BlendMode) -> Option<tiny_skia::BlendMode> {
     BlendMode::Luminosity => T::Luminosity,
     BlendMode::PlusLighter => T::Plus,
     BlendMode::PlusDarker => return None,
+    _ => return None,
   })
 }
 
 fn to_tiny_filter_quality(algorithm: ImageScalingAlgorithm) -> TinyFilterQuality {
   match algorithm {
     ImageScalingAlgorithm::Pixelated => TinyFilterQuality::Nearest,
-    ImageScalingAlgorithm::Auto | ImageScalingAlgorithm::Smooth => TinyFilterQuality::Bilinear,
+    _ => TinyFilterQuality::Bilinear,
   }
 }
 
@@ -1670,14 +1672,15 @@ mod tests {
     layout::{
       Viewport,
       style::{
-        Angle, BlendMode, Color, ColorInterpolationMethod, ConicGradient, ConicGradientTile,
-        FromCss, GradientStop, Length, LinearGradient, LinearGradientTile, PositionValue,
-        RadialGradient, RadialGradientTile, SizingContext, StopPosition,
+        Angle, BlendMode, Color, ColorInterpolationMethod, ConicGradient, GradientStop, Length,
+        LinearGradient, PositionValue, RadialGradient, SizingContext, StopPosition,
       },
     },
     pixmap_from_buffer,
     resources::image_buffer::ImageBuffer,
   };
+  use takumi_core::layout::style::FromCssStr;
+  use takumi_css::paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile};
 
   use super::*;
 
@@ -1763,7 +1766,7 @@ mod tests {
 
   #[test]
   fn test_overlay_linear_gradient_matches_reference() {
-    let Ok(gradient) = LinearGradient::from_str("linear-gradient(to right, red, blue)") else {
+    let Ok(gradient) = LinearGradient::from_css_str("linear-gradient(to right, red, blue)") else {
       return;
     };
     let global_context = Fonts::default();
@@ -1826,7 +1829,7 @@ mod tests {
 
     let global_context = Fonts::default();
     for (gradient_css, tile_size, canvas_size, offset) in cases {
-      let Ok(gradient) = RadialGradient::from_str(gradient_css) else {
+      let Ok(gradient) = RadialGradient::from_css_str(gradient_css) else {
         continue;
       };
       let render_context = RenderContext::builder()
@@ -1857,7 +1860,7 @@ mod tests {
 
   #[test]
   fn test_overlay_conic_gradient_matches_reference() {
-    let Ok(gradient) = ConicGradient::from_str("conic-gradient(red, blue)") else {
+    let Ok(gradient) = ConicGradient::from_css_str("conic-gradient(red, blue)") else {
       return;
     };
 
@@ -1957,7 +1960,7 @@ mod tests {
 
     let global_context = Fonts::default();
     for (gradient_css, tile_size, canvas_size, offset) in cases {
-      let Ok(gradient) = LinearGradient::from_str(gradient_css) else {
+      let Ok(gradient) = LinearGradient::from_css_str(gradient_css) else {
         continue;
       };
       let render_context = RenderContext::builder()
@@ -2110,7 +2113,7 @@ mod tests {
   #[test]
   fn test_overlay_radial_gradient_clustered_stops_matches_reference() {
     let Ok(gradient) =
-      RadialGradient::from_str("radial-gradient(circle, red 0%, lime 1%, blue 100%)")
+      RadialGradient::from_css_str("radial-gradient(circle, red 0%, lime 1%, blue 100%)")
     else {
       return;
     };

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -566,7 +566,7 @@ impl From<FillRule> for Fill {
   fn from(value: FillRule) -> Self {
     match value {
       FillRule::EvenOdd => Fill::EvenOdd,
-      FillRule::NonZero => Fill::NonZero,
+      _ => Fill::NonZero,
     }
   }
 }
@@ -680,6 +680,7 @@ pub(crate) fn render_clip_shape_mask(
       let scale = context.sizing.to_device(1.0);
       paths.extend(scale_commands(shape.path.as_ref().commands(), scale));
     }
+    _ => {}
   }
 
   render_mask(

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -282,7 +282,7 @@ impl BorderRasterization for BorderProperties {
       BorderStyle::Solid => {
         self.draw_side_band(paint, side, border_box, Rect::ZERO, self.width, color);
       }
-      BorderStyle::None | BorderStyle::Hidden => {}
+      _ => {}
     }
   }
 

--- a/takumi-raster/src/filter.rs
+++ b/takumi-raster/src/filter.rs
@@ -1,4 +1,3 @@
-use image::Rgba;
 use smallvec::SmallVec;
 use taffy::{Point, Size};
 use tiny_skia::{Mask as TinyMask, PixmapMut};
@@ -8,10 +7,11 @@ use crate::{
   SizedShadow, apply_blur, apply_blur_rgba_bytes, intersect_alpha_masks,
   layout::style::{
     Affine, Color, Filter, FilterCategory, LUMA_WEIGHTS, PercentageNumber, SEPIA_WEIGHTS,
-    SizingContext, TransferChannel, TransferTable, compose_transfer_table, fast_div_255,
+    SizingContext, TransferChannel, TransferTable, fast_div_255,
   },
   render_mask,
 };
+use takumi_css::paint::compose_transfer_table;
 
 /// Calculates the luma of an RGB pixel.
 #[inline(always)]
@@ -76,6 +76,7 @@ fn apply_single_pixel_filter(pixel: &mut [u8], filter: &Filter) {
     }
     // Complex filters are not handled here
     Filter::Blur(_) | Filter::DropShadow(_) | Filter::HueRotate(_) => {}
+    _ => {}
   }
 }
 
@@ -545,8 +546,7 @@ fn apply_drop_shadow_filter(
   let offset_x = shadow.offset_x.round() as i32;
   let offset_y = shadow.offset_y.round() as i32;
 
-  let shadow_color: Rgba<u8> = shadow.color.into();
-  let [sr, sg, sb, sa] = shadow_color.0;
+  let [sr, sg, sb, sa] = shadow.color.0;
   let shadow_rgb = [sr, sg, sb];
   let source_pixels = pixmap.as_ref().pixels();
   let Some(source_bounds) =

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -4,15 +4,15 @@ use tiny_skia::{Pixmap, PixmapMut};
 use crate::{
   BlurType, BorderProperties, Canvas, CanvasSubcanvas, CanvasViewport, NodeMaskAction, Placement,
   Result, SizedFontStyle, apply_backdrop_filter, apply_filters_to_pixmap, blend_pixel,
-  draw_background, draw_border, draw_debug_border, draw_inset_box_shadow, draw_node_content,
-  draw_outline, draw_outset_box_shadow,
+  color_to_premultiplied, draw_background, draw_border, draw_debug_border, draw_inset_box_shadow,
+  draw_node_content, draw_outline, draw_outset_box_shadow,
   inline_drawing::{draw_inline_box, draw_inline_layout},
   layout::{
     inline::{
       InlineLayoutMode, InlineLayoutRequest, ProcessedInlineSpan, collect_inline_items,
       create_inline_layout, resolve_inline_max_height,
     },
-    style::{Affine, BackgroundImage, BlendMode, Color, Filter, SizingContext},
+    style::{Affine, BackgroundImage, BlendMode, Filter, SizingContext},
     tree::{LayoutResults, RenderNode},
   },
   prepare_node_mask,
@@ -81,7 +81,7 @@ pub(crate) fn blend_pixmap_software(
         ((s.alpha() as f32) * opacity).clamp(0.0, 255.0) as u8,
       ]);
       blend_pixel(&mut out, top, mode);
-      *dst_pixel = Color(out.0).into();
+      *dst_pixel = color_to_premultiplied(out);
     }
   }
 }

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -123,7 +123,7 @@ pub(crate) fn draw_decoration_segment(
   let snapped_start_x = params.start_x.floor();
   let width = (params.end_x.ceil() - snapped_start_x) as u32;
 
-  let tile = ColorTile::new(color.into(), width, params.size as u32);
+  let tile = ColorTile::new(color, width, params.size as u32);
 
   canvas.overlay_image(
     &tile,

--- a/takumi-svg/Cargo.toml
+++ b/takumi-svg/Cargo.toml
@@ -19,6 +19,10 @@ typed-builder.workspace = true
 path = "../takumi-core"
 version = "0.1.0-rc.3"
 
+[dependencies.takumi-css]
+path = "../takumi-css"
+version = "0.2.0-rc.2"
+
 [lints]
 workspace = true
 

--- a/takumi-svg/src/gradient.rs
+++ b/takumi-svg/src/gradient.rs
@@ -21,13 +21,15 @@ use takumi_core::{
     node::resolve_image,
     style::{
       BackgroundImage, BackgroundRepeat, BackgroundRepeatStyle, BackgroundSize,
-      ColorInterpolationMethod, ConicGradient, ConicGradientTile, IntrinsicSizing, Length,
-      LinearGradient, LinearGradientTile, PositionComponent, PositionValue, RadialGradient,
-      RadialGradientTile, ResolvedGradientStop, SizingContext, build_color_lut_with_interpolation,
-      collect_repeat_tile_positions, collect_spaced_tile_positions,
-      collect_stretched_tile_positions, resolve_stops_along_axis,
+      ColorInterpolationMethod, ConicGradient, IntrinsicSizing, Length, LinearGradient,
+      PositionComponent, PositionValue, RadialGradient, ResolvedGradientStop, SizingContext,
     },
   },
+};
+use takumi_css::paint::{
+  ConicGradientTile, LinearGradientTile, RadialGradientTile, build_color_lut_with_interpolation,
+  collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
+  resolve_stops_along_axis,
 };
 
 use crate::{

--- a/takumi-svg/src/image.rs
+++ b/takumi-svg/src/image.rs
@@ -65,8 +65,8 @@ pub(crate) fn emit_image(
     ObjectFit::Fill => 1.0,
     ObjectFit::Contain => (w / iw).min(h / ih),
     ObjectFit::Cover => (w / iw).max(h / ih),
-    ObjectFit::None => 1.0,
     ObjectFit::ScaleDown => (w / iw).min(h / ih).min(1.0),
+    _ => 1.0,
   };
   let (dw, dh) = (iw * scale, ih * scale);
 

--- a/takumi-svg/src/lib.rs
+++ b/takumi-svg/src/lib.rs
@@ -654,6 +654,7 @@ impl SvgDocument {
         self.empty("feMergeNode", &[("in", input.into())])?;
         self.close("feMerge")
       }
+      _ => Ok(()),
     }
   }
 

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -449,6 +449,7 @@ pub(crate) fn emit_clip_path_group(
       let transform = format!("translate({} {}) scale({})", Num(x), Num(y), Num(scale));
       doc.clip_path_transformed(&path.path, even_odd, Some(&transform))?
     }
+    _ => return Ok(None),
   };
   Ok(Some(doc.begin_group(IDENTITY, 1.0, Some(&clip), None)?))
 }

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -555,9 +555,9 @@ fn emit_decoration(
 
 fn line_join_str(join: LineJoin) -> &'static str {
   match join {
-    LineJoin::Miter => "miter",
     LineJoin::Round => "round",
     LineJoin::Bevel => "bevel",
+    _ => "miter",
   }
 }
 

--- a/takumi-wasm/Cargo.toml
+++ b/takumi-wasm/Cargo.toml
@@ -13,7 +13,6 @@ wasm-bindgen.workspace = true
 base64.workspace = true
 serde_bytes.workspace = true
 js-sys.workspace = true
-parley.workspace = true
 
 [dependencies.serde]
 workspace = true

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -1,6 +1,6 @@
 //! Data models and types for the WebAssembly bindings.
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de::Error as DeError};
 use serde_bytes::ByteBuf;
 use std::sync::Arc;
 use takumi_core::{
@@ -236,7 +236,9 @@ impl<'de> Deserialize<'de> for FontStyle {
     D: Deserializer<'de>,
   {
     let value = String::deserialize(deserializer)?;
-    Ok(Self(CssFontStyle::from_css_str(&value).unwrap_or_default()))
+    Ok(Self(
+      CssFontStyle::from_css_str(&value).map_err(D::Error::custom)?,
+    ))
   }
 }
 

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -1,12 +1,14 @@
 //! Data models and types for the WebAssembly bindings.
 
-use parley::FontStyle as ParleyFontStyle;
 use serde::{Deserialize, Deserializer};
 use serde_bytes::ByteBuf;
 use std::sync::Arc;
 use takumi_core::{
   keyframes::deserialize_optional_keyframes,
-  layout::{node::Node, style::KeyframesRule},
+  layout::{
+    node::Node,
+    style::{FontStyle as CssFontStyle, FromCssStr, KeyframesRule},
+  },
   resources::image::ImageCacheMode,
 };
 use takumi_raster::DitheringAlgorithm;
@@ -226,7 +228,7 @@ pub enum AnimationOutputFormat {
 
 /// Font style input parsed from CSS-like font-style strings.
 #[derive(Clone, Copy)]
-pub struct FontStyle(pub ParleyFontStyle);
+pub struct FontStyle(pub CssFontStyle);
 
 impl<'de> Deserialize<'de> for FontStyle {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -234,11 +236,11 @@ impl<'de> Deserialize<'de> for FontStyle {
     D: Deserializer<'de>,
   {
     let value = String::deserialize(deserializer)?;
-    Ok(Self(ParleyFontStyle::parse_css(&value).unwrap_or_default()))
+    Ok(Self(CssFontStyle::from_css_str(&value).unwrap_or_default()))
   }
 }
 
-impl From<FontStyle> for ParleyFontStyle {
+impl From<FontStyle> for CssFontStyle {
   fn from(style: FontStyle) -> Self {
     style.0
   }

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -2,7 +2,6 @@
 
 use crate::{helper::map_error, model::*};
 use base64::{Engine, prelude::BASE64_STANDARD};
-use parley::{FontWeight, fontique::FontInfoOverride};
 use serde_wasm_bindgen::{from_value, to_value};
 use std::{
   borrow::Cow,
@@ -17,7 +16,7 @@ use takumi_core::{
     style::{KeyframesRule, StyleSheet},
   },
   resources::{
-    font::{FontResource, GenericFamily, RegisteredFamily},
+    font::{FontOverride, FontResource, GenericFamily, RegisteredFamily},
     image::{ImageCache, ImageSource as LoadedImageSource},
   },
 };
@@ -57,8 +56,8 @@ fn default_fonts() -> Result<Fonts, js_sys::Error> {
   let mut fonts = Fonts::default();
   for (font, family_name, generic_family) in EMBEDDED_FONTS {
     let resource = FontResource::new(*font)
-      .override_info(FontInfoOverride {
-        family_name: Some(*family_name),
+      .override_info(FontOverride {
+        family_name: Some((*family_name).into()),
         ..Default::default()
       })
       .generic_family(*generic_family);
@@ -84,12 +83,11 @@ fn load_font_internal(
       .register(FontResource::new(buffer.into_vec()))
       .map_err(map_error),
     Font::Object(details) => {
-      let resource = FontResource::new(details.data.into_vec()).override_info(FontInfoOverride {
-        family_name: details.name.as_deref(),
+      let resource = FontResource::new(details.data.into_vec()).override_info(FontOverride {
+        family_name: details.name.map(Into::into),
         style: details.style.map(Into::into),
-        weight: details.weight.map(|weight| FontWeight::new(weight as f32)),
-        axes: None,
-        width: None,
+        weight: details.weight.map(|weight| weight as f32),
+        ..Default::default()
       });
 
       let resource = match &details.subset_of {

--- a/takumi/benches-disabled/canvas.rs
+++ b/takumi/benches-disabled/canvas.rs
@@ -94,7 +94,7 @@ fn scaled_image_fixture() -> Node {
 }
 
 fn gradient_clip_mask_fixture() -> Node {
-  let gradient = BackgroundImages::from_str(
+  let gradient = BackgroundImages::from_css_str(
     "linear-gradient(135deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -107,13 +107,13 @@ fn gradient_clip_mask_fixture() -> Node {
       .with_overflow(SpacePair::from_single(Overflow::Clip))
       .with(StyleDeclaration::background_image(Some(gradient)))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("100% 100%").unwrap(),
+        BackgroundSizes::from_css_str("100% 100%").unwrap(),
       ))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("0 0").unwrap(),
+        PositionValues::from_css_str("0 0").unwrap(),
       ))
       .with(StyleDeclaration::background_repeat(
-        BackgroundRepeats::from_str("no-repeat").unwrap(),
+        BackgroundRepeats::from_css_str("no-repeat").unwrap(),
       ))
       .with(StyleDeclaration::background_clip(BackgroundClip::BorderBox)),
   )])

--- a/takumi/benches-disabled/fixtures.rs
+++ b/takumi/benches-disabled/fixtures.rs
@@ -42,7 +42,7 @@ fn simple_image_blit_fixture() -> Node {
 }
 
 fn gradient_clip_text_fixture() -> Node {
-  let gradient = BackgroundImages::from_str(
+  let gradient = BackgroundImages::from_css_str(
     "linear-gradient(90deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -53,13 +53,13 @@ fn gradient_clip_text_fixture() -> Node {
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::background_image(Some(gradient)))
         .with(StyleDeclaration::background_size(
-          BackgroundSizes::from_str("100% 100%").unwrap(),
+          BackgroundSizes::from_css_str("100% 100%").unwrap(),
         ))
         .with(StyleDeclaration::background_position(
-          PositionValues::from_str("0 0").unwrap(),
+          PositionValues::from_css_str("0 0").unwrap(),
         ))
         .with(StyleDeclaration::background_repeat(
-          BackgroundRepeats::from_str("no-repeat").unwrap(),
+          BackgroundRepeats::from_css_str("no-repeat").unwrap(),
         ))
         .with(StyleDeclaration::background_clip(BackgroundClip::Text))
         .with(StyleDeclaration::color(ColorInput::Value(
@@ -126,7 +126,7 @@ fn emoji_social_fixture() -> Node {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(48.0), Px(56.0), Px(48.0), Px(56.0)]))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str(
+        BackgroundImages::from_css_str(
           "linear-gradient(135deg, #f8fafc 0%, #e2e8f0 45%, #cbd5e1 100%)",
         )
         .unwrap(),

--- a/takumi/benches-disabled/gradient.rs
+++ b/takumi/benches-disabled/gradient.rs
@@ -36,7 +36,7 @@ fn render_gradient_node(fonts: &Fonts, node: Node) {
 }
 
 fn run_gradient_render(fonts: &Fonts, background_image_str: &str) {
-  let background_images = BackgroundImages::from_str(background_image_str).ok();
+  let background_images = BackgroundImages::from_css_str(background_image_str).ok();
   let node = build_gradient_node(background_images);
   render_gradient_node(fonts, node);
 }

--- a/takumi/benches-disabled/svg.rs
+++ b/takumi/benches-disabled/svg.rs
@@ -79,7 +79,7 @@ fn cjk_fixture() -> Node {
 }
 
 fn gradient_clip_text_fixture() -> Node {
-  let gradient = BackgroundImages::from_str(
+  let gradient = BackgroundImages::from_css_str(
     "linear-gradient(90deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -90,13 +90,13 @@ fn gradient_clip_text_fixture() -> Node {
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::background_image(Some(gradient)))
         .with(StyleDeclaration::background_size(
-          BackgroundSizes::from_str("100% 100%").unwrap(),
+          BackgroundSizes::from_css_str("100% 100%").unwrap(),
         ))
         .with(StyleDeclaration::background_position(
-          PositionValues::from_str("0 0").unwrap(),
+          PositionValues::from_css_str("0 0").unwrap(),
         ))
         .with(StyleDeclaration::background_repeat(
-          BackgroundRepeats::from_str("no-repeat").unwrap(),
+          BackgroundRepeats::from_css_str("no-repeat").unwrap(),
         ))
         .with(StyleDeclaration::background_clip(BackgroundClip::Text))
         .with(StyleDeclaration::color(ColorInput::Value(

--- a/takumi/examples/profile_many_runs.rs
+++ b/takumi/examples/profile_many_runs.rs
@@ -1,4 +1,3 @@
-use parley::fontique::FontInfoOverride;
 use std::hint::black_box;
 use takumi::{prelude::*, render};
 
@@ -17,8 +16,8 @@ fn load_global() -> Fonts {
   let regular: &[u8] = include_bytes!("../../assets/fonts/geist/Geist[wght].woff2");
   g.register(
     FontResource::new(regular.to_vec())
-      .override_info(FontInfoOverride {
-        family_name: Some("Geist"),
+      .override_info(FontOverride {
+        family_name: Some("Geist".into()),
         ..Default::default()
       })
       .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi/examples/profile_mix.rs
+++ b/takumi/examples/profile_mix.rs
@@ -1,4 +1,3 @@
-use parley::fontique::FontInfoOverride;
 use std::{env, hint::black_box};
 use takumi::{prelude::*, render};
 
@@ -12,8 +11,8 @@ fn load_global() -> Fonts {
   let regular: &[u8] = include_bytes!("../../assets/fonts/geist/Geist[wght].woff2");
   g.register(
     FontResource::new(regular.to_vec())
-      .override_info(FontInfoOverride {
-        family_name: Some("Geist"),
+      .override_info(FontOverride {
+        family_name: Some("Geist".into()),
         ..Default::default()
       })
       .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi/examples/profile_nested_clip.rs
+++ b/takumi/examples/profile_nested_clip.rs
@@ -13,7 +13,7 @@ fn nested_clip_masks_fixture() -> Node {
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::width(Percentage(100.0)))
         .with(StyleDeclaration::height(Percentage(100.0)))
-        .with_border_radius(BorderRadius::from_str(radius).unwrap())
+        .with_border_radius(BorderRadius::from_css_str(radius).unwrap())
         .with_overflow(SpacePair::from_single(Overflow::Clip))
         .with(StyleDeclaration::background_color(ColorInput::Value(
           Color([200, 30, 30, 255]),
@@ -28,7 +28,7 @@ fn nested_clip_masks_fixture() -> Node {
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::width(Percentage(95.0)))
         .with(StyleDeclaration::height(Percentage(95.0)))
-        .with_border_radius(BorderRadius::from_str(radius).unwrap())
+        .with_border_radius(BorderRadius::from_css_str(radius).unwrap())
         .with_overflow(SpacePair::from_single(Overflow::Clip))
         .with(StyleDeclaration::background_color(ColorInput::Value(
           Color([30, 30, 200, 255]),

--- a/takumi/examples/profile_text.rs
+++ b/takumi/examples/profile_text.rs
@@ -1,4 +1,3 @@
-use parley::fontique::FontInfoOverride;
 use std::hint::black_box;
 use takumi::{prelude::*, render};
 
@@ -17,8 +16,8 @@ fn load_global() -> Fonts {
   let regular: &[u8] = include_bytes!("../../assets/fonts/geist/Geist[wght].woff2");
   g.register(
     FontResource::new(regular.to_vec())
-      .override_info(FontInfoOverride {
-        family_name: Some("Geist"),
+      .override_info(FontOverride {
+        family_name: Some("Geist".into()),
         ..Default::default()
       })
       .generic_family(GenericFamily::SANS_SERIF),

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -74,7 +74,7 @@ pub mod prelude {
       style::*,
     },
     resources::{
-      font::{FontError, FontResource, GenericFamily, RegisteredFamily},
+      font::{FontError, FontOverride, FontResource, GenericFamily, RegisteredFamily},
       image::{ImageCacheMode, ImageSource},
     },
   };

--- a/takumi/tests/fixtures/color_artifacts.rs
+++ b/takumi/tests/fixtures/color_artifacts.rs
@@ -15,7 +15,7 @@ fn test_color_artifacts() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::object_fit(ObjectFit::Contain))
-      .with_border_radius(BorderRadius::from_str("10px").unwrap()),
+      .with_border_radius(BorderRadius::from_css_str("10px").unwrap()),
   )])
   .with_style(
     Style::default()
@@ -25,7 +25,7 @@ fn test_color_artifacts() {
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 96]),
       )))
-      .with_border_radius(BorderRadius::from_str("24px").unwrap())
+      .with_border_radius(BorderRadius::from_css_str("24px").unwrap())
       .with_padding(Sides([Px(24.0); 4])),
   );
 
@@ -48,7 +48,7 @@ fn test_color_artifacts() {
       )))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_border_radius(BorderRadius::from_str("24px").unwrap()),
+      .with_border_radius(BorderRadius::from_css_str("24px").unwrap()),
   );
 
   let container = Node::container([main_preview, downscaled_preview]).with_style(

--- a/takumi/tests/fixtures/inline.rs
+++ b/takumi/tests/fixtures/inline.rs
@@ -76,7 +76,7 @@ fn inline_image() {
         .with_border_style(Sides([BorderStyle::Solid; 4]))
         .with_border_color(Sides([ColorInput::Value(Color::transparent()); 4]))
         .with(StyleDeclaration::background_image(
-          BackgroundImages::from_str("linear-gradient(to right, red, blue)").ok(),
+          BackgroundImages::from_css_str("linear-gradient(to right, red, blue)").ok(),
         ))
         .with(StyleDeclaration::background_clip(
           BackgroundClip::BorderArea,

--- a/takumi/tests/fixtures/lang.rs
+++ b/takumi/tests/fixtures/lang.rs
@@ -14,14 +14,14 @@ fn lang_row(lang: &'static str) -> Node {
     Node::text(format!("{lang}: ")).with_style(
       Style::default()
         .with(StyleDeclaration::font_family(
-          FontFamily::from_str("Geist").unwrap(),
+          FontFamily::from_css_str("Geist").unwrap(),
         ))
         .with(StyleDeclaration::font_size(FontSize::Length(Px(40.0)))),
     ),
     Node::text(SAMPLE).with_lang(lang).with_style(
       Style::default()
         .with(StyleDeclaration::font_family(
-          FontFamily::from_str(FONT).unwrap(),
+          FontFamily::from_css_str(FONT).unwrap(),
         ))
         .with(StyleDeclaration::font_size(FontSize::Length(Px(40.0)))),
     ),

--- a/takumi/tests/fixtures/rtl.rs
+++ b/takumi/tests/fixtures/rtl.rs
@@ -13,7 +13,7 @@ fn create_test_nodes() -> Vec<Node> {
           .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0))))
           .with(StyleDeclaration::font_size(FontSize::Length(Px(24.0))))
           .with(StyleDeclaration::font_family(
-            FontFamily::from_str("monospace").unwrap(),
+            FontFamily::from_css_str("monospace").unwrap(),
           )),
       )
     })
@@ -66,7 +66,7 @@ fn test_direction_grid() {
       Style::default()
         .with(StyleDeclaration::display(Display::Grid))
         .with(StyleDeclaration::grid_template_columns(Some(
-          GridTemplateComponents::from_str("repeat(4, 1fr)").unwrap(),
+          GridTemplateComponents::from_css_str("repeat(4, 1fr)").unwrap(),
         )))
         .with(StyleDeclaration::direction(Direction::Ltr))
         .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
@@ -76,7 +76,7 @@ fn test_direction_grid() {
       Style::default()
         .with(StyleDeclaration::display(Display::Grid))
         .with(StyleDeclaration::grid_template_columns(Some(
-          GridTemplateComponents::from_str("repeat(4, 1fr)").unwrap(),
+          GridTemplateComponents::from_css_str("repeat(4, 1fr)").unwrap(),
         )))
         .with(StyleDeclaration::direction(Direction::Rtl))
         .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))

--- a/takumi/tests/fixtures/style_backdrop_filter.rs
+++ b/takumi/tests/fixtures/style_backdrop_filter.rs
@@ -12,7 +12,7 @@ fn create_backdrop_card(filter: &str, label_font_size_px: f32) -> Node {
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::backdrop_filter(
-        Filters::from_str(filter).unwrap(),
+        Filters::from_css_str(filter).unwrap(),
       ))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 60]),
@@ -59,16 +59,16 @@ fn test_style_backdrop_filter() {
         .with(StyleDeclaration::height(Percentage(100.0)))
         .with(StyleDeclaration::display(Display::Grid))
         .with(StyleDeclaration::grid_template_columns(
-          GridTemplateComponents::from_str("repeat(4, 1fr)").ok(),
+          GridTemplateComponents::from_css_str("repeat(4, 1fr)").ok(),
         ))
         .with(StyleDeclaration::background_image(Some(
-          BackgroundImages::from_str(
+          BackgroundImages::from_css_str(
             "linear-gradient(135deg, #667eea 0%, #764ba2 25%, #f857a6 50%, #ff5858 75%, #ffb199 100%)",
           )
           .unwrap(),
         )))
         .with(StyleDeclaration::background_position(
-          PositionValues::from_str("center center").unwrap(),
+          PositionValues::from_css_str("center center").unwrap(),
         )),)
   ;
 
@@ -104,12 +104,12 @@ fn test_style_backdrop_filter_frosted_glass() {
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::backdrop_filter(
-        Filters::from_str("blur(16px)").unwrap(),
+        Filters::from_css_str("blur(16px)").unwrap(),
       ))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 80]),
       )))
-      .with_border_radius(BorderRadius::from_str("24px").unwrap())
+      .with_border_radius(BorderRadius::from_css_str("24px").unwrap())
       .with_padding(Sides([Px(48.0); 4]))
       .with_gap(SpacePair::from_single(Px(16.0))),
   )])
@@ -122,13 +122,13 @@ fn test_style_backdrop_filter_frosted_glass() {
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str("url(assets/images/yeecord.png)").unwrap(),
+        BackgroundImages::from_css_str("url(assets/images/yeecord.png)").unwrap(),
       )))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("center center").unwrap(),
+        PositionValues::from_css_str("center center").unwrap(),
       ))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("cover").unwrap(),
+        BackgroundSizes::from_css_str("cover").unwrap(),
       )),
   );
 
@@ -152,17 +152,17 @@ fn test_style_backdrop_filter_with_mask() {
         Color([239, 68, 68, 255]),
       )))
       .with(StyleDeclaration::mask_image(Some(
-        BackgroundImages::from_str("linear-gradient(transparent 10%, black 100%)").unwrap(),
+        BackgroundImages::from_css_str("linear-gradient(transparent 10%, black 100%)").unwrap(),
       ))),
   );
 
   let masked_backdrop_blur = Node::container([]).with_style(
     absolute_inset_zero()
       .with(StyleDeclaration::backdrop_filter(
-        Filters::from_str("blur(24px)").unwrap(),
+        Filters::from_css_str("blur(24px)").unwrap(),
       ))
       .with(StyleDeclaration::mask_image(Some(
-        BackgroundImages::from_str("radial-gradient(transparent 30%, black 100%)").unwrap(),
+        BackgroundImages::from_css_str("radial-gradient(transparent 30%, black 100%)").unwrap(),
       ))),
   );
 
@@ -186,16 +186,16 @@ fn test_style_backdrop_filter_with_mask() {
         Color::black(),
       )))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str(
+        BackgroundImages::from_css_str(
           "linear-gradient(to right, white 8px, transparent 8px), linear-gradient(to bottom, white 8px, transparent 8px)",
         )
         .unwrap(),
       )))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("48px 48px").unwrap(),
+        BackgroundSizes::from_css_str("48px 48px").unwrap(),
       ))
       .with(StyleDeclaration::background_repeat(
-        BackgroundRepeats::from_str("repeat, repeat").unwrap(),
+        BackgroundRepeats::from_css_str("repeat, repeat").unwrap(),
       )),
   );
 

--- a/takumi/tests/fixtures/style_background_clip.rs
+++ b/takumi/tests/fixtures/style_background_clip.rs
@@ -74,7 +74,7 @@ fn test_style_background_clip_content_box() {
 
 #[test]
 fn test_style_background_clip_text_gradient() {
-  let gradient_images = BackgroundImages::from_str(
+  let gradient_images = BackgroundImages::from_css_str(
     "linear-gradient(90deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -84,13 +84,13 @@ fn test_style_background_clip_text_gradient() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::background_image(Some(gradient_images)))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("100% 100%").unwrap(),
+        BackgroundSizes::from_css_str("100% 100%").unwrap(),
       ))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("0 0").unwrap(),
+        PositionValues::from_css_str("0 0").unwrap(),
       ))
       .with(StyleDeclaration::background_repeat(
-        BackgroundRepeats::from_str("no-repeat").unwrap(),
+        BackgroundRepeats::from_css_str("no-repeat").unwrap(),
       ))
       .with(StyleDeclaration::background_clip(BackgroundClip::Text))
       .with(StyleDeclaration::color(ColorInput::Value(
@@ -116,17 +116,17 @@ fn test_style_background_clip_text_gradient() {
 #[test]
 fn test_style_background_clip_text_radial_gradient() {
   let gradient_images =
-    BackgroundImages::from_str("radial-gradient(circle, #ff0080, #7928ca, #0070f3)").unwrap();
+    BackgroundImages::from_css_str("radial-gradient(circle, #ff0080, #7928ca, #0070f3)").unwrap();
 
   let container = Node::container([Node::text("Radial Gradient".to_string()).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::background_image(Some(gradient_images)))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("100% 100%").unwrap(),
+        BackgroundSizes::from_css_str("100% 100%").unwrap(),
       ))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("center center").unwrap(),
+        PositionValues::from_css_str("center center").unwrap(),
       ))
       .with(StyleDeclaration::background_clip(BackgroundClip::Text))
       .with(StyleDeclaration::color(ColorInput::Value(
@@ -187,7 +187,7 @@ fn test_style_background_clip_border_area() {
 #[test]
 fn test_style_background_clip_with_gradient_background() {
   let gradient_images =
-    BackgroundImages::from_str("linear-gradient(135deg, #667eea 0%, #764ba2 100%)").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(135deg, #667eea 0%, #764ba2 100%)").unwrap();
 
   let container = Node::container([Node::container([]).with_style(
     Style::default()
@@ -196,7 +196,7 @@ fn test_style_background_clip_with_gradient_background() {
       .with(StyleDeclaration::height(Rem(10.0)))
       .with(StyleDeclaration::background_image(Some(gradient_images)))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("center center").unwrap(),
+        PositionValues::from_css_str("center center").unwrap(),
       ))
       .with(StyleDeclaration::background_clip(
         BackgroundClip::PaddingBox,
@@ -224,15 +224,15 @@ fn test_style_background_clip_with_gradient_background() {
 #[test]
 fn test_style_background_clip_text_multiline() {
   let gradient_images =
-    BackgroundImages::from_str("linear-gradient(45deg, #12c2e9, #c471ed, #f64f59)").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(45deg, #12c2e9, #c471ed, #f64f59)").unwrap();
 
   let container = Node::container([
       Node::text("This is a multiline text with a beautiful gradient background clipped to the text shape. It demonstrates how background-clip: text works with longer content.".to_string())
   .with_style(Style::default().with(StyleDeclaration::display(Display::Flex))
             .with(StyleDeclaration::background_image(Some(gradient_images)))
-            .with(StyleDeclaration::background_size(BackgroundSizes::from_str("100% 100%").unwrap()))
+            .with(StyleDeclaration::background_size(BackgroundSizes::from_css_str("100% 100%").unwrap()))
             .with(StyleDeclaration::background_position(
-              PositionValues::from_str("center center").unwrap(),
+              PositionValues::from_css_str("center center").unwrap(),
             ))
             .with(StyleDeclaration::background_clip(BackgroundClip::Text))
             .with(StyleDeclaration::color(ColorInput::Value(Color::transparent())))

--- a/takumi/tests/fixtures/style_background_image.rs
+++ b/takumi/tests/fixtures/style_background_image.rs
@@ -3,7 +3,7 @@ use takumi::prelude::{Length::*, *};
 use crate::test_utils::run_fixture_test;
 
 fn centered_background_position() -> PositionValues {
-  PositionValues::from_str("center center").unwrap()
+  PositionValues::from_css_str("center center").unwrap()
 }
 
 fn create_container(background_images: BackgroundImages) -> Node {
@@ -46,7 +46,7 @@ fn create_container_with(
 #[test]
 fn test_style_background_image_gradient() {
   let background_images =
-    BackgroundImages::from_str("linear-gradient(45deg, rgba(255,150,255,0.3), transparent)")
+    BackgroundImages::from_css_str("linear-gradient(45deg, rgba(255,150,255,0.3), transparent)")
       .unwrap();
 
   let container = create_container(background_images).with_style(
@@ -55,8 +55,10 @@ fn test_style_background_image_gradient() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str("linear-gradient(45deg, rgba(255,150,255,0.3), transparent)")
-          .unwrap(),
+        BackgroundImages::from_css_str(
+          "linear-gradient(45deg, rgba(255,150,255,0.3), transparent)",
+        )
+        .unwrap(),
       )))
       .with(StyleDeclaration::background_position(
         centered_background_position(),
@@ -72,7 +74,7 @@ fn test_style_background_image_gradient() {
 #[test]
 fn test_style_background_image_gradient_alt() {
   let background_images =
-    BackgroundImages::from_str("linear-gradient(0deg, #ff3b30, #5856d6)").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(0deg, #ff3b30, #5856d6)").unwrap();
 
   let container = create_container(background_images);
 
@@ -82,7 +84,7 @@ fn test_style_background_image_gradient_alt() {
 #[test]
 fn test_style_background_image_gradient_hard_stop() {
   let background_images =
-    BackgroundImages::from_str("linear-gradient(to left, #252525 0%, #252525 20%, #f5f5f5 20%, #f5f5f5 40%, #00b7b7 40%, #00b7b7 60%, #b70000 60%, #b70000 80%, #fcd50e 80%)").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(to left, #252525 0%, #252525 20%, #f5f5f5 20%, #f5f5f5 40%, #00b7b7 40%, #00b7b7 60%, #b70000 60%, #b70000 80%, #fcd50e 80%)").unwrap();
 
   let container = create_container(background_images);
 
@@ -97,7 +99,7 @@ fn test_style_background_image_gradient_color_space_comparison() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0 / 3.0)))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str("linear-gradient(to right in srgb, red, blue)").unwrap(),
+        BackgroundImages::from_css_str("linear-gradient(to right in srgb, red, blue)").unwrap(),
       ))),
   );
 
@@ -107,7 +109,7 @@ fn test_style_background_image_gradient_color_space_comparison() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(33.333)))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str("linear-gradient(to right in oklab, red, blue)").unwrap(),
+        BackgroundImages::from_css_str("linear-gradient(to right in oklab, red, blue)").unwrap(),
       ))),
   );
 
@@ -117,7 +119,7 @@ fn test_style_background_image_gradient_color_space_comparison() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(33.334)))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str("linear-gradient(to right in oklch longer hue, red, blue)")
+        BackgroundImages::from_css_str("linear-gradient(to right in oklch longer hue, red, blue)")
           .unwrap(),
       ))),
   );
@@ -138,7 +140,8 @@ fn test_style_background_image_gradient_color_space_comparison() {
 
 #[test]
 fn test_style_background_image_radial_basic() {
-  let background_images = BackgroundImages::from_str("radial-gradient(#e66465, #9198e5)").unwrap();
+  let background_images =
+    BackgroundImages::from_css_str("radial-gradient(#e66465, #9198e5)").unwrap();
 
   let container = create_container(background_images);
 
@@ -147,7 +150,7 @@ fn test_style_background_image_radial_basic() {
 
 #[test]
 fn test_style_background_image_radial_mixed() {
-  let background_images = BackgroundImages::from_str("radial-gradient(ellipse at top, #e66465, transparent), radial-gradient(ellipse at bottom, #4d9f0c, transparent)").unwrap();
+  let background_images = BackgroundImages::from_css_str("radial-gradient(ellipse at top, #e66465, transparent), radial-gradient(ellipse at bottom, #4d9f0c, transparent)").unwrap();
 
   let container = create_container(background_images);
 
@@ -156,7 +159,7 @@ fn test_style_background_image_radial_mixed() {
 
 #[test]
 fn test_style_background_image_conic_basic() {
-  let background_images = BackgroundImages::from_str(
+  let background_images = BackgroundImages::from_css_str(
     "conic-gradient(from 0deg at 50% 50%, #ff3b30 0%, #ffcc00 25%, #34c759 50%, #007aff 75%, #ff3b30 100%)",
   )
   .unwrap();
@@ -168,7 +171,7 @@ fn test_style_background_image_conic_basic() {
 
 #[test]
 fn test_style_background_image_linear_radial_mixed() {
-  let background_images = BackgroundImages::from_str(
+  let background_images = BackgroundImages::from_css_str(
     "linear-gradient(45deg, #0000ff, #00ff00), radial-gradient(circle, #000000, transparent)",
   )
   .unwrap();
@@ -180,7 +183,7 @@ fn test_style_background_image_linear_radial_mixed() {
 
 #[test]
 fn test_style_background_image_builder_gradient_layers() {
-  let background_images = BackgroundImages::from_str(
+  let background_images = BackgroundImages::from_css_str(
     "radial-gradient(circle at top left,rgba(236,253,245,0.9),transparent 30%),radial-gradient(circle at bottom right,rgba(45,212,191,0.22),transparent 28%),linear-gradient(135deg,#0f172a 0%,#134e4a 38%,#115e59 66%,#0f766e 100%)",
   )
   .unwrap();
@@ -198,7 +201,7 @@ fn test_style_background_image_repeating_gradients() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0))))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str(
+        BackgroundImages::from_css_str(
           "repeating-linear-gradient(90deg, rgba(99, 102, 241, 0.18) 0px, rgba(56, 189, 248, 0.14) 48px, rgba(99, 102, 241, 0.18) 96px)",
         )
         .unwrap(),
@@ -214,7 +217,7 @@ fn test_style_background_image_repeating_gradients() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0))))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str(
+        BackgroundImages::from_css_str(
           "repeating-radial-gradient(circle 320px at 50% 50%, rgba(56, 189, 248, 0.16) 0px, rgba(99, 102, 241, 0.10) 40px, rgba(56, 189, 248, 0.16) 80px)",
         )
         .unwrap(),
@@ -230,7 +233,7 @@ fn test_style_background_image_repeating_gradients() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0))))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str(
+        BackgroundImages::from_css_str(
           "repeating-conic-gradient(from 0deg at 50% 50%, rgba(99, 102, 241, 0.16) 0deg, rgba(56, 189, 248, 0.12) 90deg, rgba(99, 102, 241, 0.16) 180deg)",
         )
         .unwrap(),
@@ -255,12 +258,13 @@ fn test_style_background_image_repeating_gradients() {
 #[test]
 fn test_background_no_repeat_center_with_size_px() {
   let images =
-    BackgroundImages::from_str("linear-gradient(90deg, rgba(255,0,0,1), rgba(0,0,255,1))").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(90deg, rgba(255,0,0,1), rgba(0,0,255,1))")
+      .unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("200px 120px").unwrap()),
-    Some(PositionValues::from_str("center center").unwrap()),
-    Some(BackgroundRepeats::from_str("no-repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("200px 120px").unwrap()),
+    Some(PositionValues::from_css_str("center center").unwrap()),
+    Some(BackgroundRepeats::from_css_str("no-repeat").unwrap()),
   );
 
   run_fixture_test(container, "style_background_no_repeat_center_200x120");
@@ -269,12 +273,13 @@ fn test_background_no_repeat_center_with_size_px() {
 #[test]
 fn test_background_repeat_tile_from_top_left() {
   let images =
-    BackgroundImages::from_str("linear-gradient(90deg, rgba(0,200,0,1), rgba(0,0,0,0))").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(90deg, rgba(0,200,0,1), rgba(0,0,0,0))")
+      .unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("160px 100px").unwrap()),
-    Some(PositionValues::from_str("0 0").unwrap()),
-    Some(BackgroundRepeats::from_str("repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("160px 100px").unwrap()),
+    Some(PositionValues::from_css_str("0 0").unwrap()),
+    Some(BackgroundRepeats::from_css_str("repeat").unwrap()),
   );
 
   run_fixture_test(container, "style_background_repeat_tile_from_top_left");
@@ -282,15 +287,15 @@ fn test_background_repeat_tile_from_top_left() {
 
 #[test]
 fn test_background_repeat_space() {
-  let images = BackgroundImages::from_str(
+  let images = BackgroundImages::from_css_str(
     "radial-gradient(circle, rgba(255,165,0,1) 0%, rgba(255,165,0,0) 70%)",
   )
   .unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("120px 120px").unwrap()),
+    Some(BackgroundSizes::from_css_str("120px 120px").unwrap()),
     None,
-    Some(BackgroundRepeats::from_str("space").unwrap()),
+    Some(BackgroundRepeats::from_css_str("space").unwrap()),
   );
 
   run_fixture_test(container, "style_background_repeat_space");
@@ -299,13 +304,13 @@ fn test_background_repeat_space() {
 #[test]
 fn test_background_repeat_round() {
   let images =
-    BackgroundImages::from_str("radial-gradient(circle, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 60%)")
+    BackgroundImages::from_css_str("radial-gradient(circle, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 60%)")
       .unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("180px 120px").unwrap()),
+    Some(BackgroundSizes::from_css_str("180px 120px").unwrap()),
     None,
-    Some(BackgroundRepeats::from_str("round").unwrap()),
+    Some(BackgroundRepeats::from_css_str("round").unwrap()),
   );
 
   run_fixture_test(container, "style_background_repeat_round");
@@ -314,13 +319,13 @@ fn test_background_repeat_round() {
 #[test]
 fn test_background_position_percentage_with_no_repeat() {
   let images =
-    BackgroundImages::from_str("linear-gradient(0deg, rgba(255,0,255,1), rgba(255,0,255,0))")
+    BackgroundImages::from_css_str("linear-gradient(0deg, rgba(255,0,255,1), rgba(255,0,255,0))")
       .unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("220px 160px").unwrap()),
-    Some(PositionValues::from_str("25% 75%").unwrap()),
-    Some(BackgroundRepeats::from_str("no-repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("220px 160px").unwrap()),
+    Some(PositionValues::from_css_str("25% 75%").unwrap()),
+    Some(BackgroundRepeats::from_css_str("no-repeat").unwrap()),
   );
 
   run_fixture_test(container, "style_background_position_percent_25_75");
@@ -328,14 +333,15 @@ fn test_background_position_percentage_with_no_repeat() {
 
 #[test]
 fn test_background_size_percentage_with_repeat() {
-  let images =
-    BackgroundImages::from_str("linear-gradient(180deg, rgba(0,128,255,0.9), rgba(0,128,255,0))")
-      .unwrap();
+  let images = BackgroundImages::from_css_str(
+    "linear-gradient(180deg, rgba(0,128,255,0.9), rgba(0,128,255,0))",
+  )
+  .unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("20% 20%").unwrap()),
-    Some(PositionValues::from_str("0 0").unwrap()),
-    Some(BackgroundRepeats::from_str("repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("20% 20%").unwrap()),
+    Some(PositionValues::from_css_str("0 0").unwrap()),
+    Some(BackgroundRepeats::from_css_str("repeat").unwrap()),
   );
 
   run_fixture_test(container, "style_background_size_percent_20_20");
@@ -343,16 +349,16 @@ fn test_background_size_percentage_with_repeat() {
 
 #[test]
 fn test_background_image_grid_pattern() {
-  let images = BackgroundImages::from_str(
+  let images = BackgroundImages::from_css_str(
     "linear-gradient(to right, grey 1px, transparent 1px), linear-gradient(to bottom, grey 1px, transparent 1px)",
   )
   .unwrap();
 
   let container = create_container_with(
     images.clone(),
-    Some(BackgroundSizes::from_str("40px 40px").unwrap()),
-    Some(PositionValues::from_str("0 0, 0 0").unwrap()),
-    Some(BackgroundRepeats::from_str("repeat, repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("40px 40px").unwrap()),
+    Some(PositionValues::from_css_str("0 0, 0 0").unwrap()),
+    Some(BackgroundRepeats::from_css_str("repeat, repeat").unwrap()),
   )
   .with_style(
     Style::default()
@@ -361,13 +367,13 @@ fn test_background_image_grid_pattern() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_image(Some(images)))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("40px 40px").unwrap(),
+        BackgroundSizes::from_css_str("40px 40px").unwrap(),
       ))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("0 0, 0 0").unwrap(),
+        PositionValues::from_css_str("0 0, 0 0").unwrap(),
       ))
       .with(StyleDeclaration::background_repeat(
-        BackgroundRepeats::from_str("repeat, repeat").unwrap(),
+        BackgroundRepeats::from_css_str("repeat, repeat").unwrap(),
       ))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::white(),
@@ -379,16 +385,16 @@ fn test_background_image_grid_pattern() {
 
 #[test]
 fn test_background_image_dotted_pattern() {
-  let images = BackgroundImages::from_str(
+  let images = BackgroundImages::from_css_str(
     "radial-gradient(circle at 25px 25px, lightgray 2%, transparent 0%), radial-gradient(circle at 75px 75px, lightgray 2%, transparent 0%)",
   )
   .unwrap();
 
   let container = create_container_with(
     images.clone(),
-    Some(BackgroundSizes::from_str("100px 100px").unwrap()),
+    Some(BackgroundSizes::from_css_str("100px 100px").unwrap()),
     None,
-    Some(BackgroundRepeats::from_str("repeat").unwrap()),
+    Some(BackgroundRepeats::from_css_str("repeat").unwrap()),
   )
   .with_style(
     Style::default()
@@ -397,13 +403,13 @@ fn test_background_image_dotted_pattern() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_image(Some(images)))
       .with(StyleDeclaration::background_size(
-        BackgroundSizes::from_str("100px 100px").unwrap(),
+        BackgroundSizes::from_css_str("100px 100px").unwrap(),
       ))
       .with(StyleDeclaration::background_position(
         centered_background_position(),
       ))
       .with(StyleDeclaration::background_repeat(
-        BackgroundRepeats::from_str("repeat").unwrap(),
+        BackgroundRepeats::from_css_str("repeat").unwrap(),
       ))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::black(),
@@ -415,12 +421,12 @@ fn test_background_image_dotted_pattern() {
 
 #[test]
 fn test_background_size_contain() {
-  let images = BackgroundImages::from_str("url(assets/images/yeecord.png)").unwrap();
+  let images = BackgroundImages::from_css_str("url(assets/images/yeecord.png)").unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("contain").unwrap()),
-    Some(PositionValues::from_str("center center").unwrap()),
-    Some(BackgroundRepeats::from_str("no-repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("contain").unwrap()),
+    Some(PositionValues::from_css_str("center center").unwrap()),
+    Some(BackgroundRepeats::from_css_str("no-repeat").unwrap()),
   );
 
   run_fixture_test(container, "style_background_size_contain");
@@ -428,12 +434,12 @@ fn test_background_size_contain() {
 
 #[test]
 fn test_background_size_cover() {
-  let images = BackgroundImages::from_str("url(assets/images/yeecord.png)").unwrap();
+  let images = BackgroundImages::from_css_str("url(assets/images/yeecord.png)").unwrap();
   let container = create_container_with(
     images,
-    Some(BackgroundSizes::from_str("cover").unwrap()),
-    Some(PositionValues::from_str("center center").unwrap()),
-    Some(BackgroundRepeats::from_str("no-repeat").unwrap()),
+    Some(BackgroundSizes::from_css_str("cover").unwrap()),
+    Some(PositionValues::from_css_str("center center").unwrap()),
+    Some(BackgroundRepeats::from_css_str("no-repeat").unwrap()),
   );
 
   run_fixture_test(container, "style_background_size_cover");
@@ -441,7 +447,7 @@ fn test_background_size_cover() {
 
 #[test]
 fn test_style_background_image_repeating_hard_stop() {
-  let background_images = BackgroundImages::from_str(
+  let background_images = BackgroundImages::from_css_str(
     "repeating-linear-gradient(45deg, #fbbf24 0px, #fbbf24 10px, #f59e0b 10px, #f59e0b 20px)",
   )
   .unwrap();

--- a/takumi/tests/fixtures/style_background_origin.rs
+++ b/takumi/tests/fixtures/style_background_origin.rs
@@ -18,16 +18,16 @@ fn test_style_background_origin() {
           Color([230, 230, 230, 255]),
         )))
         .with(StyleDeclaration::background_image(Some(
-          BackgroundImages::from_str("linear-gradient(#d00, #d00)").unwrap(),
+          BackgroundImages::from_css_str("linear-gradient(#d00, #d00)").unwrap(),
         )))
         .with(StyleDeclaration::background_size(
-          BackgroundSizes::from_str("70px 70px").unwrap(),
+          BackgroundSizes::from_css_str("70px 70px").unwrap(),
         ))
         .with(StyleDeclaration::background_repeat(
-          BackgroundRepeats::from_str("no-repeat").unwrap(),
+          BackgroundRepeats::from_css_str("no-repeat").unwrap(),
         ))
         .with(StyleDeclaration::background_position(
-          PositionValues::from_str("left top").unwrap(),
+          PositionValues::from_css_str("left top").unwrap(),
         ))
         .with(StyleDeclaration::background_origin(origin)),
     )

--- a/takumi/tests/fixtures/style_clip_path.rs
+++ b/takumi/tests/fixtures/style_clip_path.rs
@@ -19,7 +19,7 @@ fn clip_path_text_stroke_filled() {
         )))
         .with(StyleDeclaration::color(ColorInput::Value(Color::white())))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("inset(0 0 50% 0)").unwrap(),
+          BasicShape::from_css_str("inset(0 0 50% 0)").unwrap(),
         ))),
     ),
     Node::text(text.to_string()).with_style(
@@ -40,7 +40,7 @@ fn clip_path_text_stroke_filled() {
           ColorInput::Value(Color([128, 128, 128, 255])),
         )))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("inset(50% 0 0 0)").unwrap(),
+          BasicShape::from_css_str("inset(50% 0 0 0)").unwrap(),
         ))),
     ),
   ])
@@ -78,7 +78,7 @@ fn clip_path_triangle_vercel() {
           Color::black(),
         )))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("polygon(0% 100%, 100% 100%, 50% 12.25%)").unwrap(),
+          BasicShape::from_css_str("polygon(0% 100%, 100% 100%, 50% 12.25%)").unwrap(),
         ))),
     ),
   ])
@@ -110,13 +110,13 @@ fn clip_path_triangle_gradient() {
         .with(StyleDeclaration::width(Px(300.0)))
         .with(StyleDeclaration::height(Px(300.0)))
         .with(StyleDeclaration::background_image(Some(
-          BackgroundImages::from_str(
+          BackgroundImages::from_css_str(
             "linear-gradient(45deg, #ff3b30, #ff9500, #ffcc00, #34c759, #007aff, #5856d6)",
           )
           .unwrap(),
         )))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("polygon(0% 100%, 100% 100%, 50% 12.25%)").unwrap(),
+          BasicShape::from_css_str("polygon(0% 100%, 100% 100%, 50% 12.25%)").unwrap(),
         ))),
     ),
   ])
@@ -151,7 +151,7 @@ fn clip_path_circle() {
           Color([255, 0, 100, 255]),
         )))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("circle(50%)").unwrap(),
+          BasicShape::from_css_str("circle(50%)").unwrap(),
         ))),
     ),
   ])
@@ -186,7 +186,7 @@ fn clip_path_inset_rounded() {
           Color([100, 200, 255, 255]),
         )))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("inset(50px 0 round 20px)").unwrap(),
+          BasicShape::from_css_str("inset(50px 0 round 20px)").unwrap(),
         ))),
     ),
   ])
@@ -237,7 +237,7 @@ fn clip_path_inset_round_clips_children() {
         .with(StyleDeclaration::width(Percentage(100.0)))
         .with(StyleDeclaration::height(Percentage(100.0)))
         .with(StyleDeclaration::clip_path(Some(
-          BasicShape::from_str("inset(0px round 50px)").unwrap(),
+          BasicShape::from_css_str("inset(0px round 50px)").unwrap(),
         )))
         .with(StyleDeclaration::background_color(ColorInput::Value(
           Color([0, 0, 0, 255]),

--- a/takumi/tests/fixtures/style_filter.rs
+++ b/takumi/tests/fixtures/style_filter.rs
@@ -22,7 +22,7 @@ fn create_filter_test_container(
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Grid))
       .with(StyleDeclaration::grid_template_columns(
-        GridTemplateComponents::from_str("repeat(5, 1fr)").ok(),
+        GridTemplateComponents::from_css_str("repeat(5, 1fr)").ok(),
       ))
       .with_gap(SpacePair::from_single(Px(gap_px)))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
@@ -40,7 +40,9 @@ fn create_filter_card(filter: &str, image_size_px: f32, label_font_size_px: f32)
       Style::default()
         .with(StyleDeclaration::width(Px(image_size_px)))
         .with(StyleDeclaration::height(Px(image_size_px)))
-        .with(StyleDeclaration::filter(Filters::from_str(filter).unwrap())),
+        .with(StyleDeclaration::filter(
+          Filters::from_css_str(filter).unwrap(),
+        )),
     ),
     Node::text(filter.to_string())
       .with_style(Style::default().with(StyleDeclaration::display(Display::Block))),
@@ -68,7 +70,9 @@ fn create_filter_transform_card(
       Style::default()
         .with(StyleDeclaration::width(Px(image_size_px)))
         .with(StyleDeclaration::height(Px(image_size_px)))
-        .with(StyleDeclaration::filter(Filters::from_str(filter).unwrap()))
+        .with(StyleDeclaration::filter(
+          Filters::from_css_str(filter).unwrap(),
+        ))
         .with(StyleDeclaration::transform(Some(transforms))),
     ),
     Node::text(label.to_string())
@@ -185,7 +189,7 @@ fn test_style_filter_combined_with_transform() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Grid))
       .with(StyleDeclaration::grid_template_columns(
-        GridTemplateComponents::from_str("repeat(4, 1fr)").ok(),
+        GridTemplateComponents::from_css_str("repeat(4, 1fr)").ok(),
       ))
       .with_gap(SpacePair::from_single(Px(16.0)))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))

--- a/takumi/tests/fixtures/style_mask_image.rs
+++ b/takumi/tests/fixtures/style_mask_image.rs
@@ -3,7 +3,7 @@ use takumi::prelude::{Length::*, *};
 use crate::test_utils::run_fixture_test;
 
 fn centered_layer_position() -> PositionValues {
-  PositionValues::from_str("center center").unwrap()
+  PositionValues::from_css_str("center center").unwrap()
 }
 
 fn create_container_with_mask(mask_image: BackgroundImages, background_color: Color) -> Node {
@@ -23,7 +23,7 @@ fn create_container_with_mask(mask_image: BackgroundImages, background_color: Co
 #[test]
 fn test_style_mask_image_linear_gradient() {
   let mask_image =
-    BackgroundImages::from_str("linear-gradient(to right, black, transparent)").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(to right, black, transparent)").unwrap();
 
   let container = create_container_with_mask(mask_image, Color([255, 0, 0, 255]));
 
@@ -33,7 +33,7 @@ fn test_style_mask_image_linear_gradient() {
 #[test]
 fn test_style_mask_image_radial_gradient() {
   let mask_image =
-    BackgroundImages::from_str("radial-gradient(circle, black, transparent)").unwrap();
+    BackgroundImages::from_css_str("radial-gradient(circle, black, transparent)").unwrap();
 
   let container = create_container_with_mask(mask_image, Color([0, 128, 255, 255]));
 
@@ -42,7 +42,7 @@ fn test_style_mask_image_radial_gradient() {
 
 #[test]
 fn test_style_mask_image_radial_gradient_ellipse() {
-  let mask_image = BackgroundImages::from_str(
+  let mask_image = BackgroundImages::from_css_str(
     "radial-gradient(ellipse at center, black 0%, black 50%, transparent 100%)",
   )
   .unwrap();
@@ -54,7 +54,7 @@ fn test_style_mask_image_radial_gradient_ellipse() {
 
 #[test]
 fn test_style_mask_image_multiple_gradients() {
-  let mask_image = BackgroundImages::from_str(
+  let mask_image = BackgroundImages::from_css_str(
     "linear-gradient(to right, black, transparent), radial-gradient(circle at 25% 25%, black, transparent 50%)",
   )
   .unwrap();
@@ -67,7 +67,7 @@ fn test_style_mask_image_multiple_gradients() {
 #[test]
 fn test_style_mask_image_diagonal_gradient() {
   let mask_image =
-    BackgroundImages::from_str("linear-gradient(45deg, black 0%, black 50%, transparent 100%)")
+    BackgroundImages::from_css_str("linear-gradient(45deg, black 0%, black 50%, transparent 100%)")
       .unwrap();
 
   let container = create_container_with_mask(mask_image, Color([138, 43, 226, 255]));
@@ -78,10 +78,10 @@ fn test_style_mask_image_diagonal_gradient() {
 #[test]
 fn test_style_mask_image_with_background_image() {
   let mask_image =
-    BackgroundImages::from_str("radial-gradient(circle at center, black 40%, transparent 70%)")
+    BackgroundImages::from_css_str("radial-gradient(circle at center, black 40%, transparent 70%)")
       .unwrap();
   let background_image =
-    BackgroundImages::from_str("linear-gradient(135deg, #667eea 0%, #764ba2 100%)").unwrap();
+    BackgroundImages::from_css_str("linear-gradient(135deg, #667eea 0%, #764ba2 100%)").unwrap();
 
   let container = Node::container([]).with_style(
     Style::default()
@@ -101,7 +101,7 @@ fn test_style_mask_image_with_background_image() {
 
 #[test]
 fn test_style_mask_image_url() {
-  let mask_image = BackgroundImages::from_str("url(assets/images/luma.svg)").unwrap();
+  let mask_image = BackgroundImages::from_css_str("url(assets/images/luma.svg)").unwrap();
 
   let container = create_container_with_mask(mask_image, Color([255, 0, 0, 255]));
 
@@ -111,7 +111,7 @@ fn test_style_mask_image_url() {
 #[test]
 fn test_style_mask_image_on_image_node() {
   let mask_image =
-    BackgroundImages::from_str("radial-gradient(circle, black 60%, transparent 100%)").unwrap();
+    BackgroundImages::from_css_str("radial-gradient(circle, black 60%, transparent 100%)").unwrap();
 
   let container = Node::container([Node::container(vec![
     Node::image("assets/images/yeecord.png").with_style(
@@ -145,7 +145,7 @@ fn test_style_mask_image_on_image_node() {
 
 #[test]
 fn test_style_mask_image_stripes_pattern() {
-  let mask_image = BackgroundImages::from_str(
+  let mask_image = BackgroundImages::from_css_str(
     "linear-gradient(90deg, black 0%, black 25%, transparent 25%, transparent 50%, black 50%, black 75%, transparent 75%, transparent 100%)",
   )
   .unwrap();
@@ -157,7 +157,7 @@ fn test_style_mask_image_stripes_pattern() {
 
 #[test]
 fn test_style_mask_image_corner_fade() {
-  let mask_image = BackgroundImages::from_str(
+  let mask_image = BackgroundImages::from_css_str(
     "radial-gradient(ellipse at top left, transparent 0%, black 50%), radial-gradient(ellipse at bottom right, transparent 0%, black 50%)",
   )
   .unwrap();

--- a/takumi/tests/fixtures/style_mix_blend_mode.rs
+++ b/takumi/tests/fixtures/style_mix_blend_mode.rs
@@ -86,7 +86,7 @@ fn test_style_mix_blend_mode() {
         .with(StyleDeclaration::align_items(AlignItems::Center))
         .with(StyleDeclaration::justify_content(JustifyContent::Center))
         .with(StyleDeclaration::background_color(
-          Color::from_str("sandybrown")
+          Color::from_css_str("sandybrown")
             .map(ColorInput::Value)
             .unwrap(),
         )),
@@ -136,7 +136,7 @@ fn test_style_mlx_blend_mode_isolation() {
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::background_color(
-        Color::from_str("deepskyblue")
+        Color::from_css_str("deepskyblue")
           .map(ColorInput::Value)
           .unwrap(),
       )),
@@ -149,7 +149,7 @@ fn test_style_mlx_blend_mode_isolation() {
 // https://github.com/kane50613/takumi/issues/644
 #[test]
 fn test_style_mix_blend_mode_text_regression() {
-  let family = FontFamily::from_str("Geist").unwrap();
+  let family = FontFamily::from_css_str("Geist").unwrap();
   let label_style = Style::default()
     .with(StyleDeclaration::display(Display::Block))
     .with(StyleDeclaration::max_width(Px(500.0)))

--- a/takumi/tests/fixtures/style_offset_path.rs
+++ b/takumi/tests/fixtures/style_offset_path.rs
@@ -46,7 +46,7 @@ fn test_offset_path_along_curve() {
       marker(
         Color([40, 90, 220u8.saturating_sub(shade), 255]),
         [
-          StyleDeclaration::offset_path(Some(OffsetPath::from_str(CURVE).unwrap())),
+          StyleDeclaration::offset_path(Some(OffsetPath::from_css_str(CURVE).unwrap())),
           StyleDeclaration::offset_distance(Percentage(*distance)),
           StyleDeclaration::offset_rotate(OffsetRotate::default()),
         ],
@@ -67,7 +67,7 @@ fn test_offset_path_ray_burst() {
         Color([220, 60, 120, 255]),
         [
           StyleDeclaration::offset_path(Some(
-            OffsetPath::from_str(&format!("ray({angle}deg closest-side at 50% 50%)")).unwrap(),
+            OffsetPath::from_css_str(&format!("ray({angle}deg closest-side at 50% 50%)")).unwrap(),
           )),
           StyleDeclaration::offset_distance(Percentage(80.0)),
           StyleDeclaration::offset_rotate(OffsetRotate::default()),
@@ -108,7 +108,7 @@ fn glyph(character: char, index: usize, distance: f32, path: &str, font_size: f3
       .with(StyleDeclaration::left(Px(0.0)))
       .with(StyleDeclaration::top(Px(0.0)))
       .with(StyleDeclaration::offset_path(Some(
-        OffsetPath::from_str(path).unwrap(),
+        OffsetPath::from_css_str(path).unwrap(),
       )))
       .with(StyleDeclaration::offset_distance(Percentage(distance)))
       .with(StyleDeclaration::offset_rotate(OffsetRotate::default())),

--- a/takumi/tests/fixtures/style_overflow.rs
+++ b/takumi/tests/fixtures/style_overflow.rs
@@ -205,10 +205,10 @@ fn create_overflow_issue_630_grid_fixture() -> Node {
     Style::default()
       .with(StyleDeclaration::display(Display::Grid))
       .with(StyleDeclaration::grid_template_columns(
-        GridTemplateComponents::from_str("repeat(2, 1fr)").ok(),
+        GridTemplateComponents::from_css_str("repeat(2, 1fr)").ok(),
       ))
       .with(StyleDeclaration::grid_template_rows(
-        GridTemplateComponents::from_str("repeat(2, 1fr)").ok(),
+        GridTemplateComponents::from_css_str("repeat(2, 1fr)").ok(),
       ))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))

--- a/takumi/tests/fixtures/svg.rs
+++ b/takumi/tests/fixtures/svg.rs
@@ -16,7 +16,8 @@ fn create_luma_logo_container() -> Node {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_image(Some(
-        BackgroundImages::from_str("linear-gradient(135deg, #2d3748 0%, #1a202c 100%)").unwrap(),
+        BackgroundImages::from_css_str("linear-gradient(135deg, #2d3748 0%, #1a202c 100%)")
+          .unwrap(),
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -57,7 +57,7 @@ fn text_typography_variable_width() {
     })
     .collect::<Vec<_>>();
 
-  let Ok(family) = FontFamily::from_str("Archivo") else {
+  let Ok(family) = FontFamily::from_css_str("Archivo") else {
     unreachable!()
   };
 
@@ -686,7 +686,7 @@ fn text_transform_all() {
 
 #[test]
 fn text_mask_image_gradient_and_emoji() {
-  let gradient_images = BackgroundImages::from_str(
+  let gradient_images = BackgroundImages::from_css_str(
     "linear-gradient(90deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -697,13 +697,13 @@ fn text_mask_image_gradient_and_emoji() {
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::background_image(Some(gradient_images)))
         .with(StyleDeclaration::background_size(
-          BackgroundSizes::from_str("100% 100%").unwrap(),
+          BackgroundSizes::from_css_str("100% 100%").unwrap(),
         ))
         .with(StyleDeclaration::background_position(
-          PositionValues::from_str("0 0").unwrap(),
+          PositionValues::from_css_str("0 0").unwrap(),
         ))
         .with(StyleDeclaration::background_repeat(
-          BackgroundRepeats::from_str("no-repeat").unwrap(),
+          BackgroundRepeats::from_css_str("no-repeat").unwrap(),
         ))
         .with(StyleDeclaration::background_clip(BackgroundClip::Text))
         .with(StyleDeclaration::color(ColorInput::Value(
@@ -753,7 +753,7 @@ fn text_stroke_black_red() {
 
 #[test]
 fn text_stroke_background_clip() {
-  let gradient_images = BackgroundImages::from_str(
+  let gradient_images = BackgroundImages::from_css_str(
     "linear-gradient(90deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -763,7 +763,7 @@ fn text_stroke_background_clip() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::background_image(Some(gradient_images)))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("center center").unwrap(),
+        PositionValues::from_css_str("center center").unwrap(),
       ))
       .with(StyleDeclaration::background_clip(BackgroundClip::Text))
       .with(StyleDeclaration::color(ColorInput::Value(Color::white())))
@@ -980,7 +980,7 @@ fn text_wrap_style_all() {
 
 #[test]
 fn text_super_bold_stroke_background_clip() {
-  let gradient_images = BackgroundImages::from_str(
+  let gradient_images = BackgroundImages::from_css_str(
     "linear-gradient(90deg, #ff3b30, #ffcc00, #34c759, #007aff, #5856d6)",
   )
   .unwrap();
@@ -990,7 +990,7 @@ fn text_super_bold_stroke_background_clip() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::background_image(Some(gradient_images)))
       .with(StyleDeclaration::background_position(
-        PositionValues::from_str("center center").unwrap(),
+        PositionValues::from_css_str("center center").unwrap(),
       ))
       .with(StyleDeclaration::background_clip(BackgroundClip::Text))
       .with(StyleDeclaration::display(Display::Block))
@@ -1071,22 +1071,22 @@ fn text_font_stretch() {
   let stretches = [
     (
       "ultra-condensed",
-      FontStretch::from_str("ultra-condensed").unwrap(),
+      FontStretch::from_css_str("ultra-condensed").unwrap(),
     ),
-    ("condensed", FontStretch::from_str("condensed").unwrap()),
+    ("condensed", FontStretch::from_css_str("condensed").unwrap()),
     (
       "semi-condensed",
-      FontStretch::from_str("semi-condensed").unwrap(),
+      FontStretch::from_css_str("semi-condensed").unwrap(),
     ),
-    ("normal", FontStretch::from_str("normal").unwrap()),
+    ("normal", FontStretch::from_css_str("normal").unwrap()),
     (
       "semi-expanded",
-      FontStretch::from_str("semi-expanded").unwrap(),
+      FontStretch::from_css_str("semi-expanded").unwrap(),
     ),
-    ("expanded", FontStretch::from_str("expanded").unwrap()),
+    ("expanded", FontStretch::from_css_str("expanded").unwrap()),
     (
       "ultra-expanded",
-      FontStretch::from_str("ultra-expanded").unwrap(),
+      FontStretch::from_css_str("ultra-expanded").unwrap(),
     ),
   ];
 
@@ -1102,7 +1102,7 @@ fn text_font_stretch() {
     })
     .collect::<Vec<_>>();
 
-  let Ok(family) = FontFamily::from_str("Archivo") else {
+  let Ok(family) = FontFamily::from_css_str("Archivo") else {
     unreachable!()
   };
 
@@ -1131,7 +1131,7 @@ fn text_flex_centered_text_node_vs_nested_container() {
       .with(StyleDeclaration::height(Px(200.0)))
       .with_margin(Sides([Px(0.0), Px(0.0), Px(30.0), Px(0.0)]))
       .with(StyleDeclaration::background_color(ColorInput::Value(
-        Color::from_str("#3b82f6").unwrap(),
+        Color::from_css_str("#3b82f6").unwrap(),
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::align_items(AlignItems::Center))
@@ -1146,7 +1146,7 @@ fn text_flex_centered_text_node_vs_nested_container() {
         .with(StyleDeclaration::width(Px(300.0)))
         .with(StyleDeclaration::height(Px(200.0)))
         .with(StyleDeclaration::background_color(ColorInput::Value(
-          Color::from_str("#ab82f6").unwrap(),
+          Color::from_css_str("#ab82f6").unwrap(),
         )))
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::align_items(AlignItems::Center))
@@ -1181,7 +1181,7 @@ fn text_flex_centered_text_node_vs_nested_container() {
 
 #[test]
 fn text_font_synthesis_weight_auto_none() {
-  let Ok(family) = FontFamily::from_str("Scheherazade New Test") else {
+  let Ok(family) = FontFamily::from_css_str("Scheherazade New Test") else {
     unreachable!()
   };
 
@@ -1216,7 +1216,7 @@ fn text_font_synthesis_weight_auto_none() {
 
 #[test]
 fn text_font_synthesis_style_auto_none() {
-  let Ok(family) = FontFamily::from_str("Scheherazade New Test") else {
+  let Ok(family) = FontFamily::from_css_str("Scheherazade New Test") else {
     unreachable!()
   };
 
@@ -1251,7 +1251,7 @@ fn text_font_synthesis_style_auto_none() {
 
 #[test]
 fn text_font_synthesis_weight_emoji() {
-  let Ok(family) = FontFamily::from_str("Scheherazade New Test") else {
+  let Ok(family) = FontFamily::from_css_str("Scheherazade New Test") else {
     unreachable!()
   };
 
@@ -1298,7 +1298,7 @@ fn text_font_synthesis_weight_emoji() {
 fn text_chinese_ellipsis() {
   let text = "日本利用壓電磁磚將腳步轉化為電能。這些瓷磚捕捉來自你腳步的動能。當你行走時，你的重量和動作會對瓷磚產生壓力。磁磚會輕微彎曲，從而產生機械應力。磁磚內部的壓電材料將這種應力轉化為電能。每一步都會產生少量電荷，而數百萬步結合在一起就能產生足夠的電力來驅動 LED燈、數位顯示器和感測器。在像澀谷車站這樣繁忙的地方，每天大約有240萬個腳步為此系統作出貢獻。這些電能可以被儲存或立即使用，從而減少對傳統電賴，並支持永續的城市基礎設施。這種方法將日常運動轉化為實用的再生能源。";
 
-  let Ok(family) = FontFamily::from_str("Noto Sans TC") else {
+  let Ok(family) = FontFamily::from_css_str("Noto Sans TC") else {
     unreachable!()
   };
 
@@ -1324,7 +1324,7 @@ fn text_devanagari_noto_sans() {
   fn create_node(weight: f32, font_family: &str) -> Node {
     let text = "नमस्ते दुनिया, यह देवनागरी लिपि का एक परीक्षण है।";
 
-    let Ok(family) = FontFamily::from_str(font_family) else {
+    let Ok(family) = FontFamily::from_css_str(font_family) else {
       unreachable!()
     };
 

--- a/takumi/tests/font_tests.rs
+++ b/takumi/tests/font_tests.rs
@@ -5,7 +5,6 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use parley::fontique::FontInfoOverride;
 use takumi::{prelude::*, render};
 
 fn font_path(path: &str) -> PathBuf {
@@ -29,8 +28,8 @@ fn register_subset(fonts: &mut Fonts, path: &str, unique_name: &str, logical: &s
   fonts
     .register(
       FontResource::new(read_font(path))
-        .override_info(FontInfoOverride {
-          family_name: Some(unique_name),
+        .override_info(FontOverride {
+          family_name: Some(unique_name.into()),
           ..Default::default()
         })
         .generic_family(GenericFamily::SANS_SERIF)
@@ -46,7 +45,7 @@ fn render_devanagari(fonts: &Fonts, family: &str) -> Bitmap {
         72.0,
       ))))
       .with(StyleDeclaration::font_family(
-        FontFamily::from_str(family).unwrap(),
+        FontFamily::from_css_str(family).unwrap(),
       )),
   );
 

--- a/takumi/tests/svg_render.rs
+++ b/takumi/tests/svg_render.rs
@@ -80,7 +80,7 @@ fn solid_background_renders_as_fill() {
 
 #[test]
 fn linear_gradient_endpoints_match_stops() {
-  let images = BackgroundImages::from_str("linear-gradient(to right, #ff0000, #0000ff)")
+  let images = BackgroundImages::from_css_str("linear-gradient(to right, #ff0000, #0000ff)")
     .expect("parse gradient");
   let node = full_container([StyleDeclaration::background_image(Some(images))]);
   let pixmap = rasterize(node, &context());

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -7,7 +7,6 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use parley::fontique::FontInfoOverride;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use takumi::{
   encode_animated_gif, encode_animated_png, encode_animated_webp, prelude::*, render, write_image,
@@ -93,8 +92,8 @@ fn create_test_context() -> Fonts {
     context
       .register(
         FontResource::new(font_data)
-          .override_info(FontInfoOverride {
-            family_name: Some(name),
+          .override_info(FontOverride {
+            family_name: Some((*name).into()),
             ..Default::default()
           })
           .generic_family(*generic),


### PR DESCRIPTION
## Why

The 2.0 stable release must not leak external 0.x crate types through the public API. When `cssparser`, `parley`, `tiny_skia`, `image`, or `smallvec` show up in a public signature, every consumer locks to that exact version and breaks the moment two versions coexist in the dependency graph.

## What

- Seal `cssparser`: `FromCss` and its companions are `pub(crate)`; parse CSS value strings through a new public `FromCssStr` trait that returns an owned `ParseError`.
- Value-list types (`Filters`, `GridTemplateComponents`, `BackgroundImages`, `BackgroundSizes`, `BackgroundRepeats`, `PositionValues`) are plain `Vec`/`Box<[_]>` aliases; the `declare_value_list` macro is gone.
- Seal `parley` from the font API: `FontResource::override_info` takes an owned `FontOverride`, and `FontSource` is an opaque struct over raw bytes.
- Move gradient tile, LUT, and transfer-table paint helpers into `takumi_css::paint`; the raster and SVG backends depend on `takumi-css` directly instead of re-exporting through `takumi-core`.
- Drop the public `From<Color>` conversions to `image::Rgba` and `tiny_skia::PremultipliedColorU8`, and keep `smallvec` off the declaration-block API.
- Mark the spec-tracking CSS value enums `#[non_exhaustive]`.
- JS: restore the format tagged union on `render` options with a distributive `Omit`.
- Update the v2 upgrade guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated paint API for rendering helpers (gradient/filter related), accessible across backends.
  * Expanded CSS-string parsing support with a unified `from_css_str` approach for many style values.
* **Bug Fixes**
  * Improved rendering consistency by standardizing premultiplied color handling and strengthening default behaviors for unhandled enum cases.
  * Updated font override and font loading to use the new override/source types and stricter CSS parsing (invalid inputs now error instead of silently defaulting).
  * Marked key CSS enums as non-exhaustive for safer forward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->