### PR TITLE
Core: replace parley::GlyphRun with a core-owned ShapedRun at the paint boundary

### DIFF
--- a/.tegami/shaped-run-paint-boundary.md
+++ b/.tegami/shaped-run-paint-boundary.md
@@ -1,0 +1,11 @@
+---
+packages:
+  cargo:takumi-core:
+    type: minor
+---
+
+### Replace `parley::GlyphRun` with a core-owned `ShapedRun` at the paint boundary
+
+`PositionedInlineRun::glyph_run` is now `ShapedRun` (owned glyphs, brush, metrics,
+font data) instead of `parley::GlyphRun<'l, InlineBrush>`; `PositionedInlineRun`
+and `InlineRunLayout` drop their lifetime. `run_decorations` takes `&ShapedRun`.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1857,12 +1857,96 @@ pub fn scale_text_fit_x(
     + (x - origin_x) * scale
 }
 
+/// A shaped glyph positioned within its run, in run-local coordinates.
+#[derive(Clone, Copy, Debug)]
+pub struct PositionedGlyph {
+  /// Glyph id in the run's font.
+  pub id: u32,
+  /// Run-local horizontal position.
+  pub x: f32,
+  /// Run-local vertical position.
+  pub y: f32,
+}
+
+/// Vertical font metrics for a shaped run, in px.
+#[derive(Clone, Copy, Debug)]
+pub struct RunMetrics {
+  /// Typographic ascent.
+  pub ascent: f32,
+  /// Typographic descent.
+  pub descent: f32,
+  /// Underline offset from the baseline.
+  pub underline_offset: f32,
+  /// Underline stroke thickness.
+  pub underline_size: f32,
+  /// Strikethrough offset from the baseline.
+  pub strikethrough_offset: f32,
+  /// Strikethrough stroke thickness.
+  pub strikethrough_size: f32,
+}
+
+/// A shaped, positioned glyph run — the core-owned replacement for
+/// `parley::GlyphRun`. Owns everything both backends need to paint a run; carries
+/// no borrow into the parley layout.
+pub struct ShapedRun {
+  glyphs: Vec<PositionedGlyph>,
+  offset: f32,
+  baseline: f32,
+  advance: f32,
+  brush: InlineBrush,
+  metrics: RunMetrics,
+  font_data: parley::fontique::Blob<u8>,
+  font_index: u32,
+}
+
+impl ShapedRun {
+  /// The run's glyphs, in run-local coordinates.
+  pub fn positioned_glyphs(&self) -> &[PositionedGlyph] {
+    &self.glyphs
+  }
+
+  /// Horizontal offset of the run's start from the line origin.
+  pub fn offset(&self) -> f32 {
+    self.offset
+  }
+
+  /// Baseline position within the line.
+  pub fn baseline(&self) -> f32 {
+    self.baseline
+  }
+
+  /// Total horizontal advance of the run.
+  pub fn advance(&self) -> f32 {
+    self.advance
+  }
+
+  /// Paint attributes carried by the run.
+  pub fn brush(&self) -> &InlineBrush {
+    &self.brush
+  }
+
+  /// Vertical font metrics for the run.
+  pub fn metrics(&self) -> &RunMetrics {
+    &self.metrics
+  }
+
+  /// Font bytes for `skrifa::FontRef::from_index`, paired with [`Self::font_index`].
+  pub fn font_data(&self) -> &[u8] {
+    self.font_data.as_ref()
+  }
+
+  /// Collection index for `skrifa::FontRef::from_index`.
+  pub fn font_index(&self) -> u32 {
+    self.font_index
+  }
+}
+
 /// One glyph run positioned on its line, carrying everything both backends need
-/// to paint it. Borrows the parley layout owned by the source [`BuiltInlineLayout`].
+/// to paint it.
 #[non_exhaustive]
-pub struct PositionedInlineRun<'l> {
-  /// The parley glyph run (metrics, brush, positioned glyphs, font).
-  pub glyph_run: GlyphRun<'l, InlineBrush>,
+pub struct PositionedInlineRun {
+  /// The shaped glyph run (metrics, brush, positioned glyphs, font).
+  pub glyph_run: ShapedRun,
   /// Glyphs resolved to outlines/bitmaps, keyed by glyph id.
   pub resolved_glyphs: HashMap<u32, ResolvedGlyph>,
   /// Text-fit scale state for the line.
@@ -1873,7 +1957,7 @@ pub struct PositionedInlineRun<'l> {
   pub baseline_shift: f32,
 }
 
-impl PositionedInlineRun<'_> {
+impl PositionedInlineRun {
   /// The run's affine transform composed onto `base` (the element transform for
   /// raster, identity for vector emission).
   pub fn transform(&self, base: Affine) -> Affine {
@@ -1899,8 +1983,7 @@ impl PositionedInlineRun<'_> {
     let Some(layers) = outline.color_layers() else {
       return Vec::new();
     };
-    let run = self.glyph_run.run();
-    let font = FontRef::from_index(run.font().data.as_ref(), run.font().index).ok();
+    let font = FontRef::from_index(self.glyph_run.font_data(), self.glyph_run.font_index()).ok();
     let palettes = font.as_ref().map(MetadataProvider::color_palettes);
     let palette = palettes.as_ref().and_then(|palettes| palettes.get(0));
     let foreground_opacity = foreground.0[3] as f32 / 255.0;
@@ -1934,9 +2017,9 @@ impl PositionedInlineRun<'_> {
 /// [`resolve_inline_runs`]; the raster backend rasterizes it and the vector
 /// backend emits it; only the painting differs.
 #[non_exhaustive]
-pub struct InlineRunLayout<'l> {
+pub struct InlineRunLayout {
   /// Glyph runs in line/visual order.
-  pub runs: Vec<PositionedInlineRun<'l>>,
+  pub runs: Vec<PositionedInlineRun>,
   /// In-flow and out-of-flow inline boxes, positioned, sorted by id.
   pub inline_boxes: Vec<VisualInlineBox>,
   /// Text-outline rects (unmerged), in collection order.
@@ -1946,11 +2029,11 @@ pub struct InlineRunLayout<'l> {
 /// Walks `built` once, resolving every glyph run, inline box, and outline rect
 /// into backend-agnostic positioned drawables. This is the one inline-layout
 /// enumeration; backends differ only in how they paint the result.
-pub fn resolve_inline_runs<'l>(
-  built: &'l BuiltInlineLayout<'_>,
+pub fn resolve_inline_runs(
+  built: &BuiltInlineLayout<'_>,
   context: &RenderContext,
   layout: Layout,
-) -> Result<InlineRunLayout<'l>, FontError> {
+) -> Result<InlineRunLayout, FontError> {
   let BuiltInlineLayout {
     layout: inline_layout,
     spans,
@@ -2010,8 +2093,34 @@ pub fn resolve_inline_runs<'l>(
             outline_rects.push(outline_rect);
           }
 
+          let metrics = run.metrics();
+          let shaped = ShapedRun {
+            glyphs: glyph_run
+              .positioned_glyphs()
+              .map(|g| PositionedGlyph {
+                id: g.id,
+                x: g.x,
+                y: g.y,
+              })
+              .collect(),
+            offset: glyph_run.offset(),
+            baseline: glyph_run.baseline(),
+            advance: glyph_run.advance(),
+            brush: glyph_run.style().brush,
+            metrics: RunMetrics {
+              ascent: metrics.ascent,
+              descent: metrics.descent,
+              underline_offset: metrics.underline_offset,
+              underline_size: metrics.underline_size,
+              strikethrough_offset: metrics.strikethrough_offset,
+              strikethrough_size: metrics.strikethrough_size,
+            },
+            font_data: run.font().data.clone(),
+            font_index: run.font().index,
+          };
+
           runs.push(PositionedInlineRun {
-            glyph_run,
+            glyph_run: shaped,
             resolved_glyphs,
             line_scale: setup.state,
             static_inline_prefix,
@@ -2081,18 +2190,18 @@ pub struct DecorationRect {
 /// omitted here). `transform` is the run's border-box transform
 /// ([`PositionedInlineRun::transform`] with an identity base).
 pub fn run_decorations(
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   layout: Layout,
   baseline_shift: f32,
   transform: Affine,
 ) -> Vec<DecorationRect> {
   let mut out = Vec::new();
-  let brush = &glyph_run.style().brush;
+  let brush = glyph_run.brush();
   let lines = brush.decoration_line;
   if lines.is_empty() {
     return out;
   }
-  let metrics = glyph_run.run().metrics();
+  let metrics = glyph_run.metrics();
   let start_x = layout.border.left + layout.padding.left + glyph_run.offset();
   let snapped_start_x = start_x.floor();
   let width = (start_x + glyph_run.advance()).ceil() - snapped_start_x;

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1889,55 +1889,28 @@ pub struct RunMetrics {
 /// `parley::GlyphRun`. Owns everything both backends need to paint a run; carries
 /// no borrow into the parley layout.
 pub struct ShapedRun {
-  glyphs: Vec<PositionedGlyph>,
-  offset: f32,
-  baseline: f32,
-  advance: f32,
-  brush: InlineBrush,
-  metrics: RunMetrics,
+  /// The run's glyphs, in run-local coordinates.
+  pub glyphs: Vec<PositionedGlyph>,
+  /// Horizontal offset of the run's start from the line origin.
+  pub offset: f32,
+  /// Baseline position within the line.
+  pub baseline: f32,
+  /// Total horizontal advance of the run.
+  pub advance: f32,
+  /// Paint attributes carried by the run.
+  pub brush: InlineBrush,
+  /// Vertical font metrics for the run.
+  pub metrics: RunMetrics,
+  /// Collection index for `skrifa::FontRef::from_index`, paired with [`Self::font_data`].
+  pub font_index: u32,
+  // Accessor, not a `pub` field: the backing `parley` blob must not leak into the public API.
   font_data: parley::fontique::Blob<u8>,
-  font_index: u32,
 }
 
 impl ShapedRun {
-  /// The run's glyphs, in run-local coordinates.
-  pub fn positioned_glyphs(&self) -> &[PositionedGlyph] {
-    &self.glyphs
-  }
-
-  /// Horizontal offset of the run's start from the line origin.
-  pub fn offset(&self) -> f32 {
-    self.offset
-  }
-
-  /// Baseline position within the line.
-  pub fn baseline(&self) -> f32 {
-    self.baseline
-  }
-
-  /// Total horizontal advance of the run.
-  pub fn advance(&self) -> f32 {
-    self.advance
-  }
-
-  /// Paint attributes carried by the run.
-  pub fn brush(&self) -> &InlineBrush {
-    &self.brush
-  }
-
-  /// Vertical font metrics for the run.
-  pub fn metrics(&self) -> &RunMetrics {
-    &self.metrics
-  }
-
   /// Font bytes for `skrifa::FontRef::from_index`, paired with [`Self::font_index`].
   pub fn font_data(&self) -> &[u8] {
     self.font_data.as_ref()
-  }
-
-  /// Collection index for `skrifa::FontRef::from_index`.
-  pub fn font_index(&self) -> u32 {
-    self.font_index
   }
 }
 
@@ -1983,7 +1956,7 @@ impl PositionedInlineRun {
     let Some(layers) = outline.color_layers() else {
       return Vec::new();
     };
-    let font = FontRef::from_index(self.glyph_run.font_data(), self.glyph_run.font_index()).ok();
+    let font = FontRef::from_index(self.glyph_run.font_data(), self.glyph_run.font_index).ok();
     let palettes = font.as_ref().map(MetadataProvider::color_palettes);
     let palette = palettes.as_ref().and_then(|palettes| palettes.get(0));
     let foreground_opacity = foreground.0[3] as f32 / 255.0;
@@ -2196,19 +2169,19 @@ pub fn run_decorations(
   transform: Affine,
 ) -> Vec<DecorationRect> {
   let mut out = Vec::new();
-  let brush = glyph_run.brush();
+  let brush = &glyph_run.brush;
   let lines = brush.decoration_line;
   if lines.is_empty() {
     return out;
   }
-  let metrics = glyph_run.metrics();
-  let start_x = layout.border.left + layout.padding.left + glyph_run.offset();
+  let metrics = &glyph_run.metrics;
+  let start_x = layout.border.left + layout.padding.left + glyph_run.offset;
   let snapped_start_x = start_x.floor();
-  let width = (start_x + glyph_run.advance()).ceil() - snapped_start_x;
+  let width = (start_x + glyph_run.advance).ceil() - snapped_start_x;
   if width <= 0.0 {
     return out;
   }
-  let baseline = glyph_run.baseline() + baseline_shift;
+  let baseline = glyph_run.baseline + baseline_shift;
   let top = layout.border.top + layout.padding.top;
   let thickness = |from_font: f32| match brush.decoration_thickness {
     SizedTextDecorationThickness::Value(value) => value,

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -157,14 +157,14 @@ fn draw_underline_with_skip_ink(
   glyph_bounds_cache: &HashMap<u32, GlyphSkipInkData>,
   options: UnderlineDrawOptions,
 ) {
-  let run_start_x = options.layout.border.left + options.layout.padding.left + glyph_run.offset();
-  let run_end_x = run_start_x + glyph_run.advance();
+  let run_start_x = options.layout.border.left + options.layout.padding.left + glyph_run.offset;
+  let run_end_x = run_start_x + glyph_run.advance;
   let line_top = options.layout.border.top + options.layout.padding.top + options.offset;
   let line_bottom = line_top + options.size;
   let skip_padding = compute_skip_padding(options.size);
   let mut skip_ranges = Vec::new();
 
-  for glyph in glyph_run.positioned_glyphs() {
+  for glyph in &glyph_run.glyphs {
     let Some(glyph_data) = glyph_bounds_cache.get(&glyph.id) else {
       continue;
     };
@@ -301,14 +301,14 @@ fn draw_glyph_run_under_overline(
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
 ) -> Result<()> {
-  let brush = glyph_run.brush();
-  let metrics = glyph_run.metrics();
+  let brush = glyph_run.brush;
+  let metrics = glyph_run.metrics;
 
   if brush
     .decoration_line
     .contains(TextDecorationLines::UNDERLINE)
   {
-    let offset = glyph_run.baseline() + options.baseline_shift - metrics.underline_offset
+    let offset = glyph_run.baseline + options.baseline_shift - metrics.underline_offset
       + brush.underline_offset;
     let size = match brush.decoration_thickness {
       SizedTextDecorationThickness::Value(v) => v,
@@ -352,8 +352,8 @@ fn draw_glyph_run_under_overline(
     draw_decoration(
       canvas,
       glyph_run,
-      glyph_run.brush().decoration_color,
-      glyph_run.baseline() + options.baseline_shift - metrics.ascent - metrics.underline_offset,
+      glyph_run.brush.decoration_color,
+      glyph_run.baseline + options.baseline_shift - metrics.ascent - metrics.underline_offset,
       match brush.decoration_thickness {
         SizedTextDecorationThickness::Value(v) => v,
         SizedTextDecorationThickness::FromFont => metrics.underline_size,
@@ -371,24 +371,24 @@ fn draw_glyph_run_line_through(
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
 ) -> Result<()> {
-  let brush = glyph_run.brush();
+  let brush = glyph_run.brush;
   let decoration_line = brush.decoration_line;
 
   if !decoration_line.contains(TextDecorationLines::LINE_THROUGH) {
     return Ok(());
   }
 
-  let metrics = glyph_run.metrics();
+  let metrics = glyph_run.metrics;
   let size = match brush.decoration_thickness {
     SizedTextDecorationThickness::Value(v) => v,
     SizedTextDecorationThickness::FromFont => metrics.strikethrough_size,
   };
-  let offset = glyph_run.baseline() + options.baseline_shift - metrics.strikethrough_offset;
+  let offset = glyph_run.baseline + options.baseline_shift - metrics.strikethrough_offset;
 
   draw_decoration(
     canvas,
     glyph_run,
-    glyph_run.brush().decoration_color,
+    glyph_run.brush.decoration_color,
     offset,
     size,
     options.layout,
@@ -489,13 +489,13 @@ fn draw_glyph_run_content(
   canvas: &mut Canvas,
   options: GlyphRunContentOptions<'_>,
 ) -> Result<()> {
-  let font = FontRef::from_index(glyph_run.font_data(), glyph_run.font_index())
+  let font = FontRef::from_index(glyph_run.font_data(), glyph_run.font_index)
     .map_err(|_| FontError::InvalidFontIndex)?;
   let palettes = font.color_palettes();
   let palette = palettes.get(0);
 
   if let Some(clip_image) = options.clip_image {
-    for glyph in glyph_run.positioned_glyphs() {
+    for glyph in &glyph_run.glyphs {
       let Some(content) = resolved_glyphs.get(&glyph.id) else {
         continue;
       };
@@ -516,7 +516,7 @@ fn draw_glyph_run_content(
     }
   }
 
-  for glyph in glyph_run.positioned_glyphs() {
+  for glyph in &glyph_run.glyphs {
     let Some(content) = resolved_glyphs.get(&glyph.id) else {
       continue;
     };
@@ -532,7 +532,7 @@ fn draw_glyph_run_content(
       options.style,
       options.transform,
       inline_offset,
-      glyph_run.brush().color,
+      glyph_run.brush.color,
       palette.as_ref(),
     )?;
   }
@@ -547,7 +547,7 @@ fn draw_glyph_run_text_shadow(
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
 ) -> Result<()> {
-  for glyph in glyph_run.positioned_glyphs() {
+  for glyph in &glyph_run.glyphs {
     let Some(content) = resolved_glyphs.get(&glyph.id) else {
       continue;
     };
@@ -640,7 +640,7 @@ pub(crate) fn draw_inline_layout(
   } = resolve_inline_runs(built, context, layout)?;
 
   let decoration_mask = runs.iter().fold(TextDecorationLines::empty(), |acc, run| {
-    acc | run.glyph_run.brush().decoration_line
+    acc | run.glyph_run.brush.decoration_line
   });
   let need_text_shadow = !font_style.text_shadow.is_empty();
   let need_under_overline =
@@ -673,7 +673,7 @@ pub(crate) fn draw_inline_layout(
   if need_text_shadow {
     for run in &runs {
       let opts = line_options(run);
-      draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
+      draw_with_inline_opacity(canvas, run.glyph_run.brush.opacity, |canvas| {
         draw_glyph_run_text_shadow(
           font_style,
           &run.glyph_run,
@@ -688,7 +688,7 @@ pub(crate) fn draw_inline_layout(
   if need_under_overline {
     for run in &runs {
       let opts = line_options(run);
-      draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
+      draw_with_inline_opacity(canvas, run.glyph_run.brush.opacity, |canvas| {
         draw_glyph_run_under_overline(&run.glyph_run, &run.resolved_glyphs, canvas, opts)
       })?;
     }
@@ -696,7 +696,7 @@ pub(crate) fn draw_inline_layout(
 
   for run in &runs {
     let transform = run.transform(context.transform);
-    draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
+    draw_with_inline_opacity(canvas, run.glyph_run.brush.opacity, |canvas| {
       draw_glyph_run_content(
         &run.glyph_run,
         &run.resolved_glyphs,
@@ -718,7 +718,7 @@ pub(crate) fn draw_inline_layout(
   if need_line_through {
     for run in &runs {
       let opts = line_options(run);
-      draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
+      draw_with_inline_opacity(canvas, run.glyph_run.brush.opacity, |canvas| {
         draw_glyph_run_line_through(&run.glyph_run, canvas, opts)
       })?;
     }

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use parley::GlyphRun;
 use skrifa::{FontRef, MetadataProvider};
 use taffy::{AvailableSpace, Layout, Point, geometry::Size};
 
@@ -12,9 +11,9 @@ use crate::{
   draw_outset_box_shadow,
   layout::{
     inline::{
-      BuiltInlineLayout, InlineBoxItem, InlineBrush, InlineOutlineRect, InlineRunLayout,
-      PositionedInlineRun, ProcessedInlineSpan, VisualInlineBox, outline_island_contour,
-      outline_islands, resolve_inline_runs,
+      BuiltInlineLayout, InlineBoxItem, InlineOutlineRect, InlineRunLayout, PositionedInlineRun,
+      ProcessedInlineSpan, ShapedRun, VisualInlineBox, outline_island_contour, outline_islands,
+      resolve_inline_runs,
     },
     tree::LayoutTree,
   },
@@ -154,7 +153,7 @@ fn compute_skip_padding(size: f32) -> f32 {
 
 fn draw_underline_with_skip_ink(
   canvas: &mut Canvas,
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   glyph_bounds_cache: &HashMap<u32, GlyphSkipInkData>,
   options: UnderlineDrawOptions,
 ) {
@@ -297,15 +296,13 @@ fn draw_underline_with_skip_ink(
 }
 
 fn draw_glyph_run_under_overline(
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   resolved_glyphs: &HashMap<u32, ResolvedGlyph>,
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
 ) -> Result<()> {
-  let brush = &glyph_run.style().brush;
-
-  let run = glyph_run.run();
-  let metrics = run.metrics();
+  let brush = glyph_run.brush();
+  let metrics = glyph_run.metrics();
 
   if brush
     .decoration_line
@@ -355,7 +352,7 @@ fn draw_glyph_run_under_overline(
     draw_decoration(
       canvas,
       glyph_run,
-      glyph_run.style().brush.decoration_color,
+      glyph_run.brush().decoration_color,
       glyph_run.baseline() + options.baseline_shift - metrics.ascent - metrics.underline_offset,
       match brush.decoration_thickness {
         SizedTextDecorationThickness::Value(v) => v,
@@ -370,18 +367,18 @@ fn draw_glyph_run_under_overline(
 }
 
 fn draw_glyph_run_line_through(
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
 ) -> Result<()> {
-  let brush = &glyph_run.style().brush;
+  let brush = glyph_run.brush();
   let decoration_line = brush.decoration_line;
 
   if !decoration_line.contains(TextDecorationLines::LINE_THROUGH) {
     return Ok(());
   }
 
-  let metrics = glyph_run.run().metrics();
+  let metrics = glyph_run.metrics();
   let size = match brush.decoration_thickness {
     SizedTextDecorationThickness::Value(v) => v,
     SizedTextDecorationThickness::FromFont => metrics.strikethrough_size,
@@ -391,7 +388,7 @@ fn draw_glyph_run_line_through(
   draw_decoration(
     canvas,
     glyph_run,
-    glyph_run.style().brush.decoration_color,
+    glyph_run.brush().decoration_color,
     offset,
     size,
     options.layout,
@@ -487,14 +484,12 @@ fn draw_merged_outline_rects(
 }
 
 fn draw_glyph_run_content(
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   resolved_glyphs: &HashMap<u32, ResolvedGlyph>,
   canvas: &mut Canvas,
   options: GlyphRunContentOptions<'_>,
 ) -> Result<()> {
-  let run = glyph_run.run();
-
-  let font = FontRef::from_index(run.font().data.as_ref(), run.font().index)
+  let font = FontRef::from_index(glyph_run.font_data(), glyph_run.font_index())
     .map_err(|_| FontError::InvalidFontIndex)?;
   let palettes = font.color_palettes();
   let palette = palettes.get(0);
@@ -537,7 +532,7 @@ fn draw_glyph_run_content(
       options.style,
       options.transform,
       inline_offset,
-      glyph_run.style().brush.color,
+      glyph_run.brush().color,
       palette.as_ref(),
     )?;
   }
@@ -547,7 +542,7 @@ fn draw_glyph_run_content(
 
 fn draw_glyph_run_text_shadow(
   style: &SizedFontStyle,
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   resolved_glyphs: &HashMap<u32, ResolvedGlyph>,
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
@@ -645,7 +640,7 @@ pub(crate) fn draw_inline_layout(
   } = resolve_inline_runs(built, context, layout)?;
 
   let decoration_mask = runs.iter().fold(TextDecorationLines::empty(), |acc, run| {
-    acc | run.glyph_run.style().brush.decoration_line
+    acc | run.glyph_run.brush().decoration_line
   });
   let need_text_shadow = !font_style.text_shadow.is_empty();
   let need_under_overline =
@@ -668,7 +663,7 @@ pub(crate) fn draw_inline_layout(
   };
   let clip_image_source = clip_image.as_ref().map(PaintSource::from);
 
-  let line_options = |run: &PositionedInlineRun<'_>| GlyphRunLineOptions {
+  let line_options = |run: &PositionedInlineRun| GlyphRunLineOptions {
     layout,
     baseline_shift: run.baseline_shift,
     transform: run.transform(context.transform),
@@ -678,7 +673,7 @@ pub(crate) fn draw_inline_layout(
   if need_text_shadow {
     for run in &runs {
       let opts = line_options(run);
-      draw_with_inline_opacity(canvas, run.glyph_run.style().brush.opacity, |canvas| {
+      draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
         draw_glyph_run_text_shadow(
           font_style,
           &run.glyph_run,
@@ -693,7 +688,7 @@ pub(crate) fn draw_inline_layout(
   if need_under_overline {
     for run in &runs {
       let opts = line_options(run);
-      draw_with_inline_opacity(canvas, run.glyph_run.style().brush.opacity, |canvas| {
+      draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
         draw_glyph_run_under_overline(&run.glyph_run, &run.resolved_glyphs, canvas, opts)
       })?;
     }
@@ -701,7 +696,7 @@ pub(crate) fn draw_inline_layout(
 
   for run in &runs {
     let transform = run.transform(context.transform);
-    draw_with_inline_opacity(canvas, run.glyph_run.style().brush.opacity, |canvas| {
+    draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
       draw_glyph_run_content(
         &run.glyph_run,
         &run.resolved_glyphs,
@@ -723,7 +718,7 @@ pub(crate) fn draw_inline_layout(
   if need_line_through {
     for run in &runs {
       let opts = line_options(run);
-      draw_with_inline_opacity(canvas, run.glyph_run.style().brush.opacity, |canvas| {
+      draw_with_inline_opacity(canvas, run.glyph_run.brush().opacity, |canvas| {
         draw_glyph_run_line_through(&run.glyph_run, canvas, opts)
       })?;
     }

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -92,8 +92,8 @@ pub(crate) fn draw_decoration(
   layout: Layout,
   transform: Affine,
 ) {
-  let start_x = layout.border.left + layout.padding.left + glyph_run.offset();
-  let end_x = start_x + glyph_run.advance();
+  let start_x = layout.border.left + layout.padding.left + glyph_run.offset;
+  let end_x = start_x + glyph_run.advance;
   draw_decoration_segment(
     canvas,
     color,

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -1,6 +1,5 @@
 use std::{cell::RefCell, collections::HashMap, convert::Into};
 
-use parley::GlyphRun;
 use skrifa::color::ColorPalette;
 use taffy::{Layout, Point, Size};
 use tiny_skia::Pixmap;
@@ -9,7 +8,7 @@ use crate::{
   BorderProperties, Canvas, ColorTile, Command, MaskSamplingOptions, MaskSourceToPixmapOptions,
   PaintSource, Placement, Result, SamplingOptions, SizedFontStyle, Stroke,
   composite_mask_source_to_pixmap, draw_outset_shadow,
-  layout::inline::InlineBrush,
+  layout::inline::ShapedRun,
   pixmap_ref_from_buffer, render_mask,
   resources::font::{ResolvedColorLayer, ResolvedGlyph},
   style::{Affine, BlendMode, Color, ImageScalingAlgorithm},
@@ -86,7 +85,7 @@ pub(crate) struct DecorationSegmentParams {
 
 pub(crate) fn draw_decoration(
   canvas: &mut Canvas,
-  glyph_run: &GlyphRun<'_, InlineBrush>,
+  glyph_run: &ShapedRun,
   color: Color,
   offset: f32,
   size: f32,

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -361,7 +361,7 @@ fn emit_clip_text_mask_glyphs(
   let run_transform = run.transform(IDENTITY);
   let glyph_offset = run.glyph_offset(frame.layout);
   let mut any = false;
-  for glyph in run.glyph_run.positioned_glyphs() {
+  for glyph in &run.glyph_run.glyphs {
     let Some(ResolvedGlyph::Outline(outline)) = run.resolved_glyphs.get(&glyph.id) else {
       continue;
     };
@@ -394,7 +394,7 @@ fn emit_run_decorations(
   over: bool,
 ) -> io::Result<()> {
   let transform = run.transform(IDENTITY);
-  let opacity = run.glyph_run.brush().opacity;
+  let opacity = run.glyph_run.brush.opacity;
   let opacity_group = (opacity < 1.0)
     .then(|| doc.begin_group(IDENTITY, opacity, None, None))
     .transpose()?;
@@ -424,12 +424,12 @@ fn emit_run_glyphs(
 ) -> io::Result<()> {
   let run_transform = run.transform(IDENTITY);
   let glyph_offset = run.glyph_offset(frame.layout);
-  let fill_color = run.glyph_run.brush().color;
+  let fill_color = run.glyph_run.brush.color;
   let bold_join = line_join_str(font_style.parent.stroke_linejoin);
 
   // Per-run (inline span) opacity, matching the raster backend's
   // `draw_with_inline_opacity`. Skipped while building a clip path (geometry only).
-  let opacity = run.glyph_run.brush().opacity;
+  let opacity = run.glyph_run.brush.opacity;
   let opacity_group = (clip_data.is_none() && opacity < 1.0)
     .then(|| doc.begin_group(IDENTITY, opacity, None, None))
     .transpose()?;
@@ -441,7 +441,7 @@ fn emit_run_glyphs(
   let fill = color_override.unwrap_or(Rgba(fill_color.0));
   let mut merged = String::new();
 
-  for glyph in run.glyph_run.positioned_glyphs() {
+  for glyph in &run.glyph_run.glyphs {
     let Some(resolved) = run.resolved_glyphs.get(&glyph.id) else {
       continue;
     };

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -157,7 +157,7 @@ pub(crate) fn emit_inline_content(
 /// decorations, glyphs, then line-through.
 fn emit_runs(
   doc: &mut SvgDocument,
-  runs: &InlineRunLayout<'_>,
+  runs: &InlineRunLayout,
   spans: &[ProcessedInlineSpan<'_>],
   font_style: &SizedFontStyle,
   context: &RenderContext,
@@ -215,7 +215,7 @@ fn emit_runs(
 /// styled span, mirroring the raster backend's merged-island outlines.
 fn emit_inline_outlines(
   doc: &mut SvgDocument,
-  runs: &InlineRunLayout<'_>,
+  runs: &InlineRunLayout,
   spans: &[ProcessedInlineSpan<'_>],
   origin_x: f32,
   origin_y: f32,
@@ -301,7 +301,7 @@ fn emit_outline_island(
 /// fill+stroke coverage.
 fn emit_clip_text_glyphs(
   doc: &mut SvgDocument,
-  runs: &InlineRunLayout<'_>,
+  runs: &InlineRunLayout,
   font_style: &SizedFontStyle,
   context: &RenderContext,
   frame: TextFrame,
@@ -352,7 +352,7 @@ fn emit_clip_text_glyphs(
 /// glyph coverage. Returns whether any glyph was emitted.
 fn emit_clip_text_mask_glyphs(
   doc: &mut SvgDocument,
-  run: &PositionedInlineRun<'_>,
+  run: &PositionedInlineRun,
   frame: TextFrame,
   color: Rgba,
   stroke_width: f32,
@@ -389,12 +389,12 @@ fn emit_clip_text_mask_glyphs(
 /// decoration rects.
 fn emit_run_decorations(
   doc: &mut SvgDocument,
-  run: &PositionedInlineRun<'_>,
+  run: &PositionedInlineRun,
   frame: TextFrame,
   over: bool,
 ) -> io::Result<()> {
   let transform = run.transform(IDENTITY);
-  let opacity = run.glyph_run.style().brush.opacity;
+  let opacity = run.glyph_run.brush().opacity;
   let opacity_group = (opacity < 1.0)
     .then(|| doc.begin_group(IDENTITY, opacity, None, None))
     .transpose()?;
@@ -415,7 +415,7 @@ fn emit_run_decorations(
 /// `background-clip: text` `<clipPath>`) instead of being painted.
 fn emit_run_glyphs(
   doc: &mut SvgDocument,
-  run: &PositionedInlineRun<'_>,
+  run: &PositionedInlineRun,
   font_style: &SizedFontStyle,
   frame: TextFrame,
   color_override: Option<Rgba>,
@@ -424,12 +424,12 @@ fn emit_run_glyphs(
 ) -> io::Result<()> {
   let run_transform = run.transform(IDENTITY);
   let glyph_offset = run.glyph_offset(frame.layout);
-  let fill_color = run.glyph_run.style().brush.color;
+  let fill_color = run.glyph_run.brush().color;
   let bold_join = line_join_str(font_style.parent.stroke_linejoin);
 
   // Per-run (inline span) opacity, matching the raster backend's
   // `draw_with_inline_opacity`. Skipped while building a clip path (geometry only).
-  let opacity = run.glyph_run.style().brush.opacity;
+  let opacity = run.glyph_run.brush().opacity;
   let opacity_group = (clip_data.is_none() && opacity < 1.0)
     .then(|| doc.begin_group(IDENTITY, opacity, None, None))
     .transpose()?;


### PR DESCRIPTION
## Why

`PositionedInlineRun.glyph_run` was `parley::GlyphRun<'l, InlineBrush>`, a foreign
type in the public painting API that both backends paint through, and the reason
`InlineRunLayout`/`PositionedInlineRun` carried a lifetime tied to the source
layout.

## What

- New core-owned `ShapedRun` (+ `PositionedGlyph`, `RunMetrics`) replaces the
  `glyph_run` field, materialised once in `resolve_inline_runs`.
- `PositionedInlineRun` and `InlineRunLayout` drop their `'l` lifetime.
- `run_decorations` and both backends (raster `inline_drawing.rs`/`text_drawing.rs`,
  svg `text.rs`) now paint through `ShapedRun`'s owned accessors
  (`.brush()`/`.metrics()`/`.positioned_glyphs()`/`.font_data()`/`.font_index()`).
- Render-neutral: `cargo test -p takumi` goldens are byte-identical, no
  `.webp`/`.svg` diff.

Deferred: the raster `measure()` path in `takumi-raster/src/render.rs` still
walks `parley::Layout` directly with its own local `glyph_run`; sealing that is a
separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the inline text pipeline to use self-contained, owned glyph-run data rather than borrowed layout runs.
  * Aligned raster and SVG text rendering to consume the new run representation and updated decoration/styling access patterns.

* **Bug Fixes**
  * Improved consistency of underline/overline/line-through, text-shadow, and glyph fill/opacity across raster and SVG outputs.
  * Ensured glyph coverage/masking iterates the correct glyph set while preserving existing painting order and clipping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->