### PR TITLE
Core: seal foreign types out of the public API, hide internals

### DIFF
--- a/.tegami/drop-image-response-wasm-subpath.md
+++ b/.tegami/drop-image-response-wasm-subpath.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:@takumi-rs/image-response:
+    type: patch
+---
+
+### Drop the `./wasm` export
+
+`@takumi-rs/image-response/wasm` aliased the same file as the root entry. Import from
+`@takumi-rs/image-response`.

--- a/.tegami/hide-internal-style-items.md
+++ b/.tegami/hide-internal-style-items.md
@@ -1,0 +1,13 @@
+---
+packages:
+  cargo:takumi-core: minor
+---
+
+### Hide internal style/layout items from the public API
+
+Roughly 200 CSS value types, parsing helpers, and internal accessors across `style::properties`,
+`style::stylesheets`, `style::tw`, `style::selector`, and `layout` are now crate-private; they were
+never meant to be constructed or matched on directly. `StyleSheet::property_rules` and
+`apply_stylesheet_animations` are crate-private; use `StyleSheet`'s public parsing/query surface
+instead. Gradient direction/keyword helpers (`GradientKeywordDirection`, `HorizontalKeyword`,
+`VerticalKeyword`) stay public since they're reachable through `LinearGradientDirection`.

--- a/.tegami/rename-resource-to-image.md
+++ b/.tegami/rename-resource-to-image.md
@@ -1,0 +1,10 @@
+---
+packages:
+  cargo:takumi-core: minor
+---
+
+### Rename `resource` naming to `image`
+
+`Node::resource_urls`/`Style::resource_urls`/`StyleDeclarationBlock::resource_urls` are now
+`image_urls`, and `ImageResourceError` is now `ImageError` — everything they cover is image
+loading, so the names say so.

--- a/.tegami/seal-taffy-in-public-api.md
+++ b/.tegami/seal-taffy-in-public-api.md
@@ -1,0 +1,16 @@
+---
+packages:
+  cargo:takumi-core: minor
+---
+
+### Remove taffy/parley/image types from the public API
+
+`Affine::transform_point`, `ComputedStyle::local_transform`/`has_non_identity_transform`,
+`OffsetAnchor::resolve`, `PositionValue::to_point`, and `BorderRadiusPair::to_px` now take
+separate `width`/`height` (or `x`/`y`) `f32` params and return tuples instead of `taffy::Point`/
+`taffy::Size`. `Affine::decompose_translation` is removed; read `.x`/`.y` directly.
+`SizingContext::container_size` is private; use the new `set_container_size` setter.
+`ComputedStyle::to_taffy_style`/`creates_stacking_context`, `LineHeight::into_parley`,
+`Float::resolve`/`Clear::resolve` are now crate-private. Dropped the `From<image::RgbaImage>`
+impls for `ImageSource`/`ImageData`; convert through `ImageBuffer::from_rgba` instead.
+`style::fast_div_255`/`fast_div_255_u32` moved under `style::math`.

--- a/docs/content/docs/upgrade/v1.mdx
+++ b/docs/content/docs/upgrade/v1.mdx
@@ -134,13 +134,13 @@ let viewport = Viewport::new((800, 600)); // [!code ++]
 
 ### Removed Rust APIs
 
-| Removed                         | Replacement                                                                   |
-| ------------------------------- | ----------------------------------------------------------------------------- |
-| `parse_svg_str(data)`           | `SvgSource::from_str(data)`                                                   |
-| `FetchTaskCollection`           | `Node::image_urls` / `Style::image_urls`, then feed URLs back to the renderer |
-| `SpacePair::from_reversed_pair` | Construct `SpacePair` with values in order                                    |
-| `TakumiError` re-export         | `takumi::prelude::Error` (or `takumi_core::error::Error`)                     |
-| `detailed_css_error` feature    | Detailed CSS errors always on; no feature flag                                |
+| Removed                         | Replacement                                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `parse_svg_str(data)`           | `SvgSource::from_str(data)`                                                         |
+| `FetchTaskCollection`           | `Node::resource_urls` / `Style::resource_urls`, then feed URLs back to the renderer |
+| `SpacePair::from_reversed_pair` | Construct `SpacePair` with values in order                                          |
+| `TakumiError` re-export         | `takumi::prelude::Error` (or `takumi_core::error::Error`)                           |
+| `detailed_css_error` feature    | Detailed CSS errors always on; no feature flag                                      |
 
 ```rust
 use takumi::TakumiError; // [!code --]

--- a/docs/content/docs/upgrade/v1.mdx
+++ b/docs/content/docs/upgrade/v1.mdx
@@ -134,13 +134,13 @@ let viewport = Viewport::new((800, 600)); // [!code ++]
 
 ### Removed Rust APIs
 
-| Removed                         | Replacement                                                                         |
-| ------------------------------- | ----------------------------------------------------------------------------------- |
-| `parse_svg_str(data)`           | `SvgSource::from_str(data)`                                                         |
-| `FetchTaskCollection`           | `Node::resource_urls` / `Style::resource_urls`, then feed URLs back to the renderer |
-| `SpacePair::from_reversed_pair` | Construct `SpacePair` with values in order                                          |
-| `TakumiError` re-export         | `takumi::prelude::Error` (or `takumi_core::error::Error`)                           |
-| `detailed_css_error` feature    | Detailed CSS errors always on; no feature flag                                      |
+| Removed                         | Replacement                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------- |
+| `parse_svg_str(data)`           | `SvgSource::from_str(data)`                                                   |
+| `FetchTaskCollection`           | `Node::image_urls` / `Style::image_urls`, then feed URLs back to the renderer |
+| `SpacePair::from_reversed_pair` | Construct `SpacePair` with values in order                                    |
+| `TakumiError` re-export         | `takumi::prelude::Error` (or `takumi_core::error::Error`)                     |
+| `detailed_css_error` feature    | Detailed CSS errors always on; no feature flag                                |
 
 ```rust
 use takumi::TakumiError; // [!code --]

--- a/docs/content/docs/upgrade/v2.mdx
+++ b/docs/content/docs/upgrade/v2.mdx
@@ -246,7 +246,7 @@ With the image store gone, the render context holds only fonts. Build a `Fonts`,
 let mut global = GlobalContext::default(); // [!code --]
 global.font_context.load_and_store(FontResource::new(font_bytes)); // [!code --]
 let mut fonts = Fonts::default(); // [!code ++]
-fonts.register(FontResource::new(font_bytes)).unwrap(); // [!code ++]
+fonts.register(FontResource::new(font_bytes))?; // [!code ++]
 
 let options = RenderOptions::builder()
   .viewport(viewport)
@@ -283,12 +283,14 @@ renderer.render(node, { format: "webp", lossless: true }); // napi only
 
 ### Renamed entry points
 
-| v1                                      | v2                       | Note                                                                             |
-| --------------------------------------- | ------------------------ | -------------------------------------------------------------------------------- |
-| `measure_layout`                        | `measure`                | Returns a `MeasuredNode`.                                                        |
-| `render_sequence_animation`             | `render_animation`       | Matches the JS binding.                                                          |
-| `render` -> `image::RgbaImage`          | `render` -> `Bitmap`     | Reach pixels with `bitmap.as_raw()` / `into_raw()`, or pass it to `write_image`. |
-| `render_for_layout(..., current_color)` | `render_for_layout(...)` | The `current_color` argument is dropped.                                         |
+| v1                                             | v2                       | Note                                                                             |
+| ---------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------- |
+| `measure_layout`                               | `measure`                | Returns a `MeasuredNode`.                                                        |
+| `render_sequence_animation`                    | `render_animation`       | Matches the JS binding.                                                          |
+| `render` -> `image::RgbaImage`                 | `render` -> `Bitmap`     | Reach pixels with `bitmap.as_raw()` / `into_raw()`, or pass it to `write_image`. |
+| `render_for_layout(..., current_color)`        | `render_for_layout(...)` | The `current_color` argument is dropped.                                         |
+| `Node::resource_urls` / `Style::resource_urls` | `image_urls`             | The URLs they collect are all images.                                            |
+| `ImageResourceError`                           | `ImageError`             | Matches `FontError`.                                                             |
 
 ```rust
 let measured = measure_layout(options)?; // [!code --]

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
   keyframes::KeyframePreludeParseError,
-  resources::{font::FontError, image::ImageResourceError},
+  resources::{font::FontError, image::ImageError},
 };
 
 /// Structured errors raised by the WebP encoding and container assembly paths.
@@ -90,7 +90,7 @@ pub enum WebPError {
 pub enum Error {
   /// Error resolving an image resource.
   #[error("Image resolution error: {0}")]
-  ImageResolveError(#[from] ImageResourceError),
+  ImageResolveError(#[from] ImageError),
 
   /// Standard IO error.
   #[error("IO error: {0}")]
@@ -265,47 +265,47 @@ impl<'i> From<KeyframePreludeParseError<'i>> for StyleSheetParseError {
 
 impl StyleSheetParseError {
   /// Builds an invalid-stylesheet error from a reason string.
-  pub fn invalid_reason(reason: impl Into<String>) -> Self {
+  pub(crate) fn invalid_reason(reason: impl Into<String>) -> Self {
     Self::new(StyleSheetParseErrorKind::InvalidStyleSheet(reason.into()))
   }
 
   /// Error for an unsupported media feature.
-  pub fn unsupported_media_feature() -> Self {
+  pub(crate) fn unsupported_media_feature() -> Self {
     Self::new(StyleSheetParseErrorKind::UnsupportedMediaFeature)
   }
 
   /// Error for a non-boolean `@property` `inherits` descriptor.
-  pub fn property_inherits_must_be_boolean() -> Self {
+  pub(crate) fn property_inherits_must_be_boolean() -> Self {
     Self::new(StyleSheetParseErrorKind::PropertyInheritsMustBeBoolean)
   }
 
   /// Error for a `@property` missing its `syntax` descriptor.
-  pub fn missing_property_syntax() -> Self {
+  pub(crate) fn missing_property_syntax() -> Self {
     Self::new(StyleSheetParseErrorKind::MissingPropertySyntax)
   }
 
   /// Error for a `@property` missing its `inherits` descriptor.
-  pub fn missing_property_inherits() -> Self {
+  pub(crate) fn missing_property_inherits() -> Self {
     Self::new(StyleSheetParseErrorKind::MissingPropertyInherits)
   }
 
   /// Error for `@supports` mixing `and`/`or` without parentheses.
-  pub fn supports_mixed_and_or_without_parentheses() -> Self {
+  pub(crate) fn supports_mixed_and_or_without_parentheses() -> Self {
     Self::new(StyleSheetParseErrorKind::SupportsMixedAndOrWithoutParentheses)
   }
 
   /// Error for a `@property` name that is not a custom property.
-  pub fn property_name_must_be_custom_property() -> Self {
+  pub(crate) fn property_name_must_be_custom_property() -> Self {
     Self::new(StyleSheetParseErrorKind::PropertyNameMustBeCustomProperty)
   }
 
   /// Error for an `@layer` block naming more than one layer.
-  pub fn layer_block_multiple_names() -> Self {
+  pub(crate) fn layer_block_multiple_names() -> Self {
     Self::new(StyleSheetParseErrorKind::LayerBlockMultipleNames)
   }
 
   /// Error for an unsupported nested at-rule.
-  pub fn unsupported_nested_at_rule() -> Self {
+  pub(crate) fn unsupported_nested_at_rule() -> Self {
     Self::new(StyleSheetParseErrorKind::UnsupportedNestedAtRule)
   }
 
@@ -324,7 +324,10 @@ impl StyleSheetParseError {
   }
 
   /// Converts a `cssparser` parse error into a stylesheet error with context.
-  pub fn from_parse_error(context: &str, error: ParseError<'_, StyleSheetParseError>) -> Self {
+  pub(crate) fn from_parse_error(
+    context: &str,
+    error: ParseError<'_, StyleSheetParseError>,
+  ) -> Self {
     match error.kind {
       ParseErrorKind::Basic(error) => Self::invalid_reason(format!("{error:?}")),
       ParseErrorKind::Custom(error) => error,

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -12,30 +12,21 @@ pub fn transformed_rect_extents(
   transform: Affine,
 ) -> Option<(f32, f32, f32, f32)> {
   let corners = [
-    transform.transform_point(origin),
-    transform.transform_point(Point {
-      x: origin.x + size.width,
-      y: origin.y,
-    }),
-    transform.transform_point(Point {
-      x: origin.x,
-      y: origin.y + size.height,
-    }),
-    transform.transform_point(Point {
-      x: origin.x + size.width,
-      y: origin.y + size.height,
-    }),
+    transform.transform_point(origin.x, origin.y),
+    transform.transform_point(origin.x + size.width, origin.y),
+    transform.transform_point(origin.x, origin.y + size.height),
+    transform.transform_point(origin.x + size.width, origin.y + size.height),
   ];
 
   let mut min_x = f32::INFINITY;
   let mut min_y = f32::INFINITY;
   let mut max_x = f32::NEG_INFINITY;
   let mut max_y = f32::NEG_INFINITY;
-  for point in corners {
-    min_x = min_x.min(point.x);
-    min_y = min_y.min(point.y);
-    max_x = max_x.max(point.x);
-    max_y = max_y.max(point.y);
+  for (x, y) in corners {
+    min_x = min_x.min(x);
+    min_y = min_y.min(y);
+    max_x = max_x.max(x);
+    max_y = max_y.max(y);
   }
 
   if !min_x.is_finite() || !min_y.is_finite() || !max_x.is_finite() || !max_y.is_finite() {

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -75,22 +75,26 @@ impl BorderProperties {
     context: &RenderContext,
     border_box: Size<f32>,
   ) -> Sides<SpacePair<f32>> {
-    let top_left = context
-      .style
-      .border_top_left_radius
-      .to_px(&context.sizing, border_box);
-    let top_right = context
-      .style
-      .border_top_right_radius
-      .to_px(&context.sizing, border_box);
-    let bottom_right = context
-      .style
-      .border_bottom_right_radius
-      .to_px(&context.sizing, border_box);
-    let bottom_left = context
-      .style
-      .border_bottom_left_radius
-      .to_px(&context.sizing, border_box);
+    let top_left = context.style.border_top_left_radius.to_px(
+      &context.sizing,
+      border_box.width,
+      border_box.height,
+    );
+    let top_right = context.style.border_top_right_radius.to_px(
+      &context.sizing,
+      border_box.width,
+      border_box.height,
+    );
+    let bottom_right = context.style.border_bottom_right_radius.to_px(
+      &context.sizing,
+      border_box.width,
+      border_box.height,
+    );
+    let bottom_left = context.style.border_bottom_left_radius.to_px(
+      &context.sizing,
+      border_box.width,
+      border_box.height,
+    );
 
     Sides([top_left, top_right, bottom_right, bottom_left])
   }

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -212,7 +212,7 @@ pub(crate) enum InlineContentKind<'c> {
 }
 
 /// Parley layout specialized to [`InlineBrush`].
-pub type InlineLayout = parley::Layout<InlineBrush>;
+pub(crate) type InlineLayout = parley::Layout<InlineBrush>;
 
 #[derive(Clone, Copy, Debug)]
 /// x-height and ascent/descent of the parent font.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2341,9 +2341,9 @@ fn make_ellipsis_layout<'c>(
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
-  use super::*;
   use std::{fs::File, io::Read, path::Path};
 
+  use super::*;
   use crate::{
     Fonts,
     context::RenderContext,

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -195,12 +195,10 @@ pub fn resolve_image(src: &str, context: &RenderContext) -> ImageResult {
 
 #[cfg(test)]
 mod tests {
-  use std::assert_matches;
+  use std::{assert_matches, borrow::Cow};
 
-  use crate::style::SizingContext;
   use image::RgbaImage;
   use serde_json::from_value;
-  use std::borrow::Cow;
   use taffy::{AvailableSpace, Dimension, Size, Style};
 
   use super::{image_url, measure_image_node};
@@ -209,6 +207,7 @@ mod tests {
     context::RenderContext,
     layout::node::{ImageData, ImageSourceInput},
     resources::{image::ImageSource, image_buffer::ImageBuffer},
+    style::SizingContext,
     viewport::Viewport,
   };
 

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -5,11 +5,11 @@ use taffy::{AvailableSpace, CompactLength, MaybeResolve, Size};
 use crate::{
   context::RenderContext,
   layout::node::{ImageData, ImageSourceInput, Node, NodeStyleLayers},
-  resources::image::{ImageResourceError, ImageResult, ImageSource, is_svg_like},
+  resources::image::{ImageError, ImageResult, ImageSource, is_svg_like},
   style::{Length, Style, StyleDeclaration},
 };
 
-pub(crate) fn image_resource_url(image: &ImageData) -> Option<&str> {
+pub(crate) fn image_url(image: &ImageData) -> Option<&str> {
   match &image.src {
     ImageSourceInput::Url(src) if src.starts_with("https://") || src.starts_with("http://") => {
       Some(src.as_ref())
@@ -165,10 +165,10 @@ fn resolve_style_size_axis(
 const DATA_URI_PREFIX: &str = "data:";
 
 fn parse_data_uri_image(src: &str) -> ImageResult {
-  let url = DataUrl::process(src).map_err(|_| ImageResourceError::InvalidDataUriFormat)?;
+  let url = DataUrl::process(src).map_err(|_| ImageError::InvalidDataUriFormat)?;
   let (data, _) = url
     .decode_to_vec()
-    .map_err(|_| ImageResourceError::InvalidDataUriFormat)?;
+    .map_err(|_| ImageError::InvalidDataUriFormat)?;
 
   ImageSource::from_bytes(&data)
 }
@@ -183,14 +183,14 @@ pub fn resolve_image(src: &str, context: &RenderContext) -> ImageResult {
     #[cfg(feature = "svg")]
     return ImageSource::from_bytes(src.as_bytes());
     #[cfg(not(feature = "svg"))]
-    return Err(ImageResourceError::SvgParseNotSupported);
+    return Err(ImageError::SvgParseNotSupported);
   }
 
   if let Some(img) = context.images.get(src) {
     return Ok(img.clone());
   }
 
-  Err(ImageResourceError::Unknown)
+  Err(ImageError::Unknown)
 }
 
 #[cfg(test)]
@@ -200,14 +200,15 @@ mod tests {
   use crate::style::SizingContext;
   use image::RgbaImage;
   use serde_json::from_value;
+  use std::borrow::Cow;
   use taffy::{AvailableSpace, Dimension, Size, Style};
 
-  use super::{image_resource_url, measure_image_node};
+  use super::{image_url, measure_image_node};
   use crate::{
     Fonts,
     context::RenderContext,
     layout::node::{ImageData, ImageSourceInput},
-    resources::image::ImageSource,
+    resources::{image::ImageSource, image_buffer::ImageBuffer},
     viewport::Viewport,
   };
 
@@ -225,7 +226,7 @@ mod tests {
 
     assert_eq!(src.as_ref(), "https://example.com/image.png");
     assert_eq!(
-      image_resource_url(&ImageData {
+      image_url(&ImageData {
         src: ImageSourceInput::Url(src),
         width: None,
         height: None
@@ -250,7 +251,7 @@ mod tests {
 
     assert_eq!(&data[..], [137, 80, 78, 71]);
     assert_eq!(
-      image_resource_url(&ImageData {
+      image_url(&ImageData {
         src: ImageSourceInput::Buffer(data),
         width: None,
         height: None
@@ -302,7 +303,8 @@ mod tests {
   #[test]
   fn from_pixmap_creates_loaded_image_source_input() {
     let bitmap = RgbaImage::new(2, 2);
-    let image = ImageData::from(bitmap);
+    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap();
+    let image = ImageData::from(buffer);
 
     assert_matches!(image.src, ImageSourceInput::Loaded(ImageSource::Bitmap(_)));
   }
@@ -318,7 +320,8 @@ mod tests {
           .build(),
       )
       .build();
-    let image = ImageData::from(ImageSource::from(RgbaImage::new(10, 10)));
+    let buffer = ImageBuffer::from_rgba(Cow::Owned(RgbaImage::new(10, 10))).unwrap();
+    let image = ImageData::from(ImageSource::from(buffer));
     let style = Style {
       size: Size {
         width: Dimension::length(42.0),

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -10,12 +10,11 @@ use taffy::{AvailableSpace, Size};
 use crate::{
   Xxh3HashSet,
   context::RenderContext,
-  layout::{inline::InlineContentKind, node::image::image_resource_url},
+  layout::{inline::InlineContentKind, node::image::image_url},
   resources::image::{ImageResult, ImageSource},
   style::{Direction, Style, StyleDeclaration, ToCss, tw::TailwindValues},
   viewport::Viewport,
 };
-use ::image::RgbaImage;
 use parley::Language;
 
 use self::{
@@ -162,12 +161,6 @@ impl From<ImageSource> for ImageData {
 impl From<ImageBuffer> for ImageData {
   fn from(buffer: ImageBuffer) -> Self {
     Self::from(ImageSource::from(buffer))
-  }
-}
-
-impl From<RgbaImage> for ImageData {
-  fn from(bitmap: RgbaImage) -> Self {
-    Self::from(ImageSource::from(bitmap))
   }
 }
 
@@ -560,7 +553,7 @@ impl Node {
   }
 
   /// Collects resource URLs referenced by this node tree.
-  pub(crate) fn metadata_resource_urls<'a>(&'a self, urls: &mut Xxh3HashSet<&'a str>) {
+  pub(crate) fn metadata_image_urls<'a>(&'a self, urls: &mut Xxh3HashSet<&'a str>) {
     match &self.kind {
       NodeKind::Container { .. } => {
         let Some(children) = self.children_ref() else {
@@ -568,11 +561,11 @@ impl Node {
         };
 
         for child in children {
-          child.metadata_resource_urls(urls);
+          child.metadata_image_urls(urls);
         }
       }
       NodeKind::Image(image) => {
-        if let Some(url) = image_resource_url(image) {
+        if let Some(url) = image_url(image) {
           urls.insert(url);
         }
       }
@@ -581,17 +574,17 @@ impl Node {
   }
 
   /// Collects resource URLs referenced by this node tree's styles.
-  pub(crate) fn style_resource_urls<'a>(&'a self, urls: &mut Xxh3HashSet<&'a str>) {
+  pub(crate) fn style_image_urls<'a>(&'a self, urls: &mut Xxh3HashSet<&'a str>) {
     if let Some(preset) = self.metadata.preset.as_ref() {
-      urls.extend(preset.resource_urls());
+      urls.extend(preset.image_urls());
     }
 
     if let Some(author_tw) = self.metadata.tw.as_ref() {
-      urls.extend(author_tw.resource_urls(Viewport::default()));
+      urls.extend(author_tw.image_urls(Viewport::default()));
     }
 
     if let Some(inline) = self.metadata.style.as_ref() {
-      urls.extend(inline.resource_urls());
+      urls.extend(inline.image_urls());
     }
 
     let Some(children) = self.children_ref() else {
@@ -599,15 +592,15 @@ impl Node {
     };
 
     for child in children {
-      child.style_resource_urls(urls);
+      child.style_image_urls(urls);
     }
   }
 
   /// Collects unique resource URLs referenced by this node tree and styles.
-  pub fn resource_urls(&self) -> impl Iterator<Item = &str> {
+  pub fn image_urls(&self) -> impl Iterator<Item = &str> {
     let mut urls = Xxh3HashSet::default();
-    self.metadata_resource_urls(&mut urls);
-    self.style_resource_urls(&mut urls);
+    self.metadata_image_urls(&mut urls);
+    self.style_image_urls(&mut urls);
 
     urls.into_iter()
   }
@@ -695,7 +688,7 @@ mod tests {
     ))]);
 
     let mut urls = Xxh3HashSet::default();
-    node.style_resource_urls(&mut urls);
+    node.style_image_urls(&mut urls);
 
     assert_eq!(urls.into_iter().collect::<Vec<_>>(), vec![background_url]);
   }
@@ -716,7 +709,7 @@ mod tests {
       .with_tw(tw);
 
     let mut urls = Xxh3HashSet::default();
-    node.style_resource_urls(&mut urls);
+    node.style_image_urls(&mut urls);
 
     let tasks = urls.into_iter().collect::<Vec<_>>();
 
@@ -732,7 +725,7 @@ mod tests {
     let node = Node::container([]).with_tw(tw);
 
     let mut urls = Xxh3HashSet::default();
-    node.style_resource_urls(&mut urls);
+    node.style_image_urls(&mut urls);
 
     assert_eq!(urls.into_iter().collect::<Vec<_>>(), vec![mask_url]);
   }

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -2,21 +2,13 @@ mod container;
 mod image;
 mod text;
 
-use crate::{matching::MatchableNode, resources::image_buffer::ImageBuffer};
-use serde::Deserialize;
 use std::{collections::BTreeMap, sync::Arc};
+
+use parley::Language;
+use serde::Deserialize;
 use taffy::{AvailableSpace, Size};
 
-use crate::{
-  Xxh3HashSet,
-  context::RenderContext,
-  layout::{inline::InlineContentKind, node::image::image_url},
-  resources::image::{ImageResult, ImageSource},
-  style::{Direction, Style, StyleDeclaration, ToCss, tw::TailwindValues},
-  viewport::Viewport,
-};
-use parley::Language;
-
+pub use self::image::resolve_image;
 use self::{
   container::{
     container_children_ref, deserialize_children, drop_container_children, take_container_children,
@@ -24,8 +16,18 @@ use self::{
   image::{measure_image_node, take_image_style_layers},
   text::measure_text_node,
 };
-
-pub use self::image::resolve_image;
+use crate::{
+  Xxh3HashSet,
+  context::RenderContext,
+  layout::{inline::InlineContentKind, node::image::image_url},
+  matching::MatchableNode,
+  resources::{
+    image::{ImageResult, ImageSource},
+    image_buffer::ImageBuffer,
+  },
+  style::{Direction, Style, StyleDeclaration, ToCss, tw::TailwindValues},
+  viewport::Viewport,
+};
 
 /// Shared metadata stored by every renderable node.
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -674,9 +676,8 @@ impl MatchableNode for Node {
 mod tests {
   use std::str::FromStr;
 
-  use crate::style::{BackgroundImage, Style, StyleDeclaration, tw::TailwindValues};
-
   use super::*;
+  use crate::style::{BackgroundImage, Style, StyleDeclaration, tw::TailwindValues};
 
   #[test]
   fn collect_style_fetch_tasks_collects_nested_background_image_urls() {
@@ -735,10 +736,9 @@ mod tests {
 mod matching_tests {
   use std::collections::BTreeMap;
 
-  use crate::matching::{MatchedDeclarationsView, match_stylesheets_view};
-
   use crate::{
     layout::node::Node,
+    matching::{MatchedDeclarationsView, match_stylesheets_view},
     style::{ComputedStyle, Length, Style, StyleSheet},
     viewport::Viewport,
   };

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, mem::take, vec::IntoIter};
 
+use parley::fontique::Attributes;
 use taffy::{
   AvailableSpace, BlockContext, Cache, CacheTree, Display as TaffyDisplay, Layout,
   LayoutBlockContainer, LayoutFlexboxContainer, LayoutGridContainer, LayoutInput, LayoutOutput,
@@ -28,7 +29,6 @@ use crate::{
   },
   viewport::Viewport,
 };
-use parley::fontique::Attributes;
 
 /// A render-tree child paired with its layout `NodeId`. `hoisted_cb` is set
 /// when the child is out-of-flow and was re-parented to a containing block in

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -51,8 +51,8 @@ pub mod paint {
       overlay_gradient_tile_fast_normal_unconstrained, resolve_stops_along_axis,
     },
     linear_gradient::{
-      LinearGradientFastPath, LinearGradientFastPathData, LinearGradientFastPathKind,
-      LinearGradientRowState, LinearGradientTile,
+      LinearGradientFastPath, LinearGradientFastPathKind, LinearGradientRowState,
+      LinearGradientTile,
     },
     radial_gradient::{RadialGradientRowState, RadialGradientTile},
   };

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -61,7 +61,6 @@ pub mod paint {
 use std::collections::HashSet;
 
 pub use error::{Error, Result};
-
 use xxhash_rust::xxh3::Xxh3DefaultBuilder;
 
 pub use crate::resources::font::Fonts;

--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -27,7 +27,7 @@ use crate::{
 ///
 /// Implemented by the caller's node type; the matcher only reads the queries
 /// below, so the caller does not depend on the `selectors` crate.
-pub trait MatchableNode {
+pub(crate) trait MatchableNode {
   /// The element's tag name, if any.
   fn tag_name(&self) -> Option<&str>;
   /// The element's `id`, if any.
@@ -350,7 +350,7 @@ impl<'a, N: MatchableNode> Element for ArenaElement<'a, N> {
 
 /// Declaration blocks that apply to one element, split by `!important`.
 #[derive(Debug, Default, Clone)]
-pub struct MatchedDeclarationsView<'a> {
+pub(crate) struct MatchedDeclarationsView<'a> {
   normal: SmallVec<[&'a StyleDeclarationBlock; 4]>,
   important: SmallVec<[&'a StyleDeclarationBlock; 4]>,
 }
@@ -362,7 +362,7 @@ impl<'a> MatchedDeclarationsView<'a> {
   }
 
   /// Matched declaration blocks marked `!important`, in cascade order.
-  pub fn important(&self) -> &[&'a StyleDeclarationBlock] {
+  pub(crate) fn important(&self) -> &[&'a StyleDeclarationBlock] {
     &self.important
   }
 }
@@ -370,7 +370,7 @@ impl<'a> MatchedDeclarationsView<'a> {
 /// Per-node matching result: the element's own declarations plus declarations
 /// for any matched `::before` / `::after` pseudo-elements.
 #[derive(Debug, Default, Clone)]
-pub struct NodeMatchedDeclarations<'a> {
+pub(crate) struct NodeMatchedDeclarations<'a> {
   element: MatchedDeclarationsView<'a>,
   before: Option<MatchedDeclarationsView<'a>>,
   after: Option<MatchedDeclarationsView<'a>>,
@@ -411,7 +411,7 @@ enum SelectorTarget {
 
 /// Matches every rule in `stylesheet` against the tree rooted at `root`,
 /// returning the declaration blocks that apply to each node in tree order.
-pub fn match_stylesheets_view<'a, N: MatchableNode>(
+pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
   root: &N,
   stylesheet: &'a StyleSheet,
   viewport: Viewport,

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -29,12 +29,11 @@ use skrifa::{
 use thiserror::Error;
 use tiny_skia::{IntSize, PathSegment as Command, Pixmap};
 
-use crate::style::FontStyle as CssFontStyle;
-
 use crate::{
   context::RenderContext,
   layout::inline::{InlineBrush, InlineLayout},
   resources::{image_buffer::ImageBuffer, image_decoder::decode_png},
+  style::FontStyle as CssFontStyle,
 };
 
 fn pixmap_from_image_buffer(buffer: ImageBuffer) -> Option<Pixmap> {

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -3,9 +3,8 @@
 //! This module provides types and utilities for managing image resources,
 //! including loading states, error handling, and image processing operations.
 
-use std::{borrow::Cow, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
-use image::RgbaImage;
 use quick_cache::{Weighter, sync::Cache};
 use serde::Deserialize;
 #[cfg(feature = "svg")]
@@ -22,7 +21,7 @@ use crate::{
 use thiserror::Error;
 
 /// Represents the state of an image resource.
-pub type ImageResult = Result<ImageSource, ImageResourceError>;
+pub(crate) type ImageResult = Result<ImageSource, ImageError>;
 
 #[derive(Debug, Clone)]
 /// Represents the source of an image.
@@ -90,9 +89,9 @@ struct GifFrame {
 }
 
 impl GifSource {
-  fn from_decoded(decoded: DecodedGif) -> Result<Self, ImageResourceError> {
+  fn from_decoded(decoded: DecodedGif) -> Result<Self, ImageError> {
     if decoded.frames.is_empty() {
-      return Err(ImageResourceError::InvalidGif);
+      return Err(ImageError::InvalidGif);
     }
 
     let mut frames = Vec::with_capacity(decoded.frames.len());
@@ -166,21 +165,6 @@ pub enum RenderedImage<'a> {
   },
 }
 
-impl From<RgbaImage> for ImageSource {
-  fn from(bitmap: RgbaImage) -> Self {
-    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap_or_else(|| {
-      let mut edge = 1_u32;
-      loop {
-        if let Some(buffer) = ImageBuffer::new(edge, edge) {
-          break buffer;
-        }
-        edge = edge.saturating_add(1);
-      }
-    });
-    ImageSource::Bitmap(Arc::new(buffer))
-  }
-}
-
 impl From<ImageBuffer> for ImageSource {
   fn from(buffer: ImageBuffer) -> Self {
     ImageSource::Bitmap(Arc::new(buffer))
@@ -222,7 +206,7 @@ type SvgRasterCache = Cache<SvgRasterCacheKey, Arc<ImageBuffer>>;
 
 #[cfg(feature = "svg")]
 impl FromStr for SvgSource {
-  type Err = ImageResourceError;
+  type Err = ImageError;
 
   fn from_str(src: &str) -> Result<Self, Self::Err> {
     use resvg::usvg::{Options, Tree};
@@ -235,11 +219,9 @@ impl FromStr for SvgSource {
       allow_dtd: true,
       ..Default::default()
     };
-    let document =
-      Document::parse_with_options(src, options).map_err(ImageResourceError::svg_parse)?;
+    let document = Document::parse_with_options(src, options).map_err(ImageError::svg_parse)?;
 
-    let tree =
-      Tree::from_xmltree(&document, &Options::default()).map_err(ImageResourceError::svg_parse)?;
+    let tree = Tree::from_xmltree(&document, &Options::default()).map_err(ImageError::svg_parse)?;
     let intrinsic = svg_intrinsic_sizing(document.root_element(), tree.size());
 
     Ok(SvgSource {
@@ -297,7 +279,7 @@ impl ImageSource {
       }
     }
 
-    let image = decode_image(bytes).map_err(ImageResourceError::decode)?;
+    let image = decode_image(bytes).map_err(ImageError::decode)?;
     let source = match image {
       DecodedImage::Buffer(buffer) => ImageSource::Bitmap(Arc::new(buffer)),
       DecodedImage::Gif(gif) => ImageSource::Gif(GifSource::from_decoded(gif)?),
@@ -316,7 +298,7 @@ impl ImageSource {
     height: u32,
     image_rendering: ImageScalingAlgorithm,
     time_ms: u64,
-  ) -> Result<RenderedImage<'i>, ImageResourceError> {
+  ) -> Result<RenderedImage<'i>, ImageError> {
     match self {
       ImageSource::Bitmap(bitmap) => Ok(RenderedImage::Borrowed {
         source: bitmap.as_ref(),
@@ -340,7 +322,7 @@ impl ImageSource {
         }
 
         let tree = &svg.tree;
-        let mut pixmap = Pixmap::new(width, height).ok_or(ImageResourceError::InvalidPixmapSize)?;
+        let mut pixmap = Pixmap::new(width, height).ok_or(ImageError::InvalidPixmapSize)?;
 
         let original_size = tree.size();
         let sx = width as f32 / original_size.width();
@@ -349,7 +331,7 @@ impl ImageSource {
         resvg::render(tree, Transform::from_scale(sx, sy), &mut pixmap.as_mut());
 
         let buffer = ImageBuffer::from_premultiplied_rgba(pixmap.data().to_vec(), width, height)
-          .ok_or(ImageResourceError::InvalidPixmapSize)?;
+          .ok_or(ImageError::InvalidPixmapSize)?;
         let buffer = Arc::new(buffer);
         svg.raster_cache.insert(cache_key, buffer.clone());
 
@@ -449,7 +431,7 @@ fn parse_viewbox_ratio(view_box: &str) -> Option<f32> {
 /// or if there was an error during the process.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum ImageResourceError {
+pub enum ImageError {
   /// An error occurred while decoding the image data
   #[error("An error occurred while decoding the image data: {0}")]
   DecodeError(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
@@ -481,7 +463,7 @@ pub enum ImageResourceError {
   InvalidGif,
 }
 
-impl ImageResourceError {
+impl ImageError {
   /// Wraps a decoder error opaquely so takumi's public API stays independent of
   /// the `image` crate's version.
   pub(crate) fn decode(err: impl std::error::Error + Send + Sync + 'static) -> Self {
@@ -660,7 +642,7 @@ mod image_cache_tests {
 mod tests {
   use std::{assert_matches, borrow::Cow};
 
-  use image::Rgba;
+  use image::{Rgba, RgbaImage};
 
   use super::*;
   use crate::resources::image_decoder::DecodedGifFrame;
@@ -767,7 +749,7 @@ mod tests {
   // color (matching browsers/satori); it renders as the SVG's own default, black.
   #[cfg(feature = "svg")]
   #[test]
-  fn svg_current_color_is_not_host_resolved() -> Result<(), ImageResourceError> {
+  fn svg_current_color_is_not_host_resolved() -> Result<(), ImageError> {
     let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect x="0" y="0" width="4" height="4" fill="currentColor"/></svg>"#;
     let image = ImageSource::from_bytes(svg.as_bytes())?;
 
@@ -779,7 +761,7 @@ mod tests {
 
   #[cfg(feature = "svg")]
   #[test]
-  fn svg_reuses_rasterized_pixmap() -> Result<(), ImageResourceError> {
+  fn svg_reuses_rasterized_pixmap() -> Result<(), ImageError> {
     let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect x="0" y="0" width="4" height="4" fill="#ff0000"/></svg>"##;
     let image: ImageSource = SvgSource::from_str(svg)?.into();
 
@@ -801,8 +783,8 @@ mod tests {
   /// them: the SVG renders identically with and without the text nodes.
   #[cfg(feature = "svg")]
   #[test]
-  fn svg_text_nodes_are_ignored_not_stripped() -> Result<(), ImageResourceError> {
-    fn rendered_data(svg: &str) -> Result<Vec<u8>, ImageResourceError> {
+  fn svg_text_nodes_are_ignored_not_stripped() -> Result<(), ImageError> {
+    fn rendered_data(svg: &str) -> Result<Vec<u8>, ImageError> {
       let image: ImageSource = SvgSource::from_str(svg)?.into();
       let rendered = image.render_for_layout(8, 8, ImageScalingAlgorithm::Auto, 0)?;
       let RenderedImage::Rasterized(pixmap) = rendered else {
@@ -821,7 +803,7 @@ mod tests {
   /// `<text>` inside `clipPath` and `foreignObject` must not break parsing.
   #[cfg(feature = "svg")]
   #[test]
-  fn svg_with_unsupported_nodes_still_parses() -> Result<(), ImageResourceError> {
+  fn svg_with_unsupported_nodes_still_parses() -> Result<(), ImageError> {
     let clip_path_text = r##"<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><clipPath id="c"><text>x</text></clipPath><rect width="8" height="8" fill="#ff0000" clip-path="url(#c)"/></svg>"##;
     let foreign_object = r##"<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><foreignObject width="8" height="8"><div xmlns="http://www.w3.org/1999/xhtml">x</div></foreignObject><rect width="8" height="8" fill="#ff0000"/></svg>"##;
 
@@ -831,11 +813,12 @@ mod tests {
   }
 
   #[test]
-  fn bitmap_renders_borrowed() -> Result<(), ImageResourceError> {
+  fn bitmap_renders_borrowed() -> Result<(), ImageError> {
     let mut bitmap = RgbaImage::new(2, 2);
     bitmap.put_pixel(0, 0, Rgba([12, 34, 56, 200]));
     bitmap.put_pixel(1, 0, Rgba([78, 90, 12, 255]));
-    let image = ImageSource::from(bitmap);
+    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap();
+    let image = ImageSource::from(buffer);
 
     let rendered = image.render_for_layout(2, 2, ImageScalingAlgorithm::Auto, 0)?;
 
@@ -844,14 +827,14 @@ mod tests {
   }
 
   #[test]
-  fn bitmap_render_for_layout_keeps_borrowed_sampling_parameters() -> Result<(), ImageResourceError>
-  {
+  fn bitmap_render_for_layout_keeps_borrowed_sampling_parameters() -> Result<(), ImageError> {
     let mut bitmap = RgbaImage::new(2, 2);
     bitmap.put_pixel(0, 0, Rgba([255, 0, 0, 255]));
     bitmap.put_pixel(1, 0, Rgba([0, 255, 0, 255]));
     bitmap.put_pixel(0, 1, Rgba([0, 0, 255, 255]));
     bitmap.put_pixel(1, 1, Rgba([255, 255, 255, 255]));
-    let image = ImageSource::from(bitmap);
+    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap();
+    let image = ImageSource::from(buffer);
 
     let rendered = image.render_for_layout(4, 4, ImageScalingAlgorithm::Pixelated, 0)?;
     let RenderedImage::Borrowed {
@@ -873,7 +856,7 @@ mod tests {
   #[test]
   fn gif_source_from_decoded_rejects_empty_frames() {
     let result = GifSource::from_decoded(DecodedGif { frames: Vec::new() });
-    assert_matches!(result, Err(ImageResourceError::InvalidGif));
+    assert_matches!(result, Err(ImageError::InvalidGif));
   }
 
   #[test]

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -7,6 +7,7 @@ use std::{str::FromStr, sync::Arc};
 
 use quick_cache::{Weighter, sync::Cache};
 use serde::Deserialize;
+use thiserror::Error;
 #[cfg(feature = "svg")]
 use tiny_skia::Pixmap;
 use xxhash_rust::xxh3::xxh3_64;
@@ -18,7 +19,6 @@ use crate::{
   },
   style::{ImageScalingAlgorithm, IntrinsicSizing, SizingContext},
 };
-use thiserror::Error;
 
 /// Represents the state of an image resource.
 pub(crate) type ImageResult = Result<ImageSource, ImageError>;

--- a/takumi-core/src/resources/image_buffer.rs
+++ b/takumi-core/src/resources/image_buffer.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 
 use image::{ExtendedColorType, ImageEncoder, RgbaImage, codecs::png::PngEncoder};
 
-use crate::style::fast_div_255;
+use crate::style::math::fast_div_255;
 
 /// A decoded image as premultiplied, row-major RGBA bytes.
 #[derive(Debug, Clone)]
@@ -32,6 +32,7 @@ impl ImageBuffer {
   }
 
   /// Allocates a transparent (all-zero) buffer of the given size.
+  #[cfg(test)]
   pub(crate) fn new(width: u32, height: u32) -> Option<Self> {
     let len = (width as usize)
       .checked_mul(height as usize)?

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -9,11 +9,10 @@ use image::{
   codecs::{gif::GifDecoder, jpeg::JpegDecoder, png::PngDecoder},
   error::{DecodingError, ImageFormatHint, UnsupportedError, UnsupportedErrorKind},
 };
-#[cfg(not(target_arch = "wasm32"))]
-use libwebp_sys::{WebPDecodeRGBA, WebPFree};
-
 #[cfg(target_arch = "wasm32")]
 use image_webp::WebPDecoder;
+#[cfg(not(target_arch = "wasm32"))]
+use libwebp_sys::{WebPDecodeRGBA, WebPFree};
 
 use crate::resources::image_buffer::ImageBuffer;
 

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -243,10 +243,11 @@ pub fn build_stacking_contexts(
 
     let mut current_transform = visit.transform;
     current_transform *= Affine::translation(layout.location.x, layout.location.y);
-    current_transform *= current
-      .context
-      .style
-      .local_transform(layout.size, &current.context.sizing);
+    current_transform *= current.context.style.local_transform(
+      layout.size.width,
+      layout.size.height,
+      &current.context.sizing,
+    );
     if !current_transform.is_invertible() {
       continue;
     }
@@ -271,7 +272,8 @@ pub fn build_stacking_contexts(
       true
     } else {
       current.context.style.creates_stacking_context(
-        layout.size,
+        layout.size.width,
+        layout.size.height,
         &current.context.sizing,
         is_flex_or_grid_item,
       ) || current

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -43,7 +43,7 @@ pub struct KeyframesRule {
 }
 
 /// Applies a stylesheet's matching animations to a style at the given time.
-pub fn apply_stylesheet_animations(
+pub(crate) fn apply_stylesheet_animations(
   mut base_style: ComputedStyle,
   stylesheet: &StyleSheet,
   time: u64,

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -1,10 +1,8 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, cmp::Ordering};
 
 use parley::{FontFeature, FontVariation};
-use std::cmp::Ordering;
-use typed_builder::TypedBuilder;
-
 use serde::Deserialize;
+use typed_builder::TypedBuilder;
 
 use crate::{
   style::{

--- a/takumi-core/src/style/calc.rs
+++ b/takumi-core/src/style/calc.rs
@@ -248,7 +248,7 @@ pub(crate) fn parse_calc_sum<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, 
 }
 
 /// Parses a `calc(...)` that must reduce to a unitless number.
-pub fn parse_calc_number_expression<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, f32> {
+pub(crate) fn parse_calc_number_expression<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, f32> {
   let location = input.current_source_location();
   let token = input.next()?.clone();
 

--- a/takumi-core/src/style/math.rs
+++ b/takumi-core/src/style/math.rs
@@ -1,3 +1,5 @@
+//! Small numeric helpers shared across style resolution and paint backends.
+
 /// Fast division by 255, returning a `u8`.
 #[inline(always)]
 pub fn fast_div_255(v: u32) -> u8 {

--- a/takumi-core/src/style/media_query.rs
+++ b/takumi-core/src/style/media_query.rs
@@ -1,5 +1,6 @@
-use cssparser::*;
 use std::rc::Rc;
+
+use cssparser::*;
 use taffy::Size;
 
 use crate::{

--- a/takumi-core/src/style/mod.rs
+++ b/takumi-core/src/style/mod.rs
@@ -1,7 +1,7 @@
 mod animation;
 mod calc;
 mod css_input;
-mod math;
+pub mod math;
 mod media_query;
 pub(crate) mod properties;
 pub(crate) mod selector;
@@ -11,11 +11,11 @@ mod supports;
 /// Tailwind utility-class parsing.
 pub mod tw;
 
-pub use animation::{KeyframeRule, KeyframesRule, apply_stylesheet_animations};
+pub(crate) use animation::apply_stylesheet_animations;
+pub use animation::{KeyframeRule, KeyframesRule};
 pub(crate) use calc::{CalcArena, parse_calc_number_expression};
 pub(crate) use css_input::{CssInput, CssNumber, CssUnexpected, CssValueSeed};
 pub(crate) use math::lerp;
-pub use math::{fast_div_255, fast_div_255_u32};
 pub(crate) use properties::unexpected_token;
 pub use properties::*;
 // Selector matching internals (CssRule, SelectorImpl, Ident, …) stay crate-private

--- a/takumi-core/src/style/properties/animation.rs
+++ b/takumi-core/src/style/properties/animation.rs
@@ -63,10 +63,10 @@ impl<'i> FromCss<'i> for AnimationTime {
 }
 
 /// Parsed value for one `animation-name`.
-pub type AnimationName = Option<String>;
+pub(crate) type AnimationName = Option<String>;
 
 /// Parsed values for `animation-name`.
-pub type AnimationNames = Box<[AnimationName]>;
+pub(crate) type AnimationNames = Box<[AnimationName]>;
 
 impl MakeComputed for AnimationNames {}
 
@@ -81,7 +81,7 @@ impl_comma_list_from_css!(
 );
 
 /// Parsed values for `animation-duration` and `animation-delay`.
-pub type AnimationDurations = Box<[AnimationTime]>;
+pub(crate) type AnimationDurations = Box<[AnimationTime]>;
 
 impl_comma_list_from_css!(AnimationDurations, AnimationTime);
 
@@ -164,7 +164,7 @@ impl<'i> FromCss<'i> for AnimationTimingFunction {
 }
 
 /// Parsed values for `animation-timing-function`.
-pub type AnimationTimingFunctions = Box<[AnimationTimingFunction]>;
+pub(crate) type AnimationTimingFunctions = Box<[AnimationTimingFunction]>;
 
 impl_comma_list_from_css!(AnimationTimingFunctions, AnimationTimingFunction);
 
@@ -210,7 +210,7 @@ impl<'i> FromCss<'i> for AnimationIterationCount {
 }
 
 /// Parsed values for `animation-iteration-count`.
-pub type AnimationIterationCounts = Box<[AnimationIterationCount]>;
+pub(crate) type AnimationIterationCounts = Box<[AnimationIterationCount]>;
 
 impl_comma_list_from_css!(AnimationIterationCounts, AnimationIterationCount);
 
@@ -238,7 +238,7 @@ declare_enum_from_css_impl!(
 );
 
 /// Parsed values for `animation-direction`.
-pub type AnimationDirections = Box<[AnimationDirection]>;
+pub(crate) type AnimationDirections = Box<[AnimationDirection]>;
 
 impl_comma_list_from_css!(AnimationDirections, AnimationDirection);
 
@@ -266,7 +266,7 @@ declare_enum_from_css_impl!(
 );
 
 /// Parsed values for `animation-fill-mode`.
-pub type AnimationFillModes = Box<[AnimationFillMode]>;
+pub(crate) type AnimationFillModes = Box<[AnimationFillMode]>;
 
 impl_comma_list_from_css!(AnimationFillModes, AnimationFillMode);
 
@@ -288,7 +288,7 @@ declare_enum_from_css_impl!(
 );
 
 /// Parsed values for `animation-play-state`.
-pub type AnimationPlayStates = Box<[AnimationPlayState]>;
+pub(crate) type AnimationPlayStates = Box<[AnimationPlayState]>;
 
 impl_comma_list_from_css!(AnimationPlayStates, AnimationPlayState);
 
@@ -374,7 +374,7 @@ impl<'i> FromCss<'i> for Animation {
 }
 
 /// Parsed values for the `animation` shorthand.
-pub type Animations = Box<[Animation]>;
+pub(crate) type Animations = Box<[Animation]>;
 
 impl<'i> FromCss<'i> for Animations {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/properties/animation.rs
+++ b/takumi-core/src/style/properties/animation.rs
@@ -1,4 +1,3 @@
-use crate::style::{ToCss, properties::write_css_string, unexpected_token};
 use std::{borrow::Cow, fmt, vec::Vec};
 
 use cssparser::{BasicParseErrorKind, Parser, Token, match_ignore_ascii_case};
@@ -6,7 +5,8 @@ use typed_builder::TypedBuilder;
 
 use crate::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
-  declare_enum_from_css_impl, next_is_comma, tw::TailwindPropertyParser,
+  ToCss, declare_enum_from_css_impl, next_is_comma, properties::write_css_string,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Implements `FromCss` for a `Box<[T]>` animation list type as a comma-separated list of `$elem`.

--- a/takumi-core/src/style/properties/aspect_ratio.rs
+++ b/takumi-core/src/style/properties/aspect_ratio.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,

--- a/takumi-core/src/style/properties/background.rs
+++ b/takumi-core/src/style/properties/background.rs
@@ -136,7 +136,7 @@ impl<'i> FromCss<'i> for Background {
 }
 
 /// A list of background properties (one per layer).
-pub type Backgrounds = Box<[Background]>;
+pub(crate) type Backgrounds = Box<[Background]>;
 
 impl<'i> FromCss<'i> for Backgrounds {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/properties/background.rs
+++ b/takumi-core/src/style/properties/background.rs
@@ -1,7 +1,6 @@
-use crate::style::unexpected_token;
 use cssparser::Parser;
 
-use crate::style::*;
+use crate::style::{unexpected_token, *};
 
 /// Parsed `background` shorthand value.
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/takumi-core/src/style/properties/background_image.rs
+++ b/takumi-core/src/style/properties/background_image.rs
@@ -1,12 +1,11 @@
-use crate::style::{ToCss, properties::write_css_string, unexpected_token};
 use std::{fmt, sync::Arc};
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   Animatable, ConicGradient, CssDescriptorKind, CssToken, FromCss, LinearGradient,
-  ListInterpolationStrategy, MakeComputed, ParseResult, RadialGradient, SizingContext,
-  tw::TailwindPropertyParser,
+  ListInterpolationStrategy, MakeComputed, ParseResult, RadialGradient, SizingContext, ToCss,
+  properties::write_css_string, tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Background image variants supported by Takumi.
@@ -131,13 +130,12 @@ impl ToCss for BackgroundImage {
 }
 #[cfg(test)]
 mod tests {
-  use crate::style::{
-    Angle, Color, ConicGradient, GradientStop, Length, LinearGradient, LinearGradientDirection,
-    PositionValue, RadialGradient, RadialShape, RadialSize, SpacePair, StopPosition,
-  };
-
   use super::*;
-  use crate::style::FromCssStr;
+  use crate::style::{
+    Angle, Color, ConicGradient, FromCssStr, GradientStop, Length, LinearGradient,
+    LinearGradientDirection, PositionValue, RadialGradient, RadialShape, RadialSize, SpacePair,
+    StopPosition,
+  };
 
   #[test]
   fn test_parse_tailwind_none() {

--- a/takumi-core/src/style/properties/background_position.rs
+++ b/takumi-core/src/style/properties/background_position.rs
@@ -1,7 +1,6 @@
 use crate::style::{ToCss, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use std::fmt;
-use taffy::{Point, Size};
 
 use super::background_image::parse_comma_list;
 use crate::style::{
@@ -126,11 +125,11 @@ impl Animatable for PositionValue {
 
 impl PositionValue {
   /// Resolves the position to a pixel point within the border box.
-  pub fn to_point(self, sizing: &SizingContext, border_box: Size<f32>) -> Point<f32> {
-    Point {
-      x: Length::from(self.0.x).to_px(sizing, border_box.width),
-      y: Length::from(self.0.y).to_px(sizing, border_box.height),
-    }
+  pub(crate) fn to_point(self, sizing: &SizingContext, width: f32, height: f32) -> (f32, f32) {
+    (
+      Length::from(self.0.x).to_px(sizing, width),
+      Length::from(self.0.y).to_px(sizing, height),
+    )
   }
 }
 

--- a/takumi-core/src/style/properties/background_position.rs
+++ b/takumi-core/src/style/properties/background_position.rs
@@ -1,11 +1,12 @@
-use crate::style::{ToCss, unexpected_token};
-use cssparser::{Parser, Token, match_ignore_ascii_case};
 use std::fmt;
+
+use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use super::background_image::parse_comma_list;
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
-  MakeComputed, ParseResult, SizingContext, SpacePair, tw::TailwindPropertyParser,
+  MakeComputed, ParseResult, SizingContext, SpacePair, ToCss, tw::TailwindPropertyParser,
+  unexpected_token,
 };
 
 /// Horizontal keywords for `background-position`.

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -1,6 +1,7 @@
+use std::{fmt, iter::successors};
+
 use cssparser::{Parser, match_ignore_ascii_case};
 use smallvec::{SmallVec, smallvec};
-use std::{fmt, iter::successors};
 
 use super::background_image::parse_comma_list;
 use crate::style::{

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -111,7 +111,7 @@ impl BackgroundRepeat {
   }
 
   /// Returns a repeat value that does not tile on either axis.
-  pub const fn no_repeat() -> Self {
+  pub(crate) const fn no_repeat() -> Self {
     Self(
       BackgroundRepeatStyle::NoRepeat,
       BackgroundRepeatStyle::NoRepeat,

--- a/takumi-core/src/style/properties/background_size.rs
+++ b/takumi-core/src/style/properties/background_size.rs
@@ -1,12 +1,12 @@
-use crate::style::{ToCss, unexpected_token};
-use cssparser::{Parser, Token, match_ignore_ascii_case};
 use std::fmt;
+
+use cssparser::{Parser, Token, match_ignore_ascii_case};
 use taffy::Size;
 
 use super::{background_image::parse_comma_list, background_size_resolve::*};
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
-  MakeComputed, ParseResult, SizingContext, tw::TailwindPropertyParser,
+  MakeComputed, ParseResult, SizingContext, ToCss, tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Parsed `background-size` for one layer.

--- a/takumi-core/src/style/properties/background_size_resolve.rs
+++ b/takumi-core/src/style/properties/background_size_resolve.rs
@@ -26,7 +26,7 @@ pub struct IntrinsicSizing {
 
 impl IntrinsicSizing {
   /// Intrinsic sizing from concrete width and height in pixels.
-  pub fn from_dimensions(width: f32, height: f32) -> Self {
+  pub(crate) fn from_dimensions(width: f32, height: f32) -> Self {
     Self {
       width: Some(width),
       height: Some(height),

--- a/takumi-core/src/style/properties/blend_mode.rs
+++ b/takumi-core/src/style/properties/blend_mode.rs
@@ -7,7 +7,7 @@ use crate::style::{
 };
 
 /// A list of blend modes.
-pub type BlendModes = Box<[BlendMode]>;
+pub(crate) type BlendModes = Box<[BlendMode]>;
 
 impl<'i> FromCss<'i> for BlendModes {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/properties/border.rs
+++ b/takumi-core/src/style/properties/border.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 
-use crate::style::{ToCss, declare_enum_from_css_impl, unexpected_token};
 use cssparser::Parser;
 
 use crate::style::{
   Animatable, BorderStyle, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, MakeComputed,
-  ParseResult, SizingContext, properties::Length, tw::TailwindPropertyParser,
+  ParseResult, SizingContext, ToCss, declare_enum_from_css_impl, properties::Length,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// CSSWG `<line-width>` keyword (`thin | medium | thick`).
@@ -198,10 +198,8 @@ impl MakeComputed for Border {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::Color;
-
   use super::*;
-  use crate::style::FromCssStr;
+  use crate::style::{Color, FromCssStr};
 
   #[test]
   fn test_parse_border_style_solid() {

--- a/takumi-core/src/style/properties/box_alignment.rs
+++ b/takumi-core/src/style/properties/box_alignment.rs
@@ -1,7 +1,6 @@
-use crate::style::unexpected_token;
 use cssparser::Parser;
 
-use crate::style::{AlignItems, CssToken, FromCss, JustifyContent, ParseResult};
+use crate::style::{AlignItems, CssToken, FromCss, JustifyContent, ParseResult, unexpected_token};
 
 /// Represents the `place-items` shorthand.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/takumi-core/src/style/properties/box_shadow.rs
+++ b/takumi-core/src/style/properties/box_shadow.rs
@@ -47,7 +47,7 @@ impl Default for BoxShadow {
 }
 
 /// Represents a collection of box shadows, have custom `FromCss` implementation for comma-separated values.
-pub type BoxShadows = Box<[BoxShadow]>;
+pub(crate) type BoxShadows = Box<[BoxShadow]>;
 
 impl<'i> FromCss<'i> for BoxShadows {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/properties/clip_path.rs
+++ b/takumi-core/src/style/properties/clip_path.rs
@@ -98,7 +98,7 @@ impl MakeComputed for EllipseShape {
 }
 
 /// Represents a single coordinate pair in a polygon.
-pub type PolygonCoordinate = SpacePair<Length>;
+pub(crate) type PolygonCoordinate = SpacePair<Length>;
 
 /// Represents a polygon() shape.
 #[derive(Debug, Clone, PartialEq)]

--- a/takumi-core/src/style/properties/clip_path.rs
+++ b/takumi-core/src/style/properties/clip_path.rs
@@ -1,11 +1,10 @@
 use std::fmt;
 
-use crate::style::{ToCss, properties::write_css_string, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult, Sides,
-  SizingContext, SpacePair,
+  SizingContext, SpacePair, ToCss, properties::write_css_string, unexpected_token,
 };
 
 /// Represents the fill rule used for determining the interior of shapes.
@@ -385,9 +384,10 @@ impl ToCss for BasicShape {
 mod tests {
   use std::assert_matches;
 
+  use Length::*;
+
   use super::*;
   use crate::style::FromCssStr;
-  use Length::*;
 
   #[test]
   fn test_parse_inset_simple() {

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -1,17 +1,17 @@
-use crate::style::{ToCss, unexpected_token};
 use std::fmt::{self, Display};
 
-use crate::style::math::fast_div_255;
-use crate::style::{
-  Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-  FromCssStr, MakeComputed, ParseResult, PercentageNumber, SizingContext,
-  properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
-};
 use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Srgb, parse_color};
 use cssparser::{
   Parser, Token,
   color::{parse_hash_color, parse_named_color},
   match_ignore_ascii_case,
+};
+
+use crate::style::{
+  Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
+  FromCssStr, MakeComputed, ParseResult, PercentageNumber, SizingContext, ToCss,
+  math::fast_div_255, properties::gradient_utils::interpolate_with_color_space,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 fn is_cylindrical_color_space(color_space: ColorSpaceTag) -> bool {

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -1,9 +1,10 @@
 use crate::style::{ToCss, unexpected_token};
 use std::fmt::{self, Display};
 
+use crate::style::math::fast_div_255;
 use crate::style::{
   Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-  FromCssStr, MakeComputed, ParseResult, PercentageNumber, SizingContext, fast_div_255,
+  FromCssStr, MakeComputed, ParseResult, PercentageNumber, SizingContext,
   properties::gradient_utils::interpolate_with_color_space, tw::TailwindPropertyParser,
 };
 use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Srgb, parse_color};
@@ -479,7 +480,7 @@ impl Color {
   }
 
   /// Apply opacity to alpha channel
-  pub fn with_opacity(mut self, opacity: u8) -> Self {
+  pub(crate) fn with_opacity(mut self, opacity: u8) -> Self {
     self.0[3] = fast_div_255(self.0[3] as u32 * opacity as u32);
 
     self

--- a/takumi-core/src/style/properties/content.rs
+++ b/takumi-core/src/style/properties/content.rs
@@ -1,5 +1,6 @@
-use cssparser::{Parser, Token, match_ignore_ascii_case};
 use std::{fmt, sync::Arc};
+
+use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   Animatable, BackgroundImage, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,

--- a/takumi-core/src/style/properties/filter.rs
+++ b/takumi-core/src/style/properties/filter.rs
@@ -1,12 +1,11 @@
 use std::fmt;
 
-use crate::style::{ToCss, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   Angle, Animatable, Color, CssDescriptorKind, CssExpectedMessage, CssToken, FromCss, Length,
   ListInterpolationStrategy, MakeComputed, ParseResult, PercentageNumber, SizingContext,
-  TextShadow, tw::TailwindPropertyParser,
+  TextShadow, ToCss, tw::TailwindPropertyParser, unexpected_token,
 };
 
 macro_rules! interpolate_field {

--- a/takumi-core/src/style/properties/flex.rs
+++ b/takumi-core/src/style/properties/flex.rs
@@ -1,9 +1,8 @@
-use crate::style::unexpected_token;
 use cssparser::{Parser, match_ignore_ascii_case};
 
 use crate::style::{
   AspectRatio, CssSyntaxKind, CssToken, FlexDirection, FlexWrap, FromCss, FromCssStr, Length,
-  MakeComputed, ParseResult, SizingContext, tw::TailwindPropertyParser,
+  MakeComputed, ParseResult, SizingContext, tw::TailwindPropertyParser, unexpected_token,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/takumi-core/src/style/properties/flex.rs
+++ b/takumi-core/src/style/properties/flex.rs
@@ -54,7 +54,7 @@ impl Flex {
   }
 
   /// The flex-grow value is 0 and the flex-shrink value is 1.
-  pub const fn initial() -> Self {
+  pub(crate) const fn initial() -> Self {
     Self {
       grow: 0.0,
       shrink: 1.0,
@@ -63,7 +63,7 @@ impl Flex {
   }
 
   /// Create a new Flex from a number.
-  pub const fn from_number(number: f32) -> Self {
+  pub(crate) const fn from_number(number: f32) -> Self {
     Self {
       grow: number,
       shrink: 1.0,

--- a/takumi-core/src/style/properties/flex_grow.rs
+++ b/takumi-core/src/style/properties/flex_grow.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,

--- a/takumi-core/src/style/properties/font_family.rs
+++ b/takumi-core/src/style/properties/font_family.rs
@@ -1,9 +1,7 @@
 use std::{fmt, string::ToString};
 
 use cssparser::{Parser, match_ignore_ascii_case};
-use parley::{
-  FontFamily as ParleyFontFamily, FontFamilyName, GenericFamily, fontique::QueryFamily,
-};
+use parley::{FontFamily as ParleyFontFamily, FontFamilyName, GenericFamily};
 
 use crate::style::{
   CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
@@ -17,7 +15,7 @@ pub struct FontFamily(Box<[FontFamilyToken]>);
 
 /// One entry in a font-family fallback list.
 #[derive(Debug, Clone, PartialEq)]
-pub enum FontFamilyToken {
+pub(crate) enum FontFamilyToken {
   /// A named family.
   Owned(String),
   /// A generic family such as `serif`.
@@ -40,16 +38,8 @@ impl FontFamily {
     Self(tokens.into_boxed_slice())
   }
 
-  /// The families as fontique query families, in declaration order.
-  pub fn query_families(&self) -> impl Iterator<Item = QueryFamily<'_>> + Clone {
-    self.0.iter().map(|token| match token {
-      FontFamilyToken::Owned(name) => QueryFamily::Named(name.as_str()),
-      FontFamilyToken::Generic(generic) => QueryFamily::Generic(*generic),
-    })
-  }
-
   /// The families as parley `FontFamilyName`s, in declaration order.
-  pub fn names(&self) -> impl Iterator<Item = FontFamilyName<'_>> + Clone {
+  pub(crate) fn names(&self) -> impl Iterator<Item = FontFamilyName<'_>> + Clone {
     self.0.iter().map(|token| match token {
       FontFamilyToken::Owned(name) => FontFamilyName::Named(name.as_str().into()),
       FontFamilyToken::Generic(generic) => FontFamilyName::Generic(*generic),

--- a/takumi-core/src/style/properties/font_feature_settings.rs
+++ b/takumi-core/src/style/properties/font_feature_settings.rs
@@ -1,9 +1,11 @@
-use crate::style::{ToCss, unexpected_token};
-use cssparser::{Parser, Token};
-use parley::{FontFeature, setting::Tag};
 use std::fmt;
 
-use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult};
+use cssparser::{Parser, Token};
+use parley::{FontFeature, setting::Tag};
+
+use crate::style::{
+  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token,
+};
 
 pub(crate) fn parse_opentype_tag<'i, T: FromCss<'i>>(
   input: &mut Parser<'i, '_>,

--- a/takumi-core/src/style/properties/font_feature_settings.rs
+++ b/takumi-core/src/style/properties/font_feature_settings.rs
@@ -25,7 +25,7 @@ pub(crate) fn parse_opentype_tag<'i, T: FromCss<'i>>(
 ///
 /// This allows enabling/disabling specific typographic features in OpenType fonts
 /// such as ligatures, kerning, small caps, and other advanced typography features.
-pub type FontFeatureSettings = Box<[FontFeature]>;
+pub(crate) type FontFeatureSettings = Box<[FontFeature]>;
 
 impl MakeComputed for FontFeatureSettings {}
 

--- a/takumi-core/src/style/properties/font_size.rs
+++ b/takumi-core/src/style/properties/font_size.rs
@@ -32,7 +32,7 @@ pub enum FontSizeKeyword {
 
 impl FontSizeKeyword {
   /// Resolves the keyword to its root-relative CSS length.
-  pub const fn to_length(self) -> Length {
+  pub(crate) const fn to_length(self) -> Length {
     match self {
       Self::XXSmall => Length::Rem(0.6),
       Self::XSmall => Length::Rem(0.75),

--- a/takumi-core/src/style/properties/font_stretch.rs
+++ b/takumi-core/src/style/properties/font_stretch.rs
@@ -1,12 +1,11 @@
 use std::fmt;
 
-use crate::style::{ToCss, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::FontWidth;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
-  SizingContext, lerp, tw::TailwindPropertyParser,
+  SizingContext, ToCss, lerp, tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Controls the width/stretch of text rendering.

--- a/takumi-core/src/style/properties/font_stretch.rs
+++ b/takumi-core/src/style/properties/font_stretch.rs
@@ -78,7 +78,7 @@ impl FontStretch {
   }
 
   /// Builds from a fraction where `1.0` is normal.
-  pub fn from_percentage(value: f32) -> Self {
+  pub(crate) fn from_percentage(value: f32) -> Self {
     Self(FontWidth::from_percentage(value.max(0.0) * 100.0))
   }
 }

--- a/takumi-core/src/style/properties/font_style.rs
+++ b/takumi-core/src/style/properties/font_style.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 
-use crate::style::{ToCss, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::style::FontStyle as ParleyFontStyle;
 
-use crate::style::{Angle, CssToken, FromCss, MakeComputed, ParseResult};
+use crate::style::{Angle, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token};
 
 /// Controls the slant (italic/oblique) of text rendering.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]

--- a/takumi-core/src/style/properties/font_synthesis.rs
+++ b/takumi-core/src/style/properties/font_synthesis.rs
@@ -1,8 +1,9 @@
-use crate::style::unexpected_token;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
-use crate::style::{CssToken, FromCss, MakeComputed, ParseResult, declare_enum_from_css_impl};
+use crate::style::{
+  CssToken, FromCss, MakeComputed, ParseResult, declare_enum_from_css_impl, unexpected_token,
+};
 
 /// Controls synthetic font behaviors.
 #[derive(Debug, Clone, Copy, PartialEq, Default, TypedBuilder)]

--- a/takumi-core/src/style/properties/font_synthesis.rs
+++ b/takumi-core/src/style/properties/font_synthesis.rs
@@ -63,7 +63,7 @@ pub enum FontSynthesic {
 
 impl FontSynthesic {
   /// Whether synthesis is permitted.
-  pub fn is_allowed(self) -> bool {
+  pub(crate) fn is_allowed(self) -> bool {
     self == FontSynthesic::Auto
   }
 }

--- a/takumi-core/src/style/properties/font_variation_settings.rs
+++ b/takumi-core/src/style/properties/font_variation_settings.rs
@@ -9,7 +9,7 @@ use super::font_feature_settings::parse_opentype_tag;
 ///
 /// This allows fine-grained control over variable font characteristics like weight,
 /// width, slant, and other custom axes defined in the font.
-pub type FontVariationSettings = Box<[FontVariation]>;
+pub(crate) type FontVariationSettings = Box<[FontVariation]>;
 
 impl MakeComputed for FontVariationSettings {}
 

--- a/takumi-core/src/style/properties/font_variation_settings.rs
+++ b/takumi-core/src/style/properties/font_variation_settings.rs
@@ -1,9 +1,10 @@
-use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss};
-use cssparser::Parser;
-use parley::FontVariation;
 use std::fmt;
 
+use cssparser::Parser;
+use parley::FontVariation;
+
 use super::font_feature_settings::parse_opentype_tag;
+use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss};
 
 /// Controls variable font axis values via CSS font-variation-settings property.
 ///

--- a/takumi-core/src/style/properties/font_weight.rs
+++ b/takumi-core/src/style/properties/font_weight.rs
@@ -128,7 +128,7 @@ impl FontWeight {
 
   /// Resolves `bolder`/`lighter` against the inherited parent weight; absolute
   /// weights pass through unchanged.
-  pub fn resolve_against(self, parent: f32) -> Self {
+  pub(crate) fn resolve_against(self, parent: f32) -> Self {
     match self {
       Self::Bolder => FontWeight::from(bolder(parent)),
       Self::Lighter => FontWeight::from(lighter(parent)),

--- a/takumi-core/src/style/properties/font_weight.rs
+++ b/takumi-core/src/style/properties/font_weight.rs
@@ -1,12 +1,11 @@
 use std::fmt;
 
-use crate::style::{ToCss, unexpected_token};
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::style::FontWeight as ParleyFontWeight;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
-  lerp, tw::TailwindPropertyParser,
+  ToCss, lerp, tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Represents font weight value.

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -6,10 +6,9 @@ use smallvec::SmallVec;
 use taffy::Point;
 use tiny_skia::{ColorU8, PremultipliedColorU8};
 
-use crate::style::math::fast_div_255;
 use crate::style::{
   Color, ColorInput, ColorInterpolationMethod, FromCss, GradientStop, ParseResult,
-  ResolvedGradientStop, SizingContext, StopPosition, ToCss,
+  ResolvedGradientStop, SizingContext, StopPosition, ToCss, math::fast_div_255,
 };
 
 const MIN_GRADIENT_LUT_SIZE: usize = 2;
@@ -761,12 +760,11 @@ pub fn resolve_stops_along_axis(
 
 #[cfg(test)]
 mod tests {
+  use super::*;
   use crate::{
     style::{Color, Length, StopPosition},
     viewport::Viewport,
   };
-
-  use super::*;
 
   #[test]
   fn test_resolve_stops_along_axis() {

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -6,9 +6,10 @@ use smallvec::SmallVec;
 use taffy::Point;
 use tiny_skia::{ColorU8, PremultipliedColorU8};
 
+use crate::style::math::fast_div_255;
 use crate::style::{
   Color, ColorInput, ColorInterpolationMethod, FromCss, GradientStop, ParseResult,
-  ResolvedGradientStop, SizingContext, StopPosition, ToCss, fast_div_255,
+  ResolvedGradientStop, SizingContext, StopPosition, ToCss,
 };
 
 const MIN_GRADIENT_LUT_SIZE: usize = 2;

--- a/takumi-core/src/style/properties/grid/grid_area.rs
+++ b/takumi-core/src/style/properties/grid/grid_area.rs
@@ -1,7 +1,8 @@
-use crate::style::unexpected_token;
 use cssparser::Parser;
 
-use crate::style::{CssSyntaxKind, CssToken, FromCss, GridPlacement, ParseResult};
+use crate::style::{
+  CssSyntaxKind, CssToken, FromCss, GridPlacement, ParseResult, unexpected_token,
+};
 
 /// Represents the `grid-area` shorthand.
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/takumi-core/src/style/properties/grid/grid_line.rs
+++ b/takumi-core/src/style/properties/grid/grid_line.rs
@@ -1,11 +1,9 @@
 use cssparser::Parser;
 
 use crate::style::{
-  CssSyntaxKind, CssToken, FromCss, GridPlacementSpan, MakeComputed, ParseResult, SizingContext,
-  tw::TailwindPropertyParser,
+  CssSyntaxKind, CssToken, FromCss, GridPlacement, GridPlacementSpan, MakeComputed, ParseResult,
+  SizingContext, tw::TailwindPropertyParser,
 };
-
-use crate::style::GridPlacement;
 
 /// Represents a grid line placement with serde support
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/takumi-core/src/style/properties/grid/grid_repeat_track.rs
+++ b/takumi-core/src/style/properties/grid/grid_repeat_track.rs
@@ -75,10 +75,10 @@ impl ToCss for GridRepeatTrack {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::GridLength;
+  use cssparser::{Parser, ParserInput};
 
   use super::*;
-  use cssparser::{Parser, ParserInput};
+  use crate::style::GridLength;
 
   #[test]
   fn test_parse_repeat_track_with_names() {

--- a/takumi-core/src/style/properties/grid/grid_repetition_count.rs
+++ b/takumi-core/src/style/properties/grid/grid_repetition_count.rs
@@ -1,7 +1,6 @@
-use crate::style::unexpected_token;
 use cssparser::{Parser, Token};
 
-use crate::style::{CssSyntaxKind, CssToken, FromCss, ParseResult, ToCss};
+use crate::style::{CssSyntaxKind, CssToken, FromCss, ParseResult, ToCss, unexpected_token};
 
 /// Represents grid track repetition keywords
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/takumi-core/src/style/properties/grid/grid_template_areas.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_areas.rs
@@ -1,10 +1,11 @@
-use crate::style::unexpected_token;
 use std::collections::HashMap;
 
 use cssparser::{Parser, Token};
 
 use super::write_space_separated;
-use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss};
+use crate::style::{
+  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token,
+};
 
 /// Represents `grid-template-areas` value
 ///

--- a/takumi-core/src/style/properties/grid/grid_template_component.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_component.rs
@@ -224,10 +224,8 @@ impl ToCss for GridTemplateComponent {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::{GridLength, GridRepetitionKeyword};
-
   use super::*;
-  use crate::style::FromCssStr;
+  use crate::style::{FromCssStr, GridLength, GridRepetitionKeyword};
 
   #[test]
   fn components_serialize_space_separated() {

--- a/takumi-core/src/style/properties/grid/grid_track_size.rs
+++ b/takumi-core/src/style/properties/grid/grid_track_size.rs
@@ -109,10 +109,8 @@ impl ToCss for GridTrackSize {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::Length;
-
   use super::*;
-  use crate::style::FromCssStr;
+  use crate::style::{FromCssStr, Length};
 
   #[test]
   fn test_parse_minmax_and_track_size() {

--- a/takumi-core/src/style/properties/grid/grid_track_size.rs
+++ b/takumi-core/src/style/properties/grid/grid_track_size.rs
@@ -9,7 +9,7 @@ use crate::style::{
 };
 
 /// A list of `GridTrackSize`
-pub type GridTrackSizes = Vec<GridTrackSize>;
+pub(crate) type GridTrackSizes = Vec<GridTrackSize>;
 
 impl<'i> FromCss<'i> for GridTrackSizes {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -1,8 +1,3 @@
-use crate::style::{
-  ToCss,
-  calc::{CalcFormula, CalcValue, parse_calc_sum},
-  unexpected_token,
-};
 use std::{fmt, ops::Neg};
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
@@ -10,8 +5,10 @@ use taffy::{CompactLength, Dimension, LengthPercentage, LengthPercentageAuto};
 
 use crate::style::{
   AspectRatio, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
-  SizingContext,
+  SizingContext, ToCss,
+  calc::{CalcFormula, CalcValue, parse_calc_sum},
   tw::{TW_VAR_SPACING, TailwindPropertyParser},
+  unexpected_token,
 };
 
 pub(crate) const ONE_CM_IN_PX: f32 = 96.0 / 2.54;

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -134,7 +134,7 @@ pub enum Length {
 impl Length {
   /// Construct a length from a Tailwind spacing-scale multiplier.
   #[inline]
-  pub fn from_spacing(units: f32) -> Self {
+  pub(crate) fn from_spacing(units: f32) -> Self {
     Length::Rem(units * TW_VAR_SPACING)
   }
 }
@@ -279,7 +279,7 @@ impl Length {
   }
 
   /// Negated value, or `None` for non-negatable forms like `auto`.
-  pub fn try_negative(self) -> Option<Self> {
+  pub(crate) fn try_negative(self) -> Option<Self> {
     if matches!(self, Length::Auto) {
       return None;
     }

--- a/takumi-core/src/style/properties/line_clamp.rs
+++ b/takumi-core/src/style/properties/line_clamp.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 
 use crate::style::{
   Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,

--- a/takumi-core/src/style/properties/line_height.rs
+++ b/takumi-core/src/style/properties/line_height.rs
@@ -79,12 +79,12 @@ impl LineHeight {
   // Match Blink text-fit line-height scaling: non-fixed line heights scale, fixed and percentage line heights do not.
   // Reference: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/layout/inline/inline_box_state.cc;l=137
   /// Whether the line height scales under text-fit (non-fixed values).
-  pub const fn scales_with_text_fit(self) -> bool {
+  pub(crate) const fn scales_with_text_fit(self) -> bool {
     matches!(self, Self::Normal | Self::Unitless(_))
   }
 
   /// Converts to parley's line-height representation.
-  pub fn into_parley(self, sizing: &SizingContext) -> parley::LineHeight {
+  pub(crate) fn into_parley(self, sizing: &SizingContext) -> parley::LineHeight {
     match self {
       Self::Normal => parley::LineHeight::MetricsRelative(1.0),
       Self::Length(length) => parley::LineHeight::Absolute(length.to_px(sizing, sizing.font_size)),

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -1,10 +1,10 @@
-use cssparser::{Parser, Token, match_ignore_ascii_case};
 use std::{
   fmt,
   ops::{Deref, Neg},
 };
-use tiny_skia::PremultipliedColorU8;
 
+use cssparser::{Parser, Token, match_ignore_ascii_case};
+use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 
 use super::gradient_utils::{
@@ -822,18 +822,17 @@ impl ToCss for LinearGradient {
 
 #[cfg(test)]
 mod tests {
-  use color::{ColorSpaceTag, HueDirection};
   use std::rc::Rc;
+
+  use color::{ColorSpaceTag, HueDirection};
   use taffy::Size;
   use tiny_skia::ColorU8;
 
+  use super::*;
   use crate::{
-    style::{CalcArena, properties::gradient_utils::red_blue_stops},
+    style::{CalcArena, FromCssStr, properties::gradient_utils::red_blue_stops},
     viewport::Viewport,
   };
-
-  use super::*;
-  use crate::style::FromCssStr;
   fn sizing() -> SizingContext {
     SizingContext {
       viewport: Viewport::new((200, 100)),

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -147,13 +147,13 @@ impl LinearGradientTile {
 
   /// Projects a pixel onto the gradient axis, in pixels.
   #[inline(always)]
-  pub fn projection_at(&self, x: f32, y: f32) -> f32 {
+  pub(crate) fn projection_at(&self, x: f32, y: f32) -> f32 {
     x * self.dir_x + y * self.dir_y + self.projection_bias
   }
 
   /// Maps an axis projection to a LUT index for a LUT of `lut_len`.
   #[inline(always)]
-  pub fn lut_index_for_projection_with_len(&self, projection: f32, lut_len: usize) -> usize {
+  pub(crate) fn lut_index_for_projection_with_len(&self, projection: f32, lut_len: usize) -> usize {
     if lut_len <= 1 {
       return 0;
     }
@@ -372,7 +372,7 @@ impl MakeComputed for GradientStop {
 }
 
 /// A list of gradient color stops, handling CSS double-stop syntax.
-pub type GradientStops = Vec<GradientStop>;
+pub(crate) type GradientStops = Vec<GradientStop>;
 
 impl<'i> FromCss<'i> for GradientStops {
   const VALID_TOKENS: &'static [CssToken] = GradientStop::VALID_TOKENS;
@@ -574,7 +574,7 @@ impl Default for LinearGradientDirection {
 
 impl HorizontalKeyword {
   /// Returns the angle in degrees.
-  pub fn degrees(&self) -> f32 {
+  pub(crate) fn degrees(&self) -> f32 {
     match self {
       HorizontalKeyword::Left => 270.0, // "to left" = 270deg
       HorizontalKeyword::Right => 90.0, // "to right" = 90deg
@@ -582,7 +582,7 @@ impl HorizontalKeyword {
   }
 
   /// Returns the mixed angle in degrees.
-  pub fn vertical_mixed_degrees(&self) -> f32 {
+  pub(crate) fn vertical_mixed_degrees(&self) -> f32 {
     match self {
       HorizontalKeyword::Left => -45.0, // For diagonals with left
       HorizontalKeyword::Right => 45.0, // For diagonals with right
@@ -592,7 +592,7 @@ impl HorizontalKeyword {
 
 impl VerticalKeyword {
   /// Returns the angle in degrees.
-  pub fn degrees(&self) -> f32 {
+  pub(crate) fn degrees(&self) -> f32 {
     match self {
       VerticalKeyword::Top => 0.0,
       VerticalKeyword::Bottom => 180.0,
@@ -602,7 +602,7 @@ impl VerticalKeyword {
 
 impl GradientKeywordDirection {
   /// Converts a side-or-corner direction into the matching CSS angle.
-  pub fn to_angle(self) -> Angle {
+  pub(crate) fn to_angle(self) -> Angle {
     Angle::degrees_from_keywords(self.horizontal, self.vertical)
   }
 }
@@ -707,7 +707,7 @@ impl<'i> FromCss<'i> for LinearGradient {
 
 impl Angle {
   /// Calculates the angle from horizontal and vertical keywords.
-  pub fn degrees_from_keywords(
+  pub(crate) fn degrees_from_keywords(
     horizontal: Option<HorizontalKeyword>,
     vertical: Option<VerticalKeyword>,
   ) -> Angle {

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -82,20 +82,21 @@ pub use filter::{
 pub use flex::*;
 pub use flex_grow::*;
 pub use font_family::*;
-pub use font_feature_settings::*;
+pub(crate) use font_feature_settings::*;
 pub use font_size::*;
 pub use font_stretch::*;
 pub use font_style::*;
 pub use font_synthesis::*;
 pub use font_variant::*;
-pub use font_variation_settings::*;
+pub(crate) use font_variation_settings::*;
 pub use font_weight::*;
 pub use grid::*;
 pub use length::*;
 pub use line_clamp::*;
 pub use line_height::*;
+pub(crate) use linear_gradient::GradientStops;
 pub use linear_gradient::{
-  Angle, GradientKeywordDirection, GradientStop, GradientStops, HorizontalKeyword, LinearGradient,
+  Angle, GradientKeywordDirection, GradientStop, HorizontalKeyword, LinearGradient,
   LinearGradientDirection, ResolvedGradientStop, StopPosition, VerticalKeyword,
 };
 pub use offset_path::*;
@@ -103,7 +104,8 @@ pub use order::*;
 pub use overflow::*;
 pub use overflow_wrap::*;
 pub use percentage_number::*;
-pub use radial_gradient::{RadialGradient, RadialShape, RadialSize};
+pub use radial_gradient::RadialGradient;
+pub use radial_gradient::{RadialShape, RadialSize};
 use serde::Deserialize;
 pub use sides::*;
 pub use space_pair::*;
@@ -568,12 +570,12 @@ impl From<Position> for taffy::Position {
 impl Position {
   /// A positioned element (anything but `static`): establishes a containing
   /// block for absolutely-positioned descendants and honors `z-index`.
-  pub const fn is_positioned(self) -> bool {
+  pub(crate) const fn is_positioned(self) -> bool {
     matches!(self, Self::Relative | Self::Absolute | Self::Fixed)
   }
 
   /// Removed from normal flow.
-  pub const fn is_out_of_flow(self) -> bool {
+  pub(crate) const fn is_out_of_flow(self) -> bool {
     matches!(self, Self::Absolute | Self::Fixed)
   }
 }
@@ -625,7 +627,7 @@ declare_enum_from_css_impl!(
 
 impl Float {
   /// Resolves the floating direction based on the layout direction.
-  pub fn resolve(self, direction: Direction) -> taffy::Float {
+  pub(crate) fn resolve(self, direction: Direction) -> taffy::Float {
     match self {
       Self::None => taffy::Float::None,
       Self::Left => taffy::Float::Left,
@@ -679,7 +681,7 @@ declare_enum_from_css_impl!(
 
 impl Clear {
   /// Resolves the clearing direction based on the layout direction.
-  pub fn resolve(self, direction: Direction) -> taffy::Clear {
+  pub(crate) fn resolve(self, direction: Direction) -> taffy::Clear {
     match self {
       Self::None => taffy::Clear::None,
       Self::Left => taffy::Clear::Left,
@@ -872,12 +874,12 @@ declare_enum_from_css_impl!(
 
 impl Display {
   /// Returns true if the display creates an inline formatting context.
-  pub fn is_inline(&self) -> bool {
+  pub(crate) fn is_inline(&self) -> bool {
     *self == Display::Inline
   }
 
   /// Returns true if the display participates in the inline flow as an atomic box.
-  pub fn is_inline_level(&self) -> bool {
+  pub(crate) fn is_inline_level(&self) -> bool {
     matches!(
       self,
       Display::Inline | Display::InlineBlock | Display::InlineFlex | Display::InlineGrid
@@ -885,7 +887,7 @@ impl Display {
   }
 
   /// Returns true if the display makes the children blockified (e.g., flex or grid).
-  pub fn should_blockify_children(&self) -> bool {
+  pub(crate) fn should_blockify_children(&self) -> bool {
     matches!(
       self,
       Display::Flex | Display::InlineFlex | Display::Grid | Display::InlineGrid
@@ -893,7 +895,7 @@ impl Display {
   }
 
   /// Cast the display to block level.
-  pub fn as_blockified(self) -> Self {
+  pub(crate) fn as_blockified(self) -> Self {
     match self {
       Display::Inline => Display::Block,
       Display::InlineBlock => Display::Block,
@@ -904,7 +906,7 @@ impl Display {
   }
 
   /// Mutate the display to be block level.
-  pub fn blockify(&mut self) {
+  pub(crate) fn blockify(&mut self) {
     *self = self.as_blockified();
   }
 }

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -59,6 +59,8 @@ mod white_space;
 mod word_break;
 mod z_index;
 
+use std::fmt;
+
 pub use animation::*;
 pub use aspect_ratio::*;
 pub use background::*;
@@ -75,6 +77,7 @@ pub use clip_path::*;
 pub use color::*;
 pub use conic_gradient::ConicGradient;
 pub use content::*;
+use cssparser::{Parser, match_ignore_ascii_case};
 pub use filter::{
   BlurType, Filter, FilterCategory, Filters, LUMA_WEIGHTS, SEPIA_WEIGHTS, TransferChannel,
   TransferTable,
@@ -103,9 +106,9 @@ pub use offset_path::*;
 pub use order::*;
 pub use overflow::*;
 pub use overflow_wrap::*;
+use parley::Alignment;
 pub use percentage_number::*;
-pub use radial_gradient::RadialGradient;
-pub use radial_gradient::{RadialShape, RadialSize};
+pub use radial_gradient::{RadialGradient, RadialShape, RadialSize};
 use serde::Deserialize;
 pub use sides::*;
 pub use space_pair::*;
@@ -125,10 +128,6 @@ pub use vertical_align::*;
 pub use white_space::*;
 pub use word_break::*;
 pub use z_index::*;
-
-use cssparser::{Parser, match_ignore_ascii_case};
-use parley::Alignment;
-use std::fmt;
 
 use crate::style::{SizingContext, tw::TailwindPropertyParser};
 

--- a/takumi-core/src/style/properties/offset_path.rs
+++ b/takumi-core/src/style/properties/offset_path.rs
@@ -217,10 +217,13 @@ impl MakeComputed for OffsetAnchor {
 
 impl OffsetAnchor {
   /// The explicit anchor point, or `None` when it defaults to transform-origin.
-  pub fn resolve(self, sizing: &SizingContext, border_box: Size<f32>) -> Option<Point<f32>> {
+  pub fn resolve(self, sizing: &SizingContext, width: f32, height: f32) -> Option<(f32, f32)> {
     match self {
       OffsetAnchor::Auto => None,
-      OffsetAnchor::Position(position) => Some(position_point(&position, sizing, border_box)),
+      OffsetAnchor::Position(position) => {
+        let point = position_point(&position, sizing, Size { width, height });
+        Some((point.x, point.y))
+      }
     }
   }
 }

--- a/takumi-core/src/style/properties/order.rs
+++ b/takumi-core/src/style/properties/order.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 
 use crate::style::{
   Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,

--- a/takumi-core/src/style/properties/percentage_number.rs
+++ b/takumi-core/src/style/properties/percentage_number.rs
@@ -1,4 +1,3 @@
-use crate::style::{ToCss, unexpected_token};
 use std::{
   fmt,
   ops::{Deref, Neg},
@@ -7,12 +6,11 @@ use std::{
 use cssparser::{Parser, Token};
 
 use crate::style::{
-  Animatable, Color, MakeComputed, SizingContext, lerp,
+  Animatable, Color, CssSyntaxKind, CssToken, MakeComputed, SizingContext, ToCss, lerp,
   properties::{FromCss, ParseResult, flex_grow::parse_numeric_tw},
   tw::TailwindPropertyParser,
+  unexpected_token,
 };
-
-use crate::style::{CssSyntaxKind, CssToken};
 
 /// Represents a percentage value (0.0-1.0) in CSS parsing.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/takumi-core/src/style/properties/radial_gradient.rs
+++ b/takumi-core/src/style/properties/radial_gradient.rs
@@ -1,5 +1,6 @@
-use cssparser::{Parser, Token, match_ignore_ascii_case};
 use std::fmt;
+
+use cssparser::{Parser, Token, match_ignore_ascii_case};
 use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 

--- a/takumi-core/src/style/properties/radial_gradient.rs
+++ b/takumi-core/src/style/properties/radial_gradient.rs
@@ -184,7 +184,11 @@ impl RadialGradientTile {
 
   /// Maps an axis-space distance to a LUT index for a LUT of `lut_len`.
   #[inline(always)]
-  pub fn lut_index_for_distance_px_with_len(&self, distance_px: f32, lut_len: usize) -> usize {
+  pub(crate) fn lut_index_for_distance_px_with_len(
+    &self,
+    distance_px: f32,
+    lut_len: usize,
+  ) -> usize {
     if lut_len <= 1 {
       return 0;
     }

--- a/takumi-core/src/style/properties/sides.rs
+++ b/takumi-core/src/style/properties/sides.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 use taffy::Rect;
 
 use crate::style::{

--- a/takumi-core/src/style/properties/space_pair.rs
+++ b/takumi-core/src/style/properties/space_pair.rs
@@ -1,6 +1,6 @@
 use cssparser::Parser;
 use std::fmt;
-use taffy::{Point, Size};
+use taffy::Point;
 
 use crate::style::{
   CssExpectedMessage, CssToken, FromCss, Length, MakeComputed, Overflow, ParseResult,
@@ -75,14 +75,14 @@ impl SpacePair<Overflow> {
 }
 
 /// A pair of values for horizontal and vertical border radii.
-pub type BorderRadiusPair = SpacePair<Length>;
+pub(crate) type BorderRadiusPair = SpacePair<Length>;
 
 impl BorderRadiusPair {
   /// Resolves both radii to non-negative pixels against the border box.
-  pub fn to_px(self, sizing: &SizingContext, border_box: Size<f32>) -> SpacePair<f32> {
+  pub fn to_px(self, sizing: &SizingContext, width: f32, height: f32) -> SpacePair<f32> {
     SpacePair::from_pair(
-      self.x.to_px(sizing, border_box.width).max(0.0),
-      self.y.to_px(sizing, border_box.height).max(0.0),
+      self.x.to_px(sizing, width).max(0.0),
+      self.y.to_px(sizing, height).max(0.0),
     )
   }
 }

--- a/takumi-core/src/style/properties/space_pair.rs
+++ b/takumi-core/src/style/properties/space_pair.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 use taffy::Point;
 
 use crate::style::{

--- a/takumi-core/src/style/properties/text_decoration.rs
+++ b/takumi-core/src/style/properties/text_decoration.rs
@@ -207,7 +207,7 @@ pub enum TextUnderlineOffset {
 
 impl TextUnderlineOffset {
   /// Resolves the offset to pixels, with `auto` yielding `0`.
-  pub fn resolve_px(&self, sizing: &SizingContext) -> f32 {
+  pub(crate) fn resolve_px(&self, sizing: &SizingContext) -> f32 {
     match self {
       Self::Auto => 0.0,
       Self::Length(length) => length.to_px(sizing, sizing.font_size),

--- a/takumi-core/src/style/properties/text_decoration.rs
+++ b/takumi-core/src/style/properties/text_decoration.rs
@@ -1,14 +1,13 @@
 use std::fmt;
 
-use crate::style::{ToCss, unexpected_token};
 use bitflags::bitflags;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length, MakeComputed,
-  ParseResult, SizingContext, declare_enum_from_css_impl, properties::ColorInput,
-  tw::TailwindPropertyParser,
+  ParseResult, SizingContext, ToCss, declare_enum_from_css_impl, properties::ColorInput,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 bitflags! {

--- a/takumi-core/src/style/properties/text_indent.rs
+++ b/takumi-core/src/style/properties/text_indent.rs
@@ -48,7 +48,7 @@ impl TextIndent {
   }
 
   /// Resolves the indent amount to pixels against the line width.
-  pub fn resolve_px(self, sizing: &SizingContext, line_width: f32) -> f32 {
+  pub(crate) fn resolve_px(self, sizing: &SizingContext, line_width: f32) -> f32 {
     self.amount.to_px(sizing, line_width)
   }
 }

--- a/takumi-core/src/style/properties/text_shadow.rs
+++ b/takumi-core/src/style/properties/text_shadow.rs
@@ -187,9 +187,8 @@ impl ToCss for TextShadow {
 
 #[cfg(test)]
 mod tests {
-  use crate::style::{Color, Length::Px};
-
   use super::*;
+  use crate::style::{Color, Length::Px};
 
   #[test]
   fn test_parse_text_shadow_no_blur_radius() {

--- a/takumi-core/src/style/properties/text_shadow.rs
+++ b/takumi-core/src/style/properties/text_shadow.rs
@@ -39,7 +39,7 @@ impl Default for TextShadow {
 }
 
 /// Represents a collection of text shadows; has custom `FromCss` implementation for comma-separated values.
-pub type TextShadows = Box<[TextShadow]>;
+pub(crate) type TextShadows = Box<[TextShadow]>;
 
 impl<'i> FromCss<'i> for TextShadows {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -321,7 +321,7 @@ pub(crate) enum CssExpectedMessage {
 
 impl CssExpectedMessage {
   /// Builds the parse-error message for an unexpected token.
-  pub fn build_message(&self, token: &str, valid_tokens: String) -> String {
+  pub(crate) fn build_message(&self, token: &str, valid_tokens: String) -> String {
     match self {
       Self::ValueOrNone => {
         format!("Unexpected token: {token}, expected a value of {valid_tokens} or 'none'")

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -1,5 +1,6 @@
-use cssparser::{Parser, ParserInput};
 use std::{borrow::Cow, fmt, sync::Arc};
+
+use cssparser::{Parser, ParserInput};
 
 use crate::style::{Color, SizingContext, math::lcm};
 

--- a/takumi-core/src/style/properties/transform.rs
+++ b/takumi-core/src/style/properties/transform.rs
@@ -1,4 +1,3 @@
-use crate::style::{ToCss, properties::filter::interpolate_field, unexpected_token};
 use std::{
   fmt,
   ops::{Mul, MulAssign},
@@ -9,7 +8,8 @@ use tiny_skia::Transform as TinyTransform;
 
 use crate::style::{
   Angle, Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
-  MakeComputed, ParseResult, PercentageNumber, SizingContext, lerp,
+  MakeComputed, ParseResult, PercentageNumber, SizingContext, ToCss, lerp,
+  properties::filter::interpolate_field, unexpected_token,
 };
 
 const DEFAULT_SCALE: f32 = 1.0;

--- a/takumi-core/src/style/properties/transform.rs
+++ b/takumi-core/src/style/properties/transform.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
-use taffy::{Point, Size};
 use tiny_skia::Transform as TinyTransform;
 
 use crate::style::{
@@ -207,14 +206,6 @@ impl Affine {
       && self.y.abs() < 1e-6
   }
 
-  /// Decomposes the translation part of the transform
-  pub fn decompose_translation(self) -> Point<f32> {
-    Point {
-      x: self.x,
-      y: self.y,
-    }
-  }
-
   /// Geometric mean of the X and Y axis scales.
   pub fn uniform_scale(self) -> f32 {
     let sx = (self.a * self.a + self.b * self.b).sqrt();
@@ -236,7 +227,7 @@ impl Affine {
   }
 
   /// Creates a new rotation transform from an angle in radians
-  pub fn rotation_radians(radians: f32) -> Self {
+  pub(crate) fn rotation_radians(radians: f32) -> Self {
     let (sin, cos) = radians.sin_cos();
 
     Self {
@@ -272,23 +263,20 @@ impl Affine {
 
   /// Transforms a point by the transform
   #[inline(always)]
-  pub fn transform_point(self, point: Point<f32>) -> Point<f32> {
+  pub fn transform_point(self, x: f32, y: f32) -> (f32, f32) {
     // Fast path: If the transform is only a translation, we can just add the translation to the point
     if self.only_translation() {
-      return Point {
-        x: point.x + self.x,
-        y: point.y + self.y,
-      };
+      return (x + self.x, y + self.y);
     }
 
-    Point {
-      x: self.a * point.x + self.c * point.y + self.x,
-      y: self.b * point.x + self.d * point.y + self.y,
-    }
+    (
+      self.a * x + self.c * y + self.x,
+      self.b * x + self.d * y + self.y,
+    )
   }
 
   /// Creates a new skew transform
-  pub fn skew(x: Angle, y: Angle) -> Self {
+  pub(crate) fn skew(x: Angle, y: Angle) -> Self {
     let tanx = x.to_radians().tan();
     let tany = y.to_radians().tan();
 
@@ -304,7 +292,7 @@ impl Affine {
 
   /// Calculates the determinant of the transform
   #[inline(always)]
-  pub fn determinant(self) -> f32 {
+  pub(crate) fn determinant(self) -> f32 {
     self.a * self.d - self.b * self.c
   }
 
@@ -338,18 +326,19 @@ impl Affine {
   /// CSS transform property applies transformations from left to right.
   /// For `transform: translate() rotate()`, the resulting matrix is translate * rotate.
   /// When applied to point p: translate * rotate * p, rotate is applied first.
-  pub fn from_transforms<'a, I: Iterator<Item = &'a Transform>>(
+  pub(crate) fn from_transforms<'a, I: Iterator<Item = &'a Transform>>(
     transforms: I,
     sizing: &SizingContext,
-    border_box: Size<f32>,
+    width: f32,
+    height: f32,
   ) -> Affine {
     let mut instance = Affine::IDENTITY;
 
     for transform in transforms {
       instance *= match *transform {
         Transform::Translate(x_length, y_length) => Affine::translation(
-          x_length.to_px(sizing, border_box.width),
-          y_length.to_px(sizing, border_box.height),
+          x_length.to_px(sizing, width),
+          y_length.to_px(sizing, height),
         ),
         Transform::Scale(x_scale, y_scale) => Affine::scale(x_scale, y_scale),
         Transform::Rotate(angle) => Affine::rotation(angle),
@@ -626,15 +615,12 @@ mod tests {
     let transform = Affine::rotation(Angle::new(45.0));
 
     assert!(transform.invert().is_some_and(|inverse| {
-      let random_point = Point {
-        x: 1234.0,
-        y: -5678.0,
-      };
+      let (x, y) = (1234.0, -5678.0);
 
-      let processed_point = inverse.transform_point(transform.transform_point(random_point));
+      let (transformed_x, transformed_y) = transform.transform_point(x, y);
+      let (processed_x, processed_y) = inverse.transform_point(transformed_x, transformed_y);
 
-      (random_point.x - processed_point.x).abs() < 1.0
-        && (random_point.y - processed_point.y).abs() < 1.0
+      (x - processed_x).abs() < 1.0 && (y - processed_y).abs() < 1.0
     }));
   }
 }

--- a/takumi-core/src/style/properties/vertical_align.rs
+++ b/takumi-core/src/style/properties/vertical_align.rs
@@ -233,9 +233,8 @@ mod tests {
 
   use taffy::Size;
 
-  use crate::viewport::Viewport;
-
   use super::*;
+  use crate::viewport::Viewport;
 
   fn sizing() -> SizingContext {
     SizingContext {

--- a/takumi-core/src/style/properties/white_space.rs
+++ b/takumi-core/src/style/properties/white_space.rs
@@ -32,7 +32,7 @@ impl TailwindPropertyParser for WhiteSpace {
 
 impl WhiteSpace {
   /// Creates a `WhiteSpace` instance with `nowrap` behavior.
-  pub const fn no_wrap() -> Self {
+  pub(crate) const fn no_wrap() -> Self {
     Self {
       text_wrap_mode: TextWrapMode::NoWrap,
       white_space_collapse: WhiteSpaceCollapse::Collapse,

--- a/takumi-core/src/style/properties/z_index.rs
+++ b/takumi-core/src/style/properties/z_index.rs
@@ -17,7 +17,7 @@ pub enum ZIndex {
 
 impl ZIndex {
   /// Returns the integer used to sort painting order.
-  pub const fn painting_order_value(self) -> i32 {
+  pub(crate) const fn painting_order_value(self) -> i32 {
     match self {
       Self::Auto => 0,
       Self::Integer(value) => value,

--- a/takumi-core/src/style/properties/z_index.rs
+++ b/takumi-core/src/style/properties/z_index.rs
@@ -1,5 +1,6 @@
-use cssparser::Parser;
 use std::fmt;
+
+use cssparser::Parser;
 
 use crate::style::{
   Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1021,7 +1021,7 @@ impl From<Vec<PropertyRule>> for StyleSheet {
 
 impl StyleSheet {
   /// The `@property` registrations declared by this stylesheet.
-  pub fn property_rules(&self) -> &[PropertyRule] {
+  pub(crate) fn property_rules(&self) -> &[PropertyRule] {
     &self.property_rules
   }
 

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1,9 +1,3 @@
-use cssparser::*;
-use precomputed_hash::PrecomputedHash;
-use selectors::parser::{
-  NonTSPseudoClass, ParseRelative, PseudoElement as PseudoElementTrait,
-  SelectorImpl as SelectorImplTrait, SelectorList,
-};
 use std::{
   collections::HashMap,
   fmt::{self, Write},
@@ -11,13 +5,19 @@ use std::{
   ops::Deref,
 };
 
+use cssparser::*;
+use precomputed_hash::PrecomputedHash;
+use selectors::parser::{
+  NonTSPseudoClass, ParseRelative, PseudoElement as PseudoElementTrait,
+  SelectorImpl as SelectorImplTrait, SelectorList,
+};
+
+pub use crate::style::media_query::MediaQueryList;
 use crate::{
   error::StyleSheetParseError,
   keyframes::parse_keyframe_prelude,
   style::{KeyframeRule, KeyframesRule, StyleDeclarationBlock, supports::parse_supports_condition},
 };
-
-pub use crate::style::media_query::MediaQueryList;
 
 /// A registered custom property from an `@property` rule.
 #[derive(Debug, Clone, PartialEq)]
@@ -1159,9 +1159,9 @@ impl StyleSheet {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use cssparser::ToCss;
 
+  use super::*;
   use crate::{
     style::{Color, ColorInput, ComputedStyle, Length, Style, StyleDeclaration},
     viewport::Viewport,

--- a/takumi-core/src/style/sizing.rs
+++ b/takumi-core/src/style/sizing.rs
@@ -11,8 +11,8 @@ pub struct SizingContext {
   /// The viewport for the image renderer.
   pub viewport: Viewport,
   /// The nearest query container size (content box) in device pixels.
-  #[builder(default)]
-  pub container_size: Size<Option<f32>>,
+  #[builder(default, setter(skip))]
+  pub(crate) container_size: Size<Option<f32>>,
   /// The font size in pixels.
   #[builder(default = viewport.to_device(viewport.font_size))]
   pub font_size: f32,
@@ -42,13 +42,13 @@ impl SizingContext {
 
   /// Converts a device-pixel value back into author-space CSS pixels.
   #[inline]
-  pub fn to_css(&self, device_px: f32) -> f32 {
+  pub(crate) fn to_css(&self, device_px: f32) -> f32 {
     self.viewport.to_css(device_px)
   }
 
   /// Returns a copy with the font and line-height metrics overridden, inheriting
   /// the viewport, container size, and shared calc arena.
-  pub fn with_font_metrics(
+  pub(crate) fn with_font_metrics(
     &self,
     font_size: f32,
     root_font_size: Option<f32>,
@@ -65,24 +65,29 @@ impl SizingContext {
   }
 
   /// Resolves an interned `calc(...)` handle against this context's arena.
-  pub fn resolve_calc(&self, value: *const (), basis: f32) -> f32 {
+  pub(crate) fn resolve_calc(&self, value: *const (), basis: f32) -> f32 {
     self.calc_arena.resolve_calc_value(value, basis)
   }
 
   /// Device-pixel basis for the `rem` unit.
-  pub fn rem_basis(&self) -> f32 {
+  pub(crate) fn rem_basis(&self) -> f32 {
     self
       .root_font_size
       .unwrap_or(self.to_device(self.viewport.font_size))
   }
 
   /// Device-pixel basis for the `rlh` unit.
-  pub fn root_line_height_basis(&self) -> f32 {
+  pub(crate) fn root_line_height_basis(&self) -> f32 {
     self.root_line_height.unwrap_or(self.line_height)
   }
 
+  /// Sets the nearest query container size (content box), in device pixels.
+  pub fn set_container_size(&mut self, width: Option<f32>, height: Option<f32>) {
+    self.container_size = Size { width, height };
+  }
+
   /// Query container width in device pixels, falling back to the viewport.
-  pub fn query_container_width(&self) -> f32 {
+  pub(crate) fn query_container_width(&self) -> f32 {
     self
       .container_size
       .width
@@ -90,7 +95,7 @@ impl SizingContext {
   }
 
   /// Query container height in device pixels, falling back to the viewport.
-  pub fn query_container_height(&self) -> f32 {
+  pub(crate) fn query_container_height(&self) -> f32 {
     self
       .container_size
       .height

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -1,7 +1,6 @@
-use crate::style::unexpected_token;
 use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
 
-use cssparser::{Parser, ParserInput, Token, match_ignore_ascii_case};
+use cssparser::{Parser, ParserInput, RuleBodyParser, Token, match_ignore_ascii_case};
 use parley::Language;
 use paste::paste;
 use serde::de::IgnoredAny;
@@ -13,9 +12,9 @@ use crate::{
     CssInput, CssValueSeed, SizingContext,
     properties::*,
     selector::{PropertyRule, StyleDeclarationParser},
+    unexpected_token,
   },
 };
-use cssparser::RuleBodyParser;
 #[path = "stylesheets_helpers.rs"]
 mod stylesheets_helpers;
 #[path = "stylesheets_mask.rs"]

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -166,7 +166,7 @@ macro_rules! define_style {
       #[repr(u8)]
       #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
       #[non_exhaustive]
-      pub enum LonghandId {
+      pub(crate) enum LonghandId {
         $(
           #[doc = concat!("The `", stringify!($longhand), "` longhand.")]
           [<$longhand:camel>],
@@ -193,7 +193,7 @@ macro_rules! define_style {
       #[repr(u8)]
       #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
       #[non_exhaustive]
-      pub enum ShorthandId {
+      pub(crate) enum ShorthandId {
         $(
           #[doc = concat!("The `", stringify!($shorthand), "` shorthand.")]
           [<$shorthand:camel>],
@@ -297,7 +297,7 @@ macro_rules! define_style {
       /// Identifies any property: longhand, shorthand, custom, or ignored.
       #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
       #[non_exhaustive]
-      pub enum PropertyId {
+      pub(crate) enum PropertyId {
         /// An unrecognized property that is dropped.
         Ignored,
         /// A custom property (`--name`).
@@ -324,7 +324,7 @@ macro_rules! define_style {
 
         /// Resolves a property from a camelCase name.
         #[allow(dead_code)]
-        pub fn from_camel_case(name: &str) -> Self {
+        pub(crate) fn from_camel_case(name: &str) -> Self {
           PropertyId::from_name(name, normalize_camel_property_name)
         }
 
@@ -530,7 +530,7 @@ macro_rules! define_style {
         }
 
         /// Appends another declaration block in source order.
-        pub fn append_block(&mut self, declarations: StyleDeclarationBlock) {
+        pub(crate) fn append_block(&mut self, declarations: StyleDeclarationBlock) {
           self.declarations.append(declarations);
         }
 
@@ -540,12 +540,12 @@ macro_rules! define_style {
         }
 
         /// Collects resource URLs referenced by this style's declarations.
-        pub fn resource_urls(&self) -> impl Iterator<Item = &str> {
-          self.declarations.resource_urls()
+        pub fn image_urls(&self) -> impl Iterator<Item = &str> {
+          self.declarations.image_urls()
         }
 
         /// Resolves this style against a parent into a computed style.
-        pub fn inherit(self, parent: &ComputedStyle) -> ComputedStyle {
+        pub(crate) fn inherit(self, parent: &ComputedStyle) -> ComputedStyle {
           let mut style = ComputedStyle::from_parent(parent);
           let mut declarations = ParsedDeclarations::new();
 
@@ -589,7 +589,7 @@ macro_rules! define_style {
         }
 
         /// Merges another style's declarations into this one.
-        pub fn merge_from(&mut self, other: Self) {
+        pub(crate) fn merge_from(&mut self, other: Self) {
           self.append_block(other.declarations);
         }
       }
@@ -659,7 +659,7 @@ macro_rules! define_style {
 
       impl ComputedStyle {
         /// Builds a child computed style inheriting from a parent.
-        pub fn from_parent(parent: &Self) -> Self {
+        pub(crate) fn from_parent(parent: &Self) -> Self {
           Self {
             custom_properties: if parent.custom_properties.is_empty() {
               HashMap::new()
@@ -677,7 +677,7 @@ macro_rules! define_style {
         }
 
         /// Resolves relative units against the sizing context.
-        pub fn make_computed_values(&mut self, sizing: &SizingContext) {
+        pub(crate) fn make_computed_values(&mut self, sizing: &SizingContext) {
           $(self.$longhand.make_computed(sizing);)*
         }
 
@@ -793,7 +793,7 @@ macro_rules! define_style {
         )*
 
         /// The longhand this declaration targets.
-        pub fn longhand_id(&self) -> LonghandId {
+        pub(crate) fn longhand_id(&self) -> LonghandId {
           match self {
             $(Self::[<$longhand:camel>](..) => LonghandId::[<$longhand:camel>],)*
             $(Self::[<$transient:camel>](..) => LonghandId::[<$transient:camel>],)*
@@ -814,7 +814,7 @@ macro_rules! define_style {
         }
 
         /// Applies this declaration to a computed style, resolving against the parent.
-        pub fn apply_with_parent(
+        pub(crate) fn apply_with_parent(
           self,
           style: &mut ComputedStyle,
           parent: &ComputedStyle,
@@ -865,7 +865,7 @@ macro_rules! define_style {
         }
 
         /// Applies this declaration to a computed style without a parent.
-        pub fn apply_to_computed(&self, style: &mut ComputedStyle) {
+        pub(crate) fn apply_to_computed(&self, style: &mut ComputedStyle) {
           let is_rtl = style.direction == Direction::Rtl;
           match self {
             Self::CssWideKeyword(property, keyword) => match keyword {
@@ -901,7 +901,7 @@ macro_rules! define_style {
         }
 
         /// Pushes a clone of this declaration onto a style.
-        pub fn merge_into_ref(&self, style: &mut Style) {
+        pub(crate) fn merge_into_ref(&self, style: &mut Style) {
           style.declarations.push(self.to_owned(), false);
         }
 
@@ -1489,7 +1489,7 @@ impl DeclarationImportance {
   }
 
   /// Records the longhands a declaration marks important.
-  pub fn insert_declaration(&mut self, declaration: &StyleDeclaration) {
+  pub(crate) fn insert_declaration(&mut self, declaration: &StyleDeclaration) {
     self
       .longhands
       .extend(declaration.affected_longhands().iter());
@@ -1500,7 +1500,7 @@ impl DeclarationImportance {
   }
 
   /// Merges another importance set, deduping custom properties.
-  pub fn append(&mut self, other: &mut Self) {
+  pub(crate) fn append(&mut self, other: &mut Self) {
     self.longhands.append(&mut other.longhands);
 
     for name in other.custom_properties.drain(..) {
@@ -1568,7 +1568,7 @@ impl StyleDeclarationBlock {
   }
 
   /// Appends another block's declarations and importance.
-  pub fn append(&mut self, mut other: Self) {
+  pub(crate) fn append(&mut self, mut other: Self) {
     self.importance.append(&mut other.importance);
     self.declarations.extend(other.declarations);
   }
@@ -1589,7 +1589,7 @@ impl StyleDeclarationBlock {
   }
 
   /// Collects resource URLs referenced by declarations in this block.
-  pub fn resource_urls(&self) -> impl Iterator<Item = &str> {
+  pub fn image_urls(&self) -> impl Iterator<Item = &str> {
     fn background_image_url(image: &BackgroundImage) -> Option<&str> {
       if let BackgroundImage::Url(url) = image {
         Some(url.as_ref())

--- a/takumi-core/src/style/stylesheets_helpers.rs
+++ b/takumi-core/src/style/stylesheets_helpers.rs
@@ -8,12 +8,12 @@ use crate::style::{
 };
 
 #[derive(Debug, Clone)]
-pub struct CssInputParseFailure {
+pub(crate) struct CssInputParseFailure {
   location: SourceLocation,
   detail: Option<String>,
 }
 
-pub enum CssInputParseError<'de> {
+pub(crate) enum CssInputParseError<'de> {
   Value {
     value: Cow<'de, str>,
     expected: Cow<'static, str>,
@@ -30,7 +30,7 @@ pub enum CssInputParseError<'de> {
 }
 
 impl CssInputParseError<'_> {
-  pub fn into_serde_error<E>(self, property_name: &str, property: PropertyId) -> E
+  pub(crate) fn into_serde_error<E>(self, property_name: &str, property: PropertyId) -> E
   where
     E: serde::de::Error,
   {

--- a/takumi-core/src/style/stylesheets_mask.rs
+++ b/takumi-core/src/style/stylesheets_mask.rs
@@ -31,7 +31,7 @@ impl PropertyMask {
     (self.words[word_index] & (1usize << bit_index)) != 0
   }
 
-  pub fn append(&mut self, other: &mut Self) {
+  pub(crate) fn append(&mut self, other: &mut Self) {
     for (word, other_word) in self.words.iter_mut().zip(other.words.iter_mut()) {
       *word |= *other_word;
       *other_word = 0;

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -8,7 +8,7 @@ use crate::style::{SizingContext, properties::*};
 
 impl ComputedStyle {
   /// Normalize inheritable text-related values to computed values for this node.
-  pub fn make_computed(&mut self, sizing: &SizingContext) {
+  pub(crate) fn make_computed(&mut self, sizing: &SizingContext) {
     // `font-size` computed value is already resolved in `sizing.font_size`.
     // Keep it as css-px in style to avoid re-resolving descendant inheritance.
     self.font_size = FontSize::Length(Length::Px(sizing.to_css(sizing.font_size)));
@@ -46,26 +46,27 @@ impl ComputedStyle {
   }
 
   /// Whether `z-index` takes effect on this element.
-  pub fn is_z_index_applicable(&self, is_flex_or_grid_item: bool) -> bool {
+  pub(crate) fn is_z_index_applicable(&self, is_flex_or_grid_item: bool) -> bool {
     !matches!(self.z_index, ZIndex::Auto) && (self.position.is_positioned() || is_flex_or_grid_item)
   }
 
   /// Whether the element paints in the positioned/z-index bucket.
-  pub fn participates_in_positioned_paint_bucket(&self, is_flex_or_grid_item: bool) -> bool {
+  pub(crate) fn participates_in_positioned_paint_bucket(&self, is_flex_or_grid_item: bool) -> bool {
     self.position.is_positioned() || self.is_z_index_applicable(is_flex_or_grid_item)
   }
 
   /// Whether the element establishes a new stacking context.
-  pub fn creates_stacking_context(
+  pub(crate) fn creates_stacking_context(
     &self,
-    border_box: Size<f32>,
+    width: f32,
+    height: f32,
     sizing: &SizingContext,
     is_flex_or_grid_item: bool,
   ) -> bool {
     self.isolation == Isolation::Isolate
       || self.is_z_index_applicable(is_flex_or_grid_item)
       || self.offset_path.is_some()
-      || self.has_non_identity_transform(border_box, sizing)
+      || self.has_non_identity_transform(width, height, sizing)
       || self.needs_offscreen_compositing()
   }
 
@@ -93,14 +94,14 @@ impl ComputedStyle {
   /// Builds the element's local affine transform around its transform-origin
   /// (CSS Transforms Level 2 order: `T(origin) * translate * rotate * scale *
   /// transform * T(-origin)`).
-  pub fn local_transform(&self, border_box: Size<f32>, sizing: &SizingContext) -> Affine {
-    let origin = self.transform_origin.to_point(sizing, border_box);
-    let mut local = Affine::translation(origin.x, origin.y);
+  pub fn local_transform(&self, width: f32, height: f32, sizing: &SizingContext) -> Affine {
+    let (origin_x, origin_y) = self.transform_origin.to_point(sizing, width, height);
+    let mut local = Affine::translation(origin_x, origin_y);
 
     if self.translate != SpacePair::default() {
       local *= Affine::translation(
-        self.translate.x.to_px(sizing, border_box.width),
-        self.translate.y.to_px(sizing, border_box.height),
+        self.translate.x.to_px(sizing, width),
+        self.translate.y.to_px(sizing, height),
       );
     }
     if let Some(rotate) = self.rotate {
@@ -112,45 +113,51 @@ impl ComputedStyle {
     // offset-path sits after translate/rotate/scale and before `transform`, and
     // resolves against the containing block (Blink `GetReferenceBox`), proxied
     // here by the query-container size, then the viewport, then the border box.
-    let reference_box = Size {
-      width: sizing
-        .container_size
-        .width
-        .filter(|width| *width > 0.0)
-        .or_else(|| sizing.viewport.size.width.map(|width| width as f32))
-        .unwrap_or(border_box.width),
-      height: sizing
-        .container_size
-        .height
-        .filter(|height| *height > 0.0)
-        .or_else(|| sizing.viewport.size.height.map(|height| height as f32))
-        .unwrap_or(border_box.height),
-    };
+    let reference_width = sizing
+      .container_size
+      .width
+      .filter(|width| *width > 0.0)
+      .or_else(|| sizing.viewport.size.width.map(|width| width as f32))
+      .unwrap_or(width);
+    let reference_height = sizing
+      .container_size
+      .height
+      .filter(|height| *height > 0.0)
+      .or_else(|| sizing.viewport.size.height.map(|height| height as f32))
+      .unwrap_or(height);
     if let Some(path) = &self.offset_path
       && let Some((point, tangent)) = sample_offset_path(
         path,
         self.offset_distance,
         &self.offset_position,
         sizing,
-        reference_box,
+        Size {
+          width: reference_width,
+          height: reference_height,
+        },
       )
     {
-      local *= Affine::translation(point.x - origin.x, point.y - origin.y);
+      local *= Affine::translation(point.x - origin_x, point.y - origin_y);
       local *= Affine::rotation_radians(self.offset_rotate.resolve(tangent));
-      if let Some(anchor) = self.offset_anchor.resolve(sizing, border_box) {
-        local *= Affine::translation(origin.x - anchor.x, origin.y - anchor.y);
+      if let Some((anchor_x, anchor_y)) = self.offset_anchor.resolve(sizing, width, height) {
+        local *= Affine::translation(origin_x - anchor_x, origin_y - anchor_y);
       }
     }
     if let Some(node_transform) = &self.transform {
-      local *= Affine::from_transforms(node_transform.iter(), sizing, border_box);
+      local *= Affine::from_transforms(node_transform.iter(), sizing, width, height);
     }
-    local *= Affine::translation(-origin.x, -origin.y);
+    local *= Affine::translation(-origin_x, -origin_y);
     local
   }
 
   /// Whether the resolved local transform differs from identity.
-  pub fn has_non_identity_transform(&self, border_box: Size<f32>, sizing: &SizingContext) -> bool {
-    !self.local_transform(border_box, sizing).is_identity()
+  pub(crate) fn has_non_identity_transform(
+    &self,
+    width: f32,
+    height: f32,
+    sizing: &SizingContext,
+  ) -> bool {
+    !self.local_transform(width, height, sizing).is_identity()
   }
 
   /// The `(overflow-x, overflow-y)` pair.
@@ -164,7 +171,7 @@ impl ComputedStyle {
   }
 
   /// The string used to mark truncated text.
-  pub fn ellipsis_char(&self) -> &str {
+  pub(crate) fn ellipsis_char(&self) -> &str {
     const ELLIPSIS_CHAR: &str = "…";
 
     match &self.text_overflow {
@@ -187,7 +194,7 @@ impl ComputedStyle {
   }
 
   /// The wrap mode used for layout, forcing wrap for single-line ellipsis.
-  pub fn resolved_text_wrap_mode(&self) -> TextWrapMode {
+  pub(crate) fn resolved_text_wrap_mode(&self) -> TextWrapMode {
     if self.forces_single_line_ellipsis() {
       TextWrapMode::Wrap
     } else {
@@ -200,7 +207,7 @@ impl ComputedStyle {
   /// `nowrap` + `ellipsis` clamps to a single line; otherwise `max-lines` applies
   /// only inside a fragmentation context (`continue: collapse`), per CSS Overflow 4.
   /// The ellipsis itself comes from [`Self::ellipsis_char`].
-  pub fn clamp_lines(&self) -> Option<u32> {
+  pub(crate) fn clamp_lines(&self) -> Option<u32> {
     if self.forces_single_line_ellipsis() {
       return Some(1);
     }
@@ -225,7 +232,7 @@ impl ComputedStyle {
 
   #[inline]
   /// The decoration thickness resolved to pixels or `from-font`.
-  pub fn resolved_text_decoration_thickness(
+  pub(crate) fn resolved_text_decoration_thickness(
     &self,
     sizing: &SizingContext,
   ) -> SizedTextDecorationThickness {
@@ -242,7 +249,7 @@ impl ComputedStyle {
   /// Resolved OpenType features: the `font-variant-*` expansions followed by explicit
   /// `font-feature-settings`, which win on tag conflicts. Borrows the settings when no
   /// `font-variant-*` is active, avoiding an allocation.
-  pub fn resolved_font_features(&self) -> Cow<'_, [FontFeature]> {
+  pub(crate) fn resolved_font_features(&self) -> Cow<'_, [FontFeature]> {
     let mut features = Vec::new();
     append_variant_features(
       &self.font_variant_ligatures,
@@ -262,7 +269,7 @@ impl ComputedStyle {
   }
 
   /// Converts the computed style into a `taffy::Style` for layout.
-  pub fn to_taffy_style(&self, sizing: &SizingContext) -> taffy::Style {
+  pub(crate) fn to_taffy_style(&self, sizing: &SizingContext) -> taffy::Style {
     // Convert grid templates and associated line names
     let (grid_template_columns, grid_template_column_names) =
       Self::grid_template(&self.grid_template_columns, sizing);

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -694,7 +694,7 @@ fn style_declaration_block_collect_style_fetch_tasks_collects_url_images() {
   ]));
 
   assert_eq!(
-    declarations.resource_urls().collect::<Vec<_>>(),
+    declarations.image_urls().collect::<Vec<_>>(),
     vec![background_url, mask_url]
   );
 }
@@ -810,10 +810,10 @@ fn test_creates_stacking_context_from_z_index_scope() {
 
   style.position = Position::Relative;
   style.z_index = ZIndex::Integer(1);
-  assert!(style.creates_stacking_context(border_box, &sizing, false));
+  assert!(style.creates_stacking_context(border_box.width, border_box.height, &sizing, false));
 
   style.position = Position::Absolute;
-  assert!(style.creates_stacking_context(border_box, &sizing, false));
+  assert!(style.creates_stacking_context(border_box.width, border_box.height, &sizing, false));
 }
 
 #[test]
@@ -868,15 +868,14 @@ fn test_offset_path_moves_element_onto_path_and_creates_stacking_context() {
   style.offset_path = OffsetPath::from_css_str("path('M 0 0 L 100 0')").ok();
   style.offset_distance = Length::Percentage(50.0);
 
-  assert!(style.creates_stacking_context(border_box, &sizing, false));
+  assert!(style.creates_stacking_context(border_box.width, border_box.height, &sizing, false));
 
   // The default offset-anchor is transform-origin (the box center). At 50% the
   // anchor lands on the path midpoint (50, 0).
-  let local = style.local_transform(border_box, &sizing);
-  let center = taffy::Point { x: 50.0, y: 20.0 };
-  let placed = local.transform_point(center);
-  assert!((placed.x - 50.0).abs() < 0.5, "x = {}", placed.x);
-  assert!(placed.y.abs() < 0.5, "y = {}", placed.y);
+  let local = style.local_transform(border_box.width, border_box.height, &sizing);
+  let (placed_x, placed_y) = local.transform_point(50.0, 20.0);
+  assert!((placed_x - 50.0).abs() < 0.5, "x = {}", placed_x);
+  assert!(placed_y.abs() < 0.5, "y = {}", placed_y);
 }
 
 #[test]
@@ -905,13 +904,13 @@ fn test_non_identity_transform_detection() {
     height: 100.0,
   };
 
-  assert!(!style.has_non_identity_transform(border_box, &sizing));
+  assert!(!style.has_non_identity_transform(border_box.width, border_box.height, &sizing));
 
   style.transform = Some([Transform::Rotate(Angle::new(0.0))].into());
-  assert!(!style.has_non_identity_transform(border_box, &sizing));
+  assert!(!style.has_non_identity_transform(border_box.width, border_box.height, &sizing));
 
   style.transform = Some([Transform::Rotate(Angle::new(10.0))].into());
-  assert!(style.has_non_identity_transform(border_box, &sizing));
+  assert!(style.has_non_identity_transform(border_box.width, border_box.height, &sizing));
 }
 
 #[test]
@@ -933,7 +932,7 @@ fn test_transform_creates_stacking_context_without_offscreen_compositing() {
 
   style.transform = Some([Transform::Rotate(Angle::new(10.0))].into());
 
-  assert!(style.creates_stacking_context(border_box, &sizing, false));
+  assert!(style.creates_stacking_context(border_box.width, border_box.height, &sizing, false));
   assert!(!style.needs_offscreen_compositing());
 }
 

--- a/takumi-core/src/style/tw/builder.rs
+++ b/takumi-core/src/style/tw/builder.rs
@@ -299,7 +299,7 @@ impl TwTransformState {
 
 /// Accumulated Tailwind gradient utilities pending synthesis into a `background-image`.
 #[derive(Debug, Default)]
-pub struct TwGradientState {
+pub(crate) struct TwGradientState {
   /// Gradient kind (linear, radial, conic).
   pub gradient_type: TwGradientType,
   /// Linear/conic angle, if set.
@@ -322,7 +322,7 @@ pub struct TwGradientState {
 
 /// Gradient kind.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub enum TwGradientType {
+pub(crate) enum TwGradientType {
   /// Linear gradient.
   #[default]
   Linear,

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -10,7 +10,7 @@ macro_rules! property_parsers {
   ($($variant:ident($arg:ty) => $parse:ty),+ $(,)?) => {
     /// Maps a parsed argument type to a [`TailwindProperty`] constructor.
     #[derive(Clone, Copy)]
-    pub enum PropertyParser {
+    pub(crate) enum PropertyParser {
       $(
         #[doc = concat!("Parser producing `", stringify!($variant), "` properties.")]
         $variant(fn($arg) -> TailwindProperty),
@@ -84,7 +84,7 @@ property_parsers! {
 }
 
 /// Maps a utility prefix to the parsers tried against its suffix.
-pub static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
+pub(crate) static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
   "object" => &[
     PropertyParser::ObjectFit(TailwindProperty::ObjectFit),
     PropertyParser::ObjectPosition(TailwindProperty::ObjectPosition),
@@ -317,7 +317,7 @@ const TEXT_SHADOW_MD: [TextShadow; 3] = [ts(1.0, 1.0, 26), ts(1.0, 2.0, 26), ts(
 const TEXT_SHADOW_LG: [TextShadow; 3] = [ts(1.0, 2.0, 26), ts(3.0, 2.0, 26), ts(4.0, 8.0, 26)];
 
 /// Maps a complete utility token to its fixed property.
-pub static FIXED_PROPERTIES: phf::Map<&str, TailwindProperty> = phf_map! {
+pub(crate) static FIXED_PROPERTIES: phf::Map<&str, TailwindProperty> = phf_map! {
   "border" => TailwindProperty::BorderDefault,
   "outline" => TailwindProperty::OutlineDefault,
   "box-border" => TailwindProperty::BoxSizing(BoxSizing::BorderBox),

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -4,11 +4,10 @@ pub mod map;
 /// Parsers for Tailwind utility-class suffixes.
 pub mod parser;
 
-use builder::TailwindDeclarationBuilder;
-pub(crate) use builder::TwGradientType;
-
 use std::{borrow::Cow, cmp::Ordering, str::FromStr};
 
+use builder::TailwindDeclarationBuilder;
+pub(crate) use builder::TwGradientType;
 use cssparser::match_ignore_ascii_case;
 use serde::{Deserialize, Deserializer, de::Error as DeError};
 

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -5,7 +5,7 @@ pub mod map;
 pub mod parser;
 
 use builder::TailwindDeclarationBuilder;
-pub use builder::{TwGradientState, TwGradientType};
+pub(crate) use builder::TwGradientType;
 
 use std::{borrow::Cow, cmp::Ordering, str::FromStr};
 
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Tailwind v4 `--spacing` (rem per unit). Prefer [`Length::from_spacing`].
-pub const TW_VAR_SPACING: f32 = 0.25;
+pub(crate) const TW_VAR_SPACING: f32 = 0.25;
 
 /// Represents a collection of tailwind properties.
 #[derive(Debug, Clone, PartialEq)]
@@ -67,7 +67,7 @@ impl FromStr for TailwindValues {
 
 impl TailwindValues {
   /// Collects resource URLs referenced by active Tailwind utilities for the given viewport.
-  pub fn resource_urls(&self, viewport: Viewport) -> impl Iterator<Item = &str> {
+  pub(crate) fn image_urls(&self, viewport: Viewport) -> impl Iterator<Item = &str> {
     self
       .inner
       .iter()
@@ -76,7 +76,7 @@ impl TailwindValues {
 
   /// Resolves all utilities for the viewport into a declaration block.
   #[inline(never)]
-  pub fn into_declaration_block(self, viewport: Viewport) -> StyleDeclarationBlock {
+  pub(crate) fn into_declaration_block(self, viewport: Viewport) -> StyleDeclarationBlock {
     let mut builder = TailwindDeclarationBuilder::default();
 
     for value in self.inner {
@@ -100,7 +100,7 @@ impl<'de> Deserialize<'de> for TailwindValues {
 
 /// Represents a tailwind value.
 #[derive(Debug, Clone, PartialEq)]
-pub struct TailwindValue {
+pub(crate) struct TailwindValue {
   /// The tailwind property.
   pub property: TailwindProperty,
   /// The breakpoint.
@@ -196,7 +196,7 @@ impl TailwindValue {
 
 /// Represents a breakpoint.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Breakpoint(pub Length);
+pub(crate) struct Breakpoint(pub Length);
 
 impl Breakpoint {
   /// Parse a breakpoint from a token.
@@ -230,7 +230,7 @@ impl Breakpoint {
 
 /// Represents a tailwind property.
 #[derive(Debug, Clone, PartialEq)]
-pub enum TailwindProperty {
+pub(crate) enum TailwindProperty {
   /// `background-clip` property.
   BackgroundClip(BackgroundClip),
   /// `box-sizing` property.

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -11,7 +11,7 @@ use crate::style::{
 
 /// Tailwind `text-*` font size with optional paired line height.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TwFontSize {
+pub(crate) struct TwFontSize {
   /// Font size.
   pub font_size: FontSize,
   /// Paired line height, if any.
@@ -93,7 +93,7 @@ impl TwFontSize {
 
 /// Tailwind `grid-cols-*` / `grid-rows-*` track template.
 #[derive(Debug, Clone, PartialEq)]
-pub struct TwGridTemplate(
+pub(crate) struct TwGridTemplate(
   /// Resolved track components.
   pub GridTemplateComponents,
 );
@@ -137,7 +137,7 @@ impl TailwindPropertyParser for TwGridTemplate {
 
 /// Tailwind `tracking-*` letter spacing.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TwLetterSpacing(
+pub(crate) struct TwLetterSpacing(
   /// Letter spacing length.
   pub Length,
 );
@@ -174,7 +174,7 @@ impl TailwindPropertyParser for TwLetterSpacing {
 
 /// Tailwind `rounded-*` corner radius.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TwRounded(
+pub(crate) struct TwRounded(
   /// Corner radius.
   pub Length,
 );
@@ -207,7 +207,7 @@ impl TailwindPropertyParser for TwRounded {
 
 /// `<length-percentage>` for `from-N%` / `via-N%` / `to-N%` stop positions.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TwGradientPosition(
+pub(crate) struct TwGradientPosition(
   /// Stop position length-percentage.
   pub Length,
 );
@@ -239,7 +239,7 @@ impl TailwindPropertyParser for TwGradientPosition {
 
 /// Tailwind `blur-*` radius.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TwBlur(
+pub(crate) struct TwBlur(
   /// Blur radius.
   pub Length,
 );

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -1,8 +1,7 @@
 use std::assert_matches;
 
-use crate::style::{ComputedStyle, LonghandId, Style, properties::BackgroundImage};
-
 use super::*;
+use crate::style::{ComputedStyle, LonghandId, Style, properties::BackgroundImage};
 
 #[test]
 fn test_box_sizing() {

--- a/takumi-core/src/viewport.rs
+++ b/takumi-core/src/viewport.rs
@@ -1,7 +1,7 @@
 use taffy::{AvailableSpace, Size};
 
 /// The default font size in pixels.
-pub const DEFAULT_FONT_SIZE: f32 = 16.0;
+pub(crate) const DEFAULT_FONT_SIZE: f32 = 16.0;
 
 /// The default device pixel ratio.
 pub const DEFAULT_DEVICE_PIXEL_RATIO: f32 = 1.0;
@@ -85,7 +85,7 @@ impl Viewport {
   /// Converts a device-pixel value back into author-space CSS pixels. The
   /// inverse of [`Self::to_device`]; the only place the ratio is divided out.
   #[inline]
-  pub fn to_css(self, device_px: f32) -> f32 {
+  pub(crate) fn to_css(self, device_px: f32) -> f32 {
     device_px / self.effective_dpr()
   }
 }

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -16,12 +16,11 @@ use html5ever::{
   tendril::TendrilSink,
 };
 use markup5ever_rcdom::{Handle, NodeData, RcDom, SerializableHandle};
-use typed_builder::TypedBuilder;
-
 use takumi_core::{
   layout::node::{ImageData, ImageSourceInput, Node, NodeKind},
   style::{Direction, FromCssStr, Style, StyleDeclarationBlock, tw::TailwindValues},
 };
+use typed_builder::TypedBuilder;
 
 /// Tags whose entire subtree is dropped, matching the JS `isHtmlVoidElement`
 /// set. Deliberately distinct from the `display:none` presets (`title`,

--- a/takumi-image-response/package.json
+++ b/takumi-image-response/package.json
@@ -27,16 +27,6 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    },
-    "./wasm": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
     }
   },
   "scripts": {

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -1,6 +1,7 @@
 //! Node.js N-API bindings for Takumi.
 
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 #![deny(missing_docs)]
 
 mod load_font_task;
@@ -15,13 +16,15 @@ use std::{fmt::Display, ops::Deref};
 
 use napi::{De, Env, Error, bindgen_prelude::*};
 use napi_derive::napi;
-use serde::{Deserialize, Deserializer, de::DeserializeOwned, de::Error as DeError};
+pub use renderer::Renderer;
+use serde::{
+  Deserialize, Deserializer,
+  de::{DeserializeOwned, Error as DeError},
+};
 use takumi_core::{
   resources::font::{FontOverride, FontResource},
   style::{FontStyle, FromCssStr, KeyframesRule, StyleSheet},
 };
-
-pub use renderer::Renderer;
 
 /// A font family produced by `registerFont`, with the faces it contains.
 #[napi(object)]

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
-
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use rayon::prelude::*;

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -3,6 +3,10 @@ use std::sync::Arc;
 use image::Rgba;
 use smallvec::{SmallVec, smallvec};
 use taffy::{Layout, Point, Size};
+use takumi_core::paint::{
+  ConicGradientTile, GradientOverlayTile, LinearGradientTile, RadialGradientTile,
+  collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
+};
 use tiny_skia::{IntSize, Pixmap, PixmapMut, PremultipliedColorU8};
 
 #[cfg(feature = "svg")]
@@ -15,10 +19,6 @@ use crate::{
   pixmap_from_buffer, pixmap_ref_from_buffer,
   resources::{image::ImageSource, image_buffer::ImageBuffer},
   style::*,
-};
-use takumi_core::paint::{
-  ConicGradientTile, GradientOverlayTile, LinearGradientTile, RadialGradientTile,
-  collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
 };
 
 pub(crate) struct TileLayer {

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -140,7 +140,10 @@ pub(crate) fn rasterize_layers(
           && layer_transform.only_translation()
           && layer.blend_mode == BlendMode::Normal
         {
-          let translation = layer_transform.decompose_translation();
+          let translation = Point {
+            x: layer_transform.x,
+            y: layer_transform.y,
+          };
           match &layer.tile {
             BackgroundTile::Linear(linear_gradient) => {
               overlay_linear_gradient_tile(

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -819,21 +819,14 @@ fn blit_sampled_paint_source_translation(
   let footprint = sampling_footprint(sampling.logical_to_source);
   for dest_y in dest_y_min..dest_y_max {
     let src_y = (dest_y - offset_y) as f32;
-    let mut sample_point = sampling.logical_to_source.transform_point(Point {
-      x: (dest_x_min - offset_x) as f32 + 0.5,
-      y: src_y + 0.5,
-    });
+    let (mut sample_x, mut sample_y) = sampling
+      .logical_to_source
+      .transform_point((dest_x_min - offset_x) as f32 + 0.5, src_y + 0.5);
     for dest_x in dest_x_min..dest_x_max {
-      let src = sample_paint_source(
-        source,
-        sampling.algorithm,
-        sample_point.x,
-        sample_point.y,
-        footprint,
-      )
-      .unwrap_or([0, 0, 0, 0]);
-      sample_point.x += sampling.logical_to_source.a;
-      sample_point.y += sampling.logical_to_source.b;
+      let src = sample_paint_source(source, sampling.algorithm, sample_x, sample_y, footprint)
+        .unwrap_or([0, 0, 0, 0]);
+      sample_x += sampling.logical_to_source.a;
+      sample_y += sampling.logical_to_source.b;
       if src[3] == 0 {
         continue;
       }
@@ -1211,7 +1204,10 @@ pub(crate) fn overlay_image<'a, I: Into<PaintSource<'a>>>(
   }
 
   if options.border.is_zero() && options.transform.only_translation() {
-    let offset = options.transform.decompose_translation();
+    let offset = Point {
+      x: options.transform.x,
+      y: options.transform.y,
+    };
     blit_paint_source_translation(pixmap, image, offset, options.mode, options.combined_mask);
     return;
   }
@@ -1331,7 +1327,10 @@ fn overlay_sampled_paint_source(
       pixmap,
       source,
       size,
-      options.transform.decompose_translation(),
+      Point {
+        x: options.transform.x,
+        y: options.transform.y,
+      },
       sampling,
       options.mode,
       options.combined_mask,

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -10,11 +10,21 @@ mod paint_source;
 
 use std::{mem::replace, sync::Arc};
 
+pub(crate) use buffer_pool::BufferPool;
 use image::{
   ImageError, Rgba, RgbaImage,
   error::{ParameterError, ParameterErrorKind},
 };
+pub(crate) use mask::{
+  CanvasViewport, NodeMaskAction, attenuate_alpha_by_mask, intersect_alpha_masks,
+  prepare_node_mask, render_mask,
+};
+pub(crate) use paint_source::{PaintSource, SamplingFootprint, interpolate_with_footprint};
 use taffy::{Point, Size};
+use takumi_core::paint::{
+  GradientOverlayTile, LinearGradientFastPathKind, LinearGradientTile, RadialGradientTile,
+  overlay_gradient_tile_fast_normal_unconstrained,
+};
 use tiny_skia::{
   FillRule as TinyFillRule, FilterQuality as TinyFilterQuality, IntSize, Mask as TinyMask,
   Paint as TinyPaint, Path as TinyPath, Pattern as TinyPattern, Pixmap, PixmapMut, PixmapPaint,
@@ -33,17 +43,6 @@ use crate::{
   stacking_context::blend_pixmap_software,
   style::{Affine, BlendMode, Color, ImageScalingAlgorithm},
 };
-use takumi_core::paint::{
-  GradientOverlayTile, LinearGradientFastPathKind, LinearGradientTile, RadialGradientTile,
-  overlay_gradient_tile_fast_normal_unconstrained,
-};
-
-pub(crate) use buffer_pool::BufferPool;
-pub(crate) use mask::{
-  CanvasViewport, NodeMaskAction, attenuate_alpha_by_mask, intersect_alpha_masks,
-  prepare_node_mask, render_mask,
-};
-pub(crate) use paint_source::{PaintSource, SamplingFootprint, interpolate_with_footprint};
 
 #[derive(Clone, Copy)]
 pub(crate) struct SamplingOptions {
@@ -1664,8 +1663,10 @@ pub(crate) fn overlay_radial_gradient_tile(
 #[cfg(test)]
 mod tests {
   use image::RgbaImage;
+  use takumi_core::paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile};
   use tiny_skia::PixmapMut;
 
+  use super::*;
   use crate::{
     Fonts, RenderContext, blend_pixel, pixmap_from_buffer,
     resources::image_buffer::ImageBuffer,
@@ -1675,9 +1676,6 @@ mod tests {
     },
     viewport::Viewport,
   };
-  use takumi_core::paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile};
-
-  use super::*;
 
   fn overlay_area_reference(
     bottom: &mut RgbaImage,

--- a/takumi-raster/src/canvas/composite.rs
+++ b/takumi-raster/src/canvas/composite.rs
@@ -322,10 +322,10 @@ fn source_general(
     let mask_y = (dest_y - offset_y) as usize;
     let dst_row = dest_y as usize * canvas_width;
     let mask_row = mask_y * mask_stride;
-    let mut sample = options.sampling.canvas_to_source.transform_point(Point {
-      x: dest_x_min as f32 + options.sampling.sample_bias.x,
-      y: dest_y as f32 + options.sampling.sample_bias.y,
-    });
+    let (mut sample_x, mut sample_y) = options.sampling.canvas_to_source.transform_point(
+      dest_x_min as f32 + options.sampling.sample_bias.x,
+      dest_y as f32 + options.sampling.sample_bias.y,
+    );
     for dest_x in dest_x_min..dest_x_max {
       let mask_alpha = mask[mask_row + (dest_x - offset_x) as usize];
       let sampled = if mask_alpha == 0 {
@@ -334,13 +334,13 @@ fn source_general(
         sample_paint_source(
           source,
           options.sampling.algorithm,
-          sample.x,
-          sample.y,
+          sample_x,
+          sample_y,
           footprint,
         )
       };
-      sample.x += options.sampling.canvas_to_source.a;
-      sample.y += options.sampling.canvas_to_source.b;
+      sample_x += options.sampling.canvas_to_source.a;
+      sample_y += options.sampling.canvas_to_source.b;
 
       let Some(mut src) = sampled else {
         continue;

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -545,15 +545,15 @@ fn transformed_mask_point(
   x: u32,
   y: u32,
 ) -> Option<Point<u32>> {
-  let original_point = inverse_transform.transform_point(Point {
-    x: x as f32,
-    y: y as f32,
-  });
-  if original_point.x < 0.0 || original_point.y < 0.0 {
+  let (original_x, original_y) = inverse_transform.transform_point(x as f32, y as f32);
+  if original_x < 0.0 || original_y < 0.0 {
     return None;
   }
 
-  let original_point = original_point.map(|point| point as u32);
+  let original_point = Point {
+    x: original_x as u32,
+    y: original_y as u32,
+  };
   let is_contained = original_point.x >= from.x
     && original_point.x < to.x
     && original_point.y >= from.y

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -1,4 +1,5 @@
 use taffy::{AbsoluteAxis, Layout, Point, Rect, Size};
+use takumi_core::geometry::transformed_rect_extents;
 use tiny_skia::{
   FillRule as TinyFillRule, IntSize, Mask as TinyMask, PathBuilder as TinyPathBuilder,
   Rect as TinyRect, Transform as TinyTransform,
@@ -14,7 +15,6 @@ use crate::{
     Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
   },
 };
-use takumi_core::geometry::transformed_rect_extents;
 
 pub(crate) enum NodeMaskAction {
   Shell(TinyMask),

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -1,5 +1,4 @@
 use taffy::{Point, Rect, Size};
-
 use takumi_core::layout::border::{
   BorderProperties, BorderSide, border_dash_pattern, inset_size, rect_offset,
   shade_3d_border_color, subtract_rect,
@@ -647,7 +646,6 @@ fn paint_mask_with_inverse(
 #[cfg(test)]
 mod tests {
   use taffy::{Rect, Size};
-
   use takumi_core::{
     layout::border::BorderProperties,
     style::{Affine, BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},

--- a/takumi-raster/src/components/shadow.rs
+++ b/takumi-raster/src/components/shadow.rs
@@ -1,13 +1,12 @@
 use taffy::{Layout, Point, Size};
 use tiny_skia::PixmapRef;
 
+pub(crate) use crate::shadow::SizedShadow;
 use crate::{
   BlurFormat, BlurType, BorderProperties, BufferPool, Canvas, Command, Fill, Placement, Result,
   SamplingOptions, Style, apply_blur, attenuate_alpha_by_mask, fast_div_255, render_mask,
   style::{Affine, BlendMode, ImageScalingAlgorithm, Sides},
 };
-
-pub(crate) use crate::shadow::SizedShadow;
 
 /// Draws the outset mask of the shadow.
 pub(crate) fn draw_outset_shadow(

--- a/takumi-raster/src/filter.rs
+++ b/takumi-raster/src/filter.rs
@@ -1,5 +1,6 @@
 use smallvec::SmallVec;
 use taffy::{Point, Size};
+use takumi_core::paint::compose_transfer_table;
 use tiny_skia::{Mask as TinyMask, PixmapMut};
 
 use crate::{
@@ -10,7 +11,6 @@ use crate::{
     SizingContext, TransferChannel, TransferTable,
   },
 };
-use takumi_core::paint::compose_transfer_table;
 
 /// Calculates the luma of an RGB pixel.
 #[inline(always)]

--- a/takumi-raster/src/filter.rs
+++ b/takumi-raster/src/filter.rs
@@ -4,10 +4,10 @@ use tiny_skia::{Mask as TinyMask, PixmapMut};
 
 use crate::{
   BlurFormat, BlurType, BorderProperties, BufferPool, Canvas, Placement, RenderContext, Result,
-  SizedShadow, apply_blur, apply_blur_rgba_bytes, intersect_alpha_masks, render_mask,
+  SizedShadow, apply_blur, apply_blur_rgba_bytes, fast_div_255, intersect_alpha_masks, render_mask,
   style::{
     Affine, Color, Filter, FilterCategory, LUMA_WEIGHTS, PercentageNumber, SEPIA_WEIGHTS,
-    SizingContext, TransferChannel, TransferTable, fast_div_255,
+    SizingContext, TransferChannel, TransferTable,
   },
 };
 use takumi_core::paint::compose_transfer_table;

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use parley::GlyphRun;
 use skrifa::{FontRef, MetadataProvider};
-use taffy::{Layout, Point};
+use taffy::{AvailableSpace, Layout, Point, geometry::Size};
 
 use crate::{
   BorderProperties, Canvas, Cap, DashPattern, DecorationSegmentParams, PaintSource, Placement,
@@ -27,7 +27,6 @@ use crate::{
     TextDecorationLines, TextDecorationSkipInk,
   },
 };
-use taffy::{AvailableSpace, geometry::Size};
 
 fn draw_with_inline_opacity(
   canvas: &mut Canvas,

--- a/takumi-raster/src/lib.rs
+++ b/takumi-raster/src/lib.rs
@@ -37,11 +37,6 @@ mod text_drawing;
 mod webp;
 mod write;
 
-use tiny_skia::{IntSize, Pixmap, PixmapRef};
-
-use crate::resources::image_buffer::ImageBuffer;
-
-pub(crate) use crate::font_style::*;
 pub(crate) use background_drawing::*;
 pub(crate) use blend::*;
 pub(crate) use canvas::*;
@@ -54,11 +49,16 @@ pub(crate) use node_paint::*;
 pub(crate) use path::*;
 pub use render::*;
 pub(crate) use text_drawing::*;
+use tiny_skia::{IntSize, Pixmap, PixmapRef};
 pub use write::*;
 
-pub(crate) use crate::style::math::{fast_div_255, fast_div_255_u32};
-
-pub(crate) use crate::{context::RenderContext, layout::inline::scale_text_fit_x};
+use crate::resources::image_buffer::ImageBuffer;
+pub(crate) use crate::{
+  context::RenderContext,
+  font_style::*,
+  layout::inline::scale_text_fit_x,
+  style::math::{fast_div_255, fast_div_255_u32},
+};
 
 /// Borrows an [`ImageBuffer`] as a zero-copy `tiny_skia` pixmap view.
 pub(crate) fn pixmap_ref_from_buffer(buffer: &ImageBuffer) -> Option<PixmapRef<'_>> {

--- a/takumi-raster/src/lib.rs
+++ b/takumi-raster/src/lib.rs
@@ -56,7 +56,7 @@ pub use render::*;
 pub(crate) use text_drawing::*;
 pub use write::*;
 
-pub(crate) use crate::style::{fast_div_255, fast_div_255_u32};
+pub(crate) use crate::style::math::{fast_div_255, fast_div_255_u32};
 
 pub(crate) use crate::{context::RenderContext, layout::inline::scale_text_fit_x};
 

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -118,7 +118,10 @@ pub(crate) fn draw_background(
               if transform.only_translation()
                 && canvas.overlay_background_tile_direct(
                   &tile.tile,
-                  transform.decompose_translation(),
+                  Point {
+                    x: transform.x,
+                    y: transform.y,
+                  },
                   tile.blend_mode,
                 )
               {

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -6,6 +6,12 @@
 
 use taffy::{AvailableSpace, Layout, Point, Size};
 
+use super::{
+  BackgroundTile, BorderPainting, BorderProperties, Canvas, Fill, PaintSource, RenderContext,
+  SizedFontStyle, SizedShadow, TileLayer, collect_background_layers, draw_image,
+  draw_inset_shadow_to_canvas, draw_outset_shadow, inline_drawing::draw_inline_layout,
+  rasterize_layers, release_rasterized_background_tile,
+};
 use crate::{
   Result,
   layout::{
@@ -16,13 +22,6 @@ use crate::{
     node::{ImageData, Node, NodeKind, TextData},
   },
   style::{Affine, BackgroundClip, BlendMode, Length, Sides},
-};
-
-use super::{
-  BackgroundTile, BorderPainting, BorderProperties, Canvas, Fill, PaintSource, RenderContext,
-  SizedFontStyle, SizedShadow, TileLayer, collect_background_layers, draw_image,
-  draw_inset_shadow_to_canvas, draw_outset_shadow, inline_drawing::draw_inline_layout,
-  rasterize_layers, release_rasterized_background_tile,
 };
 
 pub(crate) fn draw_outset_box_shadow(

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, ops::Range, rc::Rc, sync::Arc};
 use parley::{GlyphRun, InlineBoxKind, PositionedLayoutItem};
 use serde::Serialize;
 use taffy::{AvailableSpace, Layout, NodeId, TaffyError, geometry::Size};
+use takumi_core::scene::build_stacking_contexts;
 use typed_builder::TypedBuilder;
 
 use crate::{
@@ -24,7 +25,6 @@ use crate::{
   style::{Affine, ComputedStyle, FontFamily, SizingContext, StyleSheet},
   viewport::Viewport,
 };
-use takumi_core::scene::build_stacking_contexts;
 
 /// Root computed style carrying the render-level `lang` and `fontFamilies` defaults,
 /// inherited by every node that does not set its own.

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -272,14 +272,18 @@ fn collect_measure_result(
           return Err(TaffyError::InvalidInputNode(node_id).into());
         };
         let layout = *layout_results.layout(node_id)?;
-        current.context.sizing.container_size = container_size;
+        current
+          .context
+          .sizing
+          .set_container_size(container_size.width, container_size.height);
 
         transform *= Affine::translation(layout.location.x, layout.location.y);
         let mut local_transform = transform;
-        local_transform *= current
-          .context
-          .style
-          .local_transform(layout.size, &current.context.sizing);
+        local_transform *= current.context.style.local_transform(
+          layout.size.width,
+          layout.size.height,
+          &current.context.sizing,
+        );
         node_transforms.insert(node_id, local_transform);
 
         let mut children = Vec::new();

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -1,4 +1,8 @@
 use taffy::{AvailableSpace, Layout, NodeId, Point, TaffyError, geometry::Size};
+use takumi_core::{
+  geometry::transformed_rect_extents,
+  scene::{NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode},
+};
 use tiny_skia::{Pixmap, PixmapMut};
 
 use crate::{
@@ -16,10 +20,6 @@ use crate::{
   },
   prepare_node_mask,
   style::{Affine, BackgroundImage, BlendMode, Filter, SizingContext},
-};
-use takumi_core::{
-  geometry::transformed_rect_extents,
-  scene::{NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode},
 };
 
 fn bounds_intersects_viewport(bounds: SceneBounds, viewport: CanvasViewport) -> bool {

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -297,7 +297,10 @@ fn begin_node_render(
     return Ok(Some(DeferredNodeRender::SkipRendering));
   }
 
-  current.context.sizing.container_size = node_paint.container_size;
+  current.context.sizing.set_container_size(
+    node_paint.container_size.width,
+    node_paint.container_size.height,
+  );
   current.context.transform = node_paint.transform;
 
   if !current.context.style.backdrop_filter.is_empty() {

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -12,9 +12,11 @@ use typed_builder::TypedBuilder;
 pub use crate::webp::write_animated_webp;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::webp::write_webp_lossy;
-use crate::webp::{has_any_alpha_pixel, strip_alpha_channel, write_webp_lossless};
-
-use crate::{Result, error::Error};
+use crate::{
+  Result,
+  error::Error,
+  webp::{has_any_alpha_pixel, strip_alpha_channel, write_webp_lossless},
+};
 
 /// Lossy-encoding quality, clamped to the `0..=100` range (higher means better
 /// quality and larger output).

--- a/takumi-svg/src/box_model.rs
+++ b/takumi-svg/src/box_model.rs
@@ -296,7 +296,9 @@ pub(crate) fn element_transform(
   x: f32,
   y: f32,
 ) -> Option<Affine> {
-  let local = context.style.local_transform(border_box, &context.sizing);
+  let local = context
+    .style
+    .local_transform(border_box.width, border_box.height, &context.sizing);
   if local.is_identity() {
     return None;
   }

--- a/takumi-svg/src/lib.rs
+++ b/takumi-svg/src/lib.rs
@@ -22,14 +22,13 @@ mod image;
 mod render;
 mod scene_emit;
 mod text;
-pub use render::{SvgOptions, render};
-
 use std::{borrow::Cow, fmt, fmt::Write as _, io};
 
 use quick_xml::{
   Writer,
   events::{BytesEnd, BytesStart, Event},
 };
+pub use render::{SvgOptions, render};
 
 /// Straight-alpha RGBA color.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/takumi-svg/src/scene_emit.rs
+++ b/takumi-svg/src/scene_emit.rs
@@ -145,8 +145,7 @@ fn emit_box(
 
   let relative = parent.invert().unwrap_or(IDENTITY) * np.transform;
   let (x, y, group_transform) = if relative.only_translation() {
-    let origin = relative.decompose_translation();
-    (origin.x, origin.y, IDENTITY)
+    (relative.x, relative.y, IDENTITY)
   } else {
     (0.0, 0.0, relative)
   };

--- a/takumi-wasm/src/lib.rs
+++ b/takumi-wasm/src/lib.rs
@@ -1,6 +1,7 @@
 //! WebAssembly bindings for Takumi.
 
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 #![deny(missing_docs)]
 
 mod helper;

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -1,8 +1,9 @@
 //! Data models and types for the WebAssembly bindings.
 
+use std::sync::Arc;
+
 use serde::{Deserialize, Deserializer, de::Error as DeError};
 use serde_bytes::ByteBuf;
-use std::sync::Arc;
 use takumi_core::{
   keyframes::deserialize_optional_keyframes,
   layout::node::Node,

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -127,13 +127,13 @@ impl Renderer {
     Ok(stylesheet)
   }
 
-  fn fetch_resources_map(
+  fn fetch_images_map(
     &self,
-    resources: Option<&[ImageSource]>,
+    images: Option<&[ImageSource]>,
   ) -> Result<HashMap<Arc<str>, LoadedImageSource>, js_sys::Error> {
     let mut map = HashMap::new();
 
-    for source in resources.unwrap_or_default() {
+    for source in images.unwrap_or_default() {
       let mode = source.cache.unwrap_or_default();
       let image = self
         .image_cache
@@ -213,7 +213,7 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let images = self.fetch_resources_map(options.images.as_deref())?;
+    let images = self.fetch_images_map(options.images.as_deref())?;
     let state = self.read_state()?;
     self.render_internal(&state, node, options, images)
   }
@@ -281,7 +281,7 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let images = self.fetch_resources_map(options.images.as_deref())?;
+    let images = self.fetch_images_map(options.images.as_deref())?;
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
     let state = self.read_state()?;
@@ -316,7 +316,7 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let images = self.fetch_resources_map(options.images.as_deref())?;
+    let images = self.fetch_images_map(options.images.as_deref())?;
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
 
@@ -364,7 +364,7 @@ impl Renderer {
       ));
     }
 
-    let images = self.fetch_resources_map(options.images.as_deref())?;
+    let images = self.fetch_images_map(options.images.as_deref())?;
     let state = self.read_state()?;
     let buffer = self.render_internal(&state, node, options, images)?;
 
@@ -394,7 +394,7 @@ impl Renderer {
       font_families,
       lang,
     } = from_value(options.into()).map_err(map_error)?;
-    let images = self.fetch_resources_map(images.as_deref())?;
+    let images = self.fetch_images_map(images.as_deref())?;
     let lang = lang.map(Arc::from);
 
     if scenes.is_empty() {

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -1,13 +1,13 @@
 //! The main renderer for Takumi image rendering engine.
 
-use crate::{helper::map_error, model::*};
-use base64::{Engine, prelude::BASE64_STANDARD};
-use serde_wasm_bindgen::{from_value, to_value};
 use std::{
   borrow::Cow,
   collections::HashMap,
   sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
+
+use base64::{Engine, prelude::BASE64_STANDARD};
+use serde_wasm_bindgen::{from_value, to_value};
 use takumi_core::{
   Fonts,
   layout::node::Node,
@@ -24,6 +24,8 @@ use takumi_raster::{
   write_image,
 };
 use wasm_bindgen::prelude::*;
+
+use crate::{helper::map_error, model::*};
 
 const EMBEDDED_FONTS: &[(&[u8], &str, GenericFamily)] = &[(
   include_bytes!("../../assets/fonts/manrope/manrope-latin-wght-normal.woff2"),
@@ -127,7 +129,7 @@ impl Renderer {
     Ok(stylesheet)
   }
 
-  fn fetch_images_map(
+  fn images_map(
     &self,
     images: Option<&[ImageSource]>,
   ) -> Result<HashMap<Arc<str>, LoadedImageSource>, js_sys::Error> {
@@ -213,7 +215,7 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let images = self.fetch_images_map(options.images.as_deref())?;
+    let images = self.images_map(options.images.as_deref())?;
     let state = self.read_state()?;
     self.render_internal(&state, node, options, images)
   }
@@ -281,7 +283,7 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let images = self.fetch_images_map(options.images.as_deref())?;
+    let images = self.images_map(options.images.as_deref())?;
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
     let state = self.read_state()?;
@@ -316,7 +318,7 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let images = self.fetch_images_map(options.images.as_deref())?;
+    let images = self.images_map(options.images.as_deref())?;
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
 
@@ -364,7 +366,7 @@ impl Renderer {
       ));
     }
 
-    let images = self.fetch_images_map(options.images.as_deref())?;
+    let images = self.images_map(options.images.as_deref())?;
     let state = self.read_state()?;
     let buffer = self.render_internal(&state, node, options, images)?;
 
@@ -394,7 +396,7 @@ impl Renderer {
       font_families,
       lang,
     } = from_value(options.into()).map_err(map_error)?;
-    let images = self.fetch_images_map(images.as_deref())?;
+    let images = self.images_map(images.as_deref())?;
     let lang = lang.map(Arc::from);
 
     if scenes.is_empty() {

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -63,4 +63,7 @@ path = "../takumi-svg"
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 

--- a/takumi/examples/profile_many_runs.rs
+++ b/takumi/examples/profile_many_runs.rs
@@ -1,4 +1,5 @@
 use std::hint::black_box;
+
 use takumi::{prelude::*, render};
 
 const ITERS: usize = 80;

--- a/takumi/examples/profile_mix.rs
+++ b/takumi/examples/profile_mix.rs
@@ -1,4 +1,5 @@
 use std::{env, hint::black_box};
+
 use takumi::{prelude::*, render};
 
 const LONG_TEXT: &str = "Typography is the art and technique of arranging type to make written language legible, \

--- a/takumi/examples/profile_nested_clip.rs
+++ b/takumi/examples/profile_nested_clip.rs
@@ -1,4 +1,5 @@
 use std::hint::black_box;
+
 use takumi::{
   prelude::{Length::*, *},
   render,

--- a/takumi/examples/profile_text.rs
+++ b/takumi/examples/profile_text.rs
@@ -1,4 +1,5 @@
 use std::hint::black_box;
+
 use takumi::{prelude::*, render};
 
 const ITERS: usize = 80;

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -76,32 +76,27 @@ pub mod prelude {
     style::*,
     viewport::Viewport,
   };
-
+  #[cfg(feature = "from-html")]
+  pub use takumi_html::{DEFAULT_MAX_DEPTH, FromHtml, FromHtmlOptions, HtmlError, StylePresets};
   #[cfg(feature = "raster-backend")]
   pub use takumi_raster::{
     AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFrame, Bitmap,
     DitheringAlgorithm, MeasuredNode, MeasuredTextRun, OutputFormat, Quality, RenderOptions,
     SequentialScene,
   };
-
   #[cfg(feature = "svg-backend")]
   pub use takumi_svg::SvgOptions;
-
-  #[cfg(feature = "from-html")]
-  pub use takumi_html::{DEFAULT_MAX_DEPTH, FromHtml, FromHtmlOptions, HtmlError, StylePresets};
 }
 
+#[cfg(feature = "from-html")]
+pub use takumi_html::from_html;
 #[cfg(feature = "raster-backend")]
 pub use takumi_raster::{
   measure, render, render_animation, write_animated_gif, write_animated_png, write_animated_webp,
   write_image,
 };
-
 #[cfg(feature = "svg-backend")]
 pub use takumi_svg::render as render_svg;
-
-#[cfg(feature = "from-html")]
-pub use takumi_html::from_html;
 
 /// Unstable, semver-exempt access to the backend crates in full.
 ///
@@ -110,13 +105,10 @@ pub use takumi_html::from_html;
 #[cfg(feature = "unstable")]
 pub mod unstable {
   pub use takumi_core as base;
-
-  #[cfg(feature = "raster-backend")]
-  pub use takumi_raster as raster;
-
-  #[cfg(feature = "svg-backend")]
-  pub use takumi_svg as svg;
-
   #[cfg(feature = "from-html")]
   pub use takumi_html as html;
+  #[cfg(feature = "raster-backend")]
+  pub use takumi_raster as raster;
+  #[cfg(feature = "svg-backend")]
+  pub use takumi_svg as svg;
 }

--- a/takumi/tests/fixtures/style_mix_blend_mode.rs
+++ b/takumi/tests/fixtures/style_mix_blend_mode.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
+
 use takumi::prelude::{Length::*, *};
 
 use crate::test_utils::run_fixture_test;
-use std::sync::Arc;
 
 /// Creates a single card with solid blocks and mix-blend-mode for testing.
 fn create_blend_card(mode: BlendMode) -> Node {


### PR DESCRIPTION
Removes taffy/parley/image types from the umbrella-reachable public API and shrinks takumi-core's public surface for 2.0.

- Public signatures taking `taffy::Point`/`taffy::Size` now take plain `f32` width/height (or x/y) params and return tuples: `Affine::transform_point`, `ComputedStyle::local_transform`/`has_non_identity_transform`, `OffsetAnchor::resolve`, `PositionValue::to_point`, `BorderRadiusPair::to_px`, `Affine::from_transforms`. `Affine::decompose_translation` removed (fields are pub).
- `SizingContext.container_size` field is crate-private; backends use the new `set_container_size`.
- ~200 core-internal items demoted to `pub(crate)` (tw parser internals, stylesheet plumbing, gradient fast-path helpers, calc, matching, error constructors). Items still leaking through `ComputedStyle`/enum payloads stay pub for now.
- Dropped `From<RgbaImage>` for `ImageSource`/`ImageData`; `fast_div_255*` moved under `style::math`, out of the prelude glob.
- Renamed `resource_urls` → `image_urls`, `ImageResourceError` → `ImageError`.

Gates: clippy zero warnings, 957 workspace tests pass, no .svg/.webp golden changes.

https://claude.ai/code/session_01PVXatBCp5NmSA9dGYJUTQo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None

* **Bug Fixes**
  * Improved geometry/transform composition by consistently using explicit width/height inputs.

* **Documentation**
  * Updated upgrade guidance for image-focused terminology changes.

* **Breaking Changes**
  * Renamed resource-related APIs and docs to image-focused names (e.g., `resource_urls` → `image_urls`) and updated image error naming (`ImageResourceError` → `ImageError`).
  * Image construction now expects `ImageBuffer` conversions (removed direct `RgbaImage` conversions).
  * Public helper APIs were tightened/repositioned, including transform/stacking-context and sizing-related method/field access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->