### PR TITLE
Core: represent none/normal initial values of max-* and gaps

### DIFF
--- a/.tegami/max-size-gap-initial-values.md
+++ b/.tegami/max-size-gap-initial-values.md
@@ -1,0 +1,15 @@
+---
+packages:
+  cargo:takumi-core:
+    type: minor
+  cargo:takumi:
+    type: major
+---
+
+### Represent the `none`/`normal` initial values of `max-*` and gaps
+
+`max-width` and `max-height` are now a `MaxSize` value whose initial is `None`
+(unbounded), instead of borrowing `Length`'s `auto`. `column-gap`, `row-gap`, and
+the `gap` shorthand are now a `Gap` value whose initial is `Normal`. Rendering is
+unchanged — `none` resolves like the old unbounded default and `normal` computes
+to `0` — but the values now round-trip through `to_css` as `none`/`normal`.

--- a/takumi-core/src/style/properties/gap.rs
+++ b/takumi-core/src/style/properties/gap.rs
@@ -1,0 +1,127 @@
+use std::fmt;
+
+use cssparser::Parser;
+use taffy::LengthPercentage;
+
+use crate::style::{
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
+  SizingContext, ToCss,
+};
+
+/// Represents the `column-gap`/`row-gap` value: either `normal` (computes to `0`) or a [`Length`].
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum Gap {
+  /// No explicit gap; computes to `0`.
+  #[default]
+  Normal,
+  /// A concrete gap length.
+  Length(Length),
+}
+
+impl MakeComputed for Gap {
+  fn make_computed(&mut self, sizing: &SizingContext) {
+    if let Self::Length(length) = self {
+      length.make_computed(sizing);
+    }
+  }
+}
+
+impl Animatable for Gap {
+  fn interpolate(
+    &mut self,
+    from: &Self,
+    to: &Self,
+    progress: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) {
+    *self = match (from, to) {
+      (Self::Length(from), Self::Length(to)) => {
+        let mut length = *from;
+        length.interpolate(from, to, progress, sizing, current_color);
+        Self::Length(length)
+      }
+      (Self::Normal, Self::Normal) => Self::Normal,
+      (Self::Normal, Self::Length(to)) => {
+        let mut length = Length::zero();
+        length.interpolate(&Length::zero(), to, progress, sizing, current_color);
+        Self::Length(length)
+      }
+      (Self::Length(from), Self::Normal) => {
+        let mut length = *from;
+        length.interpolate(from, &Length::zero(), progress, sizing, current_color);
+        Self::Length(length)
+      }
+    };
+  }
+}
+
+impl<'i> FromCss<'i> for Gap {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if input
+      .try_parse(|input| input.expect_ident_matching("normal"))
+      .is_ok()
+    {
+      return Ok(Self::Normal);
+    }
+
+    Length::from_css(input).map(Self::Length)
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("normal"),
+    CssToken::Syntax(CssSyntaxKind::Length),
+  ];
+}
+
+impl From<Length> for Gap {
+  fn from(length: Length) -> Self {
+    Self::Length(length)
+  }
+}
+
+impl Gap {
+  /// Resolves to a taffy `LengthPercentage`, treating `normal` as `0`.
+  pub(crate) fn resolve_to_length_percentage(self, sizing: &SizingContext) -> LengthPercentage {
+    match self {
+      Self::Normal => Length::zero().resolve_to_length_percentage(sizing),
+      Self::Length(length) => length.resolve_to_length_percentage(sizing),
+    }
+  }
+}
+
+impl ToCss for Gap {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::Normal => dest.write_str("normal"),
+      Self::Length(length) => length.to_css(dest),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn parses_normal() {
+    assert_eq!(Gap::from_css_str("normal"), Ok(Gap::Normal));
+  }
+
+  #[test]
+  fn parses_length() {
+    assert_eq!(Gap::from_css_str("10px"), Ok(Gap::Length(Length::Px(10.0))));
+  }
+
+  #[test]
+  fn round_trips_to_css() {
+    let mut buf = String::new();
+    Gap::Normal.to_css(&mut buf).unwrap();
+    assert_eq!(buf, "normal");
+
+    let mut buf = String::new();
+    Gap::Length(Length::Px(10.0)).to_css(&mut buf).unwrap();
+    assert_eq!(buf, "10px");
+  }
+}

--- a/takumi-core/src/style/properties/max_size.rs
+++ b/takumi-core/src/style/properties/max_size.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+
+use cssparser::Parser;
+use taffy::Dimension;
+
+use crate::style::{
+  Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
+  SizingContext, ToCss,
+};
+
+/// Represents the `max-width`/`max-height` value: either `none` (unbounded) or a [`Length`].
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum MaxSize {
+  /// No maximum; the box is unbounded on this axis.
+  #[default]
+  None,
+  /// A concrete maximum length.
+  Length(Length),
+}
+
+impl MakeComputed for MaxSize {
+  fn make_computed(&mut self, sizing: &SizingContext) {
+    if let Self::Length(length) = self {
+      length.make_computed(sizing);
+    }
+  }
+}
+
+impl Animatable for MaxSize {
+  fn interpolate(
+    &mut self,
+    from: &Self,
+    to: &Self,
+    progress: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) {
+    *self = match (from, to) {
+      (Self::Length(from), Self::Length(to)) => {
+        let mut length = *from;
+        length.interpolate(from, to, progress, sizing, current_color);
+        Self::Length(length)
+      }
+      _ => {
+        if progress >= 0.5 {
+          *to
+        } else {
+          *from
+        }
+      }
+    };
+  }
+}
+
+impl<'i> FromCss<'i> for MaxSize {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    if input
+      .try_parse(|input| input.expect_ident_matching("none"))
+      .is_ok()
+    {
+      return Ok(Self::None);
+    }
+
+    // `auto` is not a valid `max-width`/`max-height` value, but historically
+    // accepted here; keep treating it as `none` to avoid a behavior change.
+    if input
+      .try_parse(|input| input.expect_ident_matching("auto"))
+      .is_ok()
+    {
+      return Ok(Self::None);
+    }
+
+    Length::from_css(input).map(Self::Length)
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = &[
+    CssToken::Keyword("none"),
+    CssToken::Keyword("auto"),
+    CssToken::Syntax(CssSyntaxKind::Length),
+  ];
+}
+
+impl From<Length> for MaxSize {
+  fn from(length: Length) -> Self {
+    Self::Length(length)
+  }
+}
+
+impl MaxSize {
+  /// Resolves to a taffy `Dimension`, treating `none` as unbounded (same as `Length::Auto`).
+  pub(crate) fn resolve_to_dimension(self, sizing: &SizingContext) -> Dimension {
+    match self {
+      Self::None => Length::Auto.resolve_to_dimension(sizing),
+      Self::Length(length) => length.resolve_to_dimension(sizing),
+    }
+  }
+}
+
+impl ToCss for MaxSize {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    match self {
+      Self::None => dest.write_str("none"),
+      Self::Length(length) => length.to_css(dest),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn parses_none() {
+    assert_eq!(MaxSize::from_css_str("none"), Ok(MaxSize::None));
+  }
+
+  #[test]
+  fn parses_auto_as_none() {
+    assert_eq!(MaxSize::from_css_str("auto"), Ok(MaxSize::None));
+  }
+
+  #[test]
+  fn parses_length() {
+    assert_eq!(
+      MaxSize::from_css_str("10px"),
+      Ok(MaxSize::Length(Length::Px(10.0)))
+    );
+  }
+
+  #[test]
+  fn round_trips_to_css() {
+    let mut buf = String::new();
+    MaxSize::None.to_css(&mut buf).unwrap();
+    assert_eq!(buf, "none");
+
+    let mut buf = String::new();
+    MaxSize::Length(Length::Px(10.0)).to_css(&mut buf).unwrap();
+    assert_eq!(buf, "10px");
+  }
+}

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -31,12 +31,14 @@ mod font_synthesis;
 mod font_variant;
 mod font_variation_settings;
 mod font_weight;
+mod gap;
 pub(crate) mod gradient_utils;
 mod grid;
 mod length;
 mod line_clamp;
 mod line_height;
 pub(crate) mod linear_gradient;
+mod max_size;
 mod offset_path;
 mod order;
 mod overflow;
@@ -93,6 +95,7 @@ pub use font_synthesis::*;
 pub use font_variant::*;
 pub(crate) use font_variation_settings::*;
 pub use font_weight::*;
+pub use gap::*;
 pub use grid::*;
 pub use length::*;
 pub use line_clamp::*;
@@ -102,6 +105,7 @@ pub use linear_gradient::{
   Angle, GradientKeywordDirection, GradientStop, HorizontalKeyword, LinearGradient,
   LinearGradientDirection, ResolvedGradientStop, StopPosition, VerticalKeyword,
 };
+pub use max_size::*;
 pub use offset_path::*;
 pub use order::*;
 pub use overflow::*;

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -990,8 +990,8 @@ define_style! {
     display: Display,
     width: Length,
     height: Length,
-    max_width: Length,
-    max_height: Length,
+    max_width: MaxSize,
+    max_height: MaxSize,
     min_width: Length,
     min_height: Length,
     aspect_ratio: AspectRatio,
@@ -1033,8 +1033,8 @@ define_style! {
     mask_size: BackgroundSizes,
     mask_position: PositionValues,
     mask_repeat: BackgroundRepeats,
-    column_gap: Length = Length::zero(),
-    row_gap: Length = Length::zero(),
+    column_gap: Gap,
+    row_gap: Gap,
     flex_grow: Option<FlexGrow>,
     flex_shrink: Option<FlexGrow>,
     border_top_left_radius: SpacePair<Length> = SpacePair::from_single(Length::zero()),
@@ -1234,7 +1234,7 @@ define_style! {
           .collect(),
       )));
     },
-    gap: SpacePair<Length> => [RowGap, ColumnGap] |value, target| {
+    gap: SpacePair<Gap> => [RowGap, ColumnGap] |value, target| {
       push_axis_declarations!(target, value, row_gap, column_gap);
     },
     flex_flow: FlexFlow => [FlexDirection, FlexWrap] |value, target| {

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -560,21 +560,21 @@ fn parse_style_declaration_supports_legacy_grid_gap_aliases() {
   let row_gap = parse_declarations("grid-row-gap", "4px");
   assert_eq!(
     row_gap.iter().collect::<Vec<_>>(),
-    vec![&StyleDeclaration::row_gap(Length::Px(4.0))]
+    vec![&StyleDeclaration::row_gap(Gap::Length(Length::Px(4.0)))]
   );
 
   let column_gap = parse_declarations("grid-column-gap", "3px");
   assert_eq!(
     column_gap.iter().collect::<Vec<_>>(),
-    vec![&StyleDeclaration::column_gap(Length::Px(3.0))]
+    vec![&StyleDeclaration::column_gap(Gap::Length(Length::Px(3.0)))]
   );
 
   let gap = parse_declarations("grid-gap", "1px 2px");
   assert_eq!(
     gap.iter().collect::<Vec<_>>(),
     vec![
-      &StyleDeclaration::row_gap(Length::Px(1.0)),
-      &StyleDeclaration::column_gap(Length::Px(2.0)),
+      &StyleDeclaration::row_gap(Gap::Length(Length::Px(1.0))),
+      &StyleDeclaration::column_gap(Gap::Length(Length::Px(2.0))),
     ]
   );
 }

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -819,10 +819,17 @@ impl TailwindProperty {
         push_decl!(builder, important, background_clip(background_clip));
       }
       TailwindProperty::Gap(gap) => {
-        push_decl!(builder, important, row_gap(gap), column_gap(gap));
+        push_decl!(
+          builder,
+          important,
+          row_gap(gap.into()),
+          column_gap(gap.into())
+        );
       }
-      TailwindProperty::GapX(gap_x) => push_decl!(builder, important, column_gap(gap_x)),
-      TailwindProperty::GapY(gap_y) => push_decl!(builder, important, row_gap(gap_y)),
+      TailwindProperty::GapX(gap_x) => {
+        push_decl!(builder, important, column_gap(gap_x.into()))
+      }
+      TailwindProperty::GapY(gap_y) => push_decl!(builder, important, row_gap(gap_y.into())),
       TailwindProperty::BoxSizing(box_sizing) => {
         push_decl!(builder, important, box_sizing(box_sizing))
       }
@@ -917,9 +924,11 @@ impl TailwindProperty {
       TailwindProperty::MinHeight(min_height) => {
         push_decl!(builder, important, min_height(min_height))
       }
-      TailwindProperty::MaxWidth(max_width) => push_decl!(builder, important, max_width(max_width)),
+      TailwindProperty::MaxWidth(max_width) => {
+        push_decl!(builder, important, max_width(max_width.into()))
+      }
       TailwindProperty::MaxHeight(max_height) => {
-        push_decl!(builder, important, max_height(max_height))
+        push_decl!(builder, important, max_height(max_height.into()))
       }
       TailwindProperty::Shadow(box_shadow) => builder.set_shadow_layers([box_shadow], important),
       TailwindProperty::ShadowList(&[]) => builder.reset_shadow(important),

--- a/takumi/tests/fixtures/color_artifacts.rs
+++ b/takumi/tests/fixtures/color_artifacts.rs
@@ -62,7 +62,7 @@ fn test_color_artifacts() {
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::flex_direction(FlexDirection::Row))
-      .with_gap(SpacePair::from_single(Px(40.0)))
+      .with_gap(SpacePair::from_single(Px(40.0).into()))
       .with_padding(Sides([Rem(4.0); 4])),
   );
 

--- a/takumi/tests/fixtures/inline.rs
+++ b/takumi/tests/fixtures/inline.rs
@@ -523,7 +523,7 @@ fn inline_complex_nested_fixture() {
       Style::default()
         .with(StyleDeclaration::display(Display::InlineFlex))
         .with(StyleDeclaration::align_items(AlignItems::Center))
-        .with_gap(SpacePair::from_single(Px(6.0)))
+        .with_gap(SpacePair::from_single(Px(6.0).into()))
         .with(StyleDeclaration::background_color(ColorInput::Value(
           Color([80, 138, 184, 255]),
         )))
@@ -788,7 +788,7 @@ fn inline_social_post_regression() {
           .with(StyleDeclaration::color(ColorInput::Value(Color([
             136, 153, 166, 255,
           ]))))
-          .with_gap(SpacePair::from_single(Px(24.0))),
+          .with_gap(SpacePair::from_single(Px(24.0).into())),
       ),
     ])
     .with_style(
@@ -842,7 +842,7 @@ fn inline_social_post_regression() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(24.0)))
+      .with_gap(SpacePair::from_single(Px(24.0).into()))
       .with(StyleDeclaration::flex_grow(Some(FlexGrow(1.0)))),
   )])
   .with_style(

--- a/takumi/tests/fixtures/lang.rs
+++ b/takumi/tests/fixtures/lang.rs
@@ -30,7 +30,7 @@ fn lang_row(lang: &'static str) -> Node {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_pair(Px(12.0), Px(12.0))),
+      .with_gap(SpacePair::from_pair(Px(12.0).into(), Px(12.0).into())),
   )
 }
 
@@ -47,7 +47,7 @@ fn test_lang_han_unification() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(40.0); 4]))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_pair(Px(32.0), Px(32.0))),
+      .with_gap(SpacePair::from_pair(Px(32.0).into(), Px(32.0).into())),
   );
 
   run_fixture_test(container, "lang_han_unification");

--- a/takumi/tests/fixtures/rtl.rs
+++ b/takumi/tests/fixtures/rtl.rs
@@ -29,14 +29,14 @@ fn test_direction_flex_row() {
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::direction(Direction::Ltr))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
     Node::container(children).with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::direction(Direction::Rtl))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
   ])
@@ -51,7 +51,7 @@ fn test_direction_flex_row() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(16.0); 4]))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0))),
+      .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into())),
   );
 
   run_fixture_test(container, "direction_flex_row");
@@ -69,7 +69,7 @@ fn test_direction_grid() {
           GridTemplateComponents::from_css_str("repeat(4, 1fr)").unwrap(),
         )))
         .with(StyleDeclaration::direction(Direction::Ltr))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
     Node::container(children).with_style(
@@ -79,7 +79,7 @@ fn test_direction_grid() {
           GridTemplateComponents::from_css_str("repeat(4, 1fr)").unwrap(),
         )))
         .with(StyleDeclaration::direction(Direction::Rtl))
-        .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0)))
+        .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into()))
         .with(StyleDeclaration::width(Percentage(100.0))),
     ),
   ])
@@ -94,7 +94,7 @@ fn test_direction_grid() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with_padding(Sides([Px(16.0); 4]))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_pair(Px(16.0), Px(16.0))),
+      .with_gap(SpacePair::from_pair(Px(16.0).into(), Px(16.0).into())),
   );
 
   run_fixture_test(container, "direction_grid");

--- a/takumi/tests/fixtures/style_backdrop_filter.rs
+++ b/takumi/tests/fixtures/style_backdrop_filter.rs
@@ -111,7 +111,7 @@ fn test_style_backdrop_filter_frosted_glass() {
       )))
       .with_border_radius(BorderRadius::from_css_str("24px").unwrap())
       .with_padding(Sides([Px(48.0); 4]))
-      .with_gap(SpacePair::from_single(Px(16.0))),
+      .with_gap(SpacePair::from_single(Px(16.0).into())),
   )])
   .with_style(
     Style::default()

--- a/takumi/tests/fixtures/style_background_clip.rs
+++ b/takumi/tests/fixtures/style_background_clip.rs
@@ -331,7 +331,7 @@ fn test_style_background_clip_comparison() {
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 

--- a/takumi/tests/fixtures/style_background_origin.rs
+++ b/takumi/tests/fixtures/style_background_origin.rs
@@ -43,7 +43,7 @@ fn test_style_background_origin() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::width(Percentage(100.0)))
-      .with(StyleDeclaration::row_gap(Px(20.0)))
+      .with(StyleDeclaration::row_gap(Px(20.0).into()))
       .with_padding(Sides([Px(30.0); 4]))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 255]),

--- a/takumi/tests/fixtures/style_filter.rs
+++ b/takumi/tests/fixtures/style_filter.rs
@@ -24,7 +24,7 @@ fn create_filter_test_container(
       .with(StyleDeclaration::grid_template_columns(
         GridTemplateComponents::from_css_str("repeat(5, 1fr)").ok(),
       ))
-      .with_gap(SpacePair::from_single(Px(gap_px)))
+      .with_gap(SpacePair::from_single(Px(gap_px).into()))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::background_color(ColorInput::Value(
@@ -53,7 +53,7 @@ fn create_filter_card(filter: &str, image_size_px: f32, label_font_size_px: f32)
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with(StyleDeclaration::font_size(Px(label_font_size_px).into())),
   )
 }
@@ -84,7 +84,7 @@ fn create_filter_transform_card(
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with(StyleDeclaration::font_size(Px(label_font_size_px).into())),
   )
 }
@@ -191,7 +191,7 @@ fn test_style_filter_combined_with_transform() {
       .with(StyleDeclaration::grid_template_columns(
         GridTemplateComponents::from_css_str("repeat(4, 1fr)").ok(),
       ))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::background_color(ColorInput::Value(

--- a/takumi/tests/fixtures/style_layout.rs
+++ b/takumi/tests/fixtures/style_layout.rs
@@ -134,7 +134,7 @@ fn test_style_gap() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Flex))
-      .with_gap(SpacePair::from_pair(Px(0.0), Px(20.0)))
+      .with_gap(SpacePair::from_pair(Px(0.0).into(), Px(20.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([0, 0, 255, 255]),
       ))),

--- a/takumi/tests/fixtures/style_mix_blend_mode.rs
+++ b/takumi/tests/fixtures/style_mix_blend_mode.rs
@@ -153,7 +153,7 @@ fn test_style_mix_blend_mode_text_regression() {
   let family = FontFamily::from_css_str("Geist").unwrap();
   let label_style = Style::default()
     .with(StyleDeclaration::display(Display::Block))
-    .with(StyleDeclaration::max_width(Px(500.0)))
+    .with(StyleDeclaration::max_width(Px(500.0).into()))
     .with(StyleDeclaration::font_family(family))
     .with(StyleDeclaration::font_size(Px(60.0).into()))
     .with(StyleDeclaration::font_weight(FontWeight::from(600.0)))
@@ -201,7 +201,7 @@ fn test_style_mix_blend_mode_text_regression() {
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with(StyleDeclaration::row_gap(Px(24.0))),
+      .with(StyleDeclaration::row_gap(Px(24.0).into())),
   )])
   .with_style(
     Style::default()

--- a/takumi/tests/fixtures/style_opacity.rs
+++ b/takumi/tests/fixtures/style_opacity.rs
@@ -98,7 +98,7 @@ fn test_style_opacity() {
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([255, 255, 255, 255]),
       )))
-      .with_gap(SpacePair::from_single(Length::Rem(4.0))),
+      .with_gap(SpacePair::from_single(Length::Rem(4.0).into())),
   );
 
   run_fixture_test(container, "style_opacity");
@@ -140,7 +140,7 @@ fn test_style_opacity_image_with_text() {
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Length::Rem(2.0)))
+      .with_gap(SpacePair::from_single(Length::Rem(2.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([240, 240, 240, 255]),
       ))),
@@ -198,7 +198,7 @@ fn test_style_opacity_flex_text_node_vs_nested_container() {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
-      .with_gap(SpacePair::from_single(Length::Px(48.0)))
+      .with_gap(SpacePair::from_single(Length::Px(48.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::white(),
       ))),

--- a/takumi/tests/fixtures/style_overflow.rs
+++ b/takumi/tests/fixtures/style_overflow.rs
@@ -139,7 +139,7 @@ fn create_split_pill_case(
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(12.0); 4]))
-      .with_gap(SpacePair::from_single(Px(8.0)))
+      .with_gap(SpacePair::from_single(Px(8.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([248, 250, 252, 255]),
       ))),

--- a/takumi/tests/fixtures/style_sizing.rs
+++ b/takumi/tests/fixtures/style_sizing.rs
@@ -69,7 +69,7 @@ fn test_style_max_width() {
   let container = Node::container([]).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
-      .with(StyleDeclaration::max_width(Px(100.0)))
+      .with(StyleDeclaration::max_width(Px(100.0).into()))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_color(ColorInput::Value(
@@ -85,7 +85,7 @@ fn test_style_max_height() {
   let container = Node::container([]).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
-      .with(StyleDeclaration::max_height(Px(100.0)))
+      .with(StyleDeclaration::max_height(Px(100.0).into()))
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::background_color(ColorInput::Value(

--- a/takumi/tests/fixtures/style_text_decoration.rs
+++ b/takumi/tests/fixtures/style_text_decoration.rs
@@ -59,7 +59,7 @@ fn text_decoration_skip_ink_parapsychologists() {
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with(StyleDeclaration::row_gap(Px(28.0)))
+      .with(StyleDeclaration::row_gap(Px(28.0).into()))
       .with(StyleDeclaration::padding_top(Px(40.0))),
   );
 

--- a/takumi/tests/fixtures/style_text_decoration_thickness.rs
+++ b/takumi/tests/fixtures/style_text_decoration_thickness.rs
@@ -38,7 +38,7 @@ fn test_style_text_decoration_thickness() {
       )))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with(StyleDeclaration::row_gap(Px(20.0)))
+      .with(StyleDeclaration::row_gap(Px(20.0).into()))
       .with(StyleDeclaration::padding_top(Px(40.0)))
       .with(StyleDeclaration::padding_bottom(Px(40.0))),
   );

--- a/takumi/tests/fixtures/style_text_underline_offset.rs
+++ b/takumi/tests/fixtures/style_text_underline_offset.rs
@@ -36,7 +36,7 @@ fn test_style_text_underline_offset() {
         Color([240, 240, 240, 255]),
       )))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with(StyleDeclaration::row_gap(Px(20.0)))
+      .with(StyleDeclaration::row_gap(Px(20.0).into()))
       .with(StyleDeclaration::padding_top(Px(40.0)))
       .with(StyleDeclaration::padding_bottom(Px(40.0))),
   );

--- a/takumi/tests/fixtures/style_visuals.rs
+++ b/takumi/tests/fixtures/style_visuals.rs
@@ -485,7 +485,7 @@ fn demo_card(label: &str, preview: Node) -> Node {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::width(Px(208.0)))
-      .with_gap(SpacePair::from_single(Px(12.0)))
+      .with_gap(SpacePair::from_single(Px(12.0).into()))
       .with(StyleDeclaration::align_items(AlignItems::Center)),
   )
 }
@@ -515,7 +515,7 @@ fn non_uniform_border_demo(label: &str, style: Sides<BorderStyle>, width: Sides<
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with(StyleDeclaration::width(Px(220.0)))
-      .with_gap(SpacePair::from_single(Px(12.0)))
+      .with_gap(SpacePair::from_single(Px(12.0).into()))
       .with(StyleDeclaration::align_items(AlignItems::Center)),
   )
 }
@@ -584,7 +584,7 @@ fn test_style_border_styles() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with_padding(Sides([Px(32.0); 4]))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
@@ -641,7 +641,7 @@ fn test_style_border_non_uniform_patterns() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(32.0); 4]))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
@@ -676,7 +676,7 @@ fn test_style_outline_styles() {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(16.0)))
+      .with_gap(SpacePair::from_single(Px(16.0).into()))
       .with_padding(Sides([Px(32.0); 4]))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -70,7 +70,7 @@ fn text_typography_variable_width() {
       .with(StyleDeclaration::font_family(family))
       .with(StyleDeclaration::font_size(Px(48.0).into()))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with(StyleDeclaration::row_gap(Px(48.0)))
+      .with(StyleDeclaration::row_gap(Px(48.0).into()))
       .with(StyleDeclaration::width(Percentage(100.0))),
   );
 
@@ -100,7 +100,7 @@ fn text_typography_variable_weight() {
         Color([240, 240, 240, 255]),
       )))
       .with(StyleDeclaration::font_size(Px(24.0).into()))
-      .with_gap(SpacePair::from_pair(Px(0.0), Px(24.0)))
+      .with_gap(SpacePair::from_pair(Px(0.0).into(), Px(24.0).into()))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap)),
   );
 
@@ -188,7 +188,7 @@ fn text_typography_line_height_variants() {
     .with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
-        .with_gap(SpacePair::from_single(Px(16.0)))
+        .with_gap(SpacePair::from_single(Px(16.0).into()))
         .with(StyleDeclaration::align_items(AlignItems::Stretch)),
     ),
   ])
@@ -292,7 +292,7 @@ fn text_fit_overview_container(cards: impl Into<Box<[Node]>>) -> Node {
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
-      .with_gap(SpacePair::from_single(Px(14.0)))
+      .with_gap(SpacePair::from_single(Px(14.0).into()))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color([246, 248, 251, 255]),
       )))
@@ -600,7 +600,7 @@ fn text_indent_variants() {
           .with(StyleDeclaration::display(Display::Flex))
           .with(StyleDeclaration::flex_direction(FlexDirection::Column))
           .with(StyleDeclaration::width(Px(380.0)))
-          .with_gap(SpacePair::from_single(Px(8.0))),
+          .with_gap(SpacePair::from_single(Px(8.0).into())),
       )
     })
     .collect::<Vec<_>>();
@@ -614,7 +614,7 @@ fn text_indent_variants() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(24.0))),
+      .with_gap(SpacePair::from_single(Px(24.0).into())),
   );
 
   run_fixture_test(container, "text_indent_variants");
@@ -863,7 +863,7 @@ fn text_wrap_nowrap() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 
@@ -917,7 +917,7 @@ fn text_whitespace_collapse() {
       .with(StyleDeclaration::font_size(Px(32.0).into()))
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::height(Percentage(100.0)))
-      .with_gap(SpacePair::from_single(Px(20.0)))
+      .with_gap(SpacePair::from_single(Px(20.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 
@@ -971,7 +971,7 @@ fn text_wrap_style_all() {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
-      .with_gap(SpacePair::from_single(Px(40.0)))
+      .with_gap(SpacePair::from_single(Px(40.0).into()))
       .with_padding(Sides([Px(20.0); 4])),
   );
 
@@ -1116,7 +1116,7 @@ fn text_font_stretch() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_stretch");
@@ -1208,7 +1208,7 @@ fn text_font_synthesis_weight_auto_none() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_synthesis_weight_auto_none");
@@ -1243,7 +1243,7 @@ fn text_font_synthesis_style_auto_none() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_synthesis_style_auto_none");
@@ -1288,7 +1288,7 @@ fn text_font_synthesis_weight_emoji() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_font_synthesis_weight_emoji");
@@ -1362,7 +1362,7 @@ fn text_devanagari_noto_sans() {
       .with(StyleDeclaration::width(Percentage(100.0)))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
       .with_padding(Sides([Px(20.0); 4]))
-      .with_gap(SpacePair::from_single(Px(12.0))),
+      .with_gap(SpacePair::from_single(Px(12.0).into())),
   );
 
   run_fixture_test(container, "text_devanagari_noto_sans");


### PR DESCRIPTION
`max-width`/`max-height` become a `MaxSize` value (initial `None`, unbounded) instead of borrowing `Length`'s `auto`. `column-gap`, `row-gap` and the `gap` shorthand become a `Gap` value (initial `Normal`).

Rendering is unchanged — `none` resolves like the old unbounded default, `normal` computes to `0` — but the values now round-trip through `to_css` as `none`/`normal`.

Extracted from the abandoned #910; the napi parse-error test update rides in the follow-up JS PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Layout spacing now supports the `normal` keyword and preserves it when reading/writing styles.
  * Maximum width/height values now support `none` for unbounded sizing and round-trip cleanly in CSS output.
  * Gap and max-size settings are now handled more consistently across styling and layout APIs.

* **Bug Fixes**
  * Improved compatibility for existing layout spacing and sizing values, including legacy inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->