### PR TITLE
NAPI, WASM: expect the 'normal' keyword in gap parse errors

### DIFF
--- a/takumi-napi/tests/deserialize-error.test.ts
+++ b/takumi-napi/tests/deserialize-error.test.ts
@@ -354,7 +354,7 @@ test("report deserialize error for gap (SpacePair) with invalid type", () => {
       ),
     "gap",
     "boolean `true`",
-    "1 ~ 2 values of <length>; also accepts 'initial', 'unset' or 'inherit'.",
+    "1 ~ 2 values of 'normal' or <length>; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -377,7 +377,7 @@ test("report deserialize error for gap (SpacePair) with invalid string value", (
     "gap",
     "invalid",
     "invalid",
-    "1 ~ 2 values of <length>; also accepts 'initial', 'unset' or 'inherit'.",
+    "1 ~ 2 values of 'normal' or <length>; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 

--- a/takumi-wasm/tests/deserialize-error.test.ts
+++ b/takumi-wasm/tests/deserialize-error.test.ts
@@ -348,7 +348,7 @@ test("report deserialize error for gap (SpacePair) with invalid type", () => {
       ),
     "gap",
     "boolean `true`",
-    "1 ~ 2 values of <length>; also accepts 'initial', 'unset' or 'inherit'.",
+    "1 ~ 2 values of 'normal' or <length>; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 
@@ -371,7 +371,7 @@ test("report deserialize error for gap (SpacePair) with invalid string value", (
     "gap",
     "invalid",
     "invalid",
-    "1 ~ 2 values of <length>; also accepts 'initial', 'unset' or 'inherit'.",
+    "1 ~ 2 values of 'normal' or <length>; also accepts 'initial', 'unset' or 'inherit'.",
   );
 });
 


### PR DESCRIPTION
## Why
#911 made `column-gap`/`row-gap`/`gap` a `Gap` value that accepts `normal`, changing the CSS parse-error message. The napi and wasm `deserialize-error` tests still expected the old `<length>`-only message and now fail.

## What
Update the gap parse-error expectations in `takumi-napi` and `takumi-wasm` `deserialize-error.test.ts` to `1 ~ 2 values of 'normal' or <length>`. Test-only; both suites pass against a fresh build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages for `gap` validation to reflect that `normal` is also accepted alongside length values.
  * Aligned the expected deserialization failure text across both test suites for invalid type and invalid value cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->