### PR TITLE
Core: capitalize the InvalidLayoutNode error message

### DIFF
--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -148,7 +148,7 @@ pub enum Error {
   Layout(String),
 
   /// The layout engine was asked for a node id it does not know.
-  #[error("invalid layout node id: {0}")]
+  #[error("Invalid layout node id: {0}")]
   InvalidLayoutNode(u64),
 }
 


### PR DESCRIPTION
## Why

The other `Error` variants render sentence-case messages ("Layout error", "Font error"). `InvalidLayoutNode` was lowercase.

## What

Capitalize `invalid layout node id` to `Invalid layout node id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the wording of a layout-related error message to use consistent capitalization when displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->