### PR TITLE
Core: seal `taffy` geometry types out of the public API

### DIFF
--- a/.tegami/seal-taffy-geometry-types.md
+++ b/.tegami/seal-taffy-geometry-types.md
@@ -1,0 +1,14 @@
+---
+packages:
+  cargo:takumi-core:
+    type: minor
+---
+
+### Seal `taffy` geometry types out of the public API
+
+`layout::border::BorderProperties`, `shadow::SizedShadow`, `layout::inline::InlineBoxItem`,
+and the other geometry-touching public items now use core-owned
+`geometry::{Size, Rect, Point}` instead of `taffy::{Size, Rect, Point}`.
+`layout::tree::LayoutResults::layout` returns an owned `geometry::ComputedLayout`
+instead of `&taffy::Layout`. `taffy` remains the layout engine at the
+`compute_layout` input seam (`AvailableSpace`, `NodeId`, `Style` are unaffected).

--- a/.tegami/seal-taffy-geometry-types.md
+++ b/.tegami/seal-taffy-geometry-types.md
@@ -10,5 +10,9 @@ packages:
 and the other geometry-touching public items now use core-owned
 `geometry::{Size, Rect, Point}` instead of `taffy::{Size, Rect, Point}`.
 `layout::tree::LayoutResults::layout` returns an owned `geometry::ComputedLayout`
-instead of `&taffy::Layout`. `taffy` remains the layout engine at the
-`compute_layout` input seam (`AvailableSpace`, `NodeId`, `Style` are unaffected).
+instead of `&taffy::Layout`. `LayoutTree::compute_layout` and the paint scene
+(`build_stacking_contexts`, `NodePaint`, `layout::tree::OrderedChild`) now use
+core-owned `geometry::{AvailableSpace, NodeId}` instead of `taffy::{AvailableSpace,
+NodeId}`; `NodeId::ROOT` replaces the removed `root_node_id()` accessors. `taffy`
+remains the layout engine at the `compute_layout` internals and `Style`
+construction.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,6 @@ dependencies = [
  "skrifa",
  "smallvec",
  "svgtypes",
- "taffy",
  "takumi-core",
  "tiny-skia",
  "typed-builder",
@@ -1695,7 +1694,6 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "quick-xml",
- "taffy",
  "takumi-core",
  "tiny-skia",
  "typed-builder",

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -8,10 +8,10 @@ use parley::{
   TextStyle, fontique::QueryFamily,
 };
 use smallvec::SmallVec;
-use taffy::{Size, prelude::FromLength};
 
 use crate::{
   context::RenderContext,
+  geometry::Size,
   layout::inline::InlineBrush,
   shadow::SizedShadow,
   style::{
@@ -190,7 +190,7 @@ fn resolved_text_shadows(
             *shadow,
             &context.sizing,
             context.current_color,
-            Size::from_length(context.sizing.font_size),
+            Size::new(context.sizing.font_size, context.sizing.font_size),
           )
         })
         .collect()

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -161,26 +161,24 @@ impl Rect<f32> {
   };
 }
 
-impl<T> From<taffy::geometry::Size<T>> for Size<T> {
-  fn from(s: taffy::geometry::Size<T>) -> Self {
+impl<T> Size<T> {
+  pub(crate) fn from_taffy(s: taffy::geometry::Size<T>) -> Self {
     Self {
       width: s.width,
       height: s.height,
     }
   }
-}
 
-impl<T> From<Size<T>> for taffy::geometry::Size<T> {
-  fn from(s: Size<T>) -> Self {
-    Self {
-      width: s.width,
-      height: s.height,
+  pub(crate) fn into_taffy(self) -> taffy::geometry::Size<T> {
+    taffy::geometry::Size {
+      width: self.width,
+      height: self.height,
     }
   }
 }
 
-impl<T> From<taffy::geometry::Rect<T>> for Rect<T> {
-  fn from(r: taffy::geometry::Rect<T>) -> Self {
+impl<T> Rect<T> {
+  pub(crate) fn from_taffy(r: taffy::geometry::Rect<T>) -> Self {
     Self {
       left: r.left,
       right: r.right,
@@ -190,25 +188,8 @@ impl<T> From<taffy::geometry::Rect<T>> for Rect<T> {
   }
 }
 
-impl<T> From<Rect<T>> for taffy::geometry::Rect<T> {
-  fn from(r: Rect<T>) -> Self {
-    Self {
-      left: r.left,
-      right: r.right,
-      top: r.top,
-      bottom: r.bottom,
-    }
-  }
-}
-
-impl<T> From<taffy::geometry::Point<T>> for Point<T> {
-  fn from(p: taffy::geometry::Point<T>) -> Self {
-    Self { x: p.x, y: p.y }
-  }
-}
-
-impl<T> From<Point<T>> for taffy::geometry::Point<T> {
-  fn from(p: Point<T>) -> Self {
+impl<T> Point<T> {
+  pub(crate) fn from_taffy(p: taffy::geometry::Point<T>) -> Self {
     Self { x: p.x, y: p.y }
   }
 }
@@ -256,13 +237,13 @@ impl ComputedLayout {
   }
 }
 
-impl From<&taffy::Layout> for ComputedLayout {
-  fn from(l: &taffy::Layout) -> Self {
+impl ComputedLayout {
+  pub(crate) fn from_taffy(l: &taffy::Layout) -> Self {
     Self {
-      location: l.location.into(),
-      size: l.size.into(),
-      border: l.border.into(),
-      padding: l.padding.into(),
+      location: Point::from_taffy(l.location),
+      size: Size::from_taffy(l.size),
+      border: Rect::from_taffy(l.border),
+      padding: Rect::from_taffy(l.padding),
     }
   }
 }

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -1,6 +1,6 @@
 //! Transform geometry helpers shared across backends.
 
-use taffy::{Point as TaffyPoint, geometry::Size};
+use std::ops::{Add, Sub};
 
 use crate::style::Affine;
 
@@ -17,6 +17,244 @@ impl<T> Point<T> {
   /// Creates a point from its coordinates.
   pub const fn new(x: T, y: T) -> Self {
     Self { x, y }
+  }
+
+  /// Maps both coordinates through `f`.
+  pub fn map<R>(self, f: impl Fn(T) -> R) -> Point<R> {
+    Point {
+      x: f(self.x),
+      y: f(self.y),
+    }
+  }
+}
+
+impl Point<f32> {
+  /// The origin.
+  pub const ZERO: Self = Self { x: 0.0, y: 0.0 };
+}
+
+impl<U, T: Add<U>> Add<Point<U>> for Point<T> {
+  type Output = Point<<T as Add<U>>::Output>;
+
+  fn add(self, rhs: Point<U>) -> Self::Output {
+    Point {
+      x: self.x + rhs.x,
+      y: self.y + rhs.y,
+    }
+  }
+}
+
+/// A 2D size.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Size<T> {
+  /// Width.
+  pub width: T,
+  /// Height.
+  pub height: T,
+}
+
+impl<T> Size<T> {
+  /// Creates a size from its dimensions.
+  pub const fn new(width: T, height: T) -> Self {
+    Self { width, height }
+  }
+
+  /// Maps both dimensions through `f`.
+  pub fn map<R>(self, f: impl Fn(T) -> R) -> Size<R> {
+    Size {
+      width: f(self.width),
+      height: f(self.height),
+    }
+  }
+
+  /// Combines this size with `other` dimension-wise through `f`.
+  pub fn zip_map<O, R>(self, other: Size<O>, f: impl Fn(T, O) -> R) -> Size<R> {
+    Size {
+      width: f(self.width, other.width),
+      height: f(self.height, other.height),
+    }
+  }
+}
+
+impl Size<f32> {
+  /// A zero size.
+  pub const ZERO: Self = Self {
+    width: 0.0,
+    height: 0.0,
+  };
+}
+
+impl<U, T: Add<U>> Add<Size<U>> for Size<T> {
+  type Output = Size<<T as Add<U>>::Output>;
+
+  fn add(self, rhs: Size<U>) -> Self::Output {
+    Size {
+      width: self.width + rhs.width,
+      height: self.height + rhs.height,
+    }
+  }
+}
+
+impl<U, T: Sub<U>> Sub<Size<U>> for Size<T> {
+  type Output = Size<<T as Sub<U>>::Output>;
+
+  fn sub(self, rhs: Size<U>) -> Self::Output {
+    Size {
+      width: self.width - rhs.width,
+      height: self.height - rhs.height,
+    }
+  }
+}
+
+impl Size<Option<f32>> {
+  /// A size with both dimensions unset.
+  pub const NONE: Self = Self {
+    width: None,
+    height: None,
+  };
+}
+
+/// A 2D rect defined by its four edges.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Rect<T> {
+  /// Left edge.
+  pub left: T,
+  /// Right edge.
+  pub right: T,
+  /// Top edge.
+  pub top: T,
+  /// Bottom edge.
+  pub bottom: T,
+}
+
+impl<T> Rect<T> {
+  /// Maps all four edges through `f`.
+  pub fn map<R>(self, f: impl Fn(T) -> R) -> Rect<R> {
+    Rect {
+      left: f(self.left),
+      right: f(self.right),
+      top: f(self.top),
+      bottom: f(self.bottom),
+    }
+  }
+}
+
+impl<T: Add<Output = T> + Copy> Rect<T> {
+  /// Sum of the left and right edges.
+  pub fn horizontal(self) -> T {
+    self.left + self.right
+  }
+
+  /// Sum of the top and bottom edges.
+  pub fn vertical(self) -> T {
+    self.top + self.bottom
+  }
+}
+
+impl Rect<f32> {
+  /// A zero rect.
+  pub const ZERO: Self = Self {
+    left: 0.0,
+    right: 0.0,
+    top: 0.0,
+    bottom: 0.0,
+  };
+}
+
+impl<T> From<taffy::geometry::Size<T>> for Size<T> {
+  fn from(s: taffy::geometry::Size<T>) -> Self {
+    Self {
+      width: s.width,
+      height: s.height,
+    }
+  }
+}
+
+impl<T> From<Size<T>> for taffy::geometry::Size<T> {
+  fn from(s: Size<T>) -> Self {
+    Self {
+      width: s.width,
+      height: s.height,
+    }
+  }
+}
+
+impl<T> From<taffy::geometry::Rect<T>> for Rect<T> {
+  fn from(r: taffy::geometry::Rect<T>) -> Self {
+    Self {
+      left: r.left,
+      right: r.right,
+      top: r.top,
+      bottom: r.bottom,
+    }
+  }
+}
+
+impl<T> From<Rect<T>> for taffy::geometry::Rect<T> {
+  fn from(r: Rect<T>) -> Self {
+    Self {
+      left: r.left,
+      right: r.right,
+      top: r.top,
+      bottom: r.bottom,
+    }
+  }
+}
+
+impl<T> From<taffy::geometry::Point<T>> for Point<T> {
+  fn from(p: taffy::geometry::Point<T>) -> Self {
+    Self { x: p.x, y: p.y }
+  }
+}
+
+impl<T> From<Point<T>> for taffy::geometry::Point<T> {
+  fn from(p: Point<T>) -> Self {
+    Self { x: p.x, y: p.y }
+  }
+}
+
+/// The computed box geometry of a laid-out node — the core-owned replacement for
+/// `taffy::Layout` at the public boundary. Carries only what backends read.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct ComputedLayout {
+  /// Top-left corner relative to the parent's content box.
+  pub location: Point<f32>,
+  /// Border-box width and height.
+  pub size: Size<f32>,
+  /// Border widths per side.
+  pub border: Rect<f32>,
+  /// Padding widths per side.
+  pub padding: Rect<f32>,
+}
+
+impl ComputedLayout {
+  /// Content-box width: border-box width minus padding and border on both sides.
+  pub fn content_box_width(&self) -> f32 {
+    self.size.width - self.padding.left - self.padding.right - self.border.left - self.border.right
+  }
+
+  /// Content-box height: border-box height minus padding and border on both sides.
+  pub fn content_box_height(&self) -> f32 {
+    self.size.height - self.padding.top - self.padding.bottom - self.border.top - self.border.bottom
+  }
+
+  /// Content-box size.
+  pub fn content_box_size(&self) -> Size<f32> {
+    Size {
+      width: self.content_box_width(),
+      height: self.content_box_height(),
+    }
+  }
+}
+
+impl From<&taffy::Layout> for ComputedLayout {
+  fn from(l: &taffy::Layout) -> Self {
+    Self {
+      location: l.location.into(),
+      size: l.size.into(),
+      border: l.border.into(),
+      padding: l.padding.into(),
+    }
   }
 }
 
@@ -39,7 +277,7 @@ pub enum PathCommand {
 /// Transforms a rect's four corners and returns the axis-aligned `(min_x, min_y,
 /// max_x, max_y)` extents, or `None` if any corner is non-finite.
 pub fn transformed_rect_extents(
-  origin: TaffyPoint<f32>,
+  origin: Point<f32>,
   size: Size<f32>,
   transform: Affine,
 ) -> Option<(f32, f32, f32, f32)> {

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -245,6 +245,15 @@ impl ComputedLayout {
       height: self.content_box_height(),
     }
   }
+
+  /// Offset of the content-box top-left from the border-box top-left, i.e. the
+  /// left/top border plus padding.
+  pub fn content_box_offset(&self) -> Point<f32> {
+    Point::new(
+      self.border.left + self.padding.left,
+      self.border.top + self.padding.top,
+    )
+  }
 }
 
 impl From<&taffy::Layout> for ComputedLayout {

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -264,6 +264,78 @@ impl ComputedLayout {
   }
 }
 
+/// Opaque identifier for a node within a computed layout tree. Obtained from
+/// [`crate::layout::tree::LayoutResults::box_children`] and passed back in to
+/// look up a node's layout, children, or paint scene.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeId(usize);
+
+impl NodeId {
+  /// The root of any layout tree; construction always assigns it index 0.
+  pub const ROOT: Self = Self::new(0);
+
+  const fn new(index: usize) -> Self {
+    Self(index)
+  }
+
+  pub(crate) fn from_taffy(id: taffy::NodeId) -> Self {
+    Self(id.into())
+  }
+
+  pub(crate) fn into_taffy(self) -> taffy::NodeId {
+    taffy::NodeId::from(self.0)
+  }
+}
+
+impl From<NodeId> for usize {
+  fn from(id: NodeId) -> Self {
+    id.0
+  }
+}
+
+impl From<NodeId> for u64 {
+  fn from(id: NodeId) -> Self {
+    id.0 as u64
+  }
+}
+
+/// How much space is available along one axis during layout.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AvailableSpace {
+  /// A definite amount of space, in pixels.
+  Definite(f32),
+  /// Indefinite space; the node should size to its minimum content.
+  MinContent,
+  /// Indefinite space; the node should size to its maximum content.
+  MaxContent,
+}
+
+impl AvailableSpace {
+  /// The definite amount of space, or `None` for indefinite space.
+  pub fn into_option(self) -> Option<f32> {
+    match self {
+      Self::Definite(space) => Some(space),
+      _ => None,
+    }
+  }
+
+  pub(crate) fn from_taffy(space: taffy::AvailableSpace) -> Self {
+    match space {
+      taffy::AvailableSpace::Definite(value) => Self::Definite(value),
+      taffy::AvailableSpace::MinContent => Self::MinContent,
+      taffy::AvailableSpace::MaxContent => Self::MaxContent,
+    }
+  }
+
+  pub(crate) fn into_taffy(self) -> taffy::AvailableSpace {
+    match self {
+      Self::Definite(value) => taffy::AvailableSpace::Definite(value),
+      Self::MinContent => taffy::AvailableSpace::MinContent,
+      Self::MaxContent => taffy::AvailableSpace::MaxContent,
+    }
+  }
+}
+
 /// One command of a resolved outline path, in device space. Mirrors the classic
 /// move/line/quad/cubic/close vocabulary; coordinates are y-down.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -112,6 +112,22 @@ impl Size<Option<f32>> {
     width: None,
     height: None,
   };
+
+  /// When exactly one axis is set, fills the other from `aspect_ratio` (width /
+  /// height). Mirrors `taffy::geometry::Size::maybe_apply_aspect_ratio`.
+  pub(crate) fn fill_missing_axis_from_aspect_ratio(self, aspect_ratio: Option<f32>) -> Self {
+    match (aspect_ratio, self.width, self.height) {
+      (Some(ratio), Some(width), None) => Self {
+        width: Some(width),
+        height: Some(width / ratio),
+      },
+      (Some(ratio), None, Some(height)) => Self {
+        width: Some(height * ratio),
+        height: Some(height),
+      },
+      _ => self,
+    }
+  }
 }
 
 /// A 2D rect defined by its four edges.
@@ -294,4 +310,55 @@ pub fn transformed_rect_extents(
   }
 
   Some((min_x, min_y, max_x, max_y))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::Size;
+
+  #[test]
+  fn aspect_ratio_fills_height_from_width() {
+    let filled = Size {
+      width: Some(10.0),
+      height: None,
+    }
+    .fill_missing_axis_from_aspect_ratio(Some(2.0));
+    assert_eq!(filled.width, Some(10.0));
+    assert_eq!(filled.height, Some(5.0));
+  }
+
+  #[test]
+  fn aspect_ratio_fills_width_from_height() {
+    let filled = Size {
+      width: None,
+      height: Some(10.0),
+    }
+    .fill_missing_axis_from_aspect_ratio(Some(2.0));
+    assert_eq!(filled.width, Some(20.0));
+    assert_eq!(filled.height, Some(10.0));
+  }
+
+  #[test]
+  fn aspect_ratio_leaves_both_known_and_both_unknown_untouched() {
+    let both = Size {
+      width: Some(3.0),
+      height: Some(4.0),
+    };
+    assert_eq!(both.fill_missing_axis_from_aspect_ratio(Some(2.0)), both);
+
+    let neither = Size::<Option<f32>>::NONE;
+    assert_eq!(
+      neither.fill_missing_axis_from_aspect_ratio(Some(2.0)),
+      neither
+    );
+  }
+
+  #[test]
+  fn no_aspect_ratio_is_a_noop() {
+    let one_axis = Size {
+      width: Some(10.0),
+      height: None,
+    };
+    assert_eq!(one_axis.fill_missing_axis_from_aspect_ratio(None), one_axis);
+  }
 }

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -1,10 +1,8 @@
 use std::f32::consts::{PI, SQRT_2};
 
-use taffy::{Point, Rect, Size};
-
 use crate::{
   context::RenderContext,
-  geometry::{PathCommand as Command, Point as PathPoint},
+  geometry::{PathCommand as Command, Point, Rect, Size},
   style::{BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},
 };
 
@@ -30,18 +28,18 @@ pub(crate) trait BorderPath {
 
 impl BorderPath for Vec<Command> {
   fn move_to(&mut self, point: (f32, f32)) {
-    self.push(Command::MoveTo(PathPoint::new(point.0, point.1)));
+    self.push(Command::MoveTo(Point::new(point.0, point.1)));
   }
 
   fn line_to(&mut self, point: (f32, f32)) {
-    self.push(Command::LineTo(PathPoint::new(point.0, point.1)));
+    self.push(Command::LineTo(Point::new(point.0, point.1)));
   }
 
   fn curve_to(&mut self, p1: (f32, f32), p2: (f32, f32), p3: (f32, f32)) {
     self.push(Command::CubicTo(
-      PathPoint::new(p1.0, p1.1),
-      PathPoint::new(p2.0, p2.1),
-      PathPoint::new(p3.0, p3.1),
+      Point::new(p1.0, p1.1),
+      Point::new(p2.0, p2.1),
+      Point::new(p3.0, p3.1),
     ));
   }
 

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1222,7 +1222,7 @@ fn build_inline_layout_tree<'c>(
         let atomic_metrics = render_node
           .node
           .as_ref()
-          .map(|_| render_node.measure_inline_box(available_space.into()));
+          .map(|_| render_node.measure_inline_box(available_space));
         let content_size = atomic_metrics.map_or(Size::ZERO, |metrics| metrics.size);
         let raw_baseline_offset = atomic_metrics.and_then(|metrics| metrics.baseline_offset);
 

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -5,12 +5,12 @@ use parley::{
   PositionedInlineBox, PositionedLayoutItem, TextStyle, TreeBuilder, YieldData,
 };
 use skrifa::{FontRef, MetadataProvider};
-use taffy::{AvailableSpace, Layout, Point, Rect, Size};
+use taffy::{AvailableSpace, Layout};
 
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::PathCommand,
+  geometry::{ComputedLayout, PathCommand, Point, Rect, Size},
   layout::{border::BorderPath, node::Node, tree::RenderNode},
   resources::font::{FontError, ResolvedColorLayer, ResolvedGlyph, ResolvedOutlineGlyph},
   style::{
@@ -110,15 +110,21 @@ pub struct InlineBoxItem<'c> {
 impl From<&InlineBoxItem<'_>> for Layout {
   fn from(value: &InlineBoxItem<'_>) -> Self {
     Layout {
-      size: Size {
+      size: taffy::Size {
         width: value.paint_width,
         height: value.paint_height,
       },
-      margin: value.margin,
-      padding: value.padding,
-      border: value.border,
+      margin: value.margin.into(),
+      padding: value.padding.into(),
+      border: value.border.into(),
       ..Default::default()
     }
+  }
+}
+
+impl From<&InlineBoxItem<'_>> for ComputedLayout {
+  fn from(value: &InlineBoxItem<'_>) -> Self {
+    ComputedLayout::from(&Layout::from(value))
   }
 }
 
@@ -1216,25 +1222,19 @@ fn build_inline_layout_tree<'c>(
         let atomic_metrics = render_node
           .node
           .as_ref()
-          .map(|_| render_node.measure_inline_box(available_space));
-        let content_size = atomic_metrics.map_or(Size::zero(), |metrics| metrics.size);
+          .map(|_| render_node.measure_inline_box(available_space.into()));
+        let content_size = atomic_metrics.map_or(Size::ZERO, |metrics| metrics.size);
         let raw_baseline_offset = atomic_metrics.and_then(|metrics| metrics.baseline_offset);
 
         let paint_width = if render_node.participates_as_inline_box() {
-          content_size.width + margin.grid_axis_sum(taffy::AbsoluteAxis::Horizontal)
+          content_size.width + margin.horizontal()
         } else {
-          content_size.width
-            + margin.grid_axis_sum(taffy::AbsoluteAxis::Horizontal)
-            + padding.grid_axis_sum(taffy::AbsoluteAxis::Horizontal)
-            + border.grid_axis_sum(taffy::AbsoluteAxis::Horizontal)
+          content_size.width + margin.horizontal() + padding.horizontal() + border.horizontal()
         };
         let paint_height = if render_node.participates_as_inline_box() {
-          content_size.height + margin.grid_axis_sum(taffy::AbsoluteAxis::Vertical)
+          content_size.height + margin.vertical()
         } else {
-          content_size.height
-            + margin.grid_axis_sum(taffy::AbsoluteAxis::Vertical)
-            + padding.grid_axis_sum(taffy::AbsoluteAxis::Vertical)
-            + border.grid_axis_sum(taffy::AbsoluteAxis::Vertical)
+          content_size.height + margin.vertical() + padding.vertical() + border.vertical()
         };
         let inline_box = InlineBox {
           index: index_pos,
@@ -1600,7 +1600,7 @@ impl LineSetup {
   /// Returns `None` when `line_index` is out of range for `line_vertical_metrics`.
   pub(crate) fn new(
     line: &Line<'_, InlineBrush>,
-    layout: Layout,
+    layout: ComputedLayout,
     line_vertical_metrics: &[ResolvedLineMetrics],
     line_scales: &[f32],
     line_index: usize,
@@ -1669,7 +1669,7 @@ fn scale_outline_rect(
 
 fn collect_glyph_run_outline_rect(
   glyph_run: &GlyphRun<'_, InlineBrush>,
-  layout: Layout,
+  layout: ComputedLayout,
   line_index: usize,
   line_top: f32,
   line_height: f32,
@@ -1938,7 +1938,7 @@ impl PositionedInlineRun {
   }
 
   /// Per-glyph inline-offset origin (border/padding box top-left + baseline shift).
-  pub fn glyph_offset(&self, layout: Layout) -> Point<f32> {
+  pub fn glyph_offset(&self, layout: ComputedLayout) -> Point<f32> {
     Point {
       x: layout.border.left + layout.padding.left,
       y: layout.border.top + layout.padding.top + self.baseline_shift,
@@ -2005,7 +2005,7 @@ pub struct InlineRunLayout {
 pub fn resolve_inline_runs(
   built: &BuiltInlineLayout<'_>,
   context: &RenderContext,
-  layout: Layout,
+  layout: ComputedLayout,
 ) -> Result<InlineRunLayout, FontError> {
   let BuiltInlineLayout {
     layout: inline_layout,
@@ -2164,7 +2164,7 @@ pub struct DecorationRect {
 /// ([`PositionedInlineRun::transform`] with an identity base).
 pub fn run_decorations(
   glyph_run: &ShapedRun,
-  layout: Layout,
+  layout: ComputedLayout,
   baseline_shift: f32,
   transform: Affine,
 ) -> Vec<DecorationRect> {

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -5,7 +5,7 @@ use parley::{
   PositionedInlineBox, PositionedLayoutItem, TextStyle, TreeBuilder, YieldData,
 };
 use skrifa::{FontRef, MetadataProvider};
-use taffy::{AvailableSpace, Layout};
+use taffy::AvailableSpace;
 
 use crate::{
   context::RenderContext,
@@ -107,24 +107,14 @@ pub struct InlineBoxItem<'c> {
   pub(crate) vertical_align: ResolvedVerticalAlign,
 }
 
-impl From<&InlineBoxItem<'_>> for Layout {
-  fn from(value: &InlineBoxItem<'_>) -> Self {
-    Layout {
-      size: taffy::Size {
-        width: value.paint_width,
-        height: value.paint_height,
-      },
-      margin: value.margin.into(),
-      padding: value.padding.into(),
-      border: value.border.into(),
-      ..Default::default()
-    }
-  }
-}
-
 impl From<&InlineBoxItem<'_>> for ComputedLayout {
   fn from(value: &InlineBoxItem<'_>) -> Self {
-    ComputedLayout::from(&Layout::from(value))
+    ComputedLayout {
+      location: Point::ZERO,
+      size: Size::new(value.paint_width, value.paint_height),
+      border: value.border,
+      padding: value.padding,
+    }
   }
 }
 

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1939,9 +1939,10 @@ impl PositionedInlineRun {
 
   /// Per-glyph inline-offset origin (border/padding box top-left + baseline shift).
   pub fn glyph_offset(&self, layout: ComputedLayout) -> Point<f32> {
+    let offset = layout.content_box_offset();
     Point {
-      x: layout.border.left + layout.padding.left,
-      y: layout.border.top + layout.padding.top + self.baseline_shift,
+      x: offset.x,
+      y: offset.y + self.baseline_shift,
     }
   }
 

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -5,12 +5,11 @@ use parley::{
   PositionedInlineBox, PositionedLayoutItem, TextStyle, TreeBuilder, YieldData,
 };
 use skrifa::{FontRef, MetadataProvider};
-use taffy::AvailableSpace;
 
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{ComputedLayout, PathCommand, Point, Rect, Size},
+  geometry::{AvailableSpace, ComputedLayout, PathCommand, Point, Rect, Size},
   layout::{border::BorderPath, node::Node, tree::RenderNode},
   resources::font::{FontError, ResolvedColorLayer, ResolvedGlyph, ResolvedOutlineGlyph},
   style::{

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -1,9 +1,10 @@
 use data_url::DataUrl;
 use parley::Language;
-use taffy::{AvailableSpace, CompactLength, MaybeResolve, Size};
+use taffy::{AvailableSpace, CompactLength, MaybeResolve};
 
 use crate::{
   context::RenderContext,
+  geometry::Size,
   layout::node::{ImageData, ImageSourceInput, Node, NodeStyleLayers},
   resources::image::{ImageError, ImageResult, ImageSource, is_svg_like},
   style::{Length, Style, StyleDeclaration},
@@ -55,7 +56,7 @@ pub(crate) fn measure_image_node(
   style: &taffy::Style,
 ) -> Size<f32> {
   let Ok(image_source) = image.src.resolve(context) else {
-    return Size::zero();
+    return Size::ZERO;
   };
 
   let intrinsic_size = match &image_source {
@@ -134,7 +135,22 @@ pub(crate) fn measure_image_node(
   let aspect_ratio = style.aspect_ratio.or_else(|| {
     (preferred_size.height != 0.0).then_some(preferred_size.width / preferred_size.height)
   });
-  let known_dimensions = known_dimensions.maybe_apply_aspect_ratio(aspect_ratio);
+  // Mirrors `taffy::geometry::Size::maybe_apply_aspect_ratio`: fills in the
+  // missing axis from the known one when only one dimension is set.
+  let known_dimensions = match aspect_ratio {
+    Some(ratio) => match (known_dimensions.width, known_dimensions.height) {
+      (Some(width), None) => Size {
+        width: Some(width),
+        height: Some(width / ratio),
+      },
+      (None, Some(height)) => Size {
+        width: Some(height * ratio),
+        height: Some(height),
+      },
+      _ => known_dimensions,
+    },
+    None => known_dimensions,
+  };
 
   if let Size {
     width: Some(width),
@@ -199,12 +215,13 @@ mod tests {
 
   use image::RgbaImage;
   use serde_json::from_value;
-  use taffy::{AvailableSpace, Dimension, Size, Style};
+  use taffy::{AvailableSpace, Dimension, Size as TaffySize, Style};
 
   use super::{image_url, measure_image_node};
   use crate::{
     Fonts,
     context::RenderContext,
+    geometry::Size,
     layout::node::{ImageData, ImageSourceInput},
     resources::{image::ImageSource, image_buffer::ImageBuffer},
     style::SizingContext,
@@ -322,7 +339,7 @@ mod tests {
     let buffer = ImageBuffer::from_rgba_bytes(RgbaImage::new(10, 10).into_raw(), 10, 10).unwrap();
     let image = ImageData::from(ImageSource::from(buffer));
     let style = Style {
-      size: Size {
+      size: TaffySize {
         width: Dimension::length(42.0),
         height: Dimension::length(28.0),
       },

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -1,10 +1,10 @@
 use data_url::DataUrl;
 use parley::Language;
-use taffy::{AvailableSpace, CompactLength, MaybeResolve};
+use taffy::{CompactLength, MaybeResolve};
 
 use crate::{
   context::RenderContext,
-  geometry::Size,
+  geometry::{AvailableSpace, Size},
   layout::node::{ImageData, ImageSourceInput, Node, NodeStyleLayers},
   resources::image::{ImageError, ImageResult, ImageSource, is_svg_like},
   style::{Length, Style, StyleDeclaration},
@@ -200,13 +200,13 @@ mod tests {
 
   use image::RgbaImage;
   use serde_json::from_value;
-  use taffy::{AvailableSpace, Dimension, Size as TaffySize, Style};
+  use taffy::{Dimension, Size as TaffySize, Style};
 
   use super::{image_url, measure_image_node};
   use crate::{
     Fonts,
     context::RenderContext,
-    geometry::Size,
+    geometry::{AvailableSpace, Size},
     layout::node::{ImageData, ImageSourceInput},
     resources::{image::ImageSource, image_buffer::ImageBuffer},
     style::SizingContext,

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -135,22 +135,7 @@ pub(crate) fn measure_image_node(
   let aspect_ratio = style.aspect_ratio.or_else(|| {
     (preferred_size.height != 0.0).then_some(preferred_size.width / preferred_size.height)
   });
-  // Mirrors `taffy::geometry::Size::maybe_apply_aspect_ratio`: fills in the
-  // missing axis from the known one when only one dimension is set.
-  let known_dimensions = match aspect_ratio {
-    Some(ratio) => match (known_dimensions.width, known_dimensions.height) {
-      (Some(width), None) => Size {
-        width: Some(width),
-        height: Some(width / ratio),
-      },
-      (None, Some(height)) => Size {
-        width: Some(height * ratio),
-        height: Some(height),
-      },
-      _ => known_dimensions,
-    },
-    None => known_dimensions,
-  };
+  let known_dimensions = known_dimensions.fill_missing_axis_from_aspect_ratio(aspect_ratio);
 
   if let Size {
     width: Some(width),

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -6,7 +6,6 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use parley::Language;
 use serde::Deserialize;
-use taffy::AvailableSpace;
 
 pub use self::image::resolve_image;
 use self::{
@@ -19,7 +18,7 @@ use self::{
 use crate::{
   Xxh3HashSet,
   context::RenderContext,
-  geometry::Size,
+  geometry::{AvailableSpace, Size},
   layout::{inline::InlineContentKind, node::image::image_url},
   matching::MatchableNode,
   resources::{

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use parley::Language;
 use serde::Deserialize;
-use taffy::{AvailableSpace, Size};
+use taffy::AvailableSpace;
 
 pub use self::image::resolve_image;
 use self::{
@@ -19,6 +19,7 @@ use self::{
 use crate::{
   Xxh3HashSet,
   context::RenderContext,
+  geometry::Size,
   layout::{inline::InlineContentKind, node::image::image_url},
   matching::MatchableNode,
   resources::{

--- a/takumi-core/src/layout/node/text.rs
+++ b/takumi-core/src/layout/node/text.rs
@@ -1,8 +1,9 @@
-use taffy::{AvailableSpace, Size};
+use taffy::AvailableSpace;
 
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
+  geometry::Size,
   layout::{
     inline::{
       InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,
@@ -24,12 +25,12 @@ pub(crate) fn measure_text_node(
   };
 
   let (max_width, max_height) =
-    create_inline_constraint(context, available_space.into(), known_dimensions.into());
+    create_inline_constraint(context, available_space, known_dimensions);
   let font_style = SizedFontStyle::from_style(&context.style, context);
 
   let mut built = create_inline_layout(InlineLayoutRequest {
     items: vec![inline_content],
-    available_space: available_space.into(),
+    available_space,
     max_width,
     max_height,
     style: &font_style,
@@ -50,5 +51,4 @@ pub(crate) fn measure_text_node(
       parent_font_metrics,
     },
   )
-  .into()
 }

--- a/takumi-core/src/layout/node/text.rs
+++ b/takumi-core/src/layout/node/text.rs
@@ -1,9 +1,7 @@
-use taffy::AvailableSpace;
-
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::Size,
+  geometry::{AvailableSpace, Size},
   layout::{
     inline::{
       InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,

--- a/takumi-core/src/layout/node/text.rs
+++ b/takumi-core/src/layout/node/text.rs
@@ -24,12 +24,12 @@ pub(crate) fn measure_text_node(
   };
 
   let (max_width, max_height) =
-    create_inline_constraint(context, available_space, known_dimensions);
+    create_inline_constraint(context, available_space.into(), known_dimensions.into());
   let font_style = SizedFontStyle::from_style(&context.style, context);
 
   let mut built = create_inline_layout(InlineLayoutRequest {
     items: vec![inline_content],
-    available_space,
+    available_space: available_space.into(),
     max_width,
     max_height,
     style: &font_style,
@@ -50,4 +50,5 @@ pub(crate) fn measure_text_node(
       parent_font_metrics,
     },
   )
+  .into()
 }

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -4,8 +4,8 @@ use parley::fontique::Attributes;
 use taffy::{
   AvailableSpace, BlockContext, Cache, CacheTree, Display as TaffyDisplay, Layout,
   LayoutBlockContainer, LayoutFlexboxContainer, LayoutGridContainer, LayoutInput, LayoutOutput,
-  LayoutPartialTree, NodeId, RequestedAxis, RoundTree, RunMode, Size, SizingMode, Style,
-  TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
+  LayoutPartialTree, NodeId, RequestedAxis, RoundTree, RunMode, Size as TaffySize, SizingMode,
+  Style, TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
   compute_flexbox_layout, compute_grid_layout, compute_hidden_layout, compute_leaf_layout,
   compute_root_layout, round_layout,
 };
@@ -14,7 +14,7 @@ use crate::{
   Error,
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{ComputedLayout, Size as CoreSize},
+  geometry::{ComputedLayout, Size},
   layout::{
     inline::{
       InlineContentKind, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,
@@ -126,7 +126,7 @@ pub struct RenderNode {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AtomicInlineMetrics {
-  pub(crate) size: CoreSize<f32>,
+  pub(crate) size: Size<f32>,
   pub(crate) baseline_offset: Option<f32>,
 }
 
@@ -457,7 +457,7 @@ impl<'r> LayoutTree<'r> {
   }
 
   /// Computes and rounds the layout for the whole tree.
-  pub fn compute_layout(&mut self, available_space: CoreSize<AvailableSpace>) {
+  pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>) {
     let root_node_id = self.root_node_id();
     compute_root_layout(self, root_node_id, available_space.into());
     round_layout(self, root_node_id);
@@ -496,8 +496,8 @@ impl<'r> LayoutTree<'r> {
   fn update_node_style_for_available_space(
     &mut self,
     node_id: NodeId,
-    available_space: Size<AvailableSpace>,
-    known_dimensions: Size<Option<f32>>,
+    available_space: TaffySize<AvailableSpace>,
+    known_dimensions: TaffySize<Option<f32>>,
   ) {
     let Some(idx) = self.get_index(node_id) else {
       return;
@@ -511,7 +511,7 @@ impl<'r> LayoutTree<'r> {
       style_override.clone()
     } else {
       let mut sizing = render_node.context.sizing.clone();
-      sizing.container_size = Size {
+      sizing.container_size = TaffySize {
         width: known_dimensions.width.or(match available_space.width {
           AvailableSpace::Definite(value) => Some(value),
           _ => None,
@@ -538,7 +538,7 @@ impl<'r> LayoutTree<'r> {
 fn should_strip_flex_intrinsic_stretch_known_dimension(
   render_node: &RenderNode,
   inputs: LayoutInput,
-  known_dimensions: Size<Option<f32>>,
+  known_dimensions: TaffySize<Option<f32>>,
 ) -> bool {
   if inputs.run_mode != RunMode::ComputeSize
     || !matches!(
@@ -721,7 +721,7 @@ impl<'r> LayoutTree<'r> {
               inputs,
               known_dimensions,
             ) {
-              Size::NONE
+              TaffySize::NONE
             } else {
               known_dimensions
             }
@@ -734,12 +734,12 @@ impl<'r> LayoutTree<'r> {
             |known_dimensions, available_space| {
               let known_dimensions = stripped_known_dimensions(known_dimensions);
 
-              if let Size {
+              if let TaffySize {
                 width: Some(width),
                 height: Some(height),
               } = known_dimensions.maybe_apply_aspect_ratio(node_data.style.aspect_ratio)
               {
-                return Size { width, height };
+                return TaffySize { width, height };
               }
 
               render_node.measure(
@@ -927,7 +927,7 @@ impl RenderNode {
   fn anonymous_image_item(parent_context: &RenderContext, image: BackgroundImage) -> Self {
     // Cap image content to the parent pseudo's box so explicit `width` / `height`
     // on the pseudo wins over intrinsic / default sizing.
-    let max_size = Size {
+    let max_size = TaffySize {
       width: taffy::Dimension::percent(1.0),
       height: taffy::Dimension::percent(1.0),
     };
@@ -953,7 +953,7 @@ impl RenderNode {
           children: None,
           // css-images-3 §5.1 default object size when the parent is auto.
           layout_style_override: Some(Style {
-            size: Size {
+            size: TaffySize {
               width: taffy::Dimension::length(300.0),
               height: taffy::Dimension::length(150.0),
             },
@@ -1464,7 +1464,7 @@ impl RenderNode {
 
   fn inline_box_margin_box_height(
     &self,
-    content_size: Size<f32>,
+    content_size: TaffySize<f32>,
     include_padding_border: bool,
   ) -> f32 {
     let sizing = &self.context.sizing;
@@ -1484,9 +1484,9 @@ impl RenderNode {
 
   fn inline_replaced_content_size(
     &self,
-    measured_size: Size<f32>,
+    measured_size: TaffySize<f32>,
     layout_style: &Style,
-  ) -> Size<f32> {
+  ) -> TaffySize<f32> {
     if self.context.style.box_sizing != BoxSizing::BorderBox {
       return measured_size;
     }
@@ -1526,7 +1526,7 @@ impl RenderNode {
     };
 
     match (width_auto, height_auto) {
-      (false, false) => Size {
+      (false, false) => TaffySize {
         width: (measured_size.width - horizontal_insets).max(0.0),
         height: (measured_size.height - vertical_insets).max(0.0),
       },
@@ -1535,14 +1535,14 @@ impl RenderNode {
         let height = measured_ratio
           .filter(|ratio| *ratio > 0.0)
           .map_or(measured_size.height, |ratio| width / ratio);
-        Size { width, height }
+        TaffySize { width, height }
       }
       (true, false) => {
         let height = (measured_size.height - vertical_insets).max(0.0);
         let width = measured_ratio
           .filter(|ratio| *ratio > 0.0)
           .map_or(measured_size.width, |ratio| height * ratio);
-        Size { width, height }
+        TaffySize { width, height }
       }
       (true, true) => measured_size,
     }
@@ -1562,8 +1562,8 @@ impl RenderNode {
 
   fn inline_content_baseline_offset(
     &self,
-    available_space: Size<AvailableSpace>,
-    size: Size<f32>,
+    available_space: TaffySize<AvailableSpace>,
+    size: TaffySize<f32>,
     use_last_line: bool,
   ) -> Option<f32> {
     if matches!(
@@ -1585,7 +1585,7 @@ impl RenderNode {
     let max_width = size.width.max(0.0);
     let built = create_inline_layout(InlineLayoutRequest {
       items,
-      available_space: Size {
+      available_space: TaffySize {
         width: AvailableSpace::Definite(max_width),
         height: available_space.height,
       }
@@ -1671,8 +1671,8 @@ impl RenderNode {
 
   fn resolve_inline_baseline_source(
     &self,
-    available_space: Size<AvailableSpace>,
-    size: Size<f32>,
+    available_space: TaffySize<AvailableSpace>,
+    size: TaffySize<f32>,
     source: InlineBaselineSource,
     layout_results: Option<(&LayoutResults, NodeId)>,
   ) -> Option<f32> {
@@ -1693,8 +1693,8 @@ impl RenderNode {
 
   fn resolve_inline_baseline_offset(
     &self,
-    available_space: Size<AvailableSpace>,
-    size: Size<f32>,
+    available_space: TaffySize<AvailableSpace>,
+    size: TaffySize<f32>,
     layout_results: Option<(&LayoutResults, NodeId)>,
   ) -> Option<f32> {
     let strategy = self.inline_baseline_strategy()?;
@@ -1717,7 +1717,7 @@ impl RenderNode {
 
   pub(crate) fn measure_inline_box(
     &self,
-    available_space: Size<AvailableSpace>,
+    available_space: TaffySize<AvailableSpace>,
   ) -> AtomicInlineMetrics {
     if self.participates_as_inline_box() {
       return self.measure_atomic_subtree(available_space);
@@ -1725,7 +1725,7 @@ impl RenderNode {
 
     let Some(node) = &self.node else {
       return AtomicInlineMetrics {
-        size: CoreSize::ZERO,
+        size: Size::ZERO,
         baseline_offset: None,
       };
     };
@@ -1735,7 +1735,12 @@ impl RenderNode {
       .as_ref()
       .cloned()
       .unwrap_or_else(|| self.context.style.to_taffy_style(&self.context.sizing));
-    let measured_size = node.measure(&self.context, available_space, Size::NONE, &layout_style);
+    let measured_size = node.measure(
+      &self.context,
+      available_space,
+      TaffySize::NONE,
+      &layout_style,
+    );
     let size = self.inline_replaced_content_size(measured_size, &layout_style);
 
     AtomicInlineMetrics {
@@ -1746,11 +1751,11 @@ impl RenderNode {
 
   pub(crate) fn measure_atomic_subtree(
     &self,
-    available_space: Size<AvailableSpace>,
+    available_space: TaffySize<AvailableSpace>,
   ) -> AtomicInlineMetrics {
     let measure_with = |width: AvailableSpace| {
       let mut tree = LayoutTree::from_render_node(self);
-      tree.compute_layout(CoreSize {
+      tree.compute_layout(Size {
         width,
         height: available_space.height,
       });
@@ -1758,7 +1763,7 @@ impl RenderNode {
 
       results
         .layout(results.root_node_id())
-        .map_or(CoreSize::ZERO, |layout| layout.size)
+        .map_or(Size::ZERO, |layout| layout.size)
     };
 
     if self.participates_as_inline_box() {
@@ -1778,7 +1783,7 @@ impl RenderNode {
           node.style.justify_content = Some(taffy::JustifyContent::START);
         }
 
-        tree.compute_layout(CoreSize {
+        tree.compute_layout(Size {
           width: AvailableSpace::MaxContent,
           height: available_space.height,
         });
@@ -1786,7 +1791,7 @@ impl RenderNode {
         let results = tree.into_results();
         results
           .layout(results.root_node_id())
-          .map_or(CoreSize::ZERO, |layout| layout.size)
+          .map_or(Size::ZERO, |layout| layout.size)
       };
 
       let used_width = match available_space.width {
@@ -1797,7 +1802,7 @@ impl RenderNode {
         AvailableSpace::MaxContent => max_content.width,
       };
       let mut tree = LayoutTree::from_render_node(self);
-      tree.compute_layout(CoreSize {
+      tree.compute_layout(Size {
         width: AvailableSpace::Definite(used_width),
         height: available_space.height,
       });
@@ -1806,7 +1811,7 @@ impl RenderNode {
 
       return results.layout(root_node_id).map_or(
         AtomicInlineMetrics {
-          size: CoreSize::ZERO,
+          size: Size::ZERO,
           baseline_offset: None,
         },
         |layout| {
@@ -1833,11 +1838,11 @@ impl RenderNode {
 
   pub(crate) fn measure(
     &self,
-    available_space: Size<AvailableSpace>,
-    known_dimensions: Size<Option<f32>>,
+    available_space: TaffySize<AvailableSpace>,
+    known_dimensions: TaffySize<Option<f32>>,
     style: &Style,
     is_inline_children: bool,
-  ) -> Size<f32> {
+  ) -> TaffySize<f32> {
     if is_inline_children {
       let (max_width, max_height) = create_inline_constraint(
         &self.context,
@@ -1880,7 +1885,7 @@ impl RenderNode {
     );
 
     let Some(node) = &self.node else {
-      return Size::zero();
+      return TaffySize::zero();
     };
 
     node.measure(&self.context, available_space, known_dimensions, style)

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -14,6 +14,7 @@ use crate::{
   Error,
   context::RenderContext,
   font_style::SizedFontStyle,
+  geometry::{ComputedLayout, Size as CoreSize},
   layout::{
     inline::{
       InlineContentKind, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,
@@ -62,12 +63,12 @@ impl LayoutResults {
   }
 
   /// Computed layout of a node.
-  pub fn layout(&self, node_id: NodeId) -> crate::Result<&Layout> {
+  pub fn layout(&self, node_id: NodeId) -> crate::Result<ComputedLayout> {
     let idx: usize = node_id.into();
     self
       .nodes
       .get(idx)
-      .map(|node| &node.layout)
+      .map(|node| ComputedLayout::from(&node.layout))
       .ok_or(Error::InvalidLayoutNode(node_id.into()))
   }
 
@@ -125,7 +126,7 @@ pub struct RenderNode {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AtomicInlineMetrics {
-  pub(crate) size: Size<f32>,
+  pub(crate) size: CoreSize<f32>,
   pub(crate) baseline_offset: Option<f32>,
 }
 
@@ -456,9 +457,9 @@ impl<'r> LayoutTree<'r> {
   }
 
   /// Computes and rounds the layout for the whole tree.
-  pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>) {
+  pub fn compute_layout(&mut self, available_space: CoreSize<AvailableSpace>) {
     let root_node_id = self.root_node_id();
-    compute_root_layout(self, root_node_id, available_space);
+    compute_root_layout(self, root_node_id, available_space.into());
     round_layout(self, root_node_id);
   }
 
@@ -1587,7 +1588,8 @@ impl RenderNode {
       available_space: Size {
         width: AvailableSpace::Definite(max_width),
         height: available_space.height,
-      },
+      }
+      .into(),
       max_width,
       max_height: None,
       style: &font_style,
@@ -1723,7 +1725,7 @@ impl RenderNode {
 
     let Some(node) = &self.node else {
       return AtomicInlineMetrics {
-        size: Size::zero(),
+        size: CoreSize::ZERO,
         baseline_offset: None,
       };
     };
@@ -1737,7 +1739,7 @@ impl RenderNode {
     let size = self.inline_replaced_content_size(measured_size, &layout_style);
 
     AtomicInlineMetrics {
-      size,
+      size: size.into(),
       baseline_offset: self.resolve_inline_baseline_offset(available_space, size, None),
     }
   }
@@ -1748,7 +1750,7 @@ impl RenderNode {
   ) -> AtomicInlineMetrics {
     let measure_with = |width: AvailableSpace| {
       let mut tree = LayoutTree::from_render_node(self);
-      tree.compute_layout(Size {
+      tree.compute_layout(CoreSize {
         width,
         height: available_space.height,
       });
@@ -1756,7 +1758,7 @@ impl RenderNode {
 
       results
         .layout(results.root_node_id())
-        .map_or(Size::zero(), |layout| layout.size)
+        .map_or(CoreSize::ZERO, |layout| layout.size)
     };
 
     if self.participates_as_inline_box() {
@@ -1776,7 +1778,7 @@ impl RenderNode {
           node.style.justify_content = Some(taffy::JustifyContent::START);
         }
 
-        tree.compute_layout(Size {
+        tree.compute_layout(CoreSize {
           width: AvailableSpace::MaxContent,
           height: available_space.height,
         });
@@ -1784,7 +1786,7 @@ impl RenderNode {
         let results = tree.into_results();
         results
           .layout(results.root_node_id())
-          .map_or(Size::zero(), |layout| layout.size)
+          .map_or(CoreSize::ZERO, |layout| layout.size)
       };
 
       let used_width = match available_space.width {
@@ -1795,7 +1797,7 @@ impl RenderNode {
         AvailableSpace::MaxContent => max_content.width,
       };
       let mut tree = LayoutTree::from_render_node(self);
-      tree.compute_layout(Size {
+      tree.compute_layout(CoreSize {
         width: AvailableSpace::Definite(used_width),
         height: available_space.height,
       });
@@ -1804,14 +1806,14 @@ impl RenderNode {
 
       return results.layout(root_node_id).map_or(
         AtomicInlineMetrics {
-          size: Size::zero(),
+          size: CoreSize::ZERO,
           baseline_offset: None,
         },
         |layout| {
           let size = layout.size;
           let baseline_offset = self.resolve_inline_baseline_offset(
             available_space,
-            size,
+            size.into(),
             Some((&results, root_node_id)),
           );
           AtomicInlineMetrics {
@@ -1837,14 +1839,17 @@ impl RenderNode {
     is_inline_children: bool,
   ) -> Size<f32> {
     if is_inline_children {
-      let (max_width, max_height) =
-        create_inline_constraint(&self.context, available_space, known_dimensions);
+      let (max_width, max_height) = create_inline_constraint(
+        &self.context,
+        available_space.into(),
+        known_dimensions.into(),
+      );
 
       let font_style = SizedFontStyle::from_style(&self.context.style, &self.context);
 
       let mut built = create_inline_layout(InlineLayoutRequest {
         items: collect_inline_items(self),
-        available_space,
+        available_space: available_space.into(),
         max_width,
         max_height,
         style: &font_style,
@@ -1864,7 +1869,8 @@ impl RenderNode {
           ceil_width,
           parent_font_metrics,
         },
-      );
+      )
+      .into();
     }
 
     assert_ne!(

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -496,8 +496,8 @@ impl<'r> LayoutTree<'r> {
   fn update_node_style_for_available_space(
     &mut self,
     node_id: NodeId,
-    available_space: TaffySize<AvailableSpace>,
-    known_dimensions: TaffySize<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    known_dimensions: Size<Option<f32>>,
   ) {
     let Some(idx) = self.get_index(node_id) else {
       return;
@@ -511,7 +511,7 @@ impl<'r> LayoutTree<'r> {
       style_override.clone()
     } else {
       let mut sizing = render_node.context.sizing.clone();
-      sizing.container_size = TaffySize {
+      sizing.container_size = Size {
         width: known_dimensions.width.or(match available_space.width {
           AvailableSpace::Definite(value) => Some(value),
           _ => None,
@@ -538,7 +538,7 @@ impl<'r> LayoutTree<'r> {
 fn should_strip_flex_intrinsic_stretch_known_dimension(
   render_node: &RenderNode,
   inputs: LayoutInput,
-  known_dimensions: TaffySize<Option<f32>>,
+  known_dimensions: Size<Option<f32>>,
 ) -> bool {
   if inputs.run_mode != RunMode::ComputeSize
     || !matches!(
@@ -688,8 +688,8 @@ impl<'r> LayoutTree<'r> {
   ) -> LayoutOutput {
     self.update_node_style_for_available_space(
       node,
-      inputs.available_space,
-      inputs.known_dimensions,
+      inputs.available_space.into(),
+      inputs.known_dimensions.into(),
     );
 
     if inputs.run_mode == RunMode::PerformHiddenLayout {
@@ -715,11 +715,11 @@ impl<'r> LayoutTree<'r> {
             return compute_hidden_layout(tree, node);
           };
 
-          let stripped_known_dimensions = |known_dimensions| {
+          let stripped_known_dimensions = |known_dimensions: TaffySize<Option<f32>>| {
             if should_strip_flex_intrinsic_stretch_known_dimension(
               render_node,
               inputs,
-              known_dimensions,
+              known_dimensions.into(),
             ) {
               TaffySize::NONE
             } else {
@@ -742,12 +742,14 @@ impl<'r> LayoutTree<'r> {
                 return TaffySize { width, height };
               }
 
-              render_node.measure(
-                available_space,
-                known_dimensions,
-                &node_data.style,
-                node_data.is_inline_children,
-              )
+              render_node
+                .measure(
+                  available_space.into(),
+                  known_dimensions.into(),
+                  &node_data.style,
+                  node_data.is_inline_children,
+                )
+                .into()
             },
           )
         }
@@ -1464,7 +1466,7 @@ impl RenderNode {
 
   fn inline_box_margin_box_height(
     &self,
-    content_size: TaffySize<f32>,
+    content_size: Size<f32>,
     include_padding_border: bool,
   ) -> f32 {
     let sizing = &self.context.sizing;
@@ -1484,9 +1486,9 @@ impl RenderNode {
 
   fn inline_replaced_content_size(
     &self,
-    measured_size: TaffySize<f32>,
+    measured_size: Size<f32>,
     layout_style: &Style,
-  ) -> TaffySize<f32> {
+  ) -> Size<f32> {
     if self.context.style.box_sizing != BoxSizing::BorderBox {
       return measured_size;
     }
@@ -1526,7 +1528,7 @@ impl RenderNode {
     };
 
     match (width_auto, height_auto) {
-      (false, false) => TaffySize {
+      (false, false) => Size {
         width: (measured_size.width - horizontal_insets).max(0.0),
         height: (measured_size.height - vertical_insets).max(0.0),
       },
@@ -1535,14 +1537,14 @@ impl RenderNode {
         let height = measured_ratio
           .filter(|ratio| *ratio > 0.0)
           .map_or(measured_size.height, |ratio| width / ratio);
-        TaffySize { width, height }
+        Size { width, height }
       }
       (true, false) => {
         let height = (measured_size.height - vertical_insets).max(0.0);
         let width = measured_ratio
           .filter(|ratio| *ratio > 0.0)
           .map_or(measured_size.width, |ratio| height * ratio);
-        TaffySize { width, height }
+        Size { width, height }
       }
       (true, true) => measured_size,
     }
@@ -1562,8 +1564,8 @@ impl RenderNode {
 
   fn inline_content_baseline_offset(
     &self,
-    available_space: TaffySize<AvailableSpace>,
-    size: TaffySize<f32>,
+    available_space: Size<AvailableSpace>,
+    size: Size<f32>,
     use_last_line: bool,
   ) -> Option<f32> {
     if matches!(
@@ -1585,11 +1587,10 @@ impl RenderNode {
     let max_width = size.width.max(0.0);
     let built = create_inline_layout(InlineLayoutRequest {
       items,
-      available_space: TaffySize {
+      available_space: Size {
         width: AvailableSpace::Definite(max_width),
         height: available_space.height,
-      }
-      .into(),
+      },
       max_width,
       max_height: None,
       style: &font_style,
@@ -1671,8 +1672,8 @@ impl RenderNode {
 
   fn resolve_inline_baseline_source(
     &self,
-    available_space: TaffySize<AvailableSpace>,
-    size: TaffySize<f32>,
+    available_space: Size<AvailableSpace>,
+    size: Size<f32>,
     source: InlineBaselineSource,
     layout_results: Option<(&LayoutResults, NodeId)>,
   ) -> Option<f32> {
@@ -1693,8 +1694,8 @@ impl RenderNode {
 
   fn resolve_inline_baseline_offset(
     &self,
-    available_space: TaffySize<AvailableSpace>,
-    size: TaffySize<f32>,
+    available_space: Size<AvailableSpace>,
+    size: Size<f32>,
     layout_results: Option<(&LayoutResults, NodeId)>,
   ) -> Option<f32> {
     let strategy = self.inline_baseline_strategy()?;
@@ -1717,7 +1718,7 @@ impl RenderNode {
 
   pub(crate) fn measure_inline_box(
     &self,
-    available_space: TaffySize<AvailableSpace>,
+    available_space: Size<AvailableSpace>,
   ) -> AtomicInlineMetrics {
     if self.participates_as_inline_box() {
       return self.measure_atomic_subtree(available_space);
@@ -1735,23 +1736,18 @@ impl RenderNode {
       .as_ref()
       .cloned()
       .unwrap_or_else(|| self.context.style.to_taffy_style(&self.context.sizing));
-    let measured_size = node.measure(
-      &self.context,
-      available_space,
-      TaffySize::NONE,
-      &layout_style,
-    );
+    let measured_size = node.measure(&self.context, available_space, Size::NONE, &layout_style);
     let size = self.inline_replaced_content_size(measured_size, &layout_style);
 
     AtomicInlineMetrics {
-      size: size.into(),
+      size,
       baseline_offset: self.resolve_inline_baseline_offset(available_space, size, None),
     }
   }
 
   pub(crate) fn measure_atomic_subtree(
     &self,
-    available_space: TaffySize<AvailableSpace>,
+    available_space: Size<AvailableSpace>,
   ) -> AtomicInlineMetrics {
     let measure_with = |width: AvailableSpace| {
       let mut tree = LayoutTree::from_render_node(self);
@@ -1818,7 +1814,7 @@ impl RenderNode {
           let size = layout.size;
           let baseline_offset = self.resolve_inline_baseline_offset(
             available_space,
-            size.into(),
+            size,
             Some((&results, root_node_id)),
           );
           AtomicInlineMetrics {
@@ -1838,23 +1834,20 @@ impl RenderNode {
 
   pub(crate) fn measure(
     &self,
-    available_space: TaffySize<AvailableSpace>,
-    known_dimensions: TaffySize<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    known_dimensions: Size<Option<f32>>,
     style: &Style,
     is_inline_children: bool,
-  ) -> TaffySize<f32> {
+  ) -> Size<f32> {
     if is_inline_children {
-      let (max_width, max_height) = create_inline_constraint(
-        &self.context,
-        available_space.into(),
-        known_dimensions.into(),
-      );
+      let (max_width, max_height) =
+        create_inline_constraint(&self.context, available_space, known_dimensions);
 
       let font_style = SizedFontStyle::from_style(&self.context.style, &self.context);
 
       let mut built = create_inline_layout(InlineLayoutRequest {
         items: collect_inline_items(self),
-        available_space: available_space.into(),
+        available_space,
         max_width,
         max_height,
         style: &font_style,
@@ -1874,8 +1867,7 @@ impl RenderNode {
           ceil_width,
           parent_font_metrics,
         },
-      )
-      .into();
+      );
     }
 
     assert_ne!(
@@ -1885,7 +1877,7 @@ impl RenderNode {
     );
 
     let Some(node) = &self.node else {
-      return TaffySize::zero();
+      return Size::ZERO;
     };
 
     node.measure(&self.context, available_space, known_dimensions, style)

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -68,7 +68,7 @@ impl LayoutResults {
     self
       .nodes
       .get(idx)
-      .map(|node| ComputedLayout::from(&node.layout))
+      .map(|node| ComputedLayout::from_taffy(&node.layout))
       .ok_or(Error::InvalidLayoutNode(node_id.into()))
   }
 
@@ -459,7 +459,7 @@ impl<'r> LayoutTree<'r> {
   /// Computes and rounds the layout for the whole tree.
   pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>) {
     let root_node_id = self.root_node_id();
-    compute_root_layout(self, root_node_id, available_space.into());
+    compute_root_layout(self, root_node_id, available_space.into_taffy());
     round_layout(self, root_node_id);
   }
 
@@ -688,8 +688,8 @@ impl<'r> LayoutTree<'r> {
   ) -> LayoutOutput {
     self.update_node_style_for_available_space(
       node,
-      inputs.available_space.into(),
-      inputs.known_dimensions.into(),
+      Size::from_taffy(inputs.available_space),
+      Size::from_taffy(inputs.known_dimensions),
     );
 
     if inputs.run_mode == RunMode::PerformHiddenLayout {
@@ -719,7 +719,7 @@ impl<'r> LayoutTree<'r> {
             if should_strip_flex_intrinsic_stretch_known_dimension(
               render_node,
               inputs,
-              known_dimensions.into(),
+              Size::from_taffy(known_dimensions),
             ) {
               TaffySize::NONE
             } else {
@@ -744,12 +744,12 @@ impl<'r> LayoutTree<'r> {
 
               render_node
                 .measure(
-                  available_space.into(),
-                  known_dimensions.into(),
+                  Size::from_taffy(available_space),
+                  Size::from_taffy(known_dimensions),
                   &node_data.style,
                   node_data.is_inline_children,
                 )
-                .into()
+                .into_taffy()
             },
           )
         }

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -2,10 +2,10 @@ use std::{collections::HashMap, mem::take, vec::IntoIter};
 
 use parley::fontique::Attributes;
 use taffy::{
-  AvailableSpace, BlockContext, Cache, CacheTree, Display as TaffyDisplay, Layout,
-  LayoutBlockContainer, LayoutFlexboxContainer, LayoutGridContainer, LayoutInput, LayoutOutput,
-  LayoutPartialTree, NodeId, RequestedAxis, RoundTree, RunMode, Size as TaffySize, SizingMode,
-  Style, TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
+  BlockContext, Cache, CacheTree, Display as TaffyDisplay, Layout, LayoutBlockContainer,
+  LayoutFlexboxContainer, LayoutGridContainer, LayoutInput, LayoutOutput, LayoutPartialTree,
+  NodeId as TaffyNodeId, RequestedAxis, RoundTree, RunMode, Size as TaffySize, SizingMode, Style,
+  TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
   compute_flexbox_layout, compute_grid_layout, compute_hidden_layout, compute_leaf_layout,
   compute_root_layout, round_layout,
 };
@@ -14,7 +14,7 @@ use crate::{
   Error,
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{ComputedLayout, Size},
+  geometry::{AvailableSpace, ComputedLayout, NodeId, Size},
   layout::{
     inline::{
       InlineContentKind, InlineLayoutMode, InlineLayoutRequest, InlineMeasureOptions,
@@ -32,14 +32,14 @@ use crate::{
   viewport::Viewport,
 };
 
-/// A render-tree child paired with its layout `NodeId`. `hoisted_cb` is set
+/// A render-tree child paired with its layout node id. `hoisted_cb` is set
 /// when the child is out-of-flow and was re-parented to a containing block in
-/// the taffy tree; its geometry then resolves against that block.
+/// the layout tree; its geometry then resolves against that block.
 #[derive(Debug, Clone, Copy)]
 pub struct OrderedChild {
   /// Index of the child in its parent's render order.
   pub render_index: usize,
-  /// Layout node id in the taffy tree.
+  /// Layout node id.
   pub node_id: NodeId,
   /// Containing block the child was hoisted to, if out-of-flow.
   pub hoisted_cb: Option<NodeId>,
@@ -57,11 +57,6 @@ struct LayoutResultNode {
 }
 
 impl LayoutResults {
-  /// The root node id.
-  pub const fn root_node_id(&self) -> NodeId {
-    NodeId::new(0)
-  }
-
   /// Computed layout of a node.
   pub fn layout(&self, node_id: NodeId) -> crate::Result<ComputedLayout> {
     let idx: usize = node_id.into();
@@ -105,7 +100,7 @@ struct LayoutNodeState {
   final_layout: Layout,
   first_baseline_y: Option<f32>,
   is_inline_children: bool,
-  children: Box<[NodeId]>,
+  children: Box<[TaffyNodeId]>,
   box_children: Box<[OrderedChild]>,
 }
 
@@ -306,13 +301,13 @@ fn push_layout_node<'r>(
   nodes: &mut Vec<LayoutNodeState>,
   render_nodes: &mut Vec<&'r RenderNode>,
   render_root: &'r RenderNode,
-) -> NodeId {
+) -> TaffyNodeId {
   struct PendingNode<'r> {
-    node_id: NodeId,
+    node_id: TaffyNodeId,
     position: Position,
     next_child_index: usize,
     children: Option<&'r [RenderNode]>,
-    taffy_child_ids: Vec<NodeId>,
+    taffy_child_ids: Vec<TaffyNodeId>,
     box_children: Vec<OrderedChild>,
   }
 
@@ -322,7 +317,7 @@ fn push_layout_node<'r>(
     render_node: &'r RenderNode,
   ) -> PendingNode<'r> {
     let node_index = nodes.len();
-    let node_id = NodeId::from(node_index);
+    let node_id = TaffyNodeId::from(node_index);
     let is_inline_children = render_node.should_create_inline_layout();
     let children = if is_inline_children {
       None
@@ -367,8 +362,8 @@ fn push_layout_node<'r>(
   // direct-parent positioning resolves against the correct CSS containing
   // block: nearest CB ancestor for `absolute`, the root for `fixed`. The box
   // (render) tree is preserved separately for painting.
-  let mut cb_stack: Vec<NodeId> = Vec::new();
-  let mut hoisted: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+  let mut cb_stack: Vec<TaffyNodeId> = Vec::new();
+  let mut hoisted: HashMap<TaffyNodeId, Vec<TaffyNodeId>> = HashMap::new();
 
   let root = push_node_state(nodes, render_nodes, render_root);
   let root_id = root.node_id;
@@ -427,8 +422,8 @@ fn push_layout_node<'r>(
       };
       parent.box_children.push(OrderedChild {
         render_index,
-        node_id: fid,
-        hoisted_cb,
+        node_id: NodeId::from_taffy(fid),
+        hoisted_cb: hoisted_cb.map(NodeId::from_taffy),
       });
     }
   }
@@ -443,7 +438,7 @@ impl<'r> LayoutTree<'r> {
     let mut render_nodes = Vec::with_capacity(1);
     let root_id = push_layout_node(&mut nodes, &mut render_nodes, render_root);
 
-    debug_assert_eq!(root_id, NodeId::from(0usize));
+    debug_assert_eq!(root_id, TaffyNodeId::from(0usize));
 
     Self {
       nodes,
@@ -451,15 +446,14 @@ impl<'r> LayoutTree<'r> {
     }
   }
 
-  /// The root node id.
-  pub fn root_node_id(&self) -> NodeId {
-    NodeId::from(0usize)
-  }
-
   /// Computes and rounds the layout for the whole tree.
   pub fn compute_layout(&mut self, available_space: Size<AvailableSpace>) {
-    let root_node_id = self.root_node_id();
-    compute_root_layout(self, root_node_id, available_space.into_taffy());
+    let root_node_id = NodeId::ROOT.into_taffy();
+    compute_root_layout(
+      self,
+      root_node_id,
+      available_space.map(AvailableSpace::into_taffy).into_taffy(),
+    );
     round_layout(self, root_node_id);
   }
 
@@ -478,16 +472,16 @@ impl<'r> LayoutTree<'r> {
     }
   }
 
-  fn get_index(&self, node_id: NodeId) -> Option<usize> {
+  fn get_index(&self, node_id: TaffyNodeId) -> Option<usize> {
     let idx = node_id.into();
     (idx < self.nodes.len()).then_some(idx)
   }
 
-  fn get_layout_node_ref(&self, node_id: NodeId) -> Option<&LayoutNodeState> {
+  fn get_layout_node_ref(&self, node_id: TaffyNodeId) -> Option<&LayoutNodeState> {
     self.get_index(node_id).and_then(|idx| self.nodes.get(idx))
   }
 
-  fn get_layout_node_mut_ref(&mut self, node_id: NodeId) -> Option<&mut LayoutNodeState> {
+  fn get_layout_node_mut_ref(&mut self, node_id: TaffyNodeId) -> Option<&mut LayoutNodeState> {
     self
       .get_index(node_id)
       .and_then(|idx| self.nodes.get_mut(idx))
@@ -495,7 +489,7 @@ impl<'r> LayoutTree<'r> {
 
   fn update_node_style_for_available_space(
     &mut self,
-    node_id: NodeId,
+    node_id: TaffyNodeId,
     available_space: Size<AvailableSpace>,
     known_dimensions: Size<Option<f32>>,
   ) {
@@ -576,9 +570,9 @@ fn should_strip_flex_intrinsic_stretch_known_dimension(
 }
 
 fn sort_children_by_order(
-  children: &[NodeId],
-  mut child_order: impl FnMut(NodeId) -> i32,
-) -> Vec<NodeId> {
+  children: &[TaffyNodeId],
+  mut child_order: impl FnMut(TaffyNodeId) -> i32,
+) -> Vec<TaffyNodeId> {
   let mut ordered = children
     .iter()
     .copied()
@@ -594,11 +588,11 @@ fn sort_children_by_order(
 
 impl TraversePartialTree for LayoutTree<'_> {
   type ChildIter<'a>
-    = IntoIter<NodeId>
+    = IntoIter<TaffyNodeId>
   where
     Self: 'a;
 
-  fn child_ids(&self, parent_node_id: NodeId) -> Self::ChildIter<'_> {
+  fn child_ids(&self, parent_node_id: TaffyNodeId) -> Self::ChildIter<'_> {
     let Some(node) = self.get_layout_node_ref(parent_node_id) else {
       return Vec::new().into_iter();
     };
@@ -618,7 +612,7 @@ impl TraversePartialTree for LayoutTree<'_> {
     children.into_iter()
   }
 
-  fn child_count(&self, parent_node_id: NodeId) -> usize {
+  fn child_count(&self, parent_node_id: TaffyNodeId) -> usize {
     let Some(node) = self.get_layout_node_ref(parent_node_id) else {
       return 0;
     };
@@ -626,16 +620,16 @@ impl TraversePartialTree for LayoutTree<'_> {
     node.children.len()
   }
 
-  fn get_child_id(&self, parent_node_id: NodeId, child_index: usize) -> NodeId {
+  fn get_child_id(&self, parent_node_id: TaffyNodeId, child_index: usize) -> TaffyNodeId {
     let Some(node) = self.get_layout_node_ref(parent_node_id) else {
-      return NodeId::from(0usize);
+      return TaffyNodeId::from(0usize);
     };
 
     if matches!(node.style.display, TaffyDisplay::Flex | TaffyDisplay::Grid) {
       let mut ordered_children = self.child_ids(parent_node_id);
       return ordered_children
         .nth(child_index)
-        .unwrap_or_else(|| NodeId::from(0usize));
+        .unwrap_or_else(|| TaffyNodeId::from(0usize));
     }
 
     node.children[child_index]
@@ -651,14 +645,14 @@ impl LayoutPartialTree for LayoutTree<'_> {
     Self: 'a;
   type CustomIdent = String;
 
-  fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
+  fn get_core_container_style(&self, node_id: TaffyNodeId) -> Self::CoreContainerStyle<'_> {
     if let Some(node) = self.get_layout_node_ref(node_id) {
       return &node.style;
     }
     &self.nodes[0].style
   }
 
-  fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
+  fn set_unrounded_layout(&mut self, node_id: TaffyNodeId, layout: &Layout) {
     let Some(node) = self.get_layout_node_mut_ref(node_id) else {
       return;
     };
@@ -674,7 +668,7 @@ impl LayoutPartialTree for LayoutTree<'_> {
     root.context.sizing.resolve_calc(val, basis)
   }
 
-  fn compute_child_layout(&mut self, node: NodeId, inputs: LayoutInput) -> LayoutOutput {
+  fn compute_child_layout(&mut self, node: TaffyNodeId, inputs: LayoutInput) -> LayoutOutput {
     self.compute_child_layout_inner(node, inputs, None)
   }
 }
@@ -682,13 +676,13 @@ impl LayoutPartialTree for LayoutTree<'_> {
 impl<'r> LayoutTree<'r> {
   fn compute_child_layout_inner(
     &mut self,
-    node: NodeId,
+    node: TaffyNodeId,
     inputs: LayoutInput,
     block_ctx: Option<&mut BlockContext<'_>>,
   ) -> LayoutOutput {
     self.update_node_style_for_available_space(
       node,
-      Size::from_taffy(inputs.available_space),
+      Size::from_taffy(inputs.available_space).map(AvailableSpace::from_taffy),
       Size::from_taffy(inputs.known_dimensions),
     );
 
@@ -744,7 +738,7 @@ impl<'r> LayoutTree<'r> {
 
               render_node
                 .measure(
-                  Size::from_taffy(available_space),
+                  Size::from_taffy(available_space).map(AvailableSpace::from_taffy),
                   Size::from_taffy(known_dimensions),
                   &node_data.style,
                   node_data.is_inline_children,
@@ -765,12 +759,17 @@ impl<'r> LayoutTree<'r> {
 }
 
 impl CacheTree for LayoutTree<'_> {
-  fn cache_get(&self, node_id: NodeId, input: &LayoutInput) -> Option<LayoutOutput> {
+  fn cache_get(&self, node_id: TaffyNodeId, input: &LayoutInput) -> Option<LayoutOutput> {
     let node = self.get_layout_node_ref(node_id)?;
     node.cache.get(input)
   }
 
-  fn cache_store(&mut self, node_id: NodeId, input: &LayoutInput, layout_output: LayoutOutput) {
+  fn cache_store(
+    &mut self,
+    node_id: TaffyNodeId,
+    input: &LayoutInput,
+    layout_output: LayoutOutput,
+  ) {
     let Some(node) = self.get_layout_node_mut_ref(node_id) else {
       return;
     };
@@ -778,7 +777,7 @@ impl CacheTree for LayoutTree<'_> {
     node.cache.store(input, layout_output);
   }
 
-  fn cache_clear(&mut self, node_id: NodeId) {
+  fn cache_clear(&mut self, node_id: TaffyNodeId) {
     let Some(node) = self.get_layout_node_mut_ref(node_id) else {
       return;
     };
@@ -797,17 +796,17 @@ impl LayoutBlockContainer for LayoutTree<'_> {
   where
     Self: 'a;
 
-  fn get_block_container_style(&self, node_id: NodeId) -> Self::BlockContainerStyle<'_> {
+  fn get_block_container_style(&self, node_id: TaffyNodeId) -> Self::BlockContainerStyle<'_> {
     self.get_core_container_style(node_id)
   }
 
-  fn get_block_child_style(&self, child_node_id: NodeId) -> Self::BlockItemStyle<'_> {
+  fn get_block_child_style(&self, child_node_id: TaffyNodeId) -> Self::BlockItemStyle<'_> {
     self.get_core_container_style(child_node_id)
   }
 
   fn compute_block_child_layout(
     &mut self,
-    node: NodeId,
+    node: TaffyNodeId,
     inputs: LayoutInput,
     block_ctx: Option<&mut BlockContext<'_>>,
   ) -> LayoutOutput {
@@ -825,11 +824,11 @@ impl LayoutFlexboxContainer for LayoutTree<'_> {
   where
     Self: 'a;
 
-  fn get_flexbox_container_style(&self, node_id: NodeId) -> Self::FlexboxContainerStyle<'_> {
+  fn get_flexbox_container_style(&self, node_id: TaffyNodeId) -> Self::FlexboxContainerStyle<'_> {
     self.get_core_container_style(node_id)
   }
 
-  fn get_flexbox_child_style(&self, child_node_id: NodeId) -> Self::FlexboxItemStyle<'_> {
+  fn get_flexbox_child_style(&self, child_node_id: TaffyNodeId) -> Self::FlexboxItemStyle<'_> {
     self.get_core_container_style(child_node_id)
   }
 }
@@ -844,17 +843,17 @@ impl LayoutGridContainer for LayoutTree<'_> {
   where
     Self: 'a;
 
-  fn get_grid_container_style(&self, node_id: NodeId) -> Self::GridContainerStyle<'_> {
+  fn get_grid_container_style(&self, node_id: TaffyNodeId) -> Self::GridContainerStyle<'_> {
     self.get_core_container_style(node_id)
   }
 
-  fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
+  fn get_grid_child_style(&self, child_node_id: TaffyNodeId) -> Self::GridItemStyle<'_> {
     self.get_core_container_style(child_node_id)
   }
 }
 
 impl RoundTree for LayoutTree<'_> {
-  fn get_unrounded_layout(&self, node_id: NodeId) -> Layout {
+  fn get_unrounded_layout(&self, node_id: TaffyNodeId) -> Layout {
     let Some(node) = self.get_layout_node_ref(node_id) else {
       return Layout::new();
     };
@@ -862,7 +861,7 @@ impl RoundTree for LayoutTree<'_> {
     node.unrounded_layout
   }
 
-  fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
+  fn set_final_layout(&mut self, node_id: TaffyNodeId, layout: &Layout) {
     let Some(node) = self.get_layout_node_mut_ref(node_id) else {
       return;
     };
@@ -1758,7 +1757,7 @@ impl RenderNode {
       let results = tree.into_results();
 
       results
-        .layout(results.root_node_id())
+        .layout(NodeId::ROOT)
         .map_or(Size::ZERO, |layout| layout.size)
     };
 
@@ -1771,7 +1770,7 @@ impl RenderNode {
         let mut tree = LayoutTree::from_render_node(self);
         // Hack: Use Flexbox to avoid Block's "expand to fill" behavior when calculating max-content.
         // We want the content's preferred width, not the container's available width.
-        if let Some(node) = tree.get_layout_node_mut_ref(tree.root_node_id())
+        if let Some(node) = tree.get_layout_node_mut_ref(TaffyNodeId::from(0usize))
           && node.style.display == TaffyDisplay::Block
         {
           node.style.display = TaffyDisplay::Flex;
@@ -1786,7 +1785,7 @@ impl RenderNode {
 
         let results = tree.into_results();
         results
-          .layout(results.root_node_id())
+          .layout(NodeId::ROOT)
           .map_or(Size::ZERO, |layout| layout.size)
       };
 
@@ -1803,7 +1802,7 @@ impl RenderNode {
         height: available_space.height,
       });
       let results = tree.into_results();
-      let root_node_id = results.root_node_id();
+      let root_node_id = NodeId::ROOT;
 
       return results.layout(root_node_id).map_or(
         AtomicInlineMetrics {
@@ -1930,7 +1929,7 @@ fn drop_block_boundary_whitespace(input: Vec<RenderNode>) -> Vec<RenderNode> {
 mod tests {
   use std::str::FromStr;
 
-  use taffy::NodeId;
+  use taffy::NodeId as TaffyNodeId;
 
   use super::{registered_custom_property_parent_style, sort_children_by_order};
   use crate::{
@@ -1950,9 +1949,9 @@ mod tests {
   #[test]
   fn sort_children_by_order_keeps_source_order_for_equal_values() {
     let children = vec![
-      NodeId::from(3usize),
-      NodeId::from(1usize),
-      NodeId::from(2usize),
+      TaffyNodeId::from(3usize),
+      TaffyNodeId::from(1usize),
+      TaffyNodeId::from(2usize),
     ];
     let sorted = sort_children_by_order(&children, |child_id| match usize::from(child_id) {
       1 => -1,
@@ -1961,9 +1960,9 @@ mod tests {
     assert_eq!(
       sorted,
       vec![
-        NodeId::from(1usize),
-        NodeId::from(3usize),
-        NodeId::from(2usize)
+        TaffyNodeId::from(1usize),
+        TaffyNodeId::from(3usize),
+        TaffyNodeId::from(2usize)
       ]
     );
   }

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -5,12 +5,12 @@
 use std::collections::HashMap;
 
 use parley::{InlineBoxKind, PositionedLayoutItem};
-use taffy::{AvailableSpace, Layout, NodeId, Point, geometry::Size};
+use taffy::{AvailableSpace, NodeId};
 
 use crate::{
   error::{Error, Result},
   font_style::SizedFontStyle,
-  geometry::transformed_rect_extents,
+  geometry::{ComputedLayout, Point, Size, transformed_rect_extents},
   layout::{
     inline::{
       InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,
@@ -236,7 +236,7 @@ pub fn build_stacking_contexts(
     let Some(current) = root.node_at_path(&visit.path) else {
       return Err(Error::InvalidLayoutNode(visit.node_id.into()));
     };
-    let layout = *layout_results.layout(visit.node_id)?;
+    let layout = layout_results.layout(visit.node_id)?;
     if current.context.style.is_invisible() {
       continue;
     }
@@ -372,7 +372,7 @@ pub fn build_stacking_contexts(
 
 fn compute_node_paint_bounds(
   node: &RenderNode,
-  layout: Layout,
+  layout: ComputedLayout,
   transform: Affine,
 ) -> Option<SceneBounds> {
   let mut bounds = bounds_for_rect(layout.size, transform);
@@ -540,9 +540,8 @@ fn merge_bounds(left: Option<SceneBounds>, right: Option<SceneBounds>) -> Option
 
 #[cfg(test)]
 mod tests {
-  use taffy::geometry::Size;
-
   use super::{SceneBounds, bounds_for_rect, merge_bounds};
+  use crate::geometry::Size;
   use crate::style::Affine;
 
   #[test]

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -5,12 +5,11 @@
 use std::collections::HashMap;
 
 use parley::{InlineBoxKind, PositionedLayoutItem};
-use taffy::{AvailableSpace, NodeId};
 
 use crate::{
   error::{Error, Result},
   font_style::SizedFontStyle,
-  geometry::{ComputedLayout, Point, Size, transformed_rect_extents},
+  geometry::{AvailableSpace, ComputedLayout, NodeId, Point, Size, transformed_rect_extents},
   layout::{
     inline::{
       InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,

--- a/takumi-core/src/shadow.rs
+++ b/takumi-core/src/shadow.rs
@@ -1,6 +1,7 @@
-use taffy::Size;
-
-use crate::style::{BoxShadow, Color, SizingContext, TextShadow};
+use crate::{
+  geometry::Size,
+  style::{BoxShadow, Color, SizingContext, TextShadow},
+};
 
 /// Represents a resolved box shadow with all its properties.
 #[derive(Clone, Copy)]

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -635,9 +635,8 @@ fn resolve_length_with_sizing(value: Length, sizing: &SizingContext) -> Option<f
 mod tests {
   use std::rc::Rc;
 
-  use taffy::Size;
-
   use crate::{
+    geometry::Size,
     style::{
       SizingContext,
       animation::{sample_animation_progress, tailwind_animation_keyframes},

--- a/takumi-core/src/style/media_query.rs
+++ b/takumi-core/src/style/media_query.rs
@@ -1,10 +1,10 @@
 use std::rc::Rc;
 
 use cssparser::*;
-use taffy::Size;
 
 use crate::{
   error::StyleSheetParseError,
+  geometry::Size,
   style::{CalcArena, FromCss, Length, SizingContext},
   viewport::Viewport,
 };

--- a/takumi-core/src/style/properties/background_size.rs
+++ b/takumi-core/src/style/properties/background_size.rs
@@ -1,12 +1,14 @@
 use std::fmt;
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
-use taffy::Size;
 
 use super::{background_image::parse_comma_list, background_size_resolve::*};
-use crate::style::{
-  Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
-  MakeComputed, ParseResult, SizingContext, ToCss, tw::TailwindPropertyParser, unexpected_token,
+use crate::{
+  geometry::Size,
+  style::{
+    Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
+    MakeComputed, ParseResult, SizingContext, ToCss, tw::TailwindPropertyParser, unexpected_token,
+  },
 };
 
 /// Parsed `background-size` for one layer.

--- a/takumi-core/src/style/properties/background_size_resolve.rs
+++ b/takumi-core/src/style/properties/background_size_resolve.rs
@@ -1,6 +1,7 @@
-use taffy::Size;
-
-use crate::style::{Length, SizingContext};
+use crate::{
+  geometry::Size,
+  style::{Length, SizingContext},
+};
 
 /// Which axis was left `auto` after resolving `background-size`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/takumi-core/src/style/properties/font_size.rs
+++ b/takumi-core/src/style/properties/font_size.rs
@@ -191,10 +191,9 @@ impl ToCss for FontSize {
 mod tests {
   use std::rc::Rc;
 
-  use taffy::Size;
-
   use super::*;
   use crate::{
+    geometry::Size,
     style::{CalcArena, FromCssStr, SizingContext},
     viewport::Viewport,
   };

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -3,12 +3,14 @@ use std::fmt;
 use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Rgba8, Srgb};
 use cssparser::Parser;
 use smallvec::SmallVec;
-use taffy::Point;
 use tiny_skia::{ColorU8, PremultipliedColorU8};
 
-use crate::style::{
-  Color, ColorInput, ColorInterpolationMethod, FromCss, GradientStop, ParseResult,
-  ResolvedGradientStop, SizingContext, StopPosition, ToCss, math::fast_div_255,
+use crate::{
+  geometry::Point,
+  style::{
+    Color, ColorInput, ColorInterpolationMethod, FromCss, GradientStop, ParseResult,
+    ResolvedGradientStop, SizingContext, StopPosition, ToCss, math::fast_div_255,
+  },
 };
 
 const MIN_GRADIENT_LUT_SIZE: usize = 2;

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -512,10 +512,8 @@ impl MakeComputed for Length {
 mod tests {
   use std::{assert_matches, rc::Rc};
 
-  use taffy::Size;
-
   use super::*;
-  use crate::{style::calc::CalcArena, viewport::Viewport};
+  use crate::{geometry::Size, style::calc::CalcArena, viewport::Viewport};
 
   fn sizing() -> SizingContext {
     SizingContext {

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -825,11 +825,11 @@ mod tests {
   use std::rc::Rc;
 
   use color::{ColorSpaceTag, HueDirection};
-  use taffy::Size;
   use tiny_skia::ColorU8;
 
   use super::*;
   use crate::{
+    geometry::Size,
     style::{CalcArena, FromCssStr, properties::gradient_utils::red_blue_stops},
     viewport::Viewport,
   };

--- a/takumi-core/src/style/properties/offset_path.rs
+++ b/takumi-core/src/style/properties/offset_path.rs
@@ -2,11 +2,13 @@ use std::{f32::consts::FRAC_PI_2, fmt};
 
 use cssparser::Parser;
 use kurbo::{BezPath, ParamCurve, ParamCurveArclen, PathEl, PathSeg, Shape};
-use taffy::{Point, Size};
 
-use crate::style::{
-  Angle, Animatable, BasicShape, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed,
-  ParseResult, ShapePosition, ShapeRadius, SizingContext, ToCss, declare_enum_from_css_impl,
+use crate::{
+  geometry::{Point, Size},
+  style::{
+    Angle, Animatable, BasicShape, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed,
+    ParseResult, ShapePosition, ShapeRadius, SizingContext, ToCss, declare_enum_from_css_impl,
+  },
 };
 
 /// Flattening tolerance (CSS px) for arc-length integration and shape sampling.

--- a/takumi-core/src/style/properties/sides.rs
+++ b/takumi-core/src/style/properties/sides.rs
@@ -1,10 +1,12 @@
 use std::fmt;
 
 use cssparser::Parser;
-use taffy::Rect;
 
-use crate::style::{
-  CssExpectedMessage, CssToken, FromCss, Length, MakeComputed, ParseResult, SizingContext, ToCss,
+use crate::{
+  geometry::Rect,
+  style::{
+    CssExpectedMessage, CssToken, FromCss, Length, MakeComputed, ParseResult, SizingContext, ToCss,
+  },
 };
 
 /// Represents the values for the four sides of a box (top, right, bottom, left).

--- a/takumi-core/src/style/properties/space_pair.rs
+++ b/takumi-core/src/style/properties/space_pair.rs
@@ -59,11 +59,11 @@ impl<T: Copy + MakeComputed> MakeComputed for SpacePair<T> {
   }
 }
 
-impl<T: Copy> From<SpacePair<T>> for Point<T> {
-  fn from(value: SpacePair<T>) -> Self {
+impl<T: Copy> SpacePair<T> {
+  pub(crate) fn into_taffy(self) -> Point<T> {
     Point {
-      x: value.x,
-      y: value.y,
+      x: self.x,
+      y: self.y,
     }
   }
 }

--- a/takumi-core/src/style/properties/vertical_align.rs
+++ b/takumi-core/src/style/properties/vertical_align.rs
@@ -231,10 +231,8 @@ impl TailwindPropertyParser for VerticalAlign {
 mod tests {
   use std::rc::Rc;
 
-  use taffy::Size;
-
   use super::*;
-  use crate::viewport::Viewport;
+  use crate::{geometry::Size, viewport::Viewport};
 
   fn sizing() -> SizingContext {
     SizingContext {

--- a/takumi-core/src/style/sizing.rs
+++ b/takumi-core/src/style/sizing.rs
@@ -1,9 +1,8 @@
 use std::rc::Rc;
 
-use taffy::Size;
 use typed_builder::TypedBuilder;
 
-use crate::{style::CalcArena, viewport::Viewport};
+use crate::{geometry::Size, style::CalcArena, viewport::Viewport};
 
 /// The sizing context used for length value resolving.
 #[derive(Clone, TypedBuilder)]

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use parley::FontFeature;
-use taffy::{Line, Point, Rect, Size};
+use taffy::{Line, Rect, Size};
 
 use super::ComputedStyle;
 use crate::{
@@ -390,7 +390,7 @@ impl ComputedStyle {
       aspect_ratio: self.aspect_ratio.into(),
       align_self: self.align_self.into(),
       justify_self: self.justify_self.into(),
-      overflow: Point::from(self.resolve_overflows()).map(Into::into),
+      overflow: self.resolve_overflows().into_taffy().map(Into::into),
       dummy: PhantomData,
       item_is_table: false,
       item_is_replaced: false,

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -4,7 +4,10 @@ use parley::FontFeature;
 use taffy::{Line, Point, Rect, Size};
 
 use super::ComputedStyle;
-use crate::style::{SizingContext, properties::*};
+use crate::{
+  geometry::Size as CoreSize,
+  style::{SizingContext, properties::*},
+};
 
 impl ComputedStyle {
   /// Normalize inheritable text-related values to computed values for this node.
@@ -131,7 +134,7 @@ impl ComputedStyle {
         self.offset_distance,
         &self.offset_position,
         sizing,
-        Size {
+        CoreSize {
           width: reference_width,
           height: reference_height,
         },

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -3,13 +3,13 @@ use std::{collections::HashMap, rc::Rc, str::FromStr};
 use cssparser::{Parser, ParserInput};
 use parley::FontFeature;
 use serde_json::{from_value, json};
-use taffy::Size;
 
 use super::{
   CssWideKeyword, LonghandId, PropertyId, PropertyMask, ShorthandId, StyleDeclarationBlock,
   stylesheets_vars::resolve_var_references,
 };
 use crate::{
+  geometry::Size,
   style::{CalcArena, ComputedStyle, SizingContext, Style, StyleDeclaration, properties::*},
   viewport::Viewport,
 };

--- a/takumi-core/src/viewport.rs
+++ b/takumi-core/src/viewport.rs
@@ -1,6 +1,4 @@
-use taffy::AvailableSpace;
-
-use crate::geometry::Size;
+use crate::geometry::{AvailableSpace, Size};
 
 /// The default font size in pixels.
 pub(crate) const DEFAULT_FONT_SIZE: f32 = 16.0;

--- a/takumi-core/src/viewport.rs
+++ b/takumi-core/src/viewport.rs
@@ -1,4 +1,6 @@
-use taffy::{AvailableSpace, Size};
+use taffy::AvailableSpace;
+
+use crate::geometry::Size;
 
 /// The default font size in pixels.
 pub(crate) const DEFAULT_FONT_SIZE: f32 = 16.0;

--- a/takumi-raster/Cargo.toml
+++ b/takumi-raster/Cargo.toml
@@ -18,7 +18,6 @@ typed-builder.workspace = true
 smallvec.workspace = true
 parley.workspace = true
 skrifa.workspace = true
-taffy.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 image-webp.workspace = true

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use image::Rgba;
 use smallvec::{SmallVec, smallvec};
-use taffy::{Layout, Point, Size};
-use takumi_core::paint::{
-  ConicGradientTile, GradientOverlayTile, LinearGradientTile, RadialGradientTile,
-  collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
+use takumi_core::{
+  geometry::{ComputedLayout as Layout, Point, Size},
+  paint::{
+    ConicGradientTile, GradientOverlayTile, LinearGradientTile, RadialGradientTile,
+    collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
+  },
 };
 use tiny_skia::{IntSize, Pixmap, PixmapMut, PremultipliedColorU8};
 

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -20,10 +20,12 @@ pub(crate) use mask::{
   prepare_node_mask, render_mask,
 };
 pub(crate) use paint_source::{PaintSource, SamplingFootprint, interpolate_with_footprint};
-use taffy::{Point, Size};
-use takumi_core::paint::{
-  GradientOverlayTile, LinearGradientFastPathKind, LinearGradientTile, RadialGradientTile,
-  overlay_gradient_tile_fast_normal_unconstrained,
+use takumi_core::{
+  geometry::{Point, Size},
+  paint::{
+    GradientOverlayTile, LinearGradientFastPathKind, LinearGradientTile, RadialGradientTile,
+    overlay_gradient_tile_fast_normal_unconstrained,
+  },
 };
 use tiny_skia::{
   FillRule as TinyFillRule, FilterQuality as TinyFilterQuality, IntSize, Mask as TinyMask,

--- a/takumi-raster/src/canvas/composite.rs
+++ b/takumi-raster/src/canvas/composite.rs
@@ -1,4 +1,4 @@
-use taffy::Point;
+use takumi_core::geometry::Point;
 use tiny_skia::PixmapMut;
 
 use super::{

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -1,5 +1,6 @@
-use taffy::{AbsoluteAxis, Layout, Point, Rect, Size};
-use takumi_core::geometry::transformed_rect_extents;
+use takumi_core::geometry::{
+  ComputedLayout as Layout, Point, Rect, Size, transformed_rect_extents,
+};
 use tiny_skia::{
   FillRule as TinyFillRule, IntSize, Mask as TinyMask, PathBuilder as TinyPathBuilder,
   Rect as TinyRect, Transform as TinyTransform,
@@ -607,7 +608,7 @@ pub(crate) fn render_clip_shape_mask(
         .into();
 
       let border = BorderProperties {
-        width: Rect::zero(),
+        width: Rect::ZERO,
         color: Rect {
           top: Color::transparent(),
           right: Color::transparent(),
@@ -636,8 +637,8 @@ pub(crate) fn render_clip_shape_mask(
       border.append_mask_commands(
         &mut paths,
         Size {
-          width: size.width - inset.grid_axis_sum(AbsoluteAxis::Horizontal),
-          height: size.height - inset.grid_axis_sum(AbsoluteAxis::Vertical),
+          width: size.width - inset.horizontal(),
+          height: size.height - inset.vertical(),
         },
         Point {
           x: inset.left,

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -1,7 +1,9 @@
-use taffy::{Point, Rect, Size};
-use takumi_core::layout::border::{
-  BorderProperties, BorderSide, border_dash_pattern, inset_size, rect_offset,
-  shade_3d_border_color, subtract_rect,
+use takumi_core::{
+  geometry::{Point, Rect, Size},
+  layout::border::{
+    BorderProperties, BorderSide, border_dash_pattern, inset_size, rect_offset,
+    shade_3d_border_color, subtract_rect,
+  },
 };
 
 use crate::{
@@ -645,8 +647,8 @@ fn paint_mask_with_inverse(
 
 #[cfg(test)]
 mod tests {
-  use taffy::{Rect, Size};
   use takumi_core::{
+    geometry::{Rect, Size},
     layout::border::BorderProperties,
     style::{Affine, BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},
   };

--- a/takumi-raster/src/components/shadow.rs
+++ b/takumi-raster/src/components/shadow.rs
@@ -1,4 +1,4 @@
-use taffy::{Layout, Point, Size};
+use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 use tiny_skia::PixmapRef;
 
 pub(crate) use crate::shadow::SizedShadow;

--- a/takumi-raster/src/debug_drawing.rs
+++ b/takumi-raster/src/debug_drawing.rs
@@ -1,4 +1,4 @@
-use taffy::Layout;
+use takumi_core::geometry::ComputedLayout as Layout;
 
 use crate::{
   BorderPainting, BorderProperties, Canvas,

--- a/takumi-raster/src/filter.rs
+++ b/takumi-raster/src/filter.rs
@@ -1,6 +1,8 @@
 use smallvec::SmallVec;
-use taffy::{Point, Size};
-use takumi_core::paint::compose_transfer_table;
+use takumi_core::{
+  geometry::{Point, Size},
+  paint::compose_transfer_table,
+};
 use tiny_skia::{Mask as TinyMask, PixmapMut};
 
 use crate::{

--- a/takumi-raster/src/image_drawing.rs
+++ b/takumi-raster/src/image_drawing.rs
@@ -1,4 +1,4 @@
-use taffy::{Layout, Point, Size};
+use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 
 use crate::{
   BorderProperties, Canvas, RenderContext, Result, SamplingOptions, pixmap_ref_from_buffer,
@@ -80,7 +80,7 @@ pub(crate) fn process_image_for_object_fit<'i>(
           )
         },
       },
-      Point::zero(),
+      Point::ZERO,
     )),
     ObjectFit::Contain => {
       let scale_x = content_box.width / image_width;
@@ -147,7 +147,7 @@ pub(crate) fn process_image_for_object_fit<'i>(
               * Affine::translation(crop_x, crop_y)
           },
         },
-        Point::zero(),
+        Point::ZERO,
       ))
     }
     ObjectFit::ScaleDown => {

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
 use skrifa::{FontRef, MetadataProvider};
-use taffy::AvailableSpace;
-use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
+use takumi_core::geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point, Size};
 
 use crate::{
   BorderProperties, Canvas, Cap, DashPattern, DecorationSegmentParams, PaintSource, Placement,
@@ -588,7 +587,7 @@ pub(crate) fn draw_inline_box(
       height: AvailableSpace::Definite(inline_height),
     });
     let layout_results = layout_tree.into_results();
-    let root_node_id = layout_results.root_node_id();
+    let root_node_id = NodeId::ROOT;
 
     render_node(
       &mut subtree_root,

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -158,9 +158,10 @@ fn draw_underline_with_skip_ink(
   glyph_bounds_cache: &HashMap<u32, GlyphSkipInkData>,
   options: UnderlineDrawOptions,
 ) {
-  let run_start_x = options.layout.border.left + options.layout.padding.left + glyph_run.offset;
+  let content_offset = options.layout.content_box_offset();
+  let run_start_x = content_offset.x + glyph_run.offset;
   let run_end_x = run_start_x + glyph_run.advance;
-  let line_top = options.layout.border.top + options.layout.padding.top + options.offset;
+  let line_top = content_offset.y + options.offset;
   let line_bottom = line_top + options.size;
   let skip_padding = compute_skip_padding(options.size);
   let mut skip_ranges = Vec::new();
@@ -170,9 +171,8 @@ fn draw_underline_with_skip_ink(
       continue;
     };
     let local_bounds = glyph_data.bounds;
-    let inline_x = options.layout.border.left + options.layout.padding.left + glyph.x;
-    let inline_y =
-      options.layout.border.top + options.layout.padding.top + glyph.y + options.baseline_shift;
+    let inline_x = content_offset.x + glyph.x;
+    let inline_y = content_offset.y + glyph.y + options.baseline_shift;
     let glyph_top = inline_y + local_bounds.top;
     let glyph_bottom = inline_y + local_bounds.bottom;
 
@@ -548,14 +548,16 @@ fn draw_glyph_run_text_shadow(
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
 ) -> Result<()> {
+  let content_offset = options.layout.content_box_offset();
+
   for glyph in &glyph_run.glyphs {
     let Some(content) = resolved_glyphs.get(&glyph.id) else {
       continue;
     };
 
     let inline_offset = Point {
-      x: options.layout.border.left + options.layout.padding.left + glyph.x,
-      y: options.layout.border.top + options.layout.padding.top + glyph.y + options.baseline_shift,
+      x: content_offset.x + glyph.x,
+      y: content_offset.y + glyph.y + options.baseline_shift,
     };
 
     draw_glyph_text_shadow(content, canvas, style, options.transform, inline_offset)?;

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use skrifa::{FontRef, MetadataProvider};
-use taffy::{AvailableSpace, Layout, Point, geometry::Size};
+use taffy::AvailableSpace;
+use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 
 use crate::{
   BorderProperties, Canvas, Cap, DashPattern, DecorationSegmentParams, PaintSource, Placement,
@@ -577,10 +578,8 @@ pub(crate) fn draw_inline_box(
     let mut subtree_root = item.render_node.clone();
     let mut layout_tree = LayoutTree::from_render_node(&subtree_root);
 
-    let inline_width =
-      (inline_box.width - item.margin.grid_axis_sum(taffy::AbsoluteAxis::Horizontal)).max(0.0);
-    let inline_height =
-      (inline_box.height - item.margin.grid_axis_sum(taffy::AbsoluteAxis::Vertical)).max(0.0);
+    let inline_width = (inline_box.width - item.margin.horizontal()).max(0.0);
+    let inline_height = (inline_box.height - item.margin.vertical()).max(0.0);
 
     layout_tree.compute_layout(Size {
       width: AvailableSpace::Definite(inline_width),

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -4,8 +4,7 @@
 //! [`Layout`], not on the node tree. They are candidates for promotion to a
 //! backend-agnostic scene layer when an alternative (e.g. SVG) backend lands.
 
-use taffy::AvailableSpace;
-use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
+use takumi_core::geometry::{AvailableSpace, ComputedLayout as Layout, Point, Size};
 
 use super::{
   BackgroundTile, BorderPainting, BorderProperties, Canvas, Fill, PaintSource, RenderContext,

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -4,7 +4,8 @@
 //! [`Layout`], not on the node tree. They are candidates for promotion to a
 //! backend-agnostic scene layer when an alternative (e.g. SVG) backend lands.
 
-use taffy::{AvailableSpace, Layout, Point, Size};
+use taffy::AvailableSpace;
+use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 
 use super::{
   BackgroundTile, BorderPainting, BorderProperties, Canvas, Fill, PaintSource, RenderContext,

--- a/takumi-raster/src/path.rs
+++ b/takumi-raster/src/path.rs
@@ -1,6 +1,5 @@
 use svgtypes::{SimplePathSegment, SimplifyingPathParser};
-use taffy::Size;
-use takumi_core::geometry::{PathCommand, Point};
+use takumi_core::geometry::{PathCommand, Point, Size};
 use tiny_skia::{
   FillRule as TinyFillRule, LineCap as TinyLineCap, LineJoin as TinyLineJoin, Path as TinyPath,
   PathBuilder as TinyPathBuilder, PathSegment as TinyPathSegment, Rect as TinyRect,

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -2,9 +2,8 @@ use std::{collections::HashMap, ops::Range, rc::Rc, sync::Arc};
 
 use parley::{GlyphRun, InlineBoxKind, PositionedLayoutItem};
 use serde::Serialize;
-use taffy::{AvailableSpace, NodeId};
 use takumi_core::{
-  geometry::{ComputedLayout as Layout, Point, Size},
+  geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point, Size},
   scene::build_stacking_contexts,
 };
 use typed_builder::TypedBuilder;
@@ -235,7 +234,7 @@ pub fn measure<'g>(options: RenderOptions<'g>) -> Result<MeasuredNode> {
   collect_measure_result(
     &mut root,
     &layout_results,
-    layout_results.root_node_id(),
+    NodeId::ROOT,
     Affine::IDENTITY,
     Size {
       width: viewport.size.width.map(|value| value as f32),
@@ -564,7 +563,7 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
   tree.compute_layout(render_context.sizing.viewport.into());
 
   let layout_results = tree.into_results();
-  let root_node_id = layout_results.root_node_id();
+  let root_node_id = NodeId::ROOT;
   let root_size = layout_results
     .layout(root_node_id)?
     .size

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -2,8 +2,11 @@ use std::{collections::HashMap, ops::Range, rc::Rc, sync::Arc};
 
 use parley::{GlyphRun, InlineBoxKind, PositionedLayoutItem};
 use serde::Serialize;
-use taffy::{AvailableSpace, Layout, NodeId, geometry::Size};
-use takumi_core::scene::build_stacking_contexts;
+use taffy::{AvailableSpace, NodeId};
+use takumi_core::{
+  geometry::{ComputedLayout as Layout, Point, Size},
+  scene::build_stacking_contexts,
+};
 use typed_builder::TypedBuilder;
 
 use crate::{
@@ -271,7 +274,7 @@ fn collect_measure_result(
         let Some(current) = node.node_at_path_mut(&path) else {
           return Err(Error::InvalidLayoutNode(node_id.into()));
         };
-        let layout = *layout_results.layout(node_id)?;
+        let layout = layout_results.layout(node_id)?;
         current
           .context
           .sizing
@@ -313,7 +316,7 @@ fn collect_measure_result(
             mode: InlineLayoutMode::Measure,
           });
           let parent_font_metrics = get_parent_font_metrics(&built.layout);
-          let inline_offset = taffy::Point::ZERO;
+          let inline_offset = Point::ZERO;
           let line_metrics = resolve_inline_line_metrics(
             &built.layout,
             &built.spans,
@@ -336,7 +339,7 @@ fn collect_measure_result(
                 line_scale,
                 layout.content_box_size().width,
               );
-            let line_scale_origin = taffy::Point {
+            let line_scale_origin = Point {
               x: line_scale_origin_x + inline_offset.x,
               y: resolved_metrics.resolved_baseline + inline_offset.y,
             };

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -1,6 +1,6 @@
-use taffy::{AvailableSpace, Layout, Point, geometry::Size};
+use taffy::AvailableSpace;
 use takumi_core::{
-  geometry::transformed_rect_extents,
+  geometry::{ComputedLayout as Layout, Point, Size, transformed_rect_extents},
   scene::{NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode},
 };
 use tiny_skia::{Pixmap, PixmapMut};
@@ -284,7 +284,7 @@ fn begin_node_render(
   let Some(current) = root.node_at_path_mut(&node_paint.path) else {
     return Err(Error::InvalidLayoutNode(node_paint.node_id.into()));
   };
-  let layout = *layout_results.layout(node_paint.node_id)?;
+  let layout = layout_results.layout(node_paint.node_id)?;
 
   if current.context.style.is_invisible() || !node_paint.transform.is_invertible() {
     return Ok(None);

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -1,6 +1,7 @@
-use taffy::AvailableSpace;
 use takumi_core::{
-  geometry::{ComputedLayout as Layout, Point, Size, transformed_rect_extents},
+  geometry::{
+    AvailableSpace, ComputedLayout as Layout, NodeId, Point, Size, transformed_rect_extents,
+  },
   scene::{NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode},
 };
 use tiny_skia::{Pixmap, PixmapMut};
@@ -510,9 +511,7 @@ pub(crate) fn paint_context(
   }) = deferred_root
   {
     let Some(current) = root.node_at_path_mut(&path) else {
-      let node_id = context
-        .root()
-        .map_or(layout_results.root_node_id(), |node| node.node_id);
+      let node_id = context.root().map_or(NodeId::ROOT, |node| node.node_id);
       return Err(Error::InvalidLayoutNode(node_id.into()));
     };
     finish_node_render(

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -679,10 +679,9 @@ fn draw_render_node_inline(
     &font_style,
   )?;
 
-  let inline_transform = Affine::translation(
-    inline_layout_box.border.left + inline_layout_box.padding.left,
-    inline_layout_box.border.top + inline_layout_box.padding.top,
-  ) * node.context.transform;
+  let inline_offset = inline_layout_box.content_box_offset();
+  let inline_transform =
+    Affine::translation(inline_offset.x, inline_offset.y) * node.context.transform;
 
   for (item, positioned) in boxes.zip(positioned_inline_boxes.iter()) {
     draw_inline_box(positioned, item, canvas, inline_transform)?;

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, collections::HashMap, convert::Into};
 
 use skrifa::color::ColorPalette;
-use taffy::{Layout, Point, Size};
+use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 use tiny_skia::Pixmap;
 
 use crate::{

--- a/takumi-svg/Cargo.toml
+++ b/takumi-svg/Cargo.toml
@@ -11,7 +11,6 @@ rust-version = "1.91"
 [dependencies]
 base64.workspace = true
 quick-xml.workspace = true
-taffy.workspace = true
 tiny-skia.workspace = true
 typed-builder.workspace = true
 

--- a/takumi-svg/src/box_model.rs
+++ b/takumi-svg/src/box_model.rs
@@ -6,10 +6,9 @@
 
 use std::fmt::Write as _;
 
-use taffy::Size;
 use takumi_core::{
   context::RenderContext,
-  geometry::{PathCommand, Point},
+  geometry::{PathCommand, Point, Size},
   style::Affine,
 };
 

--- a/takumi-svg/src/gradient.rs
+++ b/takumi-svg/src/gradient.rs
@@ -14,9 +14,9 @@
 
 use std::{f32::consts::TAU, io};
 
-use taffy::Size;
 use takumi_core::{
   context::RenderContext,
+  geometry::Size,
   layout::node::resolve_image,
   paint::{
     ConicGradientTile, LinearGradientTile, RadialGradientTile, build_color_lut_with_interpolation,

--- a/takumi-svg/src/lib.rs
+++ b/takumi-svg/src/lib.rs
@@ -59,8 +59,8 @@ impl Rgba {
   }
 }
 
-use taffy::Size;
 use takumi_core::{
+  geometry::Size,
   shadow::SizedShadow,
   style::{Affine, Color, Filter, LUMA_WEIGHTS, SEPIA_WEIGHTS, SizingContext},
 };

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -2,12 +2,11 @@
 
 use std::{collections::HashMap, io, rc::Rc, sync::Arc};
 
-use taffy::AvailableSpace;
 use takumi_core::{
   Fonts,
   context::RenderContext,
   error::Result,
-  geometry::{ComputedLayout as Layout, Point, Rect, Size},
+  geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point, Rect, Size},
   layout::{
     border::{BorderProperties, BorderSide, border_dash_pattern},
     inline::{InlineBoxItem, VisualInlineBox},
@@ -88,11 +87,11 @@ pub fn render(options: SvgOptions<'_>) -> Result<String> {
 
   let root = RenderNode::from_node(&context, options.node);
   let mut tree = LayoutTree::from_render_node(&root);
-  let root_id = tree.root_node_id();
 
   tree.compute_layout(viewport.into());
 
   let results = tree.into_results();
+  let root_id = NodeId::ROOT;
 
   let root_layout = results.layout(root_id)?;
   let width = viewport
@@ -653,7 +652,7 @@ pub(crate) fn emit_inline_box(
       height: AvailableSpace::Definite(inline_height),
     });
     let results = tree.into_results();
-    let root_id = results.root_node_id();
+    let root_id = NodeId::ROOT;
     // Emit the recomputed subtree through the scene, offset to the box origin.
     let origin = Affine::translation(box_x + item.margin.left, box_y + item.margin.top);
     let contexts = build_stacking_contexts(

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -589,10 +589,7 @@ fn content_box_path_data(border: &BorderProperties, layout: &Layout, x: f32, y: 
   inner.append_mask_commands(
     &mut commands,
     layout.content_box_size(),
-    Point {
-      x: layout.border.left + layout.padding.left,
-      y: layout.border.top + layout.padding.top,
-    },
+    layout.content_box_offset(),
   );
   path_data(&commands, [1.0, 0.0, 0.0, 1.0, x, y])
 }
@@ -640,10 +637,9 @@ pub(crate) fn emit_inline_box(
     return Ok(());
   }
 
-  let box_x =
-    container_x + container_layout.border.left + container_layout.padding.left + inline_box.x;
-  let box_y =
-    container_y + container_layout.border.top + container_layout.padding.top + inline_box.y;
+  let content_offset = container_layout.content_box_offset();
+  let box_x = container_x + content_offset.x + inline_box.x;
+  let box_y = container_y + content_offset.y + inline_box.y;
 
   if node.participates_as_inline_box() {
     // Atomic inline box (inline-block/float): recompute the subtree at the box

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -2,11 +2,12 @@
 
 use std::{collections::HashMap, io, rc::Rc, sync::Arc};
 
-use taffy::{AbsoluteAxis, AvailableSpace, Point, Rect, Size};
+use taffy::AvailableSpace;
 use takumi_core::{
   Fonts,
   context::RenderContext,
   error::Result,
+  geometry::{ComputedLayout as Layout, Point, Rect, Size},
   layout::{
     border::{BorderProperties, BorderSide, border_dash_pattern},
     inline::{InlineBoxItem, VisualInlineBox},
@@ -153,7 +154,7 @@ impl BoxChrome {
 /// caller after emitting the box's content.
 pub(crate) fn emit_box_chrome(
   node: &RenderNode,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
   group_transform: Affine,
@@ -242,12 +243,7 @@ pub(crate) fn emit_box_chrome(
 }
 
 /// The `background-origin` positioning area as an absolute frame within the box.
-fn background_origin_frame(
-  origin: BackgroundOrigin,
-  layout: &taffy::Layout,
-  x: f32,
-  y: f32,
-) -> Frame {
+fn background_origin_frame(origin: BackgroundOrigin, layout: &Layout, x: f32, y: f32) -> Frame {
   let b = layout.border;
   let p = layout.padding;
   let frame = |left: f32, right: f32, top: f32, bottom: f32| {
@@ -278,7 +274,7 @@ fn background_origin_frame(
 pub(crate) fn emit_background(
   node: &RenderNode,
   border: &BorderProperties,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,
@@ -513,7 +509,7 @@ pub(crate) fn padding_box_path_data(
 /// content overflows there while being clipped on the other axis.
 pub(crate) fn overflow_clip_rect_data(
   style: &ComputedStyle,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
 ) -> String {
@@ -556,7 +552,7 @@ pub(crate) fn overflow_clip_rect_data(
 fn background_clip_path(
   clip: BackgroundClip,
   border: &BorderProperties,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
 ) -> Option<(String, bool)> {
@@ -585,12 +581,7 @@ fn background_clip_path(
 
 /// Absolute SVG path `d` for the content-box rounded rectangle (border-box inset
 /// by border widths and padding, with inner radii), reusing core geometry.
-fn content_box_path_data(
-  border: &BorderProperties,
-  layout: &taffy::Layout,
-  x: f32,
-  y: f32,
-) -> String {
+fn content_box_path_data(border: &BorderProperties, layout: &Layout, x: f32, y: f32) -> String {
   let mut inner = *border;
   inner.inset_by_border_width();
   inner.expand_by(layout.padding.map(|size| -size));
@@ -610,7 +601,7 @@ fn content_box_path_data(
 /// at the border-box top-left `(x, y)`. Block children are painted separately.
 pub(crate) fn emit_own_content(
   node: &RenderNode,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,
@@ -639,7 +630,7 @@ pub(crate) fn emit_own_content(
 pub(crate) fn emit_inline_box(
   inline_box: &VisualInlineBox,
   item: &InlineBoxItem<'_>,
-  container_layout: taffy::Layout,
+  container_layout: Layout,
   container_x: f32,
   container_y: f32,
   doc: &mut SvgDocument,
@@ -659,10 +650,8 @@ pub(crate) fn emit_inline_box(
     // size, mirroring the raster backend.
     let subtree = node.clone();
     let mut tree = LayoutTree::from_render_node(&subtree);
-    let inline_width =
-      (inline_box.width - item.margin.grid_axis_sum(AbsoluteAxis::Horizontal)).max(0.0);
-    let inline_height =
-      (inline_box.height - item.margin.grid_axis_sum(AbsoluteAxis::Vertical)).max(0.0);
+    let inline_width = (inline_box.width - item.margin.horizontal()).max(0.0);
+    let inline_height = (inline_box.height - item.margin.vertical()).max(0.0);
     tree.compute_layout(Size {
       width: AvailableSpace::Definite(inline_width),
       height: AvailableSpace::Definite(inline_height),
@@ -683,7 +672,7 @@ pub(crate) fn emit_inline_box(
   }
 
   // Replaced inline box (e.g. an image): no in-flow layout to recompute.
-  let box_layout: taffy::Layout = item.into();
+  let box_layout: Layout = item.into();
   let group_transform =
     element_transform(&node.context, box_layout.size, box_x, box_y).unwrap_or(IDENTITY);
   let chrome = emit_box_chrome(node, &box_layout, box_x, box_y, group_transform, doc)?;
@@ -705,7 +694,7 @@ pub(crate) fn emit_inline_box(
 fn emit_image_node(
   image: &ImageData,
   node: &RenderNode,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,
@@ -1057,7 +1046,7 @@ fn emit_with_blur(
 /// Inset shadows are handled by [`emit_inset_box_shadows`].
 pub(crate) fn emit_box_shadows(
   node: &RenderNode,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
   w: f32,
@@ -1108,7 +1097,7 @@ pub(crate) fn emit_box_shadows(
 pub(crate) fn emit_inset_box_shadows(
   node: &RenderNode,
   border: &BorderProperties,
-  layout: &taffy::Layout,
+  layout: &Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -154,7 +154,7 @@ impl BoxChrome {
 /// caller after emitting the box's content.
 pub(crate) fn emit_box_chrome(
   node: &RenderNode,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
   group_transform: Affine,
@@ -243,7 +243,7 @@ pub(crate) fn emit_box_chrome(
 }
 
 /// The `background-origin` positioning area as an absolute frame within the box.
-fn background_origin_frame(origin: BackgroundOrigin, layout: &Layout, x: f32, y: f32) -> Frame {
+fn background_origin_frame(origin: BackgroundOrigin, layout: Layout, x: f32, y: f32) -> Frame {
   let b = layout.border;
   let p = layout.padding;
   let frame = |left: f32, right: f32, top: f32, bottom: f32| {
@@ -274,7 +274,7 @@ fn background_origin_frame(origin: BackgroundOrigin, layout: &Layout, x: f32, y:
 pub(crate) fn emit_background(
   node: &RenderNode,
   border: &BorderProperties,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,
@@ -509,7 +509,7 @@ pub(crate) fn padding_box_path_data(
 /// content overflows there while being clipped on the other axis.
 pub(crate) fn overflow_clip_rect_data(
   style: &ComputedStyle,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
 ) -> String {
@@ -552,7 +552,7 @@ pub(crate) fn overflow_clip_rect_data(
 fn background_clip_path(
   clip: BackgroundClip,
   border: &BorderProperties,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
 ) -> Option<(String, bool)> {
@@ -581,7 +581,7 @@ fn background_clip_path(
 
 /// Absolute SVG path `d` for the content-box rounded rectangle (border-box inset
 /// by border widths and padding, with inner radii), reusing core geometry.
-fn content_box_path_data(border: &BorderProperties, layout: &Layout, x: f32, y: f32) -> String {
+fn content_box_path_data(border: &BorderProperties, layout: Layout, x: f32, y: f32) -> String {
   let mut inner = *border;
   inner.inset_by_border_width();
   inner.expand_by(layout.padding.map(|size| -size));
@@ -598,13 +598,13 @@ fn content_box_path_data(border: &BorderProperties, layout: &Layout, x: f32, y: 
 /// at the border-box top-left `(x, y)`. Block children are painted separately.
 pub(crate) fn emit_own_content(
   node: &RenderNode,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
   if node.should_create_inline_layout() {
-    return emit_inline_content(node, *layout, x, y, doc);
+    return emit_inline_content(node, layout, x, y, doc);
   }
   // A node whose anonymous text became a child item paints that text through the
   // child, not as its own content (mirroring the raster backend's guard).
@@ -613,7 +613,7 @@ pub(crate) fn emit_own_content(
   }
   match node.node.as_ref().map(|n| &n.kind) {
     Some(NodeKind::Image(image)) => emit_image_node(image, node, layout, x, y, doc),
-    Some(NodeKind::Text(text)) => emit_text(text, &node.context, *layout, x, y, doc),
+    Some(NodeKind::Text(text)) => emit_text(text, &node.context, layout, x, y, doc),
     _ => Ok(()),
   }
 }
@@ -671,10 +671,10 @@ pub(crate) fn emit_inline_box(
   let box_layout: Layout = item.into();
   let group_transform =
     element_transform(&node.context, box_layout.size, box_x, box_y).unwrap_or(IDENTITY);
-  let chrome = emit_box_chrome(node, &box_layout, box_x, box_y, group_transform, doc)?;
+  let chrome = emit_box_chrome(node, box_layout, box_x, box_y, group_transform, doc)?;
 
   match node.node.as_ref().map(|n| &n.kind) {
-    Some(NodeKind::Image(image)) => emit_image_node(image, node, &box_layout, box_x, box_y, doc)?,
+    Some(NodeKind::Image(image)) => emit_image_node(image, node, box_layout, box_x, box_y, doc)?,
     Some(NodeKind::Text(text)) => emit_text(text, &node.context, box_layout, box_x, box_y, doc)?,
     _ => {}
   }
@@ -690,7 +690,7 @@ pub(crate) fn emit_inline_box(
 fn emit_image_node(
   image: &ImageData,
   node: &RenderNode,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,
@@ -1042,7 +1042,7 @@ fn emit_with_blur(
 /// Inset shadows are handled by [`emit_inset_box_shadows`].
 pub(crate) fn emit_box_shadows(
   node: &RenderNode,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
   w: f32,
@@ -1093,7 +1093,7 @@ pub(crate) fn emit_box_shadows(
 pub(crate) fn emit_inset_box_shadows(
   node: &RenderNode,
   border: &BorderProperties,
-  layout: &Layout,
+  layout: Layout,
   x: f32,
   y: f32,
   doc: &mut SvgDocument,

--- a/takumi-svg/src/scene_emit.rs
+++ b/takumi-svg/src/scene_emit.rs
@@ -13,6 +13,7 @@ use std::io;
 
 use taffy::NodeId;
 use takumi_core::{
+  geometry::ComputedLayout as Layout,
   layout::{
     border::BorderProperties,
     tree::{LayoutResults, RenderNode},
@@ -55,7 +56,7 @@ fn emit_backdrop(
   doc: &mut SvgDocument,
   node: &RenderNode,
   node_id: NodeId,
-  layout: &taffy::Layout,
+  layout: &Layout,
   frame: Affine,
   x: f32,
   y: f32,
@@ -164,7 +165,7 @@ fn emit_box(
       doc,
       node,
       np.node_id,
-      layout,
+      &layout,
       frame,
       x,
       y,
@@ -172,8 +173,8 @@ fn emit_box(
     )?;
   }
 
-  let chrome = emit_box_chrome(node, layout, x, y, group_transform, doc)?;
-  emit_own_content(node, layout, x, y, doc)?;
+  let chrome = emit_box_chrome(node, &layout, x, y, group_transform, doc)?;
+  emit_own_content(node, &layout, x, y, doc)?;
   Ok(Some((chrome, frame)))
 }
 

--- a/takumi-svg/src/scene_emit.rs
+++ b/takumi-svg/src/scene_emit.rs
@@ -11,9 +11,8 @@
 
 use std::io;
 
-use taffy::NodeId;
 use takumi_core::{
-  geometry::ComputedLayout as Layout,
+  geometry::{ComputedLayout as Layout, NodeId},
   layout::{
     border::BorderProperties,
     tree::{LayoutResults, RenderNode},

--- a/takumi-svg/src/scene_emit.rs
+++ b/takumi-svg/src/scene_emit.rs
@@ -56,7 +56,7 @@ fn emit_backdrop(
   doc: &mut SvgDocument,
   node: &RenderNode,
   node_id: NodeId,
-  layout: &Layout,
+  layout: Layout,
   frame: Affine,
   x: f32,
   y: f32,
@@ -165,7 +165,7 @@ fn emit_box(
       doc,
       node,
       np.node_id,
-      &layout,
+      layout,
       frame,
       x,
       y,
@@ -173,8 +173,8 @@ fn emit_box(
     )?;
   }
 
-  let chrome = emit_box_chrome(node, &layout, x, y, group_transform, doc)?;
-  emit_own_content(node, &layout, x, y, doc)?;
+  let chrome = emit_box_chrome(node, layout, x, y, group_transform, doc)?;
+  emit_own_content(node, layout, x, y, doc)?;
   Ok(Some((chrome, frame)))
 }
 

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -8,11 +8,10 @@
 
 use std::io;
 
-use taffy::AvailableSpace;
 use takumi_core::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{ComputedLayout as Layout, Size},
+  geometry::{AvailableSpace, ComputedLayout as Layout, Size},
   layout::{
     inline::{
       DecorationRect, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineOutlineRect,

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -8,10 +8,11 @@
 
 use std::io;
 
-use taffy::{AvailableSpace, Layout, Size};
+use taffy::AvailableSpace;
 use takumi_core::{
   context::RenderContext,
   font_style::SizedFontStyle,
+  geometry::{ComputedLayout as Layout, Size},
   layout::{
     inline::{
       DecorationRect, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineOutlineRect,


### PR DESCRIPTION
## Why

`taffy::{Size, Rect, Point}` and the computed `taffy::Layout` leaked through
`takumi-core`'s public API and into both backends. taffy is our layout engine,
not part of the public surface we want to commit to.

## What

- Added core-owned `geometry::{Size, Rect, Point, ComputedLayout}`, with
  `.into()` bridges to/from the taffy equivalents at the engine seam.
- `LayoutResults::layout()` now returns an owned `ComputedLayout` instead of
  `&taffy::Layout`.
- Migrated every taffy geometry usage in `takumi-core`'s public items
  (`BorderProperties`, `SizedShadow`, `InlineBoxItem`, `InlineLayoutRequest`,
  `create_inline_constraint`, `resolve_inline_runs`, gradient/background-size
  helpers) and across both backends (raster, svg) to the core types.
- `taffy` stays the layout engine, only crossing the boundary at
  `compute_layout`'s `Size<AvailableSpace>` input (`AvailableSpace`/`NodeId`/
  `Style` are unaffected, out of scope for this PR).
- Two non-1:1 replacements: `rect.grid_axis_sum(AbsoluteAxis::Horizontal/Vertical)`
  → `rect.horizontal()`/`rect.vertical()`; `taffy::Point{x,y}`/`Point::ZERO`
  literals → the core equivalents.

Render-neutral: `cargo test -p takumi` goldens are byte-identical (zero
`.webp`/`.svg` diffs, only the known `.html` regen noise). `cargo clippy
--workspace --all-targets` is clean.

Follow-up (separate PR, deferred by design): `taffy::AvailableSpace` and
`taffy::NodeId` still cross the boundary at the compute-input seam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout and rendering now consistently use the app’s own geometry primitives, with computed layout geometry carried through layout, raster, and SVG emission.
  * Layout results now return an owned computed layout for painting and bounds calculations.
* **Bug Fixes**
  * Improved inline and text rendering geometry (inline sizing/positioning, glyph/text shadow placement, and decorations) using content-box offsets.
  * Corrected border/shadow/clipping/background/gradient/overflow computations to rely on the unified geometry types.
* **Documentation**
  * Updated the public API changelog to note the sealed geometry types and their replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->