### PR TITLE
Core: seal foreign types out of the public API

### DIFF
--- a/.tegami/imagesinput-single-definition.md
+++ b/.tegami/imagesinput-single-definition.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:takumi-js:
+    type: major
+---
+
+### Give `ImagesInput` one definition
+
+`takumi-js` and `@takumi-rs/helpers` each exported a different type named
+`ImagesInput`. The base shape now lives only in `@takumi-rs/helpers` and
+`takumi-js` re-exports it, so `ImagesInput` means the same thing everywhere. The
+fetch-aware superset that `render`/`renderSvg`/`renderAnimation` accept is now
+`ManagedImagesInput`.

--- a/.tegami/max-size-gap-initial-values.md
+++ b/.tegami/max-size-gap-initial-values.md
@@ -1,0 +1,15 @@
+---
+packages:
+  cargo:takumi-core:
+    type: minor
+  cargo:takumi:
+    type: major
+---
+
+### Represent the `none`/`normal` initial values of `max-*` and gaps
+
+`max-width` and `max-height` are now a `MaxSize` value whose initial is `None`
+(unbounded), instead of borrowing `Length`'s `auto`. `column-gap`, `row-gap`, and
+the `gap` shorthand are now a `Gap` value whose initial is `Normal`. Rendering is
+unchanged — `none` resolves like the old unbounded default and `normal` computes
+to `0` — but the values now round-trip through `to_css` as `none`/`normal`.

--- a/.tegami/seal-core-public-api.md
+++ b/.tegami/seal-core-public-api.md
@@ -1,0 +1,13 @@
+---
+packages:
+  cargo:takumi-core:
+    type: minor
+  cargo:takumi:
+    type: major
+---
+
+### Keep taffy, parley, and tiny_skia out of the public API
+
+The layout and paint engine now lives behind a new `unstable` feature. `layout::{tree, inline, border}`, `paint`, `scene`, `geometry`, and `shadow` — which trade in `taffy`, `parley`, and `tiny_skia` types — are only compiled with that feature; the backend crates enable it. The default `takumi-core` API no longer exposes a foreign type, so a consumer can parse and hold styles without depending on the layout engine's crates.
+
+`FontWeight::Absolute` now holds an `f32` instead of a `parley` weight. `BackgroundSize::resolve` takes a `(u32, u32)` area rather than a `taffy::Size`. `BorderProperties`'s `width`/`color`/`style` fields are `Sides<T>` instead of `taffy::Rect<T>`. The `ours -> taffy`/`ours -> parley` `From` impls are gone; conversions moved to internal methods or the backend crates. The mistyped `FontSynthesic` enum is now `FontSynthesisMode`. `StyleSheetParseError`, `StyleSheetParseErrorKind`, `StyleDeclarationBlockParseError`, `RegisteredFamily`, and `RegisteredFace` are `#[non_exhaustive]`.

--- a/takumi-core/Cargo.toml
+++ b/takumi-core/Cargo.toml
@@ -74,6 +74,11 @@ default = ["woff2", "woff", "svg"]
 svg = ["dep:resvg", "dep:roxmltree"]
 woff2 = ["dep:wuff", "wuff/brotli"]
 woff = ["dep:wuff", "wuff/z"]
+# Exposes the taffy/parley/tiny-skia-backed layout and paint engine (layout::tree,
+# layout::inline, layout::border, paint, scene, geometry, shadow, font_style, and the
+# glyph-rasterization surface of resources::font) for rendering-backend crates. Not
+# part of the stable, backend-agnostic API.
+unstable = []
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use cssparser::{BasicParseErrorKind, ParseError, ParseErrorKind};
-use selectors::parser::SelectorParseErrorKind;
 use thiserror::Error;
 
 use crate::{
@@ -176,6 +175,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors raised while parsing a CSS declaration block string.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StyleDeclarationBlockParseError {
   /// The declaration block could not be parsed as CSS declarations.
   #[error("failed to parse CSS declaration block `{input}` near `{context}`: {reason}")]
@@ -191,6 +191,7 @@ pub enum StyleDeclarationBlockParseError {
 
 /// Errors raised while parsing a CSS stylesheet string.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct StyleSheetParseError {
   /// The stylesheet slice being parsed when the error was raised.
   pub context: Option<String>,
@@ -200,6 +201,7 @@ pub struct StyleSheetParseError {
 
 /// The specific stylesheet parse failure.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StyleSheetParseErrorKind {
   /// The stylesheet could not be parsed as valid CSS.
   #[error("{0}")]
@@ -253,12 +255,6 @@ impl std::fmt::Display for StyleSheetParseError {
 }
 
 impl std::error::Error for StyleSheetParseError {}
-
-impl<'i> From<SelectorParseErrorKind<'i>> for StyleSheetParseError {
-  fn from(err: SelectorParseErrorKind<'i>) -> Self {
-    Self::invalid_reason(format!("{err:?}"))
-  }
-}
 
 impl<'i> From<Cow<'i, str>> for StyleSheetParseError {
   fn from(err: Cow<'i, str>) -> Self {

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -120,11 +120,16 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
       font_size: style.sizing.font_size,
       line_height: style.line_height,
       font_weight: style.parent.font_weight.into(),
-      font_style: style.parent.font_style.into(),
-      font_variations: FontVariations::List(Cow::Borrowed(
-        style.parent.font_variation_settings.as_ref(),
+      font_style: style.parent.font_style.to_parley(),
+      font_variations: FontVariations::List(Cow::Owned(
+        style
+          .parent
+          .font_variation_settings
+          .iter()
+          .map(|setting| setting.0)
+          .collect(),
       )),
-      font_features: FontFeatures::List(style.parent.resolved_font_features()),
+      font_features: FontFeatures::List(Cow::Owned(style.parent.resolved_font_features())),
       font_family: style.font_family.to_parley(),
       letter_spacing: style.letter_spacing,
       word_spacing: style.word_spacing,
@@ -160,8 +165,8 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
       },
       text_wrap_mode: style.parent.resolved_text_wrap_mode().into(),
       font_width: style.parent.font_stretch.into(),
-
       locale: style.parent.lang,
+
       has_underline: false,
       underline_offset: None,
       underline_size: None,

--- a/takumi-core/src/layout/mod.rs
+++ b/takumi-core/src/layout/mod.rs
@@ -1,8 +1,11 @@
 /// Backend-agnostic border geometry shared across rasterization backends.
+#[cfg(feature = "unstable")]
 pub mod border;
 /// Inline-level layout: text shaping, line breaking, and text fitting.
+#[cfg(feature = "unstable")]
 pub mod inline;
 /// Node Tree
 pub mod node;
 /// Layout tree: render nodes and their computed layout results.
+#[cfg(feature = "unstable")]
 pub mod tree;

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -1,25 +1,32 @@
 mod container;
 mod image;
+#[cfg(feature = "unstable")]
 mod text;
 
 use std::{collections::BTreeMap, sync::Arc};
 
 use parley::Language;
 use serde::Deserialize;
+#[cfg(feature = "unstable")]
 use taffy::{AvailableSpace, Size};
 
+#[cfg(feature = "unstable")]
+use self::image::measure_image_node;
 pub use self::image::resolve_image;
+#[cfg(feature = "unstable")]
+use self::text::measure_text_node;
 use self::{
   container::{
     container_children_ref, deserialize_children, drop_container_children, take_container_children,
   },
-  image::{measure_image_node, take_image_style_layers},
-  text::measure_text_node,
+  image::take_image_style_layers,
 };
+#[cfg(feature = "unstable")]
+use crate::layout::inline::InlineContentKind;
 use crate::{
   Xxh3HashSet,
   context::RenderContext,
-  layout::{inline::InlineContentKind, node::image::image_url},
+  layout::node::image::image_url,
   matching::MatchableNode,
   resources::{
     image::{ImageResult, ImageSource},
@@ -530,6 +537,7 @@ impl Node {
     }
   }
 
+  #[cfg(feature = "unstable")]
   pub(crate) fn inline_content(&self) -> Option<InlineContentKind<'_>> {
     match &self.kind {
       NodeKind::Container { .. } => None,
@@ -538,6 +546,7 @@ impl Node {
     }
   }
 
+  #[cfg(feature = "unstable")]
   pub(crate) fn measure(
     &self,
     context: &RenderContext,

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -163,7 +163,7 @@ fn resolve_normal_line_height(
   }
   let attributes = Attributes {
     width: style.font_stretch.into(),
-    style: style.font_style.into(),
+    style: style.font_style.to_parley(),
     weight: style.font_weight.into(),
   };
   let font_family = context.expand_font_family(&style.font_family);

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -1,6 +1,9 @@
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 #![deny(missing_docs)]
+// Much of this crate exists only to feed the layout/paint engine behind the
+// `unstable` feature; with it off, those items are unreachable but still compiled.
+#![cfg_attr(not(feature = "unstable"), allow(dead_code))]
 //! Backend-agnostic core for takumi: the node tree, CSS-driven style and layout,
 //! and font/image resource management.
 //!
@@ -14,13 +17,17 @@ pub mod layout;
 /// Render context threading style, sizing, and resources through layout.
 pub mod context;
 /// Font style resolved against a sizing context.
+#[cfg(feature = "unstable")]
 pub mod font_style;
 /// Box, text, and inset shadow resolution.
+#[cfg(feature = "unstable")]
 pub mod shadow;
+#[cfg(feature = "unstable")]
 pub mod text_processing;
 
 /// Error types.
 pub mod error;
+#[cfg(feature = "unstable")]
 pub mod geometry;
 /// `@keyframes` rules and animation timing.
 pub mod keyframes;
@@ -28,6 +35,7 @@ pub mod keyframes;
 pub(crate) mod matching;
 /// Font and image resource management.
 pub mod resources;
+#[cfg(feature = "unstable")]
 pub mod scene;
 /// CSS value types, parsing, and the cascade.
 pub mod style;
@@ -38,6 +46,7 @@ pub mod viewport;
 /// shared with the raster and SVG renderers. Deliberately kept out of `style`
 /// (and thus `takumi`'s prelude) since they are rendering-backend internals, not
 /// part of the CSS value surface.
+#[cfg(feature = "unstable")]
 pub mod paint {
   pub use crate::style::properties::{
     background_repeat::{

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -1,20 +1,27 @@
+#[cfg(feature = "unstable")]
+use std::collections::hash_map::Entry;
 use std::{
   borrow::Cow,
   cell::RefCell,
-  collections::{BTreeSet, HashMap, hash_map::Entry},
+  collections::{BTreeSet, HashMap},
   iter::once,
   rc::Rc,
   sync::Arc,
 };
 
+#[cfg(feature = "unstable")]
 use image::{Rgba, RgbaImage};
-use parley::{
-  GenericFamily as ParleyGenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
-  fontique::{
-    Attributes, Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, FontStyle,
-    FontWeight, FontWidth, QueryFamily, QueryStatus, Script, ScriptExt,
-  },
+use parley::GenericFamily as ParleyGenericFamily;
+#[cfg(feature = "unstable")]
+use parley::fontique::{Attributes, QueryFamily, QueryStatus};
+use parley::fontique::{
+  Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, FontStyle, FontWeight,
+  FontWidth, Script, ScriptExt,
 };
+#[cfg(feature = "unstable")]
+use parley::{GlyphRun, LayoutContext, TextStyle, TreeBuilder};
+use skrifa::raw::types::Tag;
+#[cfg(feature = "unstable")]
 use skrifa::{
   FontRef, GlyphId, MetadataProvider,
   bitmap::{BitmapData, BitmapGlyph, BitmapStrikes, Origin},
@@ -24,24 +31,28 @@ use skrifa::{
   },
   instance::{LocationRef, Size},
   outline::{DrawSettings, OutlineGlyphCollection, OutlinePen},
-  raw::types::{BoundingBox, F2Dot14, Tag},
+  raw::types::{BoundingBox, F2Dot14},
 };
 use thiserror::Error;
+#[cfg(feature = "unstable")]
 use tiny_skia::{IntSize, PathSegment as Command, Pixmap};
 
+use crate::style::FontStyle as CssFontStyle;
+#[cfg(feature = "unstable")]
 use crate::{
   context::RenderContext,
   layout::inline::{InlineBrush, InlineLayout},
   resources::{image_buffer::ImageBuffer, image_decoder::decode_png},
-  style::FontStyle as CssFontStyle,
 };
 
+#[cfg(feature = "unstable")]
 fn pixmap_from_image_buffer(buffer: ImageBuffer) -> Option<Pixmap> {
   let size = IntSize::from_wh(buffer.width(), buffer.height())?;
   Pixmap::from_vec(buffer.into_data(), size)
 }
 
 /// A resolved glyph, either an embedded bitmap or a vector outline.
+#[cfg(feature = "unstable")]
 #[derive(Clone)]
 pub enum ResolvedGlyph {
   /// Embedded bitmap glyph.
@@ -51,6 +62,7 @@ pub enum ResolvedGlyph {
 }
 
 /// A glyph backed by an embedded bitmap.
+#[cfg(feature = "unstable")]
 #[derive(Clone)]
 pub struct ResolvedBitmapGlyph {
   /// Source bitmap.
@@ -63,6 +75,7 @@ pub struct ResolvedBitmapGlyph {
   pub placement: ResolvedGlyphPlacement,
 }
 
+#[cfg(feature = "unstable")]
 impl ResolvedBitmapGlyph {
   /// Write the glyph's alpha channel into `mask`, scaling to the placement size.
   pub fn write_alpha_mask(&self, mask: &mut [u8]) {
@@ -113,6 +126,7 @@ impl ResolvedBitmapGlyph {
 }
 
 /// An outline glyph, either single-color or multi-layer color.
+#[cfg(feature = "unstable")]
 #[derive(Clone)]
 pub enum ResolvedOutlineGlyph {
   /// Single-color outline.
@@ -136,6 +150,7 @@ pub enum ResolvedOutlineGlyph {
 }
 
 /// One palette-colored layer of a color glyph.
+#[cfg(feature = "unstable")]
 #[derive(Clone)]
 pub struct ResolvedColorLayer {
   /// Outline path commands for this layer.
@@ -147,6 +162,7 @@ pub struct ResolvedColorLayer {
 }
 
 /// Pixel placement of a rendered glyph.
+#[cfg(feature = "unstable")]
 #[derive(Clone, Copy)]
 pub struct ResolvedGlyphPlacement {
   /// Left offset in pixels.
@@ -159,6 +175,7 @@ pub struct ResolvedGlyphPlacement {
   pub height: u32,
 }
 
+#[cfg(feature = "unstable")]
 impl ResolvedOutlineGlyph {
   /// Outline path commands for the glyph.
   pub fn paths(&self) -> &[Command] {
@@ -203,6 +220,7 @@ const BOLD_THRESHOLD: f32 = 600.0;
 /// Skia's fake-bold stroke width as a fraction of text size: `1/24` at 9px and below,
 /// easing to `1/32` at 36px and above, linearly interpolated in between. A constant factor
 /// over-emboldens large text. See Skia's `SkTextFormatParams.h`.
+#[cfg(feature = "unstable")]
 fn skia_fake_bold_factor(font_size: f32) -> f32 {
   const SMALL_SIZE: f32 = 9.0;
   const LARGE_SIZE: f32 = 36.0;
@@ -215,10 +233,12 @@ fn skia_fake_bold_factor(font_size: f32) -> f32 {
 
 /// Stroke width for synthesized (faux) bold — the emboldened glyph is the filled outline
 /// plus a centered stroke of this width, matching Skia's fake bold.
+#[cfg(feature = "unstable")]
 pub(crate) fn synthesis_embolden_strength(font_size: f32) -> f32 {
   font_size * skia_fake_bold_factor(font_size)
 }
 
+#[cfg(feature = "unstable")]
 fn hash_path_commands(paths: &[Command]) -> u64 {
   use xxhash_rust::xxh3::Xxh3;
   let mut h = Xxh3::new();
@@ -258,17 +278,20 @@ fn hash_path_commands(paths: &[Command]) -> u64 {
   h.digest()
 }
 
+#[cfg(feature = "unstable")]
 #[derive(Default)]
 struct GlyphOutlinePen {
   paths: Vec<Command>,
 }
 
+#[cfg(feature = "unstable")]
 impl GlyphOutlinePen {
   fn finish(self) -> Vec<Command> {
     self.paths
   }
 }
 
+#[cfg(feature = "unstable")]
 impl OutlinePen for GlyphOutlinePen {
   fn move_to(&mut self, x: f32, y: f32) {
     self
@@ -302,6 +325,7 @@ impl OutlinePen for GlyphOutlinePen {
   }
 }
 
+#[cfg(feature = "unstable")]
 struct ColorLayerCollector<'a, 'g> {
   outline_glyphs: &'g OutlineGlyphCollection<'a>,
   size: Size,
@@ -309,6 +333,7 @@ struct ColorLayerCollector<'a, 'g> {
   layers: Vec<ResolvedColorLayer>,
 }
 
+#[cfg(feature = "unstable")]
 impl<'a, 'g> ColorLayerCollector<'a, 'g> {
   fn new(
     outline_glyphs: &'g OutlineGlyphCollection<'a>,
@@ -328,6 +353,7 @@ impl<'a, 'g> ColorLayerCollector<'a, 'g> {
   }
 }
 
+#[cfg(feature = "unstable")]
 struct GlyphResolveContext<'a> {
   outline_glyphs: OutlineGlyphCollection<'a>,
   color_glyphs: ColorGlyphCollection<'a>,
@@ -339,6 +365,7 @@ struct GlyphResolveContext<'a> {
   embolden: Option<f32>,
 }
 
+#[cfg(feature = "unstable")]
 impl<'a> GlyphResolveContext<'a> {
   fn resolve_glyph(&self, glyph_id: u32) -> Option<ResolvedGlyph> {
     let glyph_id = GlyphId::new(glyph_id);
@@ -408,6 +435,7 @@ impl<'a> GlyphResolveContext<'a> {
 /// `push_clip_box`, `pop_clip`, and `push_layer` are intentional no-ops, and
 /// `fill_glyph` only records `Brush::Solid` layers, so gradients and other
 /// non-solid brushes are silently skipped.
+#[cfg(feature = "unstable")]
 impl ColorPainter for ColorLayerCollector<'_, '_> {
   fn push_transform(&mut self, _transform: Transform) {}
 
@@ -458,6 +486,7 @@ impl ColorPainter for ColorLayerCollector<'_, '_> {
   fn push_layer(&mut self, _composite_mode: CompositeMode) {}
 }
 
+#[cfg(feature = "unstable")]
 fn resolve_outline_commands(
   outline_glyphs: &OutlineGlyphCollection<'_>,
   glyph_id: GlyphId,
@@ -472,6 +501,7 @@ fn resolve_outline_commands(
   Some(pen.finish())
 }
 
+#[cfg(feature = "unstable")]
 fn transform_commands(paths: &mut [Command], skew_degrees: f32) {
   let skew_tangent = skew_degrees.to_radians().tan();
   for command in paths {
@@ -493,6 +523,7 @@ fn transform_commands(paths: &mut [Command], skew_degrees: f32) {
   }
 }
 
+#[cfg(feature = "unstable")]
 fn decode_bitmap_image(bitmap: &BitmapGlyph<'_>) -> Option<(Pixmap, Origin)> {
   let pixmap = match &bitmap.data {
     BitmapData::Png(bytes) => pixmap_from_image_buffer(decode_png(bytes).ok()?)?,
@@ -514,6 +545,7 @@ fn decode_bitmap_image(bitmap: &BitmapGlyph<'_>) -> Option<(Pixmap, Origin)> {
   Some((pixmap, bitmap.placement_origin))
 }
 
+#[cfg(feature = "unstable")]
 fn scale_bitmap_glyph(bitmap: BitmapGlyph<'_>, font_size: f32) -> Option<ResolvedBitmapGlyph> {
   let (pixmap, origin) = decode_bitmap_image(&bitmap)?;
   let scale_x = if bitmap.ppem_x > 0.0 {
@@ -619,14 +651,17 @@ fn guess_font_format(source: &[u8]) -> Result<FontFormat, FontError> {
   }
 }
 
+#[cfg(feature = "unstable")]
 thread_local! {
   static LAYOUT_CONTEXT: RefCell<LayoutContext<InlineBrush>> = RefCell::new(LayoutContext::new());
   static SHARED_RESOLVED_GLYPH_CACHE: RefCell<HashMap<u64, ResolvedGlyph>> =
     RefCell::new(HashMap::new());
 }
 
+#[cfg(feature = "unstable")]
 const RESOLVED_GLYPH_CACHE_MAX_ENTRIES: usize = 4096;
 
+#[cfg(feature = "unstable")]
 fn resolved_glyph_cache_key(
   font_id: u64,
   font_index: u32,
@@ -662,6 +697,7 @@ fn resolved_glyph_cache_key(
   h.digest()
 }
 
+#[cfg(feature = "unstable")]
 fn with_layout_context<R>(f: impl FnOnce(&mut LayoutContext<InlineBrush>) -> R) -> R {
   LAYOUT_CONTEXT.with(|cell| match cell.try_borrow_mut() {
     Ok(mut ctx) => f(&mut ctx),
@@ -671,6 +707,7 @@ fn with_layout_context<R>(f: impl FnOnce(&mut LayoutContext<InlineBrush>) -> R) 
 
 /// A font family produced by [`Fonts::register`], with the faces it contains.
 #[derive(Clone, Debug, serde::Serialize)]
+#[non_exhaustive]
 pub struct RegisteredFamily {
   /// Family name as stored by the font system (normalized; reflects any override).
   pub name: String,
@@ -680,6 +717,7 @@ pub struct RegisteredFamily {
 
 /// A single face within a [`RegisteredFamily`].
 #[derive(Clone, Debug, serde::Serialize)]
+#[non_exhaustive]
 pub struct RegisteredFace {
   /// Weight class, typically `1.0..=1000.0`.
   pub weight: f32,
@@ -702,10 +740,10 @@ fn font_style_css(style: FontStyle) -> String {
 
 /// The registry of fonts available to a renderer.
 ///
-/// Registration is the only mutation; afterwards the assembled parley context is immutable
+/// Registration is the only mutation; afterwards the assembled font collection is immutable
 /// and shared as `&self` across concurrent renders. Each render takes a cheap working clone
-/// (see [`RenderContext`]) for parley's `&mut` query API, so no per-thread or global state
-/// is needed.
+/// (see [`RenderContext`]) for the shaping engine's `&mut` query API, so no per-thread or
+/// global state is needed.
 #[derive(Clone)]
 pub struct Fonts {
   inner: parley::FontContext,
@@ -814,6 +852,7 @@ impl Fonts {
     }
   }
 
+  #[cfg(feature = "unstable")]
   pub(crate) fn resolve_glyphs(
     &self,
     run: &GlyphRun<'_, InlineBrush>,
@@ -950,7 +989,7 @@ impl Fonts {
         self
           .inner
           .collection
-          .append_generic_families(generic_family.into(), once(family));
+          .append_generic_families(generic_family.to_parley(), once(family));
       }
     }
 
@@ -958,6 +997,7 @@ impl Fonts {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl RenderContext {
   /// First available font's line spacing for `families`/`attributes`, scaled to `font_size`.
   pub(crate) fn first_font_line_spacing<'a>(
@@ -1085,11 +1125,9 @@ impl GenericFamily {
   pub const MATH: Self = Self(ParleyGenericFamily::Math);
   /// `fangsong`
   pub const FANG_SONG: Self = Self(ParleyGenericFamily::FangSong);
-}
 
-impl From<GenericFamily> for ParleyGenericFamily {
-  fn from(value: GenericFamily) -> Self {
-    value.0
+  pub(crate) fn to_parley(self) -> ParleyGenericFamily {
+    self.0
   }
 }
 
@@ -1129,7 +1167,7 @@ impl FontOverride {
     FontInfoOverride {
       family_name: self.family_name.as_deref(),
       width: self.width.map(FontWidth::from_percentage),
-      style: self.style.map(Into::into),
+      style: self.style.map(CssFontStyle::to_parley),
       weight: self.weight.map(FontWeight::new),
       axes: (!axes.is_empty()).then_some(axes),
     }

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -548,7 +548,7 @@ impl_passthrough_animatable!(
   FontFamily,
   LineHeight,
   FontSynthesis,
-  FontSynthesic,
+  FontSynthesisMode,
   LineClamp,
   TextAlign,
   TextStroke,

--- a/takumi-core/src/style/mod.rs
+++ b/takumi-core/src/style/mod.rs
@@ -11,6 +11,7 @@ mod supports;
 /// Tailwind utility-class parsing.
 pub mod tw;
 
+#[cfg(feature = "unstable")]
 pub(crate) use animation::apply_stylesheet_animations;
 pub use animation::{KeyframeRule, KeyframesRule};
 pub(crate) use calc::{CalcArena, parse_calc_number_expression};

--- a/takumi-core/src/style/properties/background_size.rs
+++ b/takumi-core/src/style/properties/background_size.rs
@@ -129,10 +129,14 @@ impl BackgroundSize {
   /// Resolves this value against the positioning area and intrinsic sizing.
   pub fn resolve(
     self,
-    area: Size<u32>,
+    (area_width, area_height): (u32, u32),
     sizing: &SizingContext,
     intrinsic: IntrinsicSizing,
   ) -> ResolvedBackgroundSize {
+    let area = Size {
+      width: area_width,
+      height: area_height,
+    };
     match self {
       BackgroundSize::Explicit { width, height } => {
         if width != Length::Auto && height != Length::Auto {

--- a/takumi-core/src/style/properties/font_family.rs
+++ b/takumi-core/src/style/properties/font_family.rs
@@ -1,7 +1,7 @@
 use std::{fmt, string::ToString};
 
 use cssparser::{Parser, match_ignore_ascii_case};
-use parley::{FontFamily as ParleyFontFamily, FontFamilyName, GenericFamily};
+use parley::{FontFamilyName, GenericFamily};
 
 use crate::style::{
   CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
@@ -97,27 +97,6 @@ impl TailwindPropertyParser for FontFamily {
 impl Default for FontFamily {
   fn default() -> Self {
     GenericFamily::SansSerif.into()
-  }
-}
-
-impl<'a> From<FontFamily> for ParleyFontFamily<'a> {
-  fn from(family: FontFamily) -> Self {
-    ParleyFontFamily::List(
-      family
-        .0
-        .into_iter()
-        .map(|token| match token {
-          FontFamilyToken::Owned(name) => FontFamilyName::Named(name.into()),
-          FontFamilyToken::Generic(generic) => FontFamilyName::Generic(generic),
-        })
-        .collect(),
-    )
-  }
-}
-
-impl<'a> From<&'a FontFamily> for ParleyFontFamily<'a> {
-  fn from(family: &'a FontFamily) -> Self {
-    ParleyFontFamily::List(family.names().collect())
   }
 }
 

--- a/takumi-core/src/style/properties/font_feature_settings.rs
+++ b/takumi-core/src/style/properties/font_feature_settings.rs
@@ -4,7 +4,7 @@ use cssparser::{Parser, Token};
 use parley::{FontFeature, setting::Tag};
 
 use crate::style::{
-  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token,
+  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token,
 };
 
 pub(crate) fn parse_opentype_tag<'i, T: FromCss<'i>>(
@@ -23,11 +23,29 @@ pub(crate) fn parse_opentype_tag<'i, T: FromCss<'i>>(
     .ok_or_else(|| unexpected_token!(T, location, &Token::QuotedString(tag_name.clone())))
 }
 
+/// A single `font-feature-settings` entry: an OpenType feature tag and its value.
+/// Wraps `parley::FontFeature` so callers need not depend on `parley` (and so the
+/// engine-only type doesn't appear directly in `ComputedStyle`'s field).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FontFeatureSetting(pub(crate) FontFeature);
+
+impl FontFeatureSetting {
+  /// Creates a feature setting from its 4-byte OpenType tag (e.g. `*b"liga"`) and
+  /// value (`0`/`1` to disable/enable, or a higher value for features like
+  /// stylistic sets that take one).
+  pub fn new(tag: [u8; 4], value: u16) -> Self {
+    Self(FontFeature {
+      tag: Tag::from_bytes(tag),
+      value,
+    })
+  }
+}
+
 /// Controls OpenType font features via CSS font-feature-settings property.
 ///
 /// This allows enabling/disabling specific typographic features in OpenType fonts
 /// such as ligatures, kerning, small caps, and other advanced typography features.
-pub(crate) type FontFeatureSettings = Box<[FontFeature]>;
+pub(crate) type FontFeatureSettings = Box<[FontFeatureSetting]>;
 
 impl MakeComputed for FontFeatureSettings {}
 
@@ -58,7 +76,7 @@ impl<'i> FromCss<'i> for FontFeatureSettings {
         }
       };
 
-      Ok(FontFeature { tag, value })
+      Ok(FontFeatureSetting(FontFeature { tag, value }))
     })?;
 
     Ok(list.into_boxed_slice())
@@ -70,12 +88,14 @@ impl<'i> FromCss<'i> for FontFeatureSettings {
   ];
 }
 
-impl ToCss for parley::FontFeature {
+impl Animatable for FontFeatureSetting {}
+
+impl ToCss for FontFeatureSetting {
   // An empty `font-feature-settings` list is the keyword `normal`.
   const EMPTY_LIST_KEYWORD: Option<&'static str> = Some("normal");
 
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    write!(dest, "\"{}\" {}", self.tag, self.value)
+    write!(dest, "\"{}\" {}", self.0.tag, self.0.value)
   }
 }
 

--- a/takumi-core/src/style/properties/font_stretch.rs
+++ b/takumi-core/src/style/properties/font_stretch.rs
@@ -82,6 +82,7 @@ impl FontStretch {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<FontStretch> for FontWidth {
   fn from(value: FontStretch) -> Self {
     value.0

--- a/takumi-core/src/style/properties/font_style.rs
+++ b/takumi-core/src/style/properties/font_style.rs
@@ -49,11 +49,9 @@ impl FontStyle {
   pub const fn oblique(angle: f32) -> Self {
     Self(ParleyFontStyle::Oblique(Some(angle)))
   }
-}
 
-impl From<FontStyle> for ParleyFontStyle {
-  fn from(value: FontStyle) -> Self {
-    value.0
+  pub(crate) fn to_parley(self) -> ParleyFontStyle {
+    self.0
   }
 }
 

--- a/takumi-core/src/style/properties/font_synthesis.rs
+++ b/takumi-core/src/style/properties/font_synthesis.rs
@@ -10,17 +10,17 @@ use crate::style::{
 #[builder(field_defaults(default))]
 pub struct FontSynthesis {
   /// Controls synthetic bolding when a matching font weight is unavailable.
-  pub weight: FontSynthesic,
+  pub weight: FontSynthesisMode,
   /// Controls synthetic italics/obliques when a matching style is unavailable.
-  pub style: FontSynthesic,
+  pub style: FontSynthesisMode,
 }
 
 impl MakeComputed for FontSynthesis {}
 
 impl<'i> FromCss<'i> for FontSynthesis {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    let mut weight = FontSynthesic::None;
-    let mut style = FontSynthesic::None;
+    let mut weight = FontSynthesisMode::None;
+    let mut style = FontSynthesisMode::None;
 
     while !input.is_exhausted() {
       let location = input.current_source_location();
@@ -28,14 +28,14 @@ impl<'i> FromCss<'i> for FontSynthesis {
 
       match_ignore_ascii_case! {ident,
         "none" => {
-          weight = FontSynthesic::None;
-          style = FontSynthesic::None;
+          weight = FontSynthesisMode::None;
+          style = FontSynthesisMode::None;
         },
         "weight" => {
-          weight = FontSynthesic::Auto;
+          weight = FontSynthesisMode::Auto;
         },
         "style" => {
-          style = FontSynthesic::Auto;
+          style = FontSynthesisMode::Auto;
         },
         _ => return Err(unexpected_token!(location, &Token::Ident(ident.to_owned()))),
       };
@@ -54,7 +54,7 @@ impl<'i> FromCss<'i> for FontSynthesis {
 /// Control mode for synthetic.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[non_exhaustive]
-pub enum FontSynthesic {
+pub enum FontSynthesisMode {
   /// Synthetic is allowed.
   #[default]
   Auto,
@@ -62,15 +62,15 @@ pub enum FontSynthesic {
   None,
 }
 
-impl FontSynthesic {
+impl FontSynthesisMode {
   /// Whether synthesis is permitted.
   pub(crate) fn is_allowed(self) -> bool {
-    self == FontSynthesic::Auto
+    self == FontSynthesisMode::Auto
   }
 }
 
 declare_enum_from_css_impl!(
-  FontSynthesic,
-  "auto" => FontSynthesic::Auto,
-  "none" => FontSynthesic::None,
+  FontSynthesisMode,
+  "auto" => FontSynthesisMode::Auto,
+  "none" => FontSynthesisMode::None,
 );

--- a/takumi-core/src/style/properties/font_variation_settings.rs
+++ b/takumi-core/src/style/properties/font_variation_settings.rs
@@ -1,16 +1,34 @@
 use std::fmt;
 
 use cssparser::Parser;
-use parley::FontVariation;
+use parley::{FontVariation, setting::Tag};
 
 use super::font_feature_settings::parse_opentype_tag;
-use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss};
+use crate::style::{
+  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
+};
+
+/// A single `font-variation-settings` entry: a variation axis tag and its value.
+/// Wraps `parley::FontVariation` so callers need not depend on `parley` (and so the
+/// engine-only type doesn't appear directly in `ComputedStyle`'s field).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FontVariationSetting(pub(crate) FontVariation);
+
+impl FontVariationSetting {
+  /// Creates a variation setting from its 4-byte axis tag (e.g. `*b"wght"`) and value.
+  pub fn new(tag: [u8; 4], value: f32) -> Self {
+    Self(FontVariation {
+      tag: Tag::from_bytes(tag),
+      value,
+    })
+  }
+}
 
 /// Controls variable font axis values via CSS font-variation-settings property.
 ///
 /// This allows fine-grained control over variable font characteristics like weight,
 /// width, slant, and other custom axes defined in the font.
-pub(crate) type FontVariationSettings = Box<[FontVariation]>;
+pub(crate) type FontVariationSettings = Box<[FontVariationSetting]>;
 
 impl MakeComputed for FontVariationSettings {}
 
@@ -27,7 +45,7 @@ impl<'i> FromCss<'i> for FontVariationSettings {
       let tag = parse_opentype_tag::<FontVariationSettings>(input)?;
       let value = input.expect_number()?;
 
-      Ok(FontVariation { tag, value })
+      Ok(FontVariationSetting(FontVariation { tag, value }))
     })?;
 
     Ok(list.into_boxed_slice())
@@ -39,11 +57,13 @@ impl<'i> FromCss<'i> for FontVariationSettings {
   ];
 }
 
-impl ToCss for parley::FontVariation {
+impl Animatable for FontVariationSetting {}
+
+impl ToCss for FontVariationSetting {
   // An empty `font-variation-settings` list is the keyword `normal`.
   const EMPTY_LIST_KEYWORD: Option<&'static str> = Some("normal");
 
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    write!(dest, "\"{}\" {}", self.tag, self.value)
+    write!(dest, "\"{}\" {}", self.0.tag, self.0.value)
   }
 }

--- a/takumi-core/src/style/properties/font_weight.rs
+++ b/takumi-core/src/style/properties/font_weight.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
+#[cfg(feature = "unstable")]
 use parley::style::FontWeight as ParleyFontWeight;
 
 use crate::style::{
@@ -12,7 +13,7 @@ use crate::style::{
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FontWeight {
   /// An absolute numeric weight.
-  Absolute(ParleyFontWeight),
+  Absolute(f32),
   /// One step bolder than the inherited weight, resolved against the parent.
   Bolder,
   /// One step lighter than the inherited weight, resolved against the parent.
@@ -119,7 +120,7 @@ impl FontWeight {
   /// inheritance to step from the parent weight.
   pub fn value(self) -> f32 {
     match self {
-      Self::Absolute(weight) => weight.value(),
+      Self::Absolute(weight) => weight,
       Self::Bolder => bolder(400.0),
       Self::Lighter => lighter(400.0),
     }
@@ -136,6 +137,7 @@ impl FontWeight {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<FontWeight> for ParleyFontWeight {
   fn from(value: FontWeight) -> Self {
     ParleyFontWeight::new(value.value())
@@ -144,7 +146,7 @@ impl From<FontWeight> for ParleyFontWeight {
 
 impl From<f32> for FontWeight {
   fn from(value: f32) -> Self {
-    FontWeight::Absolute(ParleyFontWeight::new(value))
+    FontWeight::Absolute(value)
   }
 }
 
@@ -153,7 +155,7 @@ impl ToCss for FontWeight {
     match self {
       Self::Bolder => dest.write_str("bolder"),
       Self::Lighter => dest.write_str("lighter"),
-      Self::Absolute(weight) => write!(dest, "{}", weight.value()),
+      Self::Absolute(weight) => write!(dest, "{}", weight),
     }
   }
 }

--- a/takumi-core/src/style/properties/gap.rs
+++ b/takumi-core/src/style/properties/gap.rs
@@ -1,0 +1,127 @@
+use std::fmt;
+
+use cssparser::Parser;
+use taffy::LengthPercentage;
+
+use crate::style::{
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
+  SizingContext, ToCss,
+};
+
+/// Represents the `column-gap`/`row-gap` value: either `normal` (computes to `0`) or a [`Length`].
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum Gap {
+  /// No explicit gap; computes to `0`.
+  #[default]
+  Normal,
+  /// A concrete gap length.
+  Length(Length),
+}
+
+impl MakeComputed for Gap {
+  fn make_computed(&mut self, sizing: &SizingContext) {
+    if let Self::Length(length) = self {
+      length.make_computed(sizing);
+    }
+  }
+}
+
+impl Animatable for Gap {
+  fn interpolate(
+    &mut self,
+    from: &Self,
+    to: &Self,
+    progress: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) {
+    *self = match (from, to) {
+      (Self::Length(from), Self::Length(to)) => {
+        let mut length = *from;
+        length.interpolate(from, to, progress, sizing, current_color);
+        Self::Length(length)
+      }
+      (Self::Normal, Self::Normal) => Self::Normal,
+      (Self::Normal, Self::Length(to)) => {
+        let mut length = Length::zero();
+        length.interpolate(&Length::zero(), to, progress, sizing, current_color);
+        Self::Length(length)
+      }
+      (Self::Length(from), Self::Normal) => {
+        let mut length = *from;
+        length.interpolate(from, &Length::zero(), progress, sizing, current_color);
+        Self::Length(length)
+      }
+    };
+  }
+}
+
+impl<'i> FromCss<'i> for Gap {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if input
+      .try_parse(|input| input.expect_ident_matching("normal"))
+      .is_ok()
+    {
+      return Ok(Self::Normal);
+    }
+
+    Length::from_css(input).map(Self::Length)
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("normal"),
+    CssToken::Syntax(CssSyntaxKind::Length),
+  ];
+}
+
+impl From<Length> for Gap {
+  fn from(length: Length) -> Self {
+    Self::Length(length)
+  }
+}
+
+impl Gap {
+  /// Resolves to a taffy `LengthPercentage`, treating `normal` as `0`.
+  pub(crate) fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
+    match self {
+      Self::Normal => Length::zero().resolve_to_length_percentage(sizing),
+      Self::Length(length) => length.resolve_to_length_percentage(sizing),
+    }
+  }
+}
+
+impl ToCss for Gap {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::Normal => dest.write_str("normal"),
+      Self::Length(length) => length.to_css(dest),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn parses_normal() {
+    assert_eq!(Gap::from_css_str("normal"), Ok(Gap::Normal));
+  }
+
+  #[test]
+  fn parses_length() {
+    assert_eq!(Gap::from_css_str("10px"), Ok(Gap::Length(Length::Px(10.0))));
+  }
+
+  #[test]
+  fn round_trips_to_css() {
+    let mut buf = String::new();
+    Gap::Normal.to_css(&mut buf).unwrap();
+    assert_eq!(buf, "normal");
+
+    let mut buf = String::new();
+    Gap::Length(Length::Px(10.0)).to_css(&mut buf).unwrap();
+    assert_eq!(buf, "10px");
+  }
+}

--- a/takumi-core/src/style/properties/grid/grid_auto_flow.rs
+++ b/takumi-core/src/style/properties/grid/grid_auto_flow.rs
@@ -25,6 +25,7 @@ pub struct GridAutoFlow {
 
 impl MakeComputed for GridAutoFlow {}
 
+#[cfg(feature = "unstable")]
 impl From<GridAutoFlow> for taffy::GridAutoFlow {
   fn from(value: GridAutoFlow) -> Self {
     match (value.direction, value.dense) {

--- a/takumi-core/src/style/properties/grid/grid_placement.rs
+++ b/takumi-core/src/style/properties/grid/grid_placement.rs
@@ -80,6 +80,7 @@ impl TailwindPropertyParser for GridPlacementSpan {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<GridPlacement> for taffy::GridPlacement {
   fn from(placement: GridPlacement) -> Self {
     match placement {

--- a/takumi-core/src/style/properties/grid/grid_repetition_count.rs
+++ b/takumi-core/src/style/properties/grid/grid_repetition_count.rs
@@ -22,6 +22,7 @@ pub enum GridRepetitionCount {
   Count(u16),
 }
 
+#[cfg(feature = "unstable")]
 impl From<GridRepetitionCount> for taffy::RepetitionCount {
   fn from(repetition: GridRepetitionCount) -> Self {
     match repetition {

--- a/takumi-core/src/style/properties/grid/grid_template_areas.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_areas.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "unstable")]
 use std::collections::HashMap;
 
 use cssparser::{Parser, Token};
@@ -17,6 +18,7 @@ pub struct GridTemplateAreas(pub Vec<Vec<String>>);
 
 impl MakeComputed for GridTemplateAreas {}
 
+#[cfg(feature = "unstable")]
 impl From<GridTemplateAreas> for Vec<taffy::GridTemplateArea<String>> {
   fn from(value: GridTemplateAreas) -> Self {
     if value.0.is_empty() {

--- a/takumi-core/src/style/properties/grid/grid_template_component.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_component.rs
@@ -135,6 +135,7 @@ impl<'i> FromCss<'i> for GridTemplateComponents {
   const VALID_TOKENS: &'static [CssToken] = GridTemplateComponent::VALID_TOKENS;
 }
 
+#[cfg(feature = "unstable")]
 pub(crate) fn collect_components_and_names(
   components: &[GridTemplateComponent],
   sizing: &SizingContext,

--- a/takumi-core/src/style/properties/max_size.rs
+++ b/takumi-core/src/style/properties/max_size.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+
+use cssparser::Parser;
+use taffy::Dimension;
+
+use crate::style::{
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
+  SizingContext, ToCss,
+};
+
+/// Represents the `max-width`/`max-height` value: either `none` (unbounded) or a [`Length`].
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum MaxSize {
+  /// No maximum; the box is unbounded on this axis.
+  #[default]
+  None,
+  /// A concrete maximum length.
+  Length(Length),
+}
+
+impl MakeComputed for MaxSize {
+  fn make_computed(&mut self, sizing: &SizingContext) {
+    if let Self::Length(length) = self {
+      length.make_computed(sizing);
+    }
+  }
+}
+
+impl Animatable for MaxSize {
+  fn interpolate(
+    &mut self,
+    from: &Self,
+    to: &Self,
+    progress: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) {
+    *self = match (from, to) {
+      (Self::Length(from), Self::Length(to)) => {
+        let mut length = *from;
+        length.interpolate(from, to, progress, sizing, current_color);
+        Self::Length(length)
+      }
+      _ => {
+        if progress >= 0.5 {
+          *to
+        } else {
+          *from
+        }
+      }
+    };
+  }
+}
+
+impl<'i> FromCss<'i> for MaxSize {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if input
+      .try_parse(|input| input.expect_ident_matching("none"))
+      .is_ok()
+    {
+      return Ok(Self::None);
+    }
+
+    // `auto` is not a valid `max-width`/`max-height` value, but historically
+    // accepted here; keep treating it as `none` to avoid a behavior change.
+    if input
+      .try_parse(|input| input.expect_ident_matching("auto"))
+      .is_ok()
+    {
+      return Ok(Self::None);
+    }
+
+    Length::from_css(input).map(Self::Length)
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("none"),
+    CssToken::Keyword("auto"),
+    CssToken::Syntax(CssSyntaxKind::Length),
+  ];
+}
+
+impl From<Length> for MaxSize {
+  fn from(length: Length) -> Self {
+    Self::Length(length)
+  }
+}
+
+impl MaxSize {
+  /// Resolves to a taffy `Dimension`, treating `none` as unbounded (same as `Length::Auto`).
+  pub(crate) fn resolve_to_dimension(self, sizing: &SizingContext) -> Dimension {
+    match self {
+      Self::None => Length::Auto.resolve_to_dimension(sizing),
+      Self::Length(length) => length.resolve_to_dimension(sizing),
+    }
+  }
+}
+
+impl ToCss for MaxSize {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::None => dest.write_str("none"),
+      Self::Length(length) => length.to_css(dest),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn parses_none() {
+    assert_eq!(MaxSize::from_css_str("none"), Ok(MaxSize::None));
+  }
+
+  #[test]
+  fn parses_auto_as_none() {
+    assert_eq!(MaxSize::from_css_str("auto"), Ok(MaxSize::None));
+  }
+
+  #[test]
+  fn parses_length() {
+    assert_eq!(
+      MaxSize::from_css_str("10px"),
+      Ok(MaxSize::Length(Length::Px(10.0)))
+    );
+  }
+
+  #[test]
+  fn round_trips_to_css() {
+    let mut buf = String::new();
+    MaxSize::None.to_css(&mut buf).unwrap();
+    assert_eq!(buf, "none");
+
+    let mut buf = String::new();
+    MaxSize::Length(Length::Px(10.0)).to_css(&mut buf).unwrap();
+    assert_eq!(buf, "10px");
+  }
+}

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -31,12 +31,14 @@ mod font_synthesis;
 mod font_variant;
 mod font_variation_settings;
 mod font_weight;
+mod gap;
 pub(crate) mod gradient_utils;
 mod grid;
 mod length;
 mod line_clamp;
 mod line_height;
 pub(crate) mod linear_gradient;
+mod max_size;
 mod offset_path;
 mod order;
 mod overflow;
@@ -85,14 +87,17 @@ pub use filter::{
 pub use flex::*;
 pub use flex_grow::*;
 pub use font_family::*;
-pub(crate) use font_feature_settings::*;
+pub use font_feature_settings::FontFeatureSetting;
+pub(crate) use font_feature_settings::FontFeatureSettings;
 pub use font_size::*;
 pub use font_stretch::*;
 pub use font_style::*;
 pub use font_synthesis::*;
 pub use font_variant::*;
-pub(crate) use font_variation_settings::*;
+pub use font_variation_settings::FontVariationSetting;
+pub(crate) use font_variation_settings::FontVariationSettings;
 pub use font_weight::*;
+pub use gap::*;
 pub use grid::*;
 pub use length::*;
 pub use line_clamp::*;
@@ -102,10 +107,12 @@ pub use linear_gradient::{
   Angle, GradientKeywordDirection, GradientStop, HorizontalKeyword, LinearGradient,
   LinearGradientDirection, ResolvedGradientStop, StopPosition, VerticalKeyword,
 };
+pub use max_size::*;
 pub use offset_path::*;
 pub use order::*;
 pub use overflow::*;
 pub use overflow_wrap::*;
+#[cfg(feature = "unstable")]
 use parley::Alignment;
 pub use percentage_number::*;
 pub use radial_gradient::{RadialGradient, RadialShape, RadialSize};
@@ -557,6 +564,7 @@ declare_enum_from_css_impl!(
   "fixed" => Position::Fixed
 );
 
+#[cfg(feature = "unstable")]
 impl From<Position> for taffy::Position {
   fn from(value: Position) -> Self {
     match value {
@@ -814,6 +822,7 @@ impl TailwindPropertyParser for JustifyContent {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<JustifyContent> for Option<taffy::JustifyContent> {
   fn from(value: JustifyContent) -> Self {
     match value {
@@ -910,6 +919,7 @@ impl Display {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<Display> for taffy::Display {
   fn from(value: Display) -> Self {
     match value {
@@ -973,6 +983,7 @@ declare_box_alignment_enum_impl!(
   }
 );
 
+#[cfg(feature = "unstable")]
 impl From<AlignItems> for Option<taffy::AlignItems> {
   fn from(value: AlignItems) -> Self {
     match value {

--- a/takumi-core/src/style/properties/overflow.rs
+++ b/takumi-core/src/style/properties/overflow.rs
@@ -1,4 +1,5 @@
 use cssparser::match_ignore_ascii_case;
+#[cfg(feature = "unstable")]
 use taffy::Overflow as TaffyOverflow;
 
 use crate::style::{declare_enum_from_css_impl, tw::TailwindPropertyParser};
@@ -37,6 +38,7 @@ impl TailwindPropertyParser for Overflow {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<Overflow> for TaffyOverflow {
   fn from(val: Overflow) -> Self {
     match val {

--- a/takumi-core/src/style/properties/overflow_wrap.rs
+++ b/takumi-core/src/style/properties/overflow_wrap.rs
@@ -53,6 +53,7 @@ impl ToCss for OverflowWrap {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl From<OverflowWrap> for parley::OverflowWrap {
   fn from(value: OverflowWrap) -> Self {
     value.0

--- a/takumi-core/src/style/properties/sides.rs
+++ b/takumi-core/src/style/properties/sides.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use cssparser::Parser;
+#[cfg(feature = "unstable")]
 use taffy::Rect;
 
 use crate::style::{
@@ -73,6 +74,7 @@ impl<'i, T: Copy + for<'j> FromCss<'j>> FromCss<'i> for Sides<T> {
   const EXPECT_MESSAGE: CssExpectedMessage = CssExpectedMessage::OneToFourValues;
 }
 
+#[cfg(feature = "unstable")]
 impl<T: Copy> From<Sides<T>> for Rect<T> {
   fn from(value: Sides<T>) -> Self {
     Rect {

--- a/takumi-core/src/style/properties/space_pair.rs
+++ b/takumi-core/src/style/properties/space_pair.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use cssparser::Parser;
+#[cfg(feature = "unstable")]
 use taffy::Point;
 
 use crate::style::{
@@ -59,6 +60,7 @@ impl<T: Copy + MakeComputed> MakeComputed for SpacePair<T> {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl<T: Copy> From<SpacePair<T>> for Point<T> {
   fn from(value: SpacePair<T>) -> Self {
     Point {

--- a/takumi-core/src/style/properties/text_wrap.rs
+++ b/takumi-core/src/style/properties/text_wrap.rs
@@ -86,6 +86,7 @@ pub enum TextWrapMode {
   NoWrap,
 }
 
+#[cfg(feature = "unstable")]
 impl From<TextWrapMode> for parley::TextWrapMode {
   fn from(value: TextWrapMode) -> Self {
     match value {

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -754,9 +754,12 @@ impl ToCss for Arc<str> {
   }
 }
 
-/// Macro to implement From trait for Taffy enum conversions.
+/// Macro to implement From trait for Taffy/parley enum conversions. Gated
+/// behind `unstable` since the target types are foreign and would otherwise
+/// leak through the default public API.
 macro_rules! impl_from_taffy_enum {
   ($from_ty:ty, $to_ty:ty, $($variant:ident),*) => {
+    #[cfg(feature = "unstable")]
     impl From<$from_ty> for $to_ty {
       fn from(value: $from_ty) -> Self {
         match value {

--- a/takumi-core/src/style/properties/transform.rs
+++ b/takumi-core/src/style/properties/transform.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
+#[cfg(feature = "unstable")]
 use tiny_skia::Transform as TinyTransform;
 
 use crate::style::{
@@ -138,6 +139,7 @@ pub struct Affine {
   pub y: f32,
 }
 
+#[cfg(feature = "unstable")]
 impl From<Affine> for TinyTransform {
   fn from(transform: Affine) -> Self {
     TinyTransform::from_row(

--- a/takumi-core/src/style/properties/vertical_align.rs
+++ b/takumi-core/src/style/properties/vertical_align.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use cssparser::Parser;
+#[cfg(feature = "unstable")]
 use parley::LineMetrics;
 
 use crate::style::{SizingContext, ToCss, tw::TailwindPropertyParser, *};
@@ -169,6 +170,7 @@ impl MakeComputed for VerticalAlign {
   }
 }
 
+#[cfg(feature = "unstable")]
 impl ResolvedVerticalAlign {
   /// Writes the aligned `y` for a box on a line given its metrics.
   pub fn apply(
@@ -252,6 +254,7 @@ mod tests {
     }
   }
 
+  #[cfg(feature = "unstable")]
   fn line_metrics() -> LineMetrics {
     LineMetrics {
       ascent: 9.0,
@@ -341,6 +344,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn apply_baseline_shift_raises_and_lowers() {
     let metrics = line_metrics();
@@ -362,6 +366,7 @@ mod tests {
     assert_eq!(y, baseline + 5.0);
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn apply_keyword_top_uses_block_min_coord() {
     let mut y = 0.0;
@@ -373,6 +378,7 @@ mod tests {
     assert_eq!(y, metrics.block_min_coord);
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn apply_keyword_bottom_uses_block_max_coord() {
     let mut y = 0.0;
@@ -385,6 +391,7 @@ mod tests {
     assert_eq!(y, metrics.block_max_coord - box_height);
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn apply_metrics_relative_shift_uses_line_metrics_formula() {
     let metrics = line_metrics();
@@ -417,6 +424,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn apply_metrics_relative_px_shift_uses_line_metrics_formula_plus_px() {
     let metrics = line_metrics();
@@ -434,6 +442,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn keyword_apply_matches_previous_baseline_behavior() {
     let metrics = line_metrics();
@@ -443,6 +452,7 @@ mod tests {
     assert_eq!(y, metrics.baseline - 4.0);
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn keyword_apply_uses_inline_box_baseline_when_available() {
     let metrics = line_metrics();
@@ -458,6 +468,7 @@ mod tests {
     assert_eq!(y, metrics.baseline - 12.0);
   }
 
+  #[cfg(feature = "unstable")]
   #[test]
   fn sub_and_super_shift_by_font_size_fraction() {
     let metrics = line_metrics();

--- a/takumi-core/src/style/properties/word_break.rs
+++ b/takumi-core/src/style/properties/word_break.rs
@@ -25,6 +25,7 @@ declare_enum_from_css_impl!(
   "break-word" => WordBreak::BreakWord,
 );
 
+#[cfg(feature = "unstable")]
 impl From<WordBreak> for parley::WordBreak {
   fn from(value: WordBreak) -> Self {
     match value {

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -9,7 +9,7 @@ use cssparser::*;
 use precomputed_hash::PrecomputedHash;
 use selectors::parser::{
   NonTSPseudoClass, ParseRelative, PseudoElement as PseudoElementTrait,
-  SelectorImpl as SelectorImplTrait, SelectorList,
+  SelectorImpl as SelectorImplTrait, SelectorList, SelectorParseErrorKind,
 };
 
 pub use crate::style::media_query::MediaQueryList;
@@ -190,9 +190,34 @@ impl SelectorImplTrait for SelectorImpl {
 
 struct TakumiSelectorParser;
 
+/// Adapts `selectors`' generic parse error into [`StyleSheetParseError`] without
+/// naming `selectors::parser::SelectorParseErrorKind` in a public `From` impl:
+/// `selectors::Parser::Error` requires `From<SelectorParseErrorKind>`, and that impl
+/// would otherwise have to live directly on the public `StyleSheetParseError`.
+struct SelectorParseErrorAdapter(StyleSheetParseError);
+
+impl<'i> From<SelectorParseErrorKind<'i>> for SelectorParseErrorAdapter {
+  fn from(err: SelectorParseErrorKind<'i>) -> Self {
+    Self(StyleSheetParseError::invalid_reason(format!("{err:?}")))
+  }
+}
+
+/// Converts a selector-list parse error back into the stylesheet's error type.
+fn convert_selector_parse_error(
+  err: ParseError<'_, SelectorParseErrorAdapter>,
+) -> ParseError<'_, StyleSheetParseError> {
+  ParseError {
+    kind: match err.kind {
+      ParseErrorKind::Basic(basic) => ParseErrorKind::Basic(basic),
+      ParseErrorKind::Custom(adapter) => ParseErrorKind::Custom(adapter.0),
+    },
+    location: err.location,
+  }
+}
+
 impl<'i> selectors::Parser<'i> for TakumiSelectorParser {
   type Impl = SelectorImpl;
-  type Error = StyleSheetParseError;
+  type Error = SelectorParseErrorAdapter;
 
   fn parse_parent_selector(&self) -> bool {
     true
@@ -370,6 +395,7 @@ impl<'i> QualifiedRuleParser<'i> for NestedStyleRuleParser<'_> {
     input: &mut Parser<'i, 't>,
   ) -> Result<Self::Prelude, ParseError<'i, Self::Error>> {
     SelectorList::parse(&TakumiSelectorParser, input, ParseRelative::ForNesting)
+      .map_err(convert_selector_parse_error)
   }
 
   fn parse_block<'t>(
@@ -837,6 +863,7 @@ impl<'i> QualifiedRuleParser<'i> for RuleParser {
     input: &mut Parser<'i, 't>,
   ) -> Result<Self::Prelude, ParseError<'i, Self::Error>> {
     SelectorList::parse(&TakumiSelectorParser, input, ParseRelative::No)
+      .map_err(convert_selector_parse_error)
   }
 
   fn parse_block<'t>(

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -631,8 +631,10 @@ macro_rules! define_style {
         pub registered_custom_properties: HashMap<String, PropertyRule>,
         /// Resolved BCP-47 language, inherited from the `lang` attribute. Drives
         /// locale-aware shaping (Han unification, line-breaking). Has no CSS property.
-        /// Set from a tag string via [`ComputedStyle::set_lang`].
-        pub lang: Option<Language>,
+        /// Set from a tag string via [`ComputedStyle::set_lang`]. Kept crate-private
+        /// since `parley::Language` is an engine (`unstable`) type; not part of the
+        /// stable API.
+        pub(crate) lang: Option<Language>,
         $(
           #[doc = concat!("Computed `", stringify!($longhand), "` value.")]
           pub $longhand: $longhand_ty,
@@ -990,8 +992,8 @@ define_style! {
     display: Display,
     width: Length,
     height: Length,
-    max_width: Length,
-    max_height: Length,
+    max_width: MaxSize,
+    max_height: MaxSize,
     min_width: Length,
     min_height: Length,
     aspect_ratio: AspectRatio,
@@ -1033,8 +1035,8 @@ define_style! {
     mask_size: BackgroundSizes,
     mask_position: PositionValues,
     mask_repeat: BackgroundRepeats,
-    column_gap: Length = Length::zero(),
-    row_gap: Length = Length::zero(),
+    column_gap: Gap,
+    row_gap: Gap,
     flex_grow: Option<FlexGrow>,
     flex_shrink: Option<FlexGrow>,
     border_top_left_radius: SpacePair<Length> = SpacePair::from_single(Length::zero()),
@@ -1099,8 +1101,8 @@ define_style! {
     font_variant_east_asian: FontVariantEastAsian where inherit = true,
     font_variant_caps: FontVariantCaps where inherit = true,
     font_variant_position: FontVariantPosition where inherit = true,
-    font_synthesis_weight: FontSynthesic where inherit = true,
-    font_synthesis_style: FontSynthesic where inherit = true,
+    font_synthesis_weight: FontSynthesisMode where inherit = true,
+    font_synthesis_style: FontSynthesisMode where inherit = true,
     max_lines: Option<u32>,
     block_ellipsis: BlockEllipsis where inherit = true,
     r#continue: Continue,
@@ -1234,7 +1236,7 @@ define_style! {
           .collect(),
       )));
     },
-    gap: SpacePair<Length> => [RowGap, ColumnGap] |value, target| {
+    gap: SpacePair<Gap> => [RowGap, ColumnGap] |value, target| {
       push_axis_declarations!(target, value, row_gap, column_gap);
     },
     flex_flow: FlexFlow => [FlexDirection, FlexWrap] |value, target| {

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -1,7 +1,10 @@
-use std::{borrow::Cow, marker::PhantomData};
+#[cfg(feature = "unstable")]
+use std::marker::PhantomData;
 
 use parley::FontFeature;
-use taffy::{Line, Point, Rect, Size};
+use taffy::Size;
+#[cfg(feature = "unstable")]
+use taffy::{Line, Point, Rect};
 
 use super::ComputedStyle;
 use crate::style::{SizingContext, properties::*};
@@ -219,6 +222,7 @@ impl ComputedStyle {
     self.max_lines.filter(|&count| count >= 1)
   }
 
+  #[cfg(feature = "unstable")]
   #[inline]
   fn grid_template(
     components: &Option<GridTemplateComponents>,
@@ -247,9 +251,8 @@ impl ComputedStyle {
   }
 
   /// Resolved OpenType features: the `font-variant-*` expansions followed by explicit
-  /// `font-feature-settings`, which win on tag conflicts. Borrows the settings when no
-  /// `font-variant-*` is active, avoiding an allocation.
-  pub(crate) fn resolved_font_features(&self) -> Cow<'_, [FontFeature]> {
+  /// `font-feature-settings`, which win on tag conflicts.
+  pub(crate) fn resolved_font_features(&self) -> Vec<FontFeature> {
     let mut features = Vec::new();
     append_variant_features(
       &self.font_variant_ligatures,
@@ -260,15 +263,12 @@ impl ComputedStyle {
       &mut features,
     );
 
-    if features.is_empty() {
-      return Cow::Borrowed(self.font_feature_settings.as_ref());
-    }
-
-    features.extend_from_slice(&self.font_feature_settings);
-    Cow::Owned(features)
+    features.extend(self.font_feature_settings.iter().map(|setting| setting.0));
+    features
   }
 
   /// Converts the computed style into a `taffy::Style` for layout.
+  #[cfg(feature = "unstable")]
   pub(crate) fn to_taffy_style(&self, sizing: &SizingContext) -> taffy::Style {
     // Convert grid templates and associated line names
     let (grid_template_columns, grid_template_column_names) =
@@ -346,7 +346,7 @@ impl ComputedStyle {
         width: self.max_width,
         height: self.max_height,
       }
-      .map(|length| length.resolve_to_dimension(sizing)),
+      .map(|max_size| max_size.resolve_to_dimension(sizing)),
       grid_auto_columns: self
         .grid_auto_columns
         .as_ref()

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -560,21 +560,21 @@ fn parse_style_declaration_supports_legacy_grid_gap_aliases() {
   let row_gap = parse_declarations("grid-row-gap", "4px");
   assert_eq!(
     row_gap.iter().collect::<Vec<_>>(),
-    vec![&StyleDeclaration::row_gap(Length::Px(4.0))]
+    vec![&StyleDeclaration::row_gap(Gap::Length(Length::Px(4.0)))]
   );
 
   let column_gap = parse_declarations("grid-column-gap", "3px");
   assert_eq!(
     column_gap.iter().collect::<Vec<_>>(),
-    vec![&StyleDeclaration::column_gap(Length::Px(3.0))]
+    vec![&StyleDeclaration::column_gap(Gap::Length(Length::Px(3.0)))]
   );
 
   let gap = parse_declarations("grid-gap", "1px 2px");
   assert_eq!(
     gap.iter().collect::<Vec<_>>(),
     vec![
-      &StyleDeclaration::row_gap(Length::Px(1.0)),
-      &StyleDeclaration::column_gap(Length::Px(2.0)),
+      &StyleDeclaration::row_gap(Gap::Length(Length::Px(1.0))),
+      &StyleDeclaration::column_gap(Gap::Length(Length::Px(2.0))),
     ]
   );
 }

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -819,10 +819,17 @@ impl TailwindProperty {
         push_decl!(builder, important, background_clip(background_clip));
       }
       TailwindProperty::Gap(gap) => {
-        push_decl!(builder, important, row_gap(gap), column_gap(gap));
+        push_decl!(
+          builder,
+          important,
+          row_gap(gap.into()),
+          column_gap(gap.into())
+        );
       }
-      TailwindProperty::GapX(gap_x) => push_decl!(builder, important, column_gap(gap_x)),
-      TailwindProperty::GapY(gap_y) => push_decl!(builder, important, row_gap(gap_y)),
+      TailwindProperty::GapX(gap_x) => {
+        push_decl!(builder, important, column_gap(gap_x.into()))
+      }
+      TailwindProperty::GapY(gap_y) => push_decl!(builder, important, row_gap(gap_y.into())),
       TailwindProperty::BoxSizing(box_sizing) => {
         push_decl!(builder, important, box_sizing(box_sizing))
       }
@@ -917,9 +924,11 @@ impl TailwindProperty {
       TailwindProperty::MinHeight(min_height) => {
         push_decl!(builder, important, min_height(min_height))
       }
-      TailwindProperty::MaxWidth(max_width) => push_decl!(builder, important, max_width(max_width)),
+      TailwindProperty::MaxWidth(max_width) => {
+        push_decl!(builder, important, max_width(max_width.into()))
+      }
       TailwindProperty::MaxHeight(max_height) => {
-        push_decl!(builder, important, max_height(max_height))
+        push_decl!(builder, important, max_height(max_height.into()))
       }
       TailwindProperty::Shadow(box_shadow) => builder.set_shadow_layers([box_shadow], important),
       TailwindProperty::ShadowList(&[]) => builder.reset_shadow(important),

--- a/takumi-core/src/viewport.rs
+++ b/takumi-core/src/viewport.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "unstable")]
 use taffy::{AvailableSpace, Size};
 
 /// The default font size in pixels.
@@ -18,6 +19,7 @@ pub struct Viewport {
   pub device_pixel_ratio: f32,
 }
 
+#[cfg(feature = "unstable")]
 impl From<Viewport> for Size<AvailableSpace> {
   fn from(value: Viewport) -> Self {
     Self {

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -26,12 +26,13 @@ export { render, renderAnimation, renderSvg } from "./render";
 
 export type {
   AnimationScene,
-  ImagesInput,
+  ManagedImagesInput,
   RenderAnimationOptions,
   RenderInput,
   RenderOptions,
   RenderSvgOptions,
 } from "./render";
+export type { ImagesInput } from "@takumi-rs/helpers/renderer";
 
 declare module "react" {
   interface DOMAttributes<T> {

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -13,9 +13,10 @@ type ImageLoader = napi.ImageLoader | wasm.ImageLoader;
 
 /**
  * Images for a render: pre-fetched entries, or a group that also controls how remote images
- * (and emoji glyphs) are fetched and cached.
+ * (and emoji glyphs) are fetched and cached. The fetch-aware superset of
+ * {@link ImagesInput} from `@takumi-rs/helpers`.
  */
-export type ImagesInput =
+export type ManagedImagesInput =
   | ImageLoader[]
   | (FetchOptions & {
       /** Pre-fetched entries, same as the array form. */
@@ -31,7 +32,7 @@ type SharedRenderExtras = {
   renderer: Renderer;
   signal?: AbortSignal;
   jsx?: FromJsxOptions;
-  images?: ImagesInput;
+  images?: ManagedImagesInput;
   /**
    * @description The emoji provider to use when rendering emojis. If set to `"from-font"`, the renderer will attempt to source emoji glyphs from the loaded fonts.
    * @default "twemoji"

--- a/takumi-raster/Cargo.toml
+++ b/takumi-raster/Cargo.toml
@@ -38,6 +38,7 @@ features = ["aarch64_simd", "avx512_simd"]
 path = "../takumi-core"
 version = "0.1.0"
 default-features = false
+features = ["unstable"]
 
 [dependencies.serde]
 workspace = true

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -567,7 +567,7 @@ pub(crate) fn resolve_layer_tiles(
   input: ResolveLayerTilesInput<'_>,
 ) -> Result<Option<TileLayer>> {
   let resolved_size = style.size.resolve(
-    input.area,
+    (input.area.width, input.area.height),
     &input.context.sizing,
     resolve_intrinsic_size(image, input.context),
   );

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -29,12 +29,10 @@ use crate::{
 /// Root computed style carrying the render-level `lang` and `fontFamilies` defaults,
 /// inherited by every node that does not set its own.
 fn root_style(lang: Option<&str>, font_families: Option<&[String]>) -> Box<ComputedStyle> {
-  let mut style = ComputedStyle {
-    font_family: font_families.map_or_else(FontFamily::default, |names| {
-      FontFamily::from_names(names.iter().cloned())
-    }),
-    ..Default::default()
-  };
+  let mut style = ComputedStyle::default();
+  style.font_family = font_families.map_or_else(FontFamily::default, |names| {
+    FontFamily::from_names(names.iter().cloned())
+  });
   style.set_lang(lang);
 
   Box::new(style)

--- a/takumi-svg/Cargo.toml
+++ b/takumi-svg/Cargo.toml
@@ -18,6 +18,7 @@ typed-builder.workspace = true
 [dependencies.takumi-core]
 path = "../takumi-core"
 version = "0.1.0"
+features = ["unstable"]
 
 [lints]
 workspace = true

--- a/takumi-svg/src/gradient.rs
+++ b/takumi-svg/src/gradient.rs
@@ -413,7 +413,11 @@ fn resolve_placement(
     height: area.h.round().max(0.0) as u32,
   };
   let intrinsic = intrinsic_sizing(image, context);
-  let resolved = size.resolve(area_size, &context.sizing, intrinsic);
+  let resolved = size.resolve(
+    (area_size.width, area_size.height),
+    &context.sizing,
+    intrinsic,
+  );
   let tile_w = resolved.width as f32;
   let tile_h = resolved.height as f32;
   if tile_w <= 0.0 || tile_h <= 0.0 {

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -39,7 +39,7 @@ default = ["raster-backend", "woff2", "woff", "svg-source", "rayon"]
 raster-backend = ["dep:takumi-raster"]
 # Expose the backend crates wholesale under `takumi::unstable`. Everything behind
 # this flag is implementation surface with no semver guarantee.
-unstable = []
+unstable = ["takumi-core/unstable"]
 svg-source = ["takumi-core/svg", "takumi-raster?/svg"]
 svg-backend = ["dep:takumi-svg"]
 woff2 = ["takumi-core/woff2"]

--- a/takumi/tests/fixtures/color_artifacts.rs
+++ b/takumi/tests/fixtures/color_artifacts.rs
@@ -62,7 +62,7 @@ fn test_color_artifacts() {
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::flex_direction(FlexDirection::Row))
-      .with_gap(SpacePair::from_single(Px(40.0)))
+      .with_gap(SpacePair::from_single(Px(40.0).into()))
       .with_padding(Sides([Rem(4.0); 4])),
   );
 

--- a/takumi/tests/fixtures/inline.rs
+++ b/takumi/tests/fixtures/inline.rs
@@ -523,7 +523,7 @@ fn inline_complex_nested_fixture() {
       Style::default()
         .with(StyleDeclaration::display(Display::InlineFlex))
         .with(StyleDeclaration::align_items(AlignItems::Center))
-        .with_gap(SpacePair::from_single(Px(6.0)))
+        .with_gap(SpacePair::from_single(Px(6.0).into()))
         .with(StyleDeclaration::background_color(ColorInput::Value(
           Color([80, 138, 184, 255]),
         )))
@@ -788,7 +788,7 @@ fn inline_social_post_regression() {
           .with(StyleDeclaration::color(ColorInput::Value(Color([
             136, 153, 166, 255,
           ]))))
-          .with_gap(SpacePair::from_single(Px(24.0))),
+          .with_gap(SpacePair::from_single(Px(24.0).into())),
       ),
     ])
     .with_style(
@@ -842,7 +842,7 @@ fn inline_social_post_regression() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(24.0)))
+      .with_gap(SpacePair::from_single(Px(24.0).into()))
       .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0)))),
   )])
   .with_style(

--- a/takumi/tests/fixtures/lang.rs
+++ b/takumi/tests/fixtures/lang.rs
@@ -30,7 +30,7 @@ fn lang_row(lang: &'static str) -> Node {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_pair(Px(12.0), Px(12.0))),
+      .with_gap(SpacePair::from_pair(Px(12.0).into(), Px(12.0).into())),
   )
 }
 
@@ -47,7 +47,7 @@ fn test_lang_han_unification() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(40.0); 4]))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_pair(Px(32.0), Px(32.0))),
+      .with_gap(SpacePair::from_pair(Px(32.0).into(), Px(32.0).into())),
   );
 
   run_fixture_test(container, "lang_han_unification");

--- a/takumi/tests/fixtures/rtl.rs
+++ b/takumi/tests/fixtures/rtl.rs
@@ -29,14 +29,14 @@ fn test_direction_flex_row() {
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::direction(Direction::Ltr))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
     Node::container(children).with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::direction(Direction::Rtl))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
   ])
@@ -51,7 +51,7 @@ fn test_direction_flex_row() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(16.0); 4]))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0))),
+      .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into())),
   );
 
   run_fixture_test(container, "direction_flex_row");
@@ -69,7 +69,7 @@ fn test_direction_grid() {
           GridTemplateComponents::from_css_str("repeat(4, 1fr)").unwrap(),
         )))
         .with(StyleDeclaration::direction(Direction::Ltr))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
     Node::container(children).with_style(
@@ -79,7 +79,7 @@ fn test_direction_grid() {
           GridTemplateComponents::from_css_str("repeat(4, 1fr)").unwrap(),
         )))
         .with(StyleDeclaration::direction(Direction::Rtl))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
   ])
@@ -94,7 +94,7 @@ fn test_direction_grid() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(16.0); 4]))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0))),
+      .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into())),
   );
 
   run_fixture_test(container, "direction_grid");

--- a/takumi/tests/fixtures/style_backdrop_filter.rs
+++ b/takumi/tests/fixtures/style_backdrop_filter.rs
@@ -111,7 +111,7 @@ fn test_style_backdrop_filter_frosted_glass() {
       )))
       .with_border_radius(BorderRadius::from_css_str("24px").unwrap())
       .with_padding(Sides([Px(48.0); 4]))
-      .with_gap(SpacePair::from_single(Px(16.0))),
+      .with_gap(SpacePair::from_single(Px(16.0).into())),
   )])
   .with_style(
     Style::default()

--- a/takumi/tests/fixtures/style_background_clip.rs
+++ b/takumi/tests/fixtures/style_background_clip.rs
@@ -331,7 +331,7 @@ fn test_style_background_clip_comparison() {
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 

--- a/takumi/tests/fixtures/style_background_origin.rs
+++ b/takumi/tests/fixtures/style_background_origin.rs
@@ -43,7 +43,7 @@ fn test_style_background_origin() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::width(Percentage(100.0)))
-      .with(StyleDeclaration::row_gap(Px(20.0)))
+      .with(StyleDeclaration::row_gap(Px(20.0).into()))
       .with_padding(Sides([Px(30.0); 4]))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 255]),

--- a/takumi/tests/fixtures/style_filter.rs
+++ b/takumi/tests/fixtures/style_filter.rs
@@ -24,7 +24,7 @@ fn create_filter_test_container(
       .with(StyleDeclaration::grid_template_columns(
         GridTemplateComponents::from_css_str("repeat(5, 1fr)").ok(),
       ))
-      .with_gap(SpacePair::from_single(Px(gap_px)))
+      .with_gap(SpacePair::from_single(Px(gap_px).into()))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::background_color(ColorInput::Value(
@@ -53,7 +53,7 @@ fn create_filter_card(filter: &str, image_size_px: f32, label_font_size_px: f32)
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with(StyleDeclaration::font_size(Px(label_font_size_px).into())),
   )
 }
@@ -84,7 +84,7 @@ fn create_filter_transform_card(
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with(StyleDeclaration::font_size(Px(label_font_size_px).into())),
   )
 }
@@ -191,7 +191,7 @@ fn test_style_filter_combined_with_transform() {
       .with(StyleDeclaration::grid_template_columns(
         GridTemplateComponents::from_css_str("repeat(4, 1fr)").ok(),
       ))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::background_color(ColorInput::Value(

--- a/takumi/tests/fixtures/style_layout.rs
+++ b/takumi/tests/fixtures/style_layout.rs
@@ -134,7 +134,7 @@ fn test_style_gap() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Flex))
-      .with_gap(SpacePair::from_pair(Px(0.0), Px(20.0)))
+      .with_gap(SpacePair::from_pair(Px(0.0).into(), Px(20.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([0, 0, 255, 255]),
       ))),

--- a/takumi/tests/fixtures/style_mix_blend_mode.rs
+++ b/takumi/tests/fixtures/style_mix_blend_mode.rs
@@ -153,7 +153,7 @@ fn test_style_mix_blend_mode_text_regression() {
   let family = FontFamily::from_css_str("Geist").unwrap();
   let label_style = Style::default()
     .with(StyleDeclaration::display(Display::Block))
-    .with(StyleDeclaration::max_width(Px(500.0)))
+    .with(StyleDeclaration::max_width(Px(500.0).into()))
     .with(StyleDeclaration::font_family(family))
     .with(StyleDeclaration::font_size(Px(60.0).into()))
     .with(StyleDeclaration::font_weight(FontWeight::from(600.0)))
@@ -201,7 +201,7 @@ fn test_style_mix_blend_mode_text_regression() {
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with(StyleDeclaration::row_gap(Px(24.0))),
+      .with(StyleDeclaration::row_gap(Px(24.0).into())),
   )])
   .with_style(
     Style::default()

--- a/takumi/tests/fixtures/style_opacity.rs
+++ b/takumi/tests/fixtures/style_opacity.rs
@@ -98,7 +98,7 @@ fn test_style_opacity() {
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 255]),
       )))
-      .with_gap(SpacePair::from_single(Length::Rem(4.0))),
+      .with_gap(SpacePair::from_single(Length::Rem(4.0).into())),
   );
 
   run_fixture_test(container, "style_opacity");
@@ -140,7 +140,7 @@ fn test_style_opacity_image_with_text() {
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Length::Rem(2.0)))
+      .with_gap(SpacePair::from_single(Length::Rem(2.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([240, 240, 240, 255]),
       ))),
@@ -198,7 +198,7 @@ fn test_style_opacity_flex_text_node_vs_nested_container() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_single(Length::Px(48.0)))
+      .with_gap(SpacePair::from_single(Length::Px(48.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::white(),
       ))),

--- a/takumi/tests/fixtures/style_overflow.rs
+++ b/takumi/tests/fixtures/style_overflow.rs
@@ -139,7 +139,7 @@ fn create_split_pill_case(
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(12.0); 4]))
-      .with_gap(SpacePair::from_single(Px(8.0)))
+      .with_gap(SpacePair::from_single(Px(8.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([248, 250, 252, 255]),
       ))),

--- a/takumi/tests/fixtures/style_sizing.rs
+++ b/takumi/tests/fixtures/style_sizing.rs
@@ -69,7 +69,7 @@ fn test_style_max_width() {
   let container = Node::container([]).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
-      .with(StyleDeclaration::max_width(Px(100.0)))
+      .with(StyleDeclaration::max_width(Px(100.0).into()))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_color(ColorInput::Value(
@@ -85,7 +85,7 @@ fn test_style_max_height() {
   let container = Node::container([]).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
-      .with(StyleDeclaration::max_height(Px(100.0)))
+      .with(StyleDeclaration::max_height(Px(100.0).into()))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::background_color(ColorInput::Value(

--- a/takumi/tests/fixtures/style_text_decoration.rs
+++ b/takumi/tests/fixtures/style_text_decoration.rs
@@ -59,7 +59,7 @@ fn text_decoration_skip_ink_parapsychologists() {
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with(StyleDeclaration::row_gap(Px(28.0)))
+      .with(StyleDeclaration::row_gap(Px(28.0).into()))
       .with(StyleDeclaration::padding_top(Px(40.0))),
   );
 

--- a/takumi/tests/fixtures/style_text_decoration_thickness.rs
+++ b/takumi/tests/fixtures/style_text_decoration_thickness.rs
@@ -38,7 +38,7 @@ fn test_style_text_decoration_thickness() {
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with(StyleDeclaration::row_gap(Px(20.0)))
+      .with(StyleDeclaration::row_gap(Px(20.0).into()))
       .with(StyleDeclaration::padding_top(Px(40.0)))
       .with(StyleDeclaration::padding_bottom(Px(40.0))),
   );

--- a/takumi/tests/fixtures/style_text_underline_offset.rs
+++ b/takumi/tests/fixtures/style_text_underline_offset.rs
@@ -36,7 +36,7 @@ fn test_style_text_underline_offset() {
         Color([240, 240, 240, 255]),
       )))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with(StyleDeclaration::row_gap(Px(20.0)))
+      .with(StyleDeclaration::row_gap(Px(20.0).into()))
       .with(StyleDeclaration::padding_top(Px(40.0)))
       .with(StyleDeclaration::padding_bottom(Px(40.0))),
   );

--- a/takumi/tests/fixtures/style_visuals.rs
+++ b/takumi/tests/fixtures/style_visuals.rs
@@ -485,7 +485,7 @@ fn demo_card(label: &str, preview: Node) -> Node {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::width(Px(208.0)))
-      .with_gap(SpacePair::from_single(Px(12.0)))
+      .with_gap(SpacePair::from_single(Px(12.0).into()))
       .with(StyleDeclaration::align_items(AlignItems::Center)),
   )
 }
@@ -515,7 +515,7 @@ fn non_uniform_border_demo(label: &str, style: Sides<BorderStyle>, width: Sides<
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::width(Px(220.0)))
-      .with_gap(SpacePair::from_single(Px(12.0)))
+      .with_gap(SpacePair::from_single(Px(12.0).into()))
       .with(StyleDeclaration::align_items(AlignItems::Center)),
   )
 }
@@ -584,7 +584,7 @@ fn test_style_border_styles() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with_padding(Sides([Px(32.0); 4]))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
@@ -641,7 +641,7 @@ fn test_style_border_non_uniform_patterns() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(32.0); 4]))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
@@ -676,7 +676,7 @@ fn test_style_outline_styles() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with_padding(Sides([Px(32.0); 4]))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -1,4 +1,3 @@
-use parley::{FontVariation, setting::Tag};
 use serde_json::{from_value, json};
 use takumi::prelude::{Length::*, *};
 
@@ -48,10 +47,7 @@ fn text_typography_variable_width() {
         Style::default()
           .with(StyleDeclaration::display(Display::Flex))
           .with(StyleDeclaration::font_variation_settings(Box::new([
-            FontVariation {
-              tag: Tag::from_bytes(*b"wdth"),
-              value: *width,
-            },
+            FontVariationSetting::new(*b"wdth", *width),
           ]))),
       )
     })
@@ -70,7 +66,7 @@ fn text_typography_variable_width() {
       .with(StyleDeclaration::font_family(family))
       .with(StyleDeclaration::font_size(Px(48.0).into()))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with(StyleDeclaration::row_gap(Px(48.0)))
+      .with(StyleDeclaration::row_gap(Px(48.0).into()))
       .with(StyleDeclaration::width(Percentage(100.0))),
   );
 
@@ -100,7 +96,7 @@ fn text_typography_variable_weight() {
         Color([240, 240, 240, 255]),
       )))
       .with(StyleDeclaration::font_size(Px(24.0).into()))
-      .with_gap(SpacePair::from_pair(Px(0.0), Px(24.0)))
+      .with_gap(SpacePair::from_pair(Px(0.0).into(), Px(24.0).into()))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap)),
   );
 
@@ -188,7 +184,7 @@ fn text_typography_line_height_variants() {
     .with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
-        .with_gap(SpacePair::from_single(Px(16.0)))
+        .with_gap(SpacePair::from_single(Px(16.0).into()))
         .with(StyleDeclaration::align_items(AlignItems::Stretch)),
     ),
   ])
@@ -292,7 +288,7 @@ fn text_fit_overview_container(cards: impl Into<Box<[Node]>>) -> Node {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(14.0)))
+      .with_gap(SpacePair::from_single(Px(14.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([246, 248, 251, 255]),
       )))
@@ -600,7 +596,7 @@ fn text_indent_variants() {
           .with(StyleDeclaration::display(Display::Flex))
           .with(StyleDeclaration::flex_direction(FlexDirection::Column))
           .with(StyleDeclaration::width(Px(380.0)))
-          .with_gap(SpacePair::from_single(Px(8.0))),
+          .with_gap(SpacePair::from_single(Px(8.0).into())),
       )
     })
     .collect::<Vec<_>>();
@@ -614,7 +610,7 @@ fn text_indent_variants() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(24.0))),
+      .with_gap(SpacePair::from_single(Px(24.0).into())),
   );
 
   run_fixture_test(container, "text_indent_variants");
@@ -863,7 +859,7 @@ fn text_wrap_nowrap() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 
@@ -917,7 +913,7 @@ fn text_whitespace_collapse() {
       .with(StyleDeclaration::font_size(Px(32.0).into()))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 
@@ -971,7 +967,7 @@ fn text_wrap_style_all() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(40.0)))
+      .with_gap(SpacePair::from_single(Px(40.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 
@@ -1116,7 +1112,7 @@ fn text_font_stretch() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_stretch");
@@ -1185,19 +1181,22 @@ fn text_font_synthesis_weight_auto_none() {
     unreachable!()
   };
 
-  let nodes: Vec<Node> = [("auto", FontSynthesic::Auto), ("none", FontSynthesic::None)]
-    .iter()
-    .map(|(label, synthesis_weight)| {
-      Node::text(format!("font-synthesis-weight: {} - السلام عليكم", label)).with_style(
-        Style::default()
-          .with(StyleDeclaration::display(Display::Flex))
-          .with(StyleDeclaration::font_size(Px(72.0).into()))
-          .with(StyleDeclaration::font_family(family.clone()))
-          .with(StyleDeclaration::font_weight(FontWeight::from(900.0)))
-          .with(StyleDeclaration::font_synthesis_weight(*synthesis_weight)),
-      )
-    })
-    .collect::<Vec<_>>();
+  let nodes: Vec<Node> = [
+    ("auto", FontSynthesisMode::Auto),
+    ("none", FontSynthesisMode::None),
+  ]
+  .iter()
+  .map(|(label, synthesis_weight)| {
+    Node::text(format!("font-synthesis-weight: {} - السلام عليكم", label)).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::font_size(Px(72.0).into()))
+        .with(StyleDeclaration::font_family(family.clone()))
+        .with(StyleDeclaration::font_weight(FontWeight::from(900.0)))
+        .with(StyleDeclaration::font_synthesis_weight(*synthesis_weight)),
+    )
+  })
+  .collect::<Vec<_>>();
 
   let container = Node::container(nodes.into_boxed_slice()).with_style(
     Style::default()
@@ -1208,7 +1207,7 @@ fn text_font_synthesis_weight_auto_none() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_synthesis_weight_auto_none");
@@ -1220,19 +1219,22 @@ fn text_font_synthesis_style_auto_none() {
     unreachable!()
   };
 
-  let nodes: Vec<Node> = [("auto", FontSynthesic::Auto), ("none", FontSynthesic::None)]
-    .iter()
-    .map(|(label, synthesis_style)| {
-      Node::text(format!("font-synthesis-style: {} - السلام عليكم", label)).with_style(
-        Style::default()
-          .with(StyleDeclaration::display(Display::Flex))
-          .with(StyleDeclaration::font_size(Px(72.0).into()))
-          .with(StyleDeclaration::font_family(family.clone()))
-          .with(StyleDeclaration::font_style(FontStyle::italic()))
-          .with(StyleDeclaration::font_synthesis_style(*synthesis_style)),
-      )
-    })
-    .collect::<Vec<_>>();
+  let nodes: Vec<Node> = [
+    ("auto", FontSynthesisMode::Auto),
+    ("none", FontSynthesisMode::None),
+  ]
+  .iter()
+  .map(|(label, synthesis_style)| {
+    Node::text(format!("font-synthesis-style: {} - السلام عليكم", label)).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::font_size(Px(72.0).into()))
+        .with(StyleDeclaration::font_family(family.clone()))
+        .with(StyleDeclaration::font_style(FontStyle::italic()))
+        .with(StyleDeclaration::font_synthesis_style(*synthesis_style)),
+    )
+  })
+  .collect::<Vec<_>>();
 
   let container = Node::container(nodes.into_boxed_slice()).with_style(
     Style::default()
@@ -1243,7 +1245,7 @@ fn text_font_synthesis_style_auto_none() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_synthesis_style_auto_none");
@@ -1260,8 +1262,8 @@ fn text_font_synthesis_weight_emoji() {
     (
       "none",
       FontSynthesis::builder()
-        .weight(FontSynthesic::None)
-        .style(FontSynthesic::None)
+        .weight(FontSynthesisMode::None)
+        .style(FontSynthesisMode::None)
         .build(),
     ),
   ]
@@ -1288,7 +1290,7 @@ fn text_font_synthesis_weight_emoji() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_synthesis_weight_emoji");
@@ -1362,7 +1364,7 @@ fn text_devanagari_noto_sans() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_devanagari_noto_sans");


### PR DESCRIPTION
## Why

takumi-core ships as its own crate, but its public API leaked `taffy`, `parley`, and `tiny_skia` — anyone who only parses CSS or holds a node tree was dragged into depending on the layout engine's crates, and the surface couldn't reach a clean 2.0. A few properties also carried the wrong CSS initial value.

## What

- Gate the layout and paint engine (`layout::{tree,inline,border}`, `paint`, `scene`, `geometry`, `shadow`) behind an `unstable` feature that the backend crates enable. The default takumi-core API no longer names a foreign type — verified with `cargo public-api`. The ours-to-foreign `From` impls stay, now feature-gated, so no relocated conversion helpers are needed.
- Add `MaxSize` (`none`) and `Gap` (`normal`) value types so `max-width`/`max-height` and the gaps carry their real initial values. Rendering is unchanged: `none` resolves like the old unbounded default and `normal` computes to `0`, but both round-trip through `to_css`.
- `FontWeight::Absolute` holds an `f32` instead of a parley weight; `FontSynthesic` is renamed `FontSynthesisMode`; the stylesheet-parse and registered-font types are `#[non_exhaustive]`.
- `ImagesInput` had two incompatible public definitions — keep the base in `@takumi-rs/helpers`, re-export it from `takumi-js`, and rename the fetch-aware superset to `ManagedImagesInput`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed `gap` and `max-width`/`max-height` values, improving CSS round-tripping and layout handling.
  * Introduced a managed image input option for rendering, making remote image handling more consistent.
  * Exposed an optional `unstable` feature for advanced rendering/layout capabilities.

* **Bug Fixes**
  * Improved font-related styling and parsing consistency, including font synthesis, variations, and feature settings.
  * Updated error handling and selector parsing for more reliable stylesheet parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->