### PR TITLE
Core: seal tiny_skia and image types out of the public API

### DIFF
--- a/.tegami/seal-tiny-skia-image-types.md
+++ b/.tegami/seal-tiny-skia-image-types.md
@@ -1,0 +1,14 @@
+---
+packages:
+  cargo:takumi-core:
+    type: minor
+---
+
+### Seal `tiny_skia` and `image` types out of the public API
+
+Glyph outline paths now use core-owned `geometry::PathCommand`/`geometry::Point`
+instead of `tiny_skia::PathSegment`/`Point`. `ResolvedBitmapGlyph::pixmap`
+(`tiny_skia::Pixmap`) is now `image: ImageBuffer`. `ImageBuffer::from_rgba`
+(`Cow<RgbaImage>`) is now `from_rgba_bytes(Vec<u8>, width, height)`.
+`layout::border::BorderProperties`'s path-building methods take
+`Vec<geometry::PathCommand>` instead of `Vec<tiny_skia::PathSegment>`.

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -1,13 +1,45 @@
 //! Transform geometry helpers shared across backends.
 
-use taffy::{Point, geometry::Size};
+use taffy::{Point as TaffyPoint, geometry::Size};
 
 use crate::style::Affine;
+
+/// A 2D point.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Point<T> {
+  /// Horizontal coordinate.
+  pub x: T,
+  /// Vertical coordinate.
+  pub y: T,
+}
+
+impl<T> Point<T> {
+  /// Creates a point from its coordinates.
+  pub const fn new(x: T, y: T) -> Self {
+    Self { x, y }
+  }
+}
+
+/// One command of a resolved outline path, in device space. Mirrors the classic
+/// move/line/quad/cubic/close vocabulary; coordinates are y-down.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PathCommand {
+  /// Starts a new subpath at the given point.
+  MoveTo(Point<f32>),
+  /// Draws a line to the given point.
+  LineTo(Point<f32>),
+  /// Draws a quadratic Bezier curve through the control point to the end point.
+  QuadTo(Point<f32>, Point<f32>),
+  /// Draws a cubic Bezier curve through the two control points to the end point.
+  CubicTo(Point<f32>, Point<f32>, Point<f32>),
+  /// Closes the current subpath.
+  Close,
+}
 
 /// Transforms a rect's four corners and returns the axis-aligned `(min_x, min_y,
 /// max_x, max_y)` extents, or `None` if any corner is non-finite.
 pub fn transformed_rect_extents(
-  origin: Point<f32>,
+  origin: TaffyPoint<f32>,
   size: Size<f32>,
   transform: Affine,
 ) -> Option<(f32, f32, f32, f32)> {

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -1,10 +1,10 @@
 use std::f32::consts::{PI, SQRT_2};
 
 use taffy::{Point, Rect, Size};
-use tiny_skia::{PathSegment as Command, Point as TinyPoint};
 
 use crate::{
   context::RenderContext,
+  geometry::{PathCommand as Command, Point as PathPoint},
   style::{BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},
 };
 
@@ -30,18 +30,18 @@ pub(crate) trait BorderPath {
 
 impl BorderPath for Vec<Command> {
   fn move_to(&mut self, point: (f32, f32)) {
-    self.push(Command::MoveTo(TinyPoint::from_xy(point.0, point.1)));
+    self.push(Command::MoveTo(PathPoint::new(point.0, point.1)));
   }
 
   fn line_to(&mut self, point: (f32, f32)) {
-    self.push(Command::LineTo(TinyPoint::from_xy(point.0, point.1)));
+    self.push(Command::LineTo(PathPoint::new(point.0, point.1)));
   }
 
   fn curve_to(&mut self, p1: (f32, f32), p2: (f32, f32), p3: (f32, f32)) {
     self.push(Command::CubicTo(
-      TinyPoint::from_xy(p1.0, p1.1),
-      TinyPoint::from_xy(p2.0, p2.1),
-      TinyPoint::from_xy(p3.0, p3.1),
+      PathPoint::new(p1.0, p1.1),
+      PathPoint::new(p2.0, p2.1),
+      PathPoint::new(p3.0, p3.1),
     ));
   }
 

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -6,11 +6,11 @@ use parley::{
 };
 use skrifa::{FontRef, MetadataProvider};
 use taffy::{AvailableSpace, Layout, Point, Rect, Size};
-use tiny_skia::PathSegment;
 
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
+  geometry::PathCommand,
   layout::{border::BorderPath, node::Node, tree::RenderNode},
   resources::font::{FontError, ResolvedColorLayer, ResolvedGlyph, ResolvedOutlineGlyph},
   style::{
@@ -1796,7 +1796,7 @@ pub fn outline_islands(mut outline_rects: Vec<InlineOutlineRect>) -> Vec<Vec<Inl
 /// Builds the rectilinear contour around one island of outline rects, expanded
 /// by `expansion` (outline-offset plus half the outline width). Pure path
 /// geometry; callers stroke it with their own backend.
-pub fn outline_island_contour(island: &[InlineOutlineRect], expansion: f32) -> Vec<PathSegment> {
+pub fn outline_island_contour(island: &[InlineOutlineRect], expansion: f32) -> Vec<PathCommand> {
   let mut path = Vec::with_capacity(island.len() * 6);
   let mut expanded_rects = island
     .iter()
@@ -1895,7 +1895,7 @@ impl PositionedInlineRun<'_> {
     &self,
     outline: &'g ResolvedOutlineGlyph,
     foreground: Color,
-  ) -> Vec<(Color, &'g [PathSegment])> {
+  ) -> Vec<(Color, &'g [PathCommand])> {
     let Some(layers) = outline.color_layers() else {
       return Vec::new();
     };

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -195,7 +195,7 @@ pub fn resolve_image(src: &str, context: &RenderContext) -> ImageResult {
 
 #[cfg(test)]
 mod tests {
-  use std::{assert_matches, borrow::Cow};
+  use std::assert_matches;
 
   use image::RgbaImage;
   use serde_json::from_value;
@@ -302,7 +302,7 @@ mod tests {
   #[test]
   fn from_pixmap_creates_loaded_image_source_input() {
     let bitmap = RgbaImage::new(2, 2);
-    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap();
+    let buffer = ImageBuffer::from_rgba_bytes(bitmap.into_raw(), 2, 2).unwrap();
     let image = ImageData::from(buffer);
 
     assert_matches!(image.src, ImageSourceInput::Loaded(ImageSource::Bitmap(_)));
@@ -319,7 +319,7 @@ mod tests {
           .build(),
       )
       .build();
-    let buffer = ImageBuffer::from_rgba(Cow::Owned(RgbaImage::new(10, 10))).unwrap();
+    let buffer = ImageBuffer::from_rgba_bytes(RgbaImage::new(10, 10).into_raw(), 10, 10).unwrap();
     let image = ImageData::from(ImageSource::from(buffer));
     let style = Style {
       size: Size {

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -27,19 +27,14 @@ use skrifa::{
   raw::types::{BoundingBox, F2Dot14, Tag},
 };
 use thiserror::Error;
-use tiny_skia::{IntSize, PathSegment as Command, Pixmap};
 
 use crate::{
   context::RenderContext,
+  geometry::{PathCommand as Command, Point},
   layout::inline::{InlineBrush, InlineLayout},
   resources::{image_buffer::ImageBuffer, image_decoder::decode_png},
   style::FontStyle as CssFontStyle,
 };
-
-fn pixmap_from_image_buffer(buffer: ImageBuffer) -> Option<Pixmap> {
-  let size = IntSize::from_wh(buffer.width(), buffer.height())?;
-  Pixmap::from_vec(buffer.into_data(), size)
-}
 
 /// A resolved glyph, either an embedded bitmap or a vector outline.
 #[derive(Clone)]
@@ -54,7 +49,7 @@ pub enum ResolvedGlyph {
 #[derive(Clone)]
 pub struct ResolvedBitmapGlyph {
   /// Source bitmap.
-  pub pixmap: Pixmap,
+  pub image: ImageBuffer,
   /// Horizontal scale from source to placement.
   pub scale_x: f32,
   /// Vertical scale from source to placement.
@@ -76,9 +71,9 @@ impl ResolvedBitmapGlyph {
     let mask_len = mask.len();
     let write_len = alpha_len.min(mask_len);
     let mask = &mut mask[..write_len];
-    let source_width = self.pixmap.width() as usize;
-    let source_height = self.pixmap.height() as usize;
-    let source_raw = self.pixmap.data();
+    let source_width = self.image.width() as usize;
+    let source_height = self.image.height() as usize;
+    let source_raw = self.image.data();
 
     if source_width == width && source_height == height {
       for (i, alpha) in source_raw.iter().skip(3).step_by(4).copied().enumerate() {
@@ -271,29 +266,24 @@ impl GlyphOutlinePen {
 
 impl OutlinePen for GlyphOutlinePen {
   fn move_to(&mut self, x: f32, y: f32) {
-    self
-      .paths
-      .push(Command::MoveTo(tiny_skia::Point::from_xy(x, -y)));
+    self.paths.push(Command::MoveTo(Point::new(x, -y)));
   }
 
   fn line_to(&mut self, x: f32, y: f32) {
-    self
-      .paths
-      .push(Command::LineTo(tiny_skia::Point::from_xy(x, -y)));
+    self.paths.push(Command::LineTo(Point::new(x, -y)));
   }
 
   fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
-    self.paths.push(Command::QuadTo(
-      tiny_skia::Point::from_xy(cx0, -cy0),
-      tiny_skia::Point::from_xy(x, -y),
-    ));
+    self
+      .paths
+      .push(Command::QuadTo(Point::new(cx0, -cy0), Point::new(x, -y)));
   }
 
   fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
     self.paths.push(Command::CubicTo(
-      tiny_skia::Point::from_xy(cx0, -cy0),
-      tiny_skia::Point::from_xy(cx1, -cy1),
-      tiny_skia::Point::from_xy(x, -y),
+      Point::new(cx0, -cy0),
+      Point::new(cx1, -cy1),
+      Point::new(x, -y),
     ));
   }
 
@@ -493,9 +483,9 @@ fn transform_commands(paths: &mut [Command], skew_degrees: f32) {
   }
 }
 
-fn decode_bitmap_image(bitmap: &BitmapGlyph<'_>) -> Option<(Pixmap, Origin)> {
-  let pixmap = match &bitmap.data {
-    BitmapData::Png(bytes) => pixmap_from_image_buffer(decode_png(bytes).ok()?)?,
+fn decode_bitmap_image(bitmap: &BitmapGlyph<'_>) -> Option<(ImageBuffer, Origin)> {
+  let image = match &bitmap.data {
+    BitmapData::Png(bytes) => decode_png(bytes).ok()?,
     BitmapData::Bgra(bytes) => {
       let image = RgbaImage::from_fn(bitmap.width, bitmap.height, |x, y| {
         let index = ((y * bitmap.width + x) * 4) as usize;
@@ -506,16 +496,17 @@ fn decode_bitmap_image(bitmap: &BitmapGlyph<'_>) -> Option<(Pixmap, Origin)> {
           bytes[index + 3],
         ])
       });
-      pixmap_from_image_buffer(ImageBuffer::from_rgba(Cow::Owned(image))?)?
+      let (width, height) = (image.width(), image.height());
+      ImageBuffer::from_rgba_bytes(image.into_raw(), width, height)?
     }
     BitmapData::Mask(_) => return None,
   };
 
-  Some((pixmap, bitmap.placement_origin))
+  Some((image, bitmap.placement_origin))
 }
 
 fn scale_bitmap_glyph(bitmap: BitmapGlyph<'_>, font_size: f32) -> Option<ResolvedBitmapGlyph> {
-  let (pixmap, origin) = decode_bitmap_image(&bitmap)?;
+  let (image, origin) = decode_bitmap_image(&bitmap)?;
   let scale_x = if bitmap.ppem_x > 0.0 {
     font_size / bitmap.ppem_x
   } else {
@@ -526,15 +517,15 @@ fn scale_bitmap_glyph(bitmap: BitmapGlyph<'_>, font_size: f32) -> Option<Resolve
   } else {
     1.0
   };
-  let width = ((pixmap.width() as f32) * scale_x).round().max(1.0) as u32;
-  let height = ((pixmap.height() as f32) * scale_y).round().max(1.0) as u32;
+  let width = ((image.width() as f32) * scale_x).round().max(1.0) as u32;
+  let height = ((image.height() as f32) * scale_y).round().max(1.0) as u32;
   let top = match origin {
     Origin::TopLeft => bitmap.inner_bearing_y,
     Origin::BottomLeft => bitmap.inner_bearing_y + bitmap.height as f32,
   };
 
   Some(ResolvedBitmapGlyph {
-    pixmap,
+    image,
     scale_x,
     scale_y,
     placement: ResolvedGlyphPlacement {

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -640,7 +640,7 @@ mod image_cache_tests {
 
 #[cfg(test)]
 mod tests {
-  use std::{assert_matches, borrow::Cow};
+  use std::assert_matches;
 
   use image::{Rgba, RgbaImage};
 
@@ -694,7 +694,7 @@ mod tests {
 
   fn frame_buffer(seed: u8) -> Arc<ImageBuffer> {
     let bitmap = RgbaImage::from_pixel(1, 1, Rgba([seed, 0, 0, 255]));
-    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap_or_else(|| {
+    let buffer = ImageBuffer::from_rgba_bytes(bitmap.into_raw(), 1, 1).unwrap_or_else(|| {
       let mut edge = 1_u32;
       loop {
         if let Some(buffer) = ImageBuffer::new(edge, edge) {
@@ -817,7 +817,7 @@ mod tests {
     let mut bitmap = RgbaImage::new(2, 2);
     bitmap.put_pixel(0, 0, Rgba([12, 34, 56, 200]));
     bitmap.put_pixel(1, 0, Rgba([78, 90, 12, 255]));
-    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap();
+    let buffer = ImageBuffer::from_rgba_bytes(bitmap.into_raw(), 2, 2).unwrap();
     let image = ImageSource::from(buffer);
 
     let rendered = image.render_for_layout(2, 2, ImageScalingAlgorithm::Auto, 0)?;
@@ -833,7 +833,7 @@ mod tests {
     bitmap.put_pixel(1, 0, Rgba([0, 255, 0, 255]));
     bitmap.put_pixel(0, 1, Rgba([0, 0, 255, 255]));
     bitmap.put_pixel(1, 1, Rgba([255, 255, 255, 255]));
-    let buffer = ImageBuffer::from_rgba(Cow::Owned(bitmap)).unwrap();
+    let buffer = ImageBuffer::from_rgba_bytes(bitmap.into_raw(), 2, 2).unwrap();
     let image = ImageSource::from(buffer);
 
     let rendered = image.render_for_layout(4, 4, ImageScalingAlgorithm::Pixelated, 0)?;

--- a/takumi-core/src/resources/image_buffer.rs
+++ b/takumi-core/src/resources/image_buffer.rs
@@ -4,9 +4,7 @@
 //! layout as `tiny_skia::Pixmap`, so a paint backend can borrow it zero-copy via
 //! `PixmapRef::from_bytes(buffer.data(), w, h)` without a per-composite copy.
 
-use std::borrow::Cow;
-
-use image::{ExtendedColorType, ImageEncoder, RgbaImage, codecs::png::PngEncoder};
+use image::{ExtendedColorType, ImageEncoder, codecs::png::PngEncoder};
 
 use crate::style::math::fast_div_255;
 
@@ -44,33 +42,13 @@ impl ImageBuffer {
     })
   }
 
-  /// Builds a premultiplied buffer from a straight-alpha [`RgbaImage`].
-  pub fn from_rgba(source: Cow<'_, RgbaImage>) -> Option<Self> {
-    let (width, height, premultiplied) = match source {
-      Cow::Owned(image) => {
-        let width = image.width();
-        let height = image.height();
-        let mut raw = image.into_raw();
-        if !has_opaque_alpha(&raw) {
-          premultiply_rgba_in_place(&mut raw);
-        }
-        (width, height, raw)
-      }
-      Cow::Borrowed(image) => {
-        let width = image.width();
-        let height = image.height();
-        let raw = image.as_raw();
-        if has_opaque_alpha(raw) {
-          (width, height, raw.to_vec())
-        } else {
-          let mut premultiplied = vec![0u8; raw.len()];
-          write_premultiplied_rgba(&mut premultiplied, raw);
-          (width, height, premultiplied)
-        }
-      }
-    };
-
-    Self::from_premultiplied_rgba(premultiplied, width, height)
+  /// Builds a premultiplied buffer from straight-alpha RGBA bytes (row-major, 4 bytes/pixel).
+  /// Returns `None` if `raw.len() != width * height * 4`.
+  pub fn from_rgba_bytes(mut raw: Vec<u8>, width: u32, height: u32) -> Option<Self> {
+    if !has_opaque_alpha(&raw) {
+      premultiply_rgba_in_place(&mut raw);
+    }
+    Self::from_premultiplied_rgba(raw, width, height)
   }
 
   /// The image width in pixels.
@@ -91,11 +69,6 @@ impl ImageBuffer {
   /// Mutable access to the premultiplied RGBA bytes.
   pub fn data_mut(&mut self) -> &mut [u8] {
     &mut self.data
-  }
-
-  /// Consumes the buffer, returning the premultiplied RGBA bytes.
-  pub(crate) fn into_data(self) -> Vec<u8> {
-    self.data
   }
 
   /// Encodes the image as straight-alpha PNG bytes, for embedding in an SVG
@@ -168,27 +141,6 @@ fn premultiply_rgba_in_place(raw: &mut [u8]) {
     pixel[0] = fast_div_255(pixel[0] as u32 * alpha_u32);
     pixel[1] = fast_div_255(pixel[1] as u32 * alpha_u32);
     pixel[2] = fast_div_255(pixel[2] as u32 * alpha_u32);
-  }
-}
-
-#[inline(always)]
-fn write_premultiplied_rgba(dst: &mut [u8], src: &[u8]) {
-  for (dst_px, src_px) in dst.chunks_exact_mut(4).zip(src.chunks_exact(4)) {
-    let alpha = src_px[3];
-    if alpha == u8::MAX {
-      dst_px.copy_from_slice(src_px);
-      continue;
-    }
-    if alpha == 0 {
-      dst_px.copy_from_slice(&[0, 0, 0, 0]);
-      continue;
-    }
-
-    let alpha_u32 = alpha as u32;
-    dst_px[0] = fast_div_255(src_px[0] as u32 * alpha_u32);
-    dst_px[1] = fast_div_255(src_px[1] as u32 * alpha_u32);
-    dst_px[2] = fast_div_255(src_px[2] as u32 * alpha_u32);
-    dst_px[3] = alpha;
   }
 }
 

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -1,5 +1,4 @@
 use std::{
-  borrow::Cow,
   io::{Cursor, Error as IoError, ErrorKind},
   sync::Arc,
 };
@@ -181,7 +180,8 @@ fn decode_webp(bytes: &[u8]) -> ImageResult<ImageBuffer> {
 }
 
 fn rgba_to_buffer(image: RgbaImage, format: ImageFormat) -> ImageResult<ImageBuffer> {
-  ImageBuffer::from_rgba(Cow::Owned(image)).ok_or_else(|| {
+  let (width, height) = (image.width(), image.height());
+  ImageBuffer::from_rgba_bytes(image.into_raw(), width, height).ok_or_else(|| {
     ImageError::Decoding(DecodingError::new(
       format.into(),
       IoError::new(

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -1991,10 +1991,11 @@ mod tests {
         Rgba([0, 0, 255, 255])
       }
     });
-    let source_pixmap = ImageBuffer::from_rgba(std::borrow::Cow::Borrowed(&source))
-      .as_ref()
-      .and_then(pixmap_from_buffer)
-      .expect("fixture pixmap conversion");
+    let source_pixmap =
+      ImageBuffer::from_rgba_bytes(source.as_raw().to_vec(), source.width(), source.height())
+        .as_ref()
+        .and_then(pixmap_from_buffer)
+        .expect("fixture pixmap conversion");
 
     let mut direct = Canvas::new(Size {
       width: 8,

--- a/takumi-raster/src/path.rs
+++ b/takumi-raster/src/path.rs
@@ -1,9 +1,10 @@
 use svgtypes::{SimplePathSegment, SimplifyingPathParser};
 use taffy::Size;
+use takumi_core::geometry::{PathCommand, Point};
 use tiny_skia::{
   FillRule as TinyFillRule, LineCap as TinyLineCap, LineJoin as TinyLineJoin, Path as TinyPath,
-  PathBuilder as TinyPathBuilder, PathSegment as TinyPathSegment, Point as TinyPoint,
-  Rect as TinyRect, Stroke as TinyStroke, StrokeDash as TinyStrokeDash,
+  PathBuilder as TinyPathBuilder, PathSegment as TinyPathSegment, Rect as TinyRect,
+  Stroke as TinyStroke, StrokeDash as TinyStrokeDash,
 };
 
 use crate::style::LineJoin;
@@ -203,7 +204,23 @@ impl Placement {
   }
 }
 
-pub(crate) type Command = TinyPathSegment;
+pub(crate) type Command = PathCommand;
+
+fn from_tiny(segment: TinyPathSegment) -> Command {
+  match segment {
+    TinyPathSegment::MoveTo(p) => Command::MoveTo(Point::new(p.x, p.y)),
+    TinyPathSegment::LineTo(p) => Command::LineTo(Point::new(p.x, p.y)),
+    TinyPathSegment::QuadTo(p1, p2) => {
+      Command::QuadTo(Point::new(p1.x, p1.y), Point::new(p2.x, p2.y))
+    }
+    TinyPathSegment::CubicTo(p1, p2, p3) => Command::CubicTo(
+      Point::new(p1.x, p1.y),
+      Point::new(p2.x, p2.y),
+      Point::new(p3.x, p3.y),
+    ),
+    TinyPathSegment::Close => Command::Close,
+  }
+}
 
 pub(crate) trait PathBuilder {
   fn move_to(&mut self, point: (f32, f32));
@@ -214,11 +231,11 @@ pub(crate) trait PathBuilder {
 
 impl PathBuilder for Vec<Command> {
   fn move_to(&mut self, point: (f32, f32)) {
-    self.push(Command::MoveTo(TinyPoint::from_xy(point.0, point.1)));
+    self.push(Command::MoveTo(Point::new(point.0, point.1)));
   }
 
   fn line_to(&mut self, point: (f32, f32)) {
-    self.push(Command::LineTo(TinyPoint::from_xy(point.0, point.1)));
+    self.push(Command::LineTo(Point::new(point.0, point.1)));
   }
 
   fn close(&mut self) {
@@ -238,7 +255,7 @@ impl PathBuilder for Vec<Command> {
     let mut builder = TinyPathBuilder::new();
     builder.push_oval(rect);
     if let Some(path) = builder.finish() {
-      self.extend(path.segments());
+      self.extend(path.segments().map(from_tiny));
     }
   }
 }
@@ -255,7 +272,7 @@ impl PathData for str {
 
 /// Scale a command list's coordinates uniformly (CSS px → device space).
 pub(crate) fn scale_commands(commands: Vec<Command>, scale: f32) -> Vec<Command> {
-  let point = |pt: TinyPoint| TinyPoint::from_xy(pt.x * scale, pt.y * scale);
+  let point = |pt: Point<f32>| Point::new(pt.x * scale, pt.y * scale);
 
   commands
     .into_iter()
@@ -293,10 +310,10 @@ fn parse_svg_path_segments(input: &str) -> Option<Vec<Command>> {
   for segment in SimplifyingPathParser::from(input) {
     match segment.ok()? {
       SimplePathSegment::MoveTo { x, y } => {
-        commands.push(Command::MoveTo(TinyPoint::from_xy(x as f32, y as f32)));
+        commands.push(Command::MoveTo(Point::new(x as f32, y as f32)));
       }
       SimplePathSegment::LineTo { x, y } => {
-        commands.push(Command::LineTo(TinyPoint::from_xy(x as f32, y as f32)));
+        commands.push(Command::LineTo(Point::new(x as f32, y as f32)));
       }
       SimplePathSegment::CurveTo {
         x1,
@@ -307,15 +324,15 @@ fn parse_svg_path_segments(input: &str) -> Option<Vec<Command>> {
         y,
       } => {
         commands.push(Command::CubicTo(
-          TinyPoint::from_xy(x1 as f32, y1 as f32),
-          TinyPoint::from_xy(x2 as f32, y2 as f32),
-          TinyPoint::from_xy(x as f32, y as f32),
+          Point::new(x1 as f32, y1 as f32),
+          Point::new(x2 as f32, y2 as f32),
+          Point::new(x as f32, y as f32),
         ));
       }
       SimplePathSegment::Quadratic { x1, y1, x, y } => {
         commands.push(Command::QuadTo(
-          TinyPoint::from_xy(x1 as f32, y1 as f32),
-          TinyPoint::from_xy(x as f32, y as f32),
+          Point::new(x1 as f32, y1 as f32),
+          Point::new(x as f32, y as f32),
         ));
       }
       SimplePathSegment::ClosePath => {

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -10,7 +10,7 @@ use crate::{
   PaintSource, Placement, Result, SamplingOptions, SizedFontStyle, Stroke,
   composite_mask_source_to_pixmap, draw_outset_shadow,
   layout::inline::InlineBrush,
-  render_mask,
+  pixmap_ref_from_buffer, render_mask,
   resources::font::{ResolvedColorLayer, ResolvedGlyph},
   style::{Affine, BlendMode, Color, ImageScalingAlgorithm},
 };
@@ -288,13 +288,16 @@ pub(crate) fn draw_glyph(
 
   match glyph {
     ResolvedGlyph::Bitmap(bitmap) => {
+      let Some(source) = pixmap_ref_from_buffer(&bitmap.image) else {
+        return Ok(());
+      };
       transform *= Affine::translation(bitmap.placement.left as f32, -bitmap.placement.top as f32);
       transform *= Affine::scale(bitmap.scale_x, bitmap.scale_y);
       canvas.overlay_sampled_pixmap(
-        bitmap.pixmap.as_ref(),
+        source,
         Size {
-          width: bitmap.pixmap.width(),
-          height: bitmap.pixmap.height(),
+          width: source.width(),
+          height: source.height(),
         },
         Default::default(),
         transform,

--- a/takumi-svg/src/box_model.rs
+++ b/takumi-svg/src/box_model.rs
@@ -7,8 +7,11 @@
 use std::fmt::Write as _;
 
 use taffy::Size;
-use takumi_core::{context::RenderContext, style::Affine};
-use tiny_skia::{PathSegment, Point};
+use takumi_core::{
+  context::RenderContext,
+  geometry::{PathCommand, Point},
+  style::Affine,
+};
 
 use crate::{APPROX_CHARS_PER_NUMBER, Num};
 
@@ -92,43 +95,43 @@ fn quantize_path(value: f32) -> f32 {
   (value * PATH_COORD_FACTOR).round() / PATH_COORD_FACTOR
 }
 
-/// Serializes takumi-core path commands ([`tiny_skia::PathSegment`], the shared
-/// `Command` type) to compact SVG path `d` data, applying `transform`
-/// (`[a, b, c, d, e, f]`, SVG `matrix` order) to every point. Shared by glyph,
-/// border, background, and clip emission.
+/// Serializes takumi-core path commands ([`PathCommand`], the shared `Command`
+/// type) to compact SVG path `d` data, applying `transform` (`[a, b, c, d, e,
+/// f]`, SVG `matrix` order) to every point. Shared by glyph, border, background,
+/// and clip emission.
 ///
 /// Coordinates are emitted relative to the previous point (the first move stays
 /// absolute), axis-aligned lines collapse to `h`/`v`, and smooth cubics/quadratics
 /// use the `s`/`t` shorthands. Each delta is quantized with its rounding error
 /// folded into the next, so multi-contour fills stay closed — the core of SVGO's
 /// `convertPathData`.
-pub(crate) fn path_data(commands: &[PathSegment], [a, b, c, d, e, f]: [f32; 6]) -> String {
+pub(crate) fn path_data(commands: &[PathCommand], [a, b, c, d, e, f]: [f32; 6]) -> String {
   let path =
     PathData::with_capacity(commands.len() * NUMBERS_PER_COMMAND * APPROX_CHARS_PER_NUMBER);
-  let map = |p: Point| (a * p.x + c * p.y + e, b * p.x + d * p.y + f);
+  let map = |p: Point<f32>| (a * p.x + c * p.y + e, b * p.x + d * p.y + f);
   let mut emit = RelEmit::new(path);
   for command in commands {
     match command {
-      PathSegment::MoveTo(p) => {
+      PathCommand::MoveTo(p) => {
         let (x, y) = map(*p);
         emit.move_to(x, y);
       }
-      PathSegment::LineTo(p) => {
+      PathCommand::LineTo(p) => {
         let (x, y) = map(*p);
         emit.line_to(x, y);
       }
-      PathSegment::QuadTo(c0, p) => {
+      PathCommand::QuadTo(c0, p) => {
         let (cx, cy) = map(*c0);
         let (x, y) = map(*p);
         emit.quad_to(cx, cy, x, y);
       }
-      PathSegment::CubicTo(c0, c1, p) => {
+      PathCommand::CubicTo(c0, c1, p) => {
         let (c1x, c1y) = map(*c0);
         let (c2x, c2y) = map(*c1);
         let (x, y) = map(*p);
         emit.cubic_to(c1x, c1y, c2x, c2y, x, y);
       }
-      PathSegment::Close => emit.close(),
+      PathCommand::Close => emit.close(),
     }
   }
   emit.finish()
@@ -371,8 +374,8 @@ mod tests {
     assert_eq!(path, "M0 0 1 1 2 2");
   }
 
-  fn pt(x: f32, y: f32) -> Point {
-    Point::from_xy(x, y)
+  fn pt(x: f32, y: f32) -> Point<f32> {
+    Point::new(x, y)
   }
 
   const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -380,10 +383,10 @@ mod tests {
   #[test]
   fn path_data_is_relative_with_hv_shorthands() {
     let commands = [
-      PathSegment::MoveTo(pt(10.0, 10.0)),
-      PathSegment::LineTo(pt(20.0, 10.0)),
-      PathSegment::LineTo(pt(20.0, 20.0)),
-      PathSegment::Close,
+      PathCommand::MoveTo(pt(10.0, 10.0)),
+      PathCommand::LineTo(pt(20.0, 10.0)),
+      PathCommand::LineTo(pt(20.0, 20.0)),
+      PathCommand::Close,
     ];
     assert_eq!(path_data(&commands, IDENTITY), "M10 10h10v10Z");
   }
@@ -393,9 +396,9 @@ mod tests {
     // The second cubic's first control is the reflection of the first cubic's
     // second control about the join, so it collapses to `s`.
     let commands = [
-      PathSegment::MoveTo(pt(0.0, 0.0)),
-      PathSegment::CubicTo(pt(0.0, 5.0), pt(5.0, 5.0), pt(5.0, 0.0)),
-      PathSegment::CubicTo(pt(5.0, -5.0), pt(10.0, -5.0), pt(10.0, 0.0)),
+      PathCommand::MoveTo(pt(0.0, 0.0)),
+      PathCommand::CubicTo(pt(0.0, 5.0), pt(5.0, 5.0), pt(5.0, 0.0)),
+      PathCommand::CubicTo(pt(5.0, -5.0), pt(10.0, -5.0), pt(10.0, 0.0)),
     ];
     assert_eq!(path_data(&commands, IDENTITY), "M0 0c0 5 5 5 5 0s5-5 5 0");
   }
@@ -403,8 +406,8 @@ mod tests {
   #[test]
   fn path_data_quantizes_to_two_decimals() {
     let commands = [
-      PathSegment::MoveTo(pt(0.0, 0.0)),
-      PathSegment::LineTo(pt(1.2345, 6.789)),
+      PathCommand::MoveTo(pt(0.0, 0.0)),
+      PathCommand::LineTo(pt(1.2345, 6.789)),
     ];
     assert_eq!(path_data(&commands, IDENTITY), "M0 0l1.23 6.79");
   }

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -497,11 +497,11 @@ fn emit_run_glyphs(
         if color_override.is_some() || clip_data.is_some() {
           continue;
         }
-        let Ok(png) = bitmap.pixmap.encode_png() else {
+        let Some(png) = bitmap.image.encode_png() else {
           continue;
         };
         flush_glyph_run(doc, &mut merged, fill, stroke)?;
-        let (width, height) = (bitmap.pixmap.width(), bitmap.pixmap.height());
+        let (width, height) = (bitmap.image.width(), bitmap.image.height());
         let bitmap_matrix = placed
           * Affine::translation(bitmap.placement.left as f32, -(bitmap.placement.top as f32))
           * Affine::scale(bitmap.scale_x, bitmap.scale_y);


### PR DESCRIPTION
## Why

`takumi-core`'s glyph outline paths carried `tiny_skia::PathSegment`/`Point` directly, `ResolvedBitmapGlyph` held a `tiny_skia::Pixmap`, and `ImageBuffer::from_rgba` took an `image::RgbaImage`. A consumer of `takumi-core` alone would need to depend on `tiny_skia` and `image` just to name these types, even though the crate's own job is layout and style, not painting.

## What

- New `geometry::Point<T>` and `geometry::PathCommand` replace `tiny_skia::PathSegment`/`Point` in the glyph outline payload (`resources::font`, `layout::inline`) and in `layout::border::BorderProperties`'s path-building methods.
- `ResolvedBitmapGlyph::pixmap` (`tiny_skia::Pixmap`) is now `image: ImageBuffer`, the existing core image type.
- `ImageBuffer::from_rgba(Cow<RgbaImage>)` is now `from_rgba_bytes(Vec<u8>, width, height)`.
- The raster and svg backends updated to consume the new core types; raster's own `path::Command` now aliases `takumi_core::geometry::PathCommand` instead of `tiny_skia::PathSegment`.
- Render-neutral: goldens are byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated path handling to use the app’s built-in geometry types across rendering and SVG output.
  * Bitmap glyphs and images now use a more direct image buffer format, improving consistency in text and image rendering.

* **Bug Fixes**
  * Fixed several rendering paths to work correctly with the new geometry and image formats.
  * Adjusted bitmap glyph drawing so embedded images use the correct dimensions and data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->