### PR TITLE
Raster: stream animation frames into the encoder

### DIFF
--- a/.tegami/animation-frame-rate-cap.md
+++ b/.tegami/animation-frame-rate-cap.md
@@ -1,0 +1,15 @@
+---
+packages:
+  "cargo:takumi-raster": minor
+  "cargo:takumi": minor
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Cap animation frame rate per format
+
+Browsers clamp any animation frame of 10ms or less to 100ms, so a high frame
+rate stalls instead of playing fast. `write_animation` now rejects a frame rate
+above `AnimationFormat::max_fps` with the new `AnimationFrameRateTooHigh` error:
+90 fps for WebP and APNG, 50 fps for GIF (centisecond delays). The napi and WASM
+`renderAnimation` bindings surface the error.

--- a/.tegami/render-animation-keyframes.md
+++ b/.tegami/render-animation-keyframes.md
@@ -1,11 +1,7 @@
 ---
 packages:
-  npm:@takumi-rs/core:
-    replay:
-      - exit-prerelease(npm:@takumi-rs/core)
-  npm:@takumi-rs/wasm:
-    replay:
-      - exit-prerelease(npm:@takumi-rs/wasm)
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
 ---
 
 ### Apply structured keyframes in `renderAnimation`

--- a/.tegami/render-animation-keyframes.md
+++ b/.tegami/render-animation-keyframes.md
@@ -1,0 +1,15 @@
+---
+packages:
+  npm:@takumi-rs/core:
+    replay:
+      - exit-prerelease(npm:@takumi-rs/core)
+  npm:@takumi-rs/wasm:
+    replay:
+      - exit-prerelease(npm:@takumi-rs/wasm)
+---
+
+### Apply structured keyframes in `renderAnimation`
+
+`renderAnimation` accepted a `keyframes` option but never registered it, so
+structured keyframes animated with `render` yet stayed static in animations. It
+now extends the stylesheet with them like the other entry points.

--- a/.tegami/streaming-animation-encode.md
+++ b/.tegami/streaming-animation-encode.md
@@ -9,12 +9,17 @@ packages:
   npm:@takumi-rs/wasm:
     replay:
       - exit-prerelease(npm:@takumi-rs/wasm)
+  npm:@takumi-rs/core:
+    replay:
+      - exit-prerelease(npm:@takumi-rs/core)
 ---
 
 ### Stream animation frames straight into the encoder
 
 Add `write_animation`, which renders a timeline and feeds each frame to the
 encoder as it arrives, holding one raw frame at a time instead of the whole
-sequence. The WASM `renderAnimation` binding uses it, so a high frame rate or a
-long duration no longer exhausts memory. The eager `render_animation` +
-`write_animated_*` path stays for callers that want every frame at once.
+sequence. Both the napi and WASM `renderAnimation` bindings use it, so a high
+frame rate or a long duration no longer exhausts memory. On native the WebP
+encoder still runs frames in parallel, now over bounded chunks. The eager
+`render_animation` + `write_animated_*` path stays for callers that want every
+frame at once.

--- a/.tegami/streaming-animation-encode.md
+++ b/.tegami/streaming-animation-encode.md
@@ -1,17 +1,9 @@
 ---
 packages:
-  cargo:takumi-raster:
-    replay:
-      - exit-prerelease(cargo:takumi-raster)
-  cargo:takumi:
-    replay:
-      - exit-prerelease(cargo:takumi)
-  npm:@takumi-rs/wasm:
-    replay:
-      - exit-prerelease(npm:@takumi-rs/wasm)
-  npm:@takumi-rs/core:
-    replay:
-      - exit-prerelease(npm:@takumi-rs/core)
+  "cargo:takumi-raster": minor
+  "cargo:takumi": minor
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
 ---
 
 ### Stream animation frames straight into the encoder

--- a/.tegami/streaming-animation-encode.md
+++ b/.tegami/streaming-animation-encode.md
@@ -20,6 +20,7 @@ Add `write_animation`, which renders a timeline and feeds each frame to the
 encoder as it arrives, holding one raw frame at a time instead of the whole
 sequence. Both the napi and WASM `renderAnimation` bindings use it, so a high
 frame rate or a long duration no longer exhausts memory. On native the WebP
-encoder still runs frames in parallel, now over bounded chunks. The eager
-`render_animation` + `write_animated_*` path stays for callers that want every
-frame at once.
+encoder still runs frames in parallel, now over bounded chunks. The WASM WebP
+encoder now merges runs of identical frames like the native one, so a static or
+slow animation encodes and stores far less. The eager `render_animation` +
+`write_animated_*` path stays for callers that want every frame at once.

--- a/.tegami/streaming-animation-encode.md
+++ b/.tegami/streaming-animation-encode.md
@@ -1,0 +1,20 @@
+---
+packages:
+  cargo:takumi-raster:
+    replay:
+      - exit-prerelease(cargo:takumi-raster)
+  cargo:takumi:
+    replay:
+      - exit-prerelease(cargo:takumi)
+  npm:@takumi-rs/wasm:
+    replay:
+      - exit-prerelease(npm:@takumi-rs/wasm)
+---
+
+### Stream animation frames straight into the encoder
+
+Add `write_animation`, which renders a timeline and feeds each frame to the
+encoder as it arrives, holding one raw frame at a time instead of the whole
+sequence. The WASM `renderAnimation` binding uses it, so a high frame rate or a
+long duration no longer exhausts memory. The eager `render_animation` +
+`write_animated_*` path stays for callers that want every frame at once.

--- a/docs/app/playground/options.ts
+++ b/docs/app/playground/options.ts
@@ -1,54 +1,62 @@
-// oxlint-disable-next-line no-unused-vars
-declare type PlaygroundOptions = {
-  /**
-   * @description width of the render viewport.
-   */
-  width?: number;
-  /**
-   * @description height of the render viewport.
-   */
-  height?: number;
-  /**
-   * @description format to render.
-   * @default png
-   */
-  format?: "png" | "jpeg" | "webp" | "ico";
-  /**
-   * @description quality of jpeg format (0-100).
-   * @default 75
-   */
-  quality?: number;
-  /**
-   * @description device pixel ratio.
-   * @default 1.0
-   */
-  devicePixelRatio?: number;
-  /**
-   * @description CSS stylesheets applied before rendering.
-   */
-  stylesheets?: string[];
-  /**
-   * @description timeline animation output. When present, the playground renders an animated image instead of a single frame.
-   */
-  animation?: {
+import type { Keyframes } from "takumi-js";
+
+declare global {
+  // oxlint-disable-next-line no-unused-vars
+  type PlaygroundOptions = {
     /**
-     * @description total timeline duration in milliseconds.
+     * @description width of the render viewport.
      */
-    durationMs: number;
+    width?: number;
     /**
-     * @description frames per second used to sample keyframes.
-     * @default 30
+     * @description height of the render viewport.
      */
-    fps?: number;
+    height?: number;
     /**
-     * @description animation output format.
-     * @default webp
+     * @description format to render.
+     * @default png
      */
-    format?: "webp" | "apng" | "gif";
+    format?: "png" | "jpeg" | "webp" | "ico";
+    /**
+     * @description quality of jpeg format (0-100).
+     * @default 75
+     */
+    quality?: number;
+    /**
+     * @description device pixel ratio.
+     * @default 1.0
+     */
+    devicePixelRatio?: number;
+    /**
+     * @description CSS stylesheets applied before rendering.
+     */
+    stylesheets?: string[];
+    /**
+     * @description structured keyframes registered alongside the stylesheets.
+     */
+    keyframes?: Keyframes;
+    /**
+     * @description timeline animation output. When present, the playground renders an animated image instead of a single frame.
+     */
+    animation?: {
+      /**
+       * @description total timeline duration in milliseconds.
+       */
+      durationMs: number;
+      /**
+       * @description frames per second used to sample keyframes.
+       * @default 30
+       */
+      fps?: number;
+      /**
+       * @description animation output format.
+       * @default webp
+       */
+      format?: "webp" | "apng" | "gif";
+    };
+    /**
+     * @description emoji style to use.
+     * @default twemoji
+     */
+    emoji?: "twemoji" | "blobmoji" | "noto" | "openmoji";
   };
-  /**
-   * @description emoji style to use.
-   * @default twemoji
-   */
-  emoji?: "twemoji" | "blobmoji" | "noto" | "openmoji";
-};
+}

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -1,3 +1,4 @@
+import type { Keyframes } from "takumi-js";
 import * as z from "zod/mini";
 
 export const optionsSchema = z.object({
@@ -7,6 +8,7 @@ export const optionsSchema = z.object({
   format: z.optional(z.enum(["png", "jpeg", "webp"])),
   devicePixelRatio: z.optional(z.number().check(z.positive(), z.minimum(0.1), z.maximum(10.0))),
   stylesheets: z.optional(z.array(z.string())),
+  keyframes: z.optional(z.custom<Keyframes>()),
   animation: z.optional(
     z.object({
       durationMs: z.int().check(z.positive(), z.minimum(1)),

--- a/docs/app/playground/templates/animated-showcase.tsx
+++ b/docs/app/playground/templates/animated-showcase.tsx
@@ -27,8 +27,6 @@ export default function AnimatedShowcase() {
 export const options: PlaygroundOptions = {
   width: 640,
   height: 360,
-  // `DURATION_MS` drives the animation and the timeline, so they always match and
-  // the loop is seamless. Change it once to retime both.
   keyframes: {
     "stretch-cube": {
       "0%": { transform: "rotate(0deg) scale(1, 1)", borderRadius: "16px" },

--- a/docs/app/playground/templates/animated-showcase.tsx
+++ b/docs/app/playground/templates/animated-showcase.tsx
@@ -1,3 +1,5 @@
+const DURATION_MS = 3000;
+
 export default function AnimatedShowcase() {
   return (
     <div
@@ -7,8 +9,14 @@ export default function AnimatedShowcase() {
       }}
     >
       <div
-        className="cube"
         tw="flex h-32 w-32 items-center justify-center rounded-2xl bg-amber-300 font-semibold text-xl text-orange-950"
+        style={{
+          transformOrigin: "center",
+          animationName: "stretch-cube",
+          animationDuration: `${DURATION_MS}ms`,
+          animationTimingFunction: "cubic-bezier(0.65, 0, 0.35, 1)",
+          animationIterationCount: "infinite",
+        }}
       >
         Animated!
       </div>
@@ -19,43 +27,19 @@ export default function AnimatedShowcase() {
 export const options: PlaygroundOptions = {
   width: 640,
   height: 360,
-  stylesheets: [
-    `
-      .cube {
-        animation: stretch-cube 3000ms cubic-bezier(0.65, 0, 0.35, 1) infinite;
-        transform-origin: center;
-      }
-
-      @keyframes stretch-cube {
-        0% {
-          transform: rotate(0deg) scale(1, 1);
-          border-radius: 16px;
-        }
-
-        25% {
-          transform: rotate(-3deg) scale(1.08, 0.92);
-          border-radius: 28px 18px 24px 14px;
-        }
-
-        50% {
-          transform: rotate(0deg) scale(0.94, 1.06);
-          border-radius: 50%;
-        }
-
-        75% {
-          transform: rotate(3deg) scale(1.04, 0.96);
-          border-radius: 14px 26px 18px 30px;
-        }
-
-        100% {
-          transform: rotate(0deg) scale(1, 1);
-          border-radius: 16px;
-        }
-      }
-    `,
-  ],
+  // `DURATION_MS` drives the animation and the timeline, so they always match and
+  // the loop is seamless. Change it once to retime both.
+  keyframes: {
+    "stretch-cube": {
+      "0%": { transform: "rotate(0deg) scale(1, 1)", borderRadius: "16px" },
+      "25%": { transform: "rotate(-3deg) scale(1.08, 0.92)", borderRadius: "28px 18px 24px 14px" },
+      "50%": { transform: "rotate(0deg) scale(0.94, 1.06)", borderRadius: "50%" },
+      "75%": { transform: "rotate(3deg) scale(1.04, 0.96)", borderRadius: "14px 26px 18px 30px" },
+      "100%": { transform: "rotate(0deg) scale(1, 1)", borderRadius: "16px" },
+    },
+  },
   animation: {
-    durationMs: 3000,
+    durationMs: DURATION_MS,
     fps: 24,
     format: "webp",
   },

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -89,6 +89,7 @@ self.onmessage = async (event: MessageEvent) => {
                 devicePixelRatio: options.devicePixelRatio,
                 images,
                 stylesheets: effectiveStylesheets,
+                keyframes: options.keyframes,
                 fonts,
                 fps,
               });

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -38,6 +38,37 @@ let renderer: Renderer | undefined;
   postMessage({ type: "ready" });
 })();
 
+function declarationsToCss(declarations: object): string {
+  return Object.entries(declarations)
+    .map(
+      ([property, value]) =>
+        `${property.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}: ${value};`,
+    )
+    .join(" ");
+}
+
+/** Serializes structured keyframes into a `@keyframes` rule for the browser preview. */
+function keyframesToCss(keyframes: NonNullable<PlaygroundOptions["keyframes"]>): string {
+  const rules = Array.isArray(keyframes)
+    ? keyframes.map((rule) => {
+        const body = rule.keyframes
+          .map(
+            (frame) =>
+              `${frame.offsets.map((offset) => `${offset * 100}%`).join(", ")} { ${declarationsToCss(frame.declarations)} }`,
+          )
+          .join(" ");
+        return `@keyframes ${rule.name} { ${body} }`;
+      })
+    : Object.entries(keyframes).map(([name, offsets]) => {
+        const body = Object.entries(offsets)
+          .map(([offset, declarations]) => `${offset} { ${declarationsToCss(declarations)} }`)
+          .join(" ");
+        return `@keyframes ${name} { ${body} }`;
+      });
+
+  return rules.join("\n");
+}
+
 self.onmessage = async (event: MessageEvent) => {
   const payload = messageSchema.parse(event.data);
 
@@ -52,6 +83,11 @@ self.onmessage = async (event: MessageEvent) => {
         );
         let { node, stylesheets } = await fromJsx(element);
         const effectiveStylesheets = options.stylesheets ?? stylesheets;
+        // The browser preview only understands CSS, so serialize any structured
+        // keyframes (which the engine takes as an object) into a `@keyframes` rule.
+        const previewStylesheets = options.keyframes
+          ? [...effectiveStylesheets, keyframesToCss(options.keyframes)]
+          : effectiveStylesheets;
 
         postMessage({
           type: "preview-result",
@@ -59,7 +95,7 @@ self.onmessage = async (event: MessageEvent) => {
           html: renderToStaticMarkup(element),
           width: options.width,
           height: options.height,
-          cssContents: effectiveStylesheets,
+          cssContents: previewStylesheets,
         });
 
         node = extractEmojis(node, options.emoji ?? "twemoji");

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -124,6 +124,17 @@ pub enum Error {
   #[error("Animation must contain at least one frame")]
   EmptyAnimationFrames,
 
+  /// The requested frame rate is too high for the target format. Above this
+  /// ceiling some frames fall to or below the shortest duration decoders honor,
+  /// so browsers clamp them to 100ms and playback stalls.
+  #[error("Frame rate {fps} fps exceeds the maximum {max_fps} fps for this animation format")]
+  AnimationFrameRateTooHigh {
+    /// The requested frame rate.
+    fps: u32,
+    /// The highest frame rate the format encodes without decoder clamping.
+    max_fps: u32,
+  },
+
   /// Animated frames for a given format did not all share the same dimensions.
   #[error("Animation frames must share the same dimensions")]
   MixedAnimationFrameDimensions,

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -140,11 +140,10 @@ impl Task for RenderAnimationTask {
         .collect::<Vec<_>>();
       let format = match self.format {
         AnimationOutputFormat::WebP => {
-          let mut options = AnimatedWebpOptions::default();
-          options.lossless = webp_lossless(self.quality, self.lossless);
-          if let Some(quality) = self.quality {
-            options.quality = quality;
-          }
+          let options = AnimatedWebpOptions::builder()
+            .lossless(webp_lossless(self.quality, self.lossless))
+            .quality(self.quality.unwrap_or(75))
+            .build();
           AnimationFormat::WebP(options)
         }
         AnimationOutputFormat::Apng => AnimationFormat::Apng(AnimatedPngOptions::default()),

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, mem::take, sync::Arc};
+use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use takumi_core::{
@@ -6,12 +6,12 @@ use takumi_core::{
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{
-  AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, RenderOptions, SequentialScene,
-  render_animation, write_animated_gif, write_animated_png, write_animated_webp,
+  AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFormat, RenderOptions,
+  SequentialScene, write_animation,
 };
 
 use crate::{
-  buffer_from_object, deserialize_with_tracing, map_error, parse_stylesheet,
+  buffer_from_object, deserialize_with_tracing, parse_stylesheet,
   renderer::{
     AnimationOutputFormat, ImageCacheMode, ImageSource, RenderAnimationOptions, RendererState,
     decode_images, webp_lossless,
@@ -138,34 +138,22 @@ impl Task for RenderAnimationTask {
             .build()
         })
         .collect::<Vec<_>>();
-      let frames = render_animation(&scene_options, self.fps).map_err(map_error)?;
-
-      let mut buffer = Vec::new();
-
-      match self.format {
+      let format = match self.format {
         AnimationOutputFormat::WebP => {
           let mut options = AnimatedWebpOptions::default();
           options.lossless = webp_lossless(self.quality, self.lossless);
           if let Some(quality) = self.quality {
             options.quality = quality;
           }
+          AnimationFormat::WebP(options)
+        }
+        AnimationOutputFormat::Apng => AnimationFormat::Apng(AnimatedPngOptions::default()),
+        AnimationOutputFormat::Gif => AnimationFormat::Gif(AnimatedGifOptions::default()),
+      };
 
-          write_animated_webp(Cow::Owned(frames), &mut buffer, options)
-            .map_err(|e| Error::from_reason(e.to_string()))?;
-        }
-        AnimationOutputFormat::Apng => {
-          write_animated_png(&frames, &mut buffer, AnimatedPngOptions::default())
-            .map_err(|e| Error::from_reason(e.to_string()))?;
-        }
-        AnimationOutputFormat::Gif => {
-          write_animated_gif(
-            Cow::Owned(frames),
-            &mut buffer,
-            AnimatedGifOptions::default(),
-          )
-          .map_err(|e| Error::from_reason(e.to_string()))?;
-        }
-      }
+      let mut buffer = Vec::new();
+      write_animation(&scene_options, self.fps, format, &mut buffer)
+        .map_err(|e| Error::from_reason(e.to_string()))?;
 
       Ok(buffer)
     })

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, mem::take, sync::Arc};
 use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
+  style::KeyframesRule,
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{
@@ -14,7 +15,7 @@ use crate::{
   buffer_from_object, deserialize_with_tracing, parse_stylesheet,
   renderer::{
     AnimationOutputFormat, ImageCacheMode, ImageSource, RenderAnimationOptions, RendererState,
-    decode_images, webp_lossless,
+    decode_images, deserialize_keyframes, webp_lossless,
   },
 };
 
@@ -27,6 +28,7 @@ pub struct RenderAnimationTask {
   pub(crate) lossless: Option<bool>,
   pub(crate) draw_debug_border: bool,
   pub(crate) stylesheets: Option<Vec<String>>,
+  pub(crate) keyframes: Vec<KeyframesRule>,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
   pub(crate) font_families: Option<Vec<String>>,
   pub(crate) lang: Option<Arc<str>>,
@@ -50,6 +52,7 @@ impl RenderAnimationTask {
       fps,
       images,
       stylesheets,
+      keyframes,
       device_pixel_ratio,
       font_families,
       lang,
@@ -86,6 +89,7 @@ impl RenderAnimationTask {
       lossless,
       draw_debug_border: draw_debug_border.unwrap_or_default(),
       stylesheets,
+      keyframes: deserialize_keyframes(keyframes)?,
       images: images
         .unwrap_or_default()
         .into_iter()
@@ -117,7 +121,7 @@ impl Task for RenderAnimationTask {
       };
       let fonts = self.state.fonts.load();
       let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
-      let stylesheet = parse_stylesheet(take(&mut self.stylesheets), Vec::new())?;
+      let stylesheet = parse_stylesheet(take(&mut self.stylesheets), take(&mut self.keyframes))?;
       let scene_options = scenes
         .into_iter()
         .map(|(node, duration_ms)| {

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -246,6 +246,9 @@ pub struct RenderAnimationOptions<'env> {
   pub images: Option<Vec<ImageSource<'env>>>,
   /// CSS stylesheets to apply before rendering.
   pub stylesheets: Option<Vec<String>>,
+  /// Structured keyframes to register alongside stylesheets.
+  #[napi(ts_type = "Keyframes")]
+  pub keyframes: Option<Object<'env>>,
   /// The device pixel ratio.
   /// @default 1.0
   pub device_pixel_ratio: Option<f64>,

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -857,6 +857,55 @@ mod tests {
   }
 
   #[test]
+  fn write_animation_rejects_frame_rate_above_format_cap() {
+    use crate::{AnimatedGifOptions, AnimatedWebpOptions, AnimationFormat, Error, write_animation};
+
+    let fonts = Fonts::default();
+    let scenes = vec![make_scene(&fonts, 100)];
+
+    let mut sink = Vec::new();
+    let over_webp = write_animation(
+      &scenes,
+      91,
+      AnimationFormat::WebP(AnimatedWebpOptions::default()),
+      &mut sink,
+    );
+    assert!(matches!(
+      over_webp,
+      Err(Error::AnimationFrameRateTooHigh {
+        fps: 91,
+        max_fps: 90
+      })
+    ));
+    assert!(sink.is_empty(), "cap must reject before writing bytes");
+
+    let mut sink = Vec::new();
+    let over_gif = write_animation(
+      &scenes,
+      51,
+      AnimationFormat::Gif(AnimatedGifOptions::default()),
+      &mut sink,
+    );
+    assert!(matches!(
+      over_gif,
+      Err(Error::AnimationFrameRateTooHigh {
+        fps: 51,
+        max_fps: 50
+      })
+    ));
+
+    let mut sink = Vec::new();
+    let at_cap = write_animation(
+      &scenes,
+      90,
+      AnimationFormat::WebP(AnimatedWebpOptions::default()),
+      &mut sink,
+    );
+    assert!(at_cap.is_ok());
+    assert!(!sink.is_empty());
+  }
+
+  #[test]
   fn render_sequence_animation_uses_per_frame_integer_durations() {
     let fonts = Fonts::default();
     let scenes = vec![make_scene(&fonts, 150)];

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -617,38 +617,64 @@ pub(crate) fn render_sequence_at_time<'g>(
   render_at_time(scene.options.clone(), local_time_ms)
 }
 
-/// Renders all frames for a sequential animation timeline at a fixed frame rate.
-pub fn render_animation<'g>(
-  scenes: &[SequentialScene<'g>],
-  fps: u32,
-) -> Result<Vec<AnimationFrame>> {
+/// A frame's start offset and displayed duration, both in milliseconds. Computed
+/// from the timeline and frame rate without rendering any pixels.
+#[derive(Clone, Copy)]
+pub(crate) struct FrameSpan {
+  pub(crate) start_ms: u64,
+  pub(crate) duration_ms: u32,
+}
+
+/// The frame schedule for a timeline at a fixed frame rate: one [`FrameSpan`] per
+/// visible frame, dropping any that round to a zero-millisecond duration.
+pub(crate) fn frame_spans<'g>(scenes: &[SequentialScene<'g>], fps: u32) -> Vec<FrameSpan> {
   if scenes.is_empty() || fps == 0 {
-    return Ok(Vec::new());
+    return Vec::new();
   }
 
   let total_duration_ms = total_sequence_duration(scenes);
   if total_duration_ms == 0 {
-    return Ok(Vec::new());
+    return Vec::new();
   }
 
   let frame_count = total_duration_ms
     .saturating_mul(u64::from(fps))
     .div_ceil(1000);
-  let mut frames = Vec::with_capacity(frame_count as usize);
 
-  for frame_index in 0..frame_count {
-    let start_ms = frame_index * 1000 / u64::from(fps);
-    let end_ms = ((frame_index + 1) * 1000 / u64::from(fps)).min(total_duration_ms);
-    let frame_duration_ms = end_ms.saturating_sub(start_ms);
-    if frame_duration_ms == 0 {
-      continue;
-    }
+  (0..frame_count)
+    .filter_map(|frame_index| {
+      let start_ms = frame_index * 1000 / u64::from(fps);
+      let end_ms = ((frame_index + 1) * 1000 / u64::from(fps)).min(total_duration_ms);
+      let duration_ms = end_ms.saturating_sub(start_ms);
+      (duration_ms != 0).then_some(FrameSpan {
+        start_ms,
+        duration_ms: duration_ms as u32,
+      })
+    })
+    .collect()
+}
 
-    let image = render_sequence_at_time(scenes, start_ms)?;
-    frames.push(AnimationFrame::new(image, frame_duration_ms as u32));
-  }
+/// Renders one frame of the timeline for the given [`FrameSpan`].
+pub(crate) fn render_frame<'g>(
+  scenes: &[SequentialScene<'g>],
+  span: FrameSpan,
+) -> Result<AnimationFrame> {
+  let image = render_sequence_at_time(scenes, span.start_ms)?;
+  Ok(AnimationFrame::new(image, span.duration_ms))
+}
 
-  Ok(frames)
+/// Renders all frames for a sequential animation timeline at a fixed frame rate.
+///
+/// Holds every frame in memory. To bound memory, stream straight into an encoder
+/// with [`write_animation`](crate::write_animation) instead.
+pub fn render_animation<'g>(
+  scenes: &[SequentialScene<'g>],
+  fps: u32,
+) -> Result<Vec<AnimationFrame>> {
+  frame_spans(scenes, fps)
+    .into_iter()
+    .map(|span| render_frame(scenes, span))
+    .collect()
 }
 
 fn total_sequence_duration<'g>(scenes: &[SequentialScene<'g>]) -> u64 {
@@ -769,6 +795,65 @@ mod tests {
     let frames = frames_result.unwrap_or_default();
 
     assert!(frames.is_empty());
+  }
+
+  #[test]
+  fn write_animation_streams_the_same_bytes_as_render_then_encode() -> crate::Result<()> {
+    use std::borrow::Cow;
+
+    use crate::{
+      AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFormat,
+      write_animated_gif, write_animated_png, write_animated_webp, write_animation,
+    };
+
+    let fonts = Fonts::default();
+    let scenes = vec![make_scene(&fonts, 100), make_scene(&fonts, 100)];
+    let fps = 30;
+    let frames = render_animation(&scenes, fps)?;
+    assert!(!frames.is_empty());
+
+    let mut eager = Vec::new();
+    write_animated_gif(
+      Cow::Owned(frames.clone()),
+      &mut eager,
+      AnimatedGifOptions::default(),
+    )?;
+    let mut streamed = Vec::new();
+    write_animation(
+      &scenes,
+      fps,
+      AnimationFormat::Gif(AnimatedGifOptions::default()),
+      &mut streamed,
+    )?;
+    assert_eq!(eager, streamed, "gif");
+
+    let mut eager = Vec::new();
+    write_animated_png(&frames, &mut eager, AnimatedPngOptions::default())?;
+    let mut streamed = Vec::new();
+    write_animation(
+      &scenes,
+      fps,
+      AnimationFormat::Apng(AnimatedPngOptions::default()),
+      &mut streamed,
+    )?;
+    assert_eq!(eager, streamed, "apng");
+
+    let mut eager = Vec::new();
+    write_animated_webp(
+      Cow::Owned(frames.clone()),
+      &mut eager,
+      AnimatedWebpOptions::default(),
+    )?;
+    let mut streamed = Vec::new();
+    write_animation(
+      &scenes,
+      fps,
+      AnimationFormat::WebP(AnimatedWebpOptions::default()),
+      &mut streamed,
+    )?;
+    assert_eq!(eager, streamed, "webp");
+
+    Ok(())
   }
 
   #[test]

--- a/takumi-raster/src/webp/image_webp.rs
+++ b/takumi-raster/src/webp/image_webp.rs
@@ -7,7 +7,7 @@ use crate::{
   Result,
   error::{Error, WebPError},
   webp::{U24_MAX, has_any_alpha_pixel, strip_alpha_channel},
-  write::{AnimatedWebpOptions, AnimationFrame},
+  write::{AnimatedWebpOptions, AnimationFrame, Bitmap},
 };
 
 const RIFF_HEADER_SIZE: usize = 12;
@@ -190,9 +190,9 @@ where
   validate_u24_dimension("WebP canvas width", canvas_width)?;
   validate_u24_dimension("WebP canvas height", canvas_height)?;
 
-  let encode_frame = |frame: AnimationFrame, index: usize| -> Result<EncodedAnmf> {
-    let width = frame.image.width();
-    let height = frame.image.height();
+  let validate_frame = |image: &Bitmap, index: usize| -> Result<()> {
+    let width = image.width();
+    let height = image.height();
     validate_u24_dimension("WebP frame width", width)?;
     validate_u24_dimension("WebP frame height", height)?;
     if width > canvas_width || height > canvas_height {
@@ -207,28 +207,51 @@ where
         .into(),
       );
     }
+    Ok(())
+  };
 
+  let encode_frame = |image: &Bitmap, duration_ms: u32| -> Result<EncodedAnmf> {
     let mut buf = Vec::new();
     let mut encoder = WebPEncoder::new(&mut buf);
     let mut params = EncoderParams::default();
     params.use_predictor_transform = true;
     encoder.set_params(params);
     encoder
-      .encode(frame.image.as_raw(), width, height, ColorType::Rgba8)
+      .encode(
+        image.as_raw(),
+        image.width(),
+        image.height(),
+        ColorType::Rgba8,
+      )
       .map_err(|_| WebPError::EncodeFailed)?;
 
     Ok(EncodedAnmf {
-      width,
-      height,
-      duration_ms: frame.duration_ms,
+      width: image.width(),
+      height: image.height(),
+      duration_ms,
       vp8: buf,
     })
   };
 
-  let mut anmfs = vec![encode_frame(first, 0)?];
-  for (index, frame) in frames.enumerate() {
-    anmfs.push(encode_frame(frame?, index + 1)?);
+  // Merge runs of identical frames, matching the native encoder, so a static
+  // stretch encodes and stores once.
+  validate_frame(&first.image, 0)?;
+  let mut anmfs = Vec::new();
+  let mut pending_image = first.image;
+  let mut pending_duration_ms = first.duration_ms.clamp(0, U24_MAX);
+
+  for (offset, frame) in frames.enumerate() {
+    let frame = frame?;
+    validate_frame(&frame.image, offset + 1)?;
+    if frame.image.as_raw() == pending_image.as_raw() {
+      pending_duration_ms = pending_duration_ms.saturating_add(frame.duration_ms.clamp(0, U24_MAX));
+      continue;
+    }
+    anmfs.push(encode_frame(&pending_image, pending_duration_ms)?);
+    pending_image = frame.image;
+    pending_duration_ms = frame.duration_ms.clamp(0, U24_MAX);
   }
+  anmfs.push(encode_frame(&pending_image, pending_duration_ms)?);
 
   let riff_size = estimate_riff_size(anmfs.iter().map(|anmf| anmf.vp8.as_slice()))?;
 

--- a/takumi-raster/src/webp/image_webp.rs
+++ b/takumi-raster/src/webp/image_webp.rs
@@ -153,57 +153,84 @@ pub fn write_animated_webp<W: Write>(
   destination: &mut W,
   options: AnimatedWebpOptions,
 ) -> Result<()> {
-  if frames.is_empty() {
-    return Err(WebPError::EmptyAnimation.into());
-  }
+  encode_animated_webp(
+    frames.into_owned().into_iter().map(Ok),
+    destination,
+    options,
+  )
+}
 
-  let canvas_width = frames[0].image.width();
-  let canvas_height = frames[0].image.height();
+/// A frame's dimensions, duration, and its already-encoded VP8 payload. Small
+/// enough to keep for every frame; the raw pixels are dropped after encoding.
+struct EncodedAnmf {
+  width: u32,
+  height: u32,
+  duration_ms: u32,
+  vp8: Vec<u8>,
+}
+
+/// Streams frames into an animated WebP, encoding each as it arrives so only one
+/// raw frame is held at a time. Only the compact VP8 payloads are retained, since
+/// the RIFF container needs every frame's size before the first byte is written.
+pub(crate) fn encode_animated_webp<W, I>(
+  mut frames: I,
+  destination: &mut W,
+  options: AnimatedWebpOptions,
+) -> Result<()>
+where
+  W: Write,
+  I: Iterator<Item = Result<AnimationFrame>>,
+{
+  let Some(first) = frames.next().transpose()? else {
+    return Err(WebPError::EmptyAnimation.into());
+  };
+
+  let canvas_width = first.image.width();
+  let canvas_height = first.image.height();
   validate_u24_dimension("WebP canvas width", canvas_width)?;
   validate_u24_dimension("WebP canvas height", canvas_height)?;
 
-  for (index, frame) in frames.iter().enumerate() {
-    let frame_width = frame.image.width();
-    let frame_height = frame.image.height();
-    validate_u24_dimension("WebP frame width", frame_width)?;
-    validate_u24_dimension("WebP frame height", frame_height)?;
-
-    if frame_width > canvas_width || frame_height > canvas_height {
+  let encode_frame = |frame: AnimationFrame, index: usize| -> Result<EncodedAnmf> {
+    let width = frame.image.width();
+    let height = frame.image.height();
+    validate_u24_dimension("WebP frame width", width)?;
+    validate_u24_dimension("WebP frame height", height)?;
+    if width > canvas_width || height > canvas_height {
       return Err(
         WebPError::FrameExceedsCanvas {
           index,
-          frame_width,
-          frame_height,
+          frame_width: width,
+          frame_height: height,
           canvas_width,
           canvas_height,
         }
         .into(),
       );
     }
+
+    let mut buf = Vec::new();
+    let mut encoder = WebPEncoder::new(&mut buf);
+    let mut params = EncoderParams::default();
+    params.use_predictor_transform = true;
+    encoder.set_params(params);
+    encoder
+      .encode(frame.image.as_raw(), width, height, ColorType::Rgba8)
+      .map_err(|_| WebPError::EncodeFailed)?;
+
+    Ok(EncodedAnmf {
+      width,
+      height,
+      duration_ms: frame.duration_ms,
+      vp8: buf,
+    })
+  };
+
+  let mut anmfs = vec![encode_frame(first, 0)?];
+  for (index, frame) in frames.enumerate() {
+    anmfs.push(encode_frame(frame?, index + 1)?);
   }
 
-  let frames_payloads: Vec<(&AnimationFrame, Vec<u8>)> = frames
-    .iter()
-    .map(|frame| {
-      let mut buf = Vec::new();
-      let mut encoder = WebPEncoder::new(&mut buf);
-      let mut params = EncoderParams::default();
-      params.use_predictor_transform = true;
-      encoder.set_params(params);
-      encoder
-        .encode(
-          frame.image.as_raw(),
-          frame.image.width(),
-          frame.image.height(),
-          ColorType::Rgba8,
-        )
-        .map_err(|_| WebPError::EncodeFailed)?;
-
-      Ok((frame, buf))
-    })
-    .collect::<Result<Vec<(&AnimationFrame, Vec<u8>)>>>()?;
-
-  let riff_size = estimate_riff_size(frames_payloads.iter().map(|(_, buf)| buf.as_slice()))?;
+  let riff_size = estimate_riff_size(anmfs.iter().map(|anmf| anmf.vp8.as_slice()))?;
 
   destination.write_all(b"RIFF")?;
   destination.write_all(&riff_size.to_le_bytes())?;
@@ -229,13 +256,12 @@ pub fn write_animated_webp<W: Write>(
   let dispose_flag = options.dispose as u8;
   let frame_flags = (blend_flag << 1) | dispose_flag;
 
-  for (frame, vp8_data) in frames_payloads.into_iter() {
-    let w_bytes = (frame.image.width() - 1).to_le_bytes();
-    let h_bytes = (frame.image.height() - 1).to_le_bytes();
+  for anmf in anmfs {
+    let w_bytes = (anmf.width - 1).to_le_bytes();
+    let h_bytes = (anmf.height - 1).to_le_bytes();
 
-    let (start, len) = vp8_payload_coords(&vp8_data).ok_or(WebPError::InvalidEncodedData)?;
-
-    let vp8_payload = &vp8_data[start..start + len];
+    let (start, len) = vp8_payload_coords(&anmf.vp8).ok_or(WebPError::InvalidEncodedData)?;
+    let vp8_payload = &anmf.vp8[start..start + len];
 
     let padding = vp8_payload.len() & 1;
     let vp8_payload_len_u32 =
@@ -253,10 +279,10 @@ pub fn write_animated_webp<W: Write>(
     destination.write_all(&[0u8; 6])?;
     destination.write_all(&w_bytes[..3])?;
     destination.write_all(&h_bytes[..3])?;
-    destination.write_all(&frame.duration_ms.clamp(0, U24_MAX).to_le_bytes()[..3])?;
+    destination.write_all(&anmf.duration_ms.clamp(0, U24_MAX).to_le_bytes()[..3])?;
     destination.write_all(&[frame_flags])?;
 
-    let chunk_tag = vp8_chunk_tag(&vp8_data, start)
+    let chunk_tag = vp8_chunk_tag(&anmf.vp8, start)
       .ok_or(WebPError::InvalidEncodedData)
       .and_then(|tag| {
         if &tag == b"VP8 " || &tag == b"VP8L" {

--- a/takumi-raster/src/webp/libwebp.rs
+++ b/takumi-raster/src/webp/libwebp.rs
@@ -366,6 +366,76 @@ fn encode_frames(
     .collect()
 }
 
+/// Streams frames into an animated WebP, encoding each as it arrives so only one
+/// raw frame is held at a time. Bytes match [`write_animated_webp`] for the same
+/// frames; frames encode sequentially rather than in parallel.
+pub(crate) fn encode_animated_webp<W, I>(
+  mut frames: I,
+  destination: &mut W,
+  options: AnimatedWebpOptions,
+) -> Result<()>
+where
+  W: Write,
+  I: Iterator<Item = Result<AnimationFrame>>,
+{
+  let Some(first) = frames.next().transpose()? else {
+    return Err(WebPError::EmptyAnimation.into());
+  };
+
+  let frame_width = first.image.width();
+  let frame_height = first.image.height();
+  if !(1..=U24_MAX + 1).contains(&frame_width) || !(1..=U24_MAX + 1).contains(&frame_height) {
+    return Err(
+      WebPError::InvalidFrameDimensions {
+        width: frame_width,
+        height: frame_height,
+        max: U24_MAX + 1,
+      }
+      .into(),
+    );
+  }
+
+  let speed = options.speed.unwrap_or(1).clamp(0, 6);
+  let config = webp_config(options.lossless, options.quality, speed)?;
+
+  let mut encoded = Vec::new();
+  let mut pending_image = first.image;
+  let mut pending_duration_ms = first.duration_ms.clamp(0, U24_MAX);
+
+  for frame in frames {
+    let frame = frame?;
+    if frame.image.width() != frame_width || frame.image.height() != frame_height {
+      return Err(WebPError::MixedFrameDimensions.into());
+    }
+    if frame.image.as_raw() == pending_image.as_raw() {
+      pending_duration_ms = pending_duration_ms.saturating_add(frame.duration_ms.clamp(0, U24_MAX));
+      continue;
+    }
+    encoded.push(encode_single_frame(
+      pending_image.as_rgba(),
+      pending_duration_ms,
+      &config,
+    )?);
+    pending_image = frame.image;
+    pending_duration_ms = frame.duration_ms.clamp(0, U24_MAX);
+  }
+  encoded.push(encode_single_frame(
+    pending_image.as_rgba(),
+    pending_duration_ms,
+    &config,
+  )?);
+
+  write_riff_container(
+    destination,
+    frame_width,
+    frame_height,
+    options.loop_count.unwrap_or(0),
+    options.blend,
+    options.dispose,
+    &encoded,
+  )
+}
+
 /// Encodes a sequence of RGBA frames into an animated WebP.
 pub fn write_animated_webp<W: Write>(
   frames: Cow<'_, [AnimationFrame]>,

--- a/takumi-raster/src/webp/libwebp.rs
+++ b/takumi-raster/src/webp/libwebp.rs
@@ -9,7 +9,7 @@ use crate::{
   Result,
   error::{Error, WebPError},
   webp::U24_MAX,
-  write::{AnimatedWebpOptions, AnimationFrame, Quality},
+  write::{AnimatedWebpOptions, AnimationFrame, Bitmap, Quality},
 };
 
 fn webp_config(lossless: bool, quality: u8, speed: u8) -> Result<WebPConfig> {
@@ -366,9 +366,9 @@ fn encode_frames(
     .collect()
 }
 
-/// Streams frames into an animated WebP, encoding each as it arrives so only one
-/// raw frame is held at a time. Bytes match [`write_animated_webp`] for the same
-/// frames; frames encode sequentially rather than in parallel.
+/// Streams frames into an animated WebP a bounded chunk at a time, so peak
+/// raw-pixel memory stays fixed while each chunk still encodes in parallel.
+/// Produces the same bytes as [`write_animated_webp`] for the same frames.
 pub(crate) fn encode_animated_webp<W, I>(
   mut frames: I,
   destination: &mut W,
@@ -398,7 +398,11 @@ where
   let speed = options.speed.unwrap_or(1).clamp(0, 6);
   let config = webp_config(options.lossless, options.quality, speed)?;
 
+  // Buffer unique frames a chunk at a time and encode each chunk in parallel, so
+  // peak raw-pixel memory stays bounded while frames still encode concurrently.
+  let chunk_capacity = frames_per_chunk(frame_width, frame_height);
   let mut encoded = Vec::new();
+  let mut chunk: Vec<(Bitmap, u32)> = Vec::new();
   let mut pending_image = first.image;
   let mut pending_duration_ms = first.duration_ms.clamp(0, U24_MAX);
 
@@ -411,19 +415,15 @@ where
       pending_duration_ms = pending_duration_ms.saturating_add(frame.duration_ms.clamp(0, U24_MAX));
       continue;
     }
-    encoded.push(encode_single_frame(
-      pending_image.as_rgba(),
-      pending_duration_ms,
-      &config,
-    )?);
+    chunk.push((pending_image, pending_duration_ms));
+    if chunk.len() >= chunk_capacity {
+      encode_frame_chunk(&mut chunk, &config, &mut encoded)?;
+    }
     pending_image = frame.image;
     pending_duration_ms = frame.duration_ms.clamp(0, U24_MAX);
   }
-  encoded.push(encode_single_frame(
-    pending_image.as_rgba(),
-    pending_duration_ms,
-    &config,
-  )?);
+  chunk.push((pending_image, pending_duration_ms));
+  encode_frame_chunk(&mut chunk, &config, &mut encoded)?;
 
   write_riff_container(
     destination,
@@ -434,6 +434,41 @@ where
     options.dispose,
     &encoded,
   )
+}
+
+/// Frames to buffer per parallel encode pass. Sized so the buffered raw pixels
+/// stay near a fixed budget whatever the frame dimensions, with at least one
+/// frame per pass.
+fn frames_per_chunk(width: u32, height: u32) -> usize {
+  const CHUNK_MEMORY_BUDGET: usize = 64 * 1024 * 1024;
+  let frame_bytes = (width as usize)
+    .saturating_mul(height as usize)
+    .saturating_mul(4)
+    .max(1);
+  (CHUNK_MEMORY_BUDGET / frame_bytes).max(1)
+}
+
+/// Encodes a chunk of unique frames (in parallel when `rayon` is enabled), appends
+/// the results in order, and frees the raw frames.
+fn encode_frame_chunk(
+  chunk: &mut Vec<(Bitmap, u32)>,
+  config: &WebPConfig,
+  encoded: &mut Vec<EncodedFrame>,
+) -> Result<()> {
+  #[cfg(feature = "rayon")]
+  let batch = chunk
+    .par_iter()
+    .map(|(image, duration_ms)| encode_single_frame(image.as_rgba(), *duration_ms, config))
+    .collect::<Result<Vec<_>>>()?;
+  #[cfg(not(feature = "rayon"))]
+  let batch = chunk
+    .iter()
+    .map(|(image, duration_ms)| encode_single_frame(image.as_rgba(), *duration_ms, config))
+    .collect::<Result<Vec<_>>>()?;
+
+  encoded.extend(batch);
+  chunk.clear();
+  Ok(())
 }
 
 /// Encodes a sequence of RGBA frames into an animated WebP.

--- a/takumi-raster/src/webp/mod.rs
+++ b/takumi-raster/src/webp/mod.rs
@@ -10,11 +10,11 @@ mod libwebp;
 #[cfg(target_arch = "wasm32")]
 pub use image_webp::write_animated_webp;
 #[cfg(target_arch = "wasm32")]
-pub(crate) use image_webp::write_webp_lossless;
+pub(crate) use image_webp::{encode_animated_webp, write_webp_lossless};
 #[cfg(not(target_arch = "wasm32"))]
 pub use libwebp::write_animated_webp;
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) use libwebp::{write_webp_lossless, write_webp_lossy};
+pub(crate) use libwebp::{encode_animated_webp, write_webp_lossless, write_webp_lossy};
 
 pub(super) const U24_MAX: u32 = 0xffffff;
 

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, io::Write};
+use std::{
+  borrow::{Borrow, Cow},
+  io::Write,
+};
 
 use gif::{Encoder as GifEncoder, Frame as GifFrame, Repeat};
 use image::{
@@ -15,7 +18,8 @@ use crate::webp::write_webp_lossy;
 use crate::{
   Result,
   error::Error,
-  webp::{has_any_alpha_pixel, strip_alpha_channel, write_webp_lossless},
+  render::{SequentialScene, frame_spans, render_frame},
+  webp::{encode_animated_webp, has_any_alpha_pixel, strip_alpha_channel, write_webp_lossless},
 };
 
 /// Lossy-encoding quality, clamped to the `0..=100` range (higher means better
@@ -301,25 +305,52 @@ pub fn write_animated_gif<W: Write>(
   destination: &mut W,
   options: AnimatedGifOptions,
 ) -> Result<()> {
-  if frames.is_empty() {
-    return Err(Error::EmptyAnimationFrames);
+  ensure_uniform_frame_dimensions(&frames)?;
+  encode_animated_gif(
+    frames.into_owned().into_iter().map(Ok),
+    destination,
+    options,
+  )
+}
+
+/// Rejects mismatched frame dimensions up front, so a slice-based encoder writes
+/// nothing before failing. The streaming encoders check each frame as it arrives.
+fn ensure_uniform_frame_dimensions(frames: &[AnimationFrame]) -> Result<()> {
+  let Some(first) = frames.first() else {
+    return Ok(());
+  };
+  let (width, height) = (first.image.width(), first.image.height());
+  for frame in &frames[1..] {
+    if frame.image.width() != width || frame.image.height() != height {
+      return Err(Error::MixedAnimationFrameDimensions);
+    }
   }
+  Ok(())
+}
 
-  let width = frames[0].image.width();
-  let height = frames[0].image.height();
+/// Streams frames into an animated GIF, encoding each as it arrives so only one
+/// raw frame is held at a time.
+pub(crate) fn encode_animated_gif<W, I>(
+  mut frames: I,
+  destination: &mut W,
+  options: AnimatedGifOptions,
+) -> Result<()>
+where
+  W: Write,
+  I: Iterator<Item = Result<AnimationFrame>>,
+{
+  let Some(first) = frames.next().transpose()? else {
+    return Err(Error::EmptyAnimationFrames);
+  };
 
+  let width = first.image.width();
+  let height = first.image.height();
   if width > u16::MAX as u32 || height > u16::MAX as u32 {
     return Err(Error::GifFrameDimensionsTooLarge {
       width,
       height,
       max: u16::MAX,
     });
-  }
-
-  for frame in frames.iter() {
-    if frame.image.width() != width || frame.image.height() != height {
-      return Err(Error::MixedAnimationFrameDimensions);
-    }
   }
 
   let width = width as u16;
@@ -329,11 +360,19 @@ pub fn write_animated_gif<W: Write>(
     .set_repeat(options.loop_count.map_or(Repeat::Infinite, Repeat::Finite))
     .map_err(Error::encode)?;
 
-  for frame in frames.into_owned().into_iter() {
+  let mut write_gif_frame = |frame: AnimationFrame| -> Result<()> {
+    if frame.image.width() != u32::from(width) || frame.image.height() != u32::from(height) {
+      return Err(Error::MixedAnimationFrameDimensions);
+    }
     let mut pixels = frame.image.into_raw();
     let mut gif_frame = GifFrame::from_rgba_speed(width, height, &mut pixels, 28);
     gif_frame.delay = duration_ms_to_gif_delay(frame.duration_ms);
-    encoder.write_frame(&gif_frame).map_err(Error::encode)?;
+    encoder.write_frame(&gif_frame).map_err(Error::encode)
+  };
+
+  write_gif_frame(first)?;
+  for frame in frames {
+    write_gif_frame(frame?)?;
   }
 
   Ok(())
@@ -348,36 +387,67 @@ pub fn write_animated_png<W: Write>(
   if frames.is_empty() {
     return Err(Error::EmptyAnimationFrames);
   }
+  ensure_uniform_frame_dimensions(frames)?;
 
-  let width = frames[0].image.width();
-  let height = frames[0].image.height();
-  for frame in frames.iter() {
-    if frame.image.width() != width || frame.image.height() != height {
-      return Err(Error::MixedAnimationFrameDimensions);
-    }
-  }
-
-  let mut encoder = png::Encoder::new(destination, width, height);
-  configure_png_encoder(&mut encoder);
-  encoder.set_color(ColorType::Rgba);
-  encoder
-    .set_animated(frames.len() as u32, options.loop_count.unwrap_or(0) as u32)
-    .map_err(Error::encode)?;
-
-  // Since APNG doesn't support variable frame duration, we use the minimum duration of all frames.
+  let frame_count = frames.len() as u32;
+  // APNG doesn't support variable frame duration, so use the minimum across frames.
   let min_duration_ms = frames
     .iter()
     .map(|frame| frame.duration_ms)
     .min()
     .unwrap_or(0);
 
+  encode_animated_png(
+    frames.iter().map(Ok),
+    frame_count,
+    min_duration_ms,
+    destination,
+    options,
+  )
+}
+
+/// Streams frames into an animated PNG. `frame_count` and `min_duration_ms` are
+/// passed in because APNG writes both into the header before the first frame.
+pub(crate) fn encode_animated_png<W, F, I>(
+  mut frames: I,
+  frame_count: u32,
+  min_duration_ms: u32,
+  destination: &mut W,
+  options: AnimatedPngOptions,
+) -> Result<()>
+where
+  W: Write,
+  F: Borrow<AnimationFrame>,
+  I: Iterator<Item = Result<F>>,
+{
+  let Some(first) = frames.next().transpose()? else {
+    return Err(Error::EmptyAnimationFrames);
+  };
+  let first = first.borrow();
+  let width = first.image.width();
+  let height = first.image.height();
+
+  let mut encoder = png::Encoder::new(destination, width, height);
+  configure_png_encoder(&mut encoder);
+  encoder.set_color(ColorType::Rgba);
+  encoder
+    .set_animated(frame_count, options.loop_count.unwrap_or(0) as u32)
+    .map_err(Error::encode)?;
   encoder
     .set_frame_delay(min_duration_ms.clamp(0, u16::MAX as u32) as u16, 1000)
     .map_err(Error::encode)?;
 
   let mut writer = encoder.write_header().map_err(Error::encode)?;
+  writer
+    .write_image_data(first.image.as_raw())
+    .map_err(Error::encode)?;
 
   for frame in frames {
+    let frame = frame?;
+    let frame = frame.borrow();
+    if frame.image.width() != width || frame.image.height() != height {
+      return Err(Error::MixedAnimationFrameDimensions);
+    }
     writer
       .write_image_data(frame.image.as_raw())
       .map_err(Error::encode)?;
@@ -386,6 +456,45 @@ pub fn write_animated_png<W: Write>(
   writer.finish().map_err(Error::encode)?;
 
   Ok(())
+}
+
+/// Output format and per-format options for [`write_animation`].
+#[non_exhaustive]
+pub enum AnimationFormat {
+  /// Animated WebP.
+  WebP(AnimatedWebpOptions),
+  /// Animated PNG.
+  Apng(AnimatedPngOptions),
+  /// Animated GIF.
+  Gif(AnimatedGifOptions),
+}
+
+/// Renders a timeline at `fps` and streams each frame straight into `format`,
+/// holding one raw frame at a time instead of the whole animation.
+///
+/// The eager alternative — [`render_animation`](crate::render_animation) followed
+/// by a `write_animated_*` call — keeps every frame in memory at once.
+pub fn write_animation<W: Write>(
+  scenes: &[SequentialScene<'_>],
+  fps: u32,
+  format: AnimationFormat,
+  destination: &mut W,
+) -> Result<()> {
+  let spans = frame_spans(scenes, fps);
+  if spans.is_empty() {
+    return Err(Error::EmptyAnimationFrames);
+  }
+
+  let frames = spans.iter().map(|&span| render_frame(scenes, span));
+  match format {
+    AnimationFormat::WebP(options) => encode_animated_webp(frames, destination, options),
+    AnimationFormat::Gif(options) => encode_animated_gif(frames, destination, options),
+    AnimationFormat::Apng(options) => {
+      let frame_count = spans.len() as u32;
+      let min_duration_ms = spans.iter().map(|span| span.duration_ms).min().unwrap_or(0);
+      encode_animated_png(frames, frame_count, min_duration_ms, destination, options)
+    }
+  }
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -471,6 +471,25 @@ pub enum AnimationFormat {
   Gif(AnimatedGifOptions),
 }
 
+impl AnimationFormat {
+  /// Shortest per-frame duration, in milliseconds, the format encodes without
+  /// decoders clamping it. Browsers bump any frame of 10ms or less to 100ms; GIF
+  /// stores delays in centiseconds, so its shortest honored step is 20ms.
+  const fn min_frame_duration_ms(self) -> u32 {
+    match self {
+      AnimationFormat::Gif(_) => 20,
+      AnimationFormat::WebP(_) | AnimationFormat::Apng(_) => 11,
+    }
+  }
+
+  /// Highest frame rate this format encodes faithfully. Above it, per-frame
+  /// durations fall to or below [`min_frame_duration_ms`](Self::min_frame_duration_ms)
+  /// and decoders clamp them to 100ms, stalling playback.
+  pub const fn max_fps(self) -> u32 {
+    1000 / self.min_frame_duration_ms()
+  }
+}
+
 /// Renders a timeline at `fps` and streams each frame straight into `format`,
 /// holding one raw frame at a time instead of the whole animation.
 ///
@@ -479,6 +498,11 @@ pub enum AnimationFormat {
 /// timeline whose scenes use different viewports may write partial GIF or APNG
 /// output before failing with
 /// [`MixedAnimationFrameDimensions`](Error::MixedAnimationFrameDimensions).
+///
+/// `fps` must not exceed [`AnimationFormat::max_fps`]. Above that ceiling frames
+/// fall to a duration decoders clamp to 100ms, so `write_animation` rejects it
+/// with [`AnimationFrameRateTooHigh`](Error::AnimationFrameRateTooHigh) before
+/// rendering anything.
 ///
 /// [`render_animation`](crate::render_animation) plus a `write_animated_*` call is
 /// the eager alternative. It holds every frame at once but rejects mismatched
@@ -489,6 +513,11 @@ pub fn write_animation<W: Write>(
   format: AnimationFormat,
   destination: &mut W,
 ) -> Result<()> {
+  let max_fps = format.max_fps();
+  if fps > max_fps {
+    return Err(Error::AnimationFrameRateTooHigh { fps, max_fps });
+  }
+
   let spans = frame_spans(scenes, fps);
   if spans.is_empty() {
     return Err(Error::EmptyAnimationFrames);

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -184,6 +184,7 @@ pub struct AnimatedWebpOptions {
   /// Encode losslessly. When `true`, `quality` is ignored.
   pub lossless: bool,
   /// Quality in range `0..=100` for lossy encoding; ignored when `lossless`.
+  #[builder(default = 75)]
   pub quality: u8,
   /// Encoding speed in range `0..=6`; `0` is fastest (lowest compression), `6` is
   /// slowest (best compression). `None` uses the default speed of `1`.

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -460,6 +460,7 @@ where
 
 /// Output format and per-format options for [`write_animation`].
 #[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
 pub enum AnimationFormat {
   /// Animated WebP.
   WebP(AnimatedWebpOptions),
@@ -472,8 +473,15 @@ pub enum AnimationFormat {
 /// Renders a timeline at `fps` and streams each frame straight into `format`,
 /// holding one raw frame at a time instead of the whole animation.
 ///
-/// The eager alternative — [`render_animation`](crate::render_animation) followed
-/// by a `write_animated_*` call — keeps every frame in memory at once.
+/// Every scene must render to the same frame size. `write_animation` encodes each
+/// frame as it renders it, so it cannot reject mismatched sizes up front: a
+/// timeline whose scenes use different viewports may write partial GIF or APNG
+/// output before failing with
+/// [`MixedAnimationFrameDimensions`](Error::MixedAnimationFrameDimensions).
+///
+/// [`render_animation`](crate::render_animation) plus a `write_animated_*` call is
+/// the eager alternative. It holds every frame at once but rejects mismatched
+/// dimensions before writing.
 pub fn write_animation<W: Write>(
   scenes: &[SequentialScene<'_>],
   fps: u32,

--- a/takumi-wasm/src/dts-header.d.ts
+++ b/takumi-wasm/src/dts-header.d.ts
@@ -125,6 +125,10 @@ export type RenderAnimationOptions = {
    */
   stylesheets?: string[];
   /**
+   * Structured keyframes to register alongside stylesheets.
+   */
+  keyframes?: Keyframes;
+  /**
    * Defines the ratio resolution of the image to the physical pixels.
    * @default 1.0
    */

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -131,6 +131,9 @@ pub struct RenderAnimationOptions {
   pub draw_debug_border: Option<bool>,
   /// CSS stylesheets to apply before rendering.
   pub stylesheets: Option<Vec<String>>,
+  /// Structured keyframes to register alongside stylesheets.
+  #[serde(default, deserialize_with = "deserialize_optional_keyframes")]
+  pub(crate) keyframes: Option<Vec<KeyframesRule>>,
   /// The device pixel ratio for scaling.
   pub device_pixel_ratio: Option<f32>,
   /// Frames per second for timeline sampling.

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -355,6 +355,7 @@ impl Renderer {
       images,
       draw_debug_border,
       stylesheets,
+      keyframes,
       device_pixel_ratio,
       fps,
       font_families,
@@ -374,7 +375,7 @@ impl Renderer {
     let viewport = Viewport::new((width, height))
       .with_device_pixel_ratio(device_pixel_ratio.unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO));
     let draw_debug_border = draw_debug_border.unwrap_or_default();
-    let stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
+    let stylesheet = self.parse_stylesheet(stylesheets, keyframes.unwrap_or_default())?;
     let state = self.read_state()?;
     let scene_options = scenes
       .into_iter()

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -1,7 +1,6 @@
 //! The main renderer for Takumi image rendering engine.
 
 use std::{
-  borrow::Cow,
   collections::HashMap,
   sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
@@ -19,9 +18,8 @@ use takumi_core::{
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{
-  AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFrame, SequentialScene,
-  measure, render, render_animation, write_animated_gif, write_animated_png, write_animated_webp,
-  write_image,
+  AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFormat, SequentialScene,
+  measure, render, write_animation, write_image,
 };
 use wasm_bindgen::prelude::*;
 
@@ -146,40 +144,6 @@ impl Renderer {
     }
 
     Ok(map)
-  }
-
-  fn encode_animation(
-    &self,
-    frames: Vec<AnimationFrame>,
-    format: Option<AnimationOutputFormat>,
-  ) -> Result<Vec<u8>, JsValue> {
-    let mut buffer = Vec::new();
-
-    match format.unwrap_or(AnimationOutputFormat::WebP) {
-      AnimationOutputFormat::WebP => {
-        // wasm `image-webp` is lossless-only.
-        write_animated_webp(
-          Cow::Owned(frames),
-          &mut buffer,
-          AnimatedWebpOptions::default(),
-        )
-        .map_err(map_error)?;
-      }
-      AnimationOutputFormat::APng => {
-        write_animated_png(&frames, &mut buffer, AnimatedPngOptions::default())
-          .map_err(map_error)?;
-      }
-      AnimationOutputFormat::Gif => {
-        write_animated_gif(
-          Cow::Owned(frames),
-          &mut buffer,
-          AnimatedGifOptions::default(),
-        )
-        .map_err(map_error)?;
-      }
-    }
-
-    Ok(buffer)
   }
 
   /// Creates a new Renderer instance.
@@ -432,8 +396,17 @@ impl Renderer {
           .build()
       })
       .collect::<Vec<_>>();
-    let rendered_frames = render_animation(&scene_options, fps).map_err(map_error)?;
 
-    self.encode_animation(rendered_frames, format)
+    // wasm `image-webp` is lossless-only, which the WebP option defaults to.
+    let format = match format.unwrap_or(AnimationOutputFormat::WebP) {
+      AnimationOutputFormat::WebP => AnimationFormat::WebP(AnimatedWebpOptions::default()),
+      AnimationOutputFormat::APng => AnimationFormat::Apng(AnimatedPngOptions::default()),
+      AnimationOutputFormat::Gif => AnimationFormat::Gif(AnimatedGifOptions::default()),
+    };
+
+    let mut buffer = Vec::new();
+    write_animation(&scene_options, fps, format, &mut buffer).map_err(map_error)?;
+
+    Ok(buffer)
   }
 }

--- a/takumi-wasm/tests/render.test.ts
+++ b/takumi-wasm/tests/render.test.ts
@@ -364,6 +364,42 @@ describe("renderAsDataUrl", () => {
       expect(result).toBeInstanceOf(Uint8Array);
       expect(Buffer.from(result.subarray(0, 6)).toString("ascii")).toMatch(/^GIF8[79]a$/);
     });
+
+    test("applies structured keyframes over the timeline", async () => {
+      const base = { width: "128px", height: "128px", backgroundColor: "#ef4444" } as const;
+      const staticNode = container({ style: base });
+      const animatedNode = container({
+        style: {
+          ...base,
+          animationName: "grow",
+          animationDuration: "1000ms",
+          animationIterationCount: "infinite",
+        },
+      });
+      const keyframes = {
+        grow: { "0%": { borderRadius: "0px" }, "100%": { borderRadius: "64px" } },
+      };
+
+      const staticOut = await renderer.renderAnimation({
+        scenes: [{ node: staticNode, durationMs: 1000 }],
+        width: 128,
+        height: 128,
+        format: "webp",
+        fps: 12,
+      });
+      const animatedOut = await renderer.renderAnimation({
+        scenes: [{ node: animatedNode, durationMs: 1000 }],
+        width: 128,
+        height: 128,
+        format: "webp",
+        fps: 12,
+        keyframes,
+      });
+
+      // The static timeline dedups to one frame; the animated one keeps distinct
+      // frames, so its output is much larger.
+      expect(animatedOut.length).toBeGreaterThan(staticOut.length * 2);
+    });
   });
 
   test("with structured keyframes in render options", async () => {

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -74,9 +74,9 @@ pub mod prelude {
   pub use takumi_html::{DEFAULT_MAX_DEPTH, FromHtml, FromHtmlOptions, HtmlError, StylePresets};
   #[cfg(feature = "raster-backend")]
   pub use takumi_raster::{
-    AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFrame, Bitmap,
-    DitheringAlgorithm, MeasuredNode, MeasuredTextRun, OutputFormat, Quality, RenderOptions,
-    SequentialScene,
+    AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFormat, AnimationFrame,
+    Bitmap, DitheringAlgorithm, MeasuredNode, MeasuredTextRun, OutputFormat, Quality,
+    RenderOptions, SequentialScene,
   };
   #[cfg(feature = "svg-backend")]
   pub use takumi_svg::SvgOptions;
@@ -87,7 +87,7 @@ pub use takumi_html::from_html;
 #[cfg(feature = "raster-backend")]
 pub use takumi_raster::{
   measure, render, render_animation, write_animated_gif, write_animated_png, write_animated_webp,
-  write_image,
+  write_animation, write_image,
 };
 #[cfg(feature = "svg-backend")]
 pub use takumi_svg::render as render_svg;


### PR DESCRIPTION
## Why

`renderAnimation` rendered every frame into a `Vec` before encoding. Memory grew with `frame_count = duration_ms * fps / 1000`, so a high frame rate or a long timeline held hundreds of raw frames at once (a 640×360 3s clip at ~91fps is ~273 frames ≈ 250 MB of RGBA). On the WASM playground that exhausts the worker heap and the render appears to hang.

## What

- Add `write_animation(scenes, fps, format, out)` to `takumi-raster` (re-exported from `takumi`). It computes the frame schedule, renders one frame at a time, and feeds each straight into the encoder, so peak memory is a bounded window of raw frames plus the compact encoded payloads (WebP keeps every VP8 payload because the RIFF container needs their sizes up front, but those are small).
- Refactor the GIF, APNG, and WebP encoders around a lazy `Iterator<Item = Result<AnimationFrame>>`. The eager `write_animated_*` functions delegate to the streaming cores and stay byte-identical (a parity test renders a timeline and asserts `write_animation` matches `render_animation` + `write_animated_*` for all three formats).
- The native WebP path encodes in bounded chunks: it buffers a memory-capped batch of unique frames, encodes the batch in parallel (rayon), then frees the raw pixels. Frame-parallelism stays; peak raw memory is fixed regardless of frame size.
- Both the napi and WASM `renderAnimation` bindings use `write_animation`.
- Slice callers keep the "reject mismatched dimensions before writing any bytes" guarantee via an up-front check. `write_animation` streams, so it documents that every scene must share a frame size and can write partial GIF/APNG output before raising `MixedAnimationFrameDimensions` (the bindings always render at one viewport, so they never hit it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `write_animation` to stream-render and encode animations as WebP, GIF, or APNG via `AnimationFormat`.
  * Added structured `keyframes` support to `renderAnimation` (WASM, N-API, and playground) so keyframes apply over the full timeline.
* **Bug Fixes**
  * `renderAnimation` no longer keeps keyframe-driven animations static.
  * Streamed animated encoding now matches prior eager encoding byte-for-byte (WebP/GIF/APNG).
  * `write_animation` rejects frame rates above the format’s maximum (`AnimationFrameRateTooHigh`).
* **Documentation**
  * Expanded streaming animation-frame encoding docs and clarified the “all frames at once” alternative.
* **Chores**
  * Updated automated replay/pre-release configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->