### PR TITLE
Core: seal taffy/parley leaks out of the public style API

### DIFF
--- a/.tegami/seal-style-taffy-parley-leaks.md
+++ b/.tegami/seal-style-taffy-parley-leaks.md
@@ -1,0 +1,19 @@
+---
+packages:
+  cargo:takumi-core: minor
+  cargo:takumi-raster: minor
+---
+
+### Seal remaining `taffy`/`parley` leaks out of the public `style` API
+
+`Position`, `Display`, `AlignItems`, `JustifyContent`, `BoxSizing`, `Direction`,
+`FlexDirection`, `FlexWrap`, `Overflow`, `TextAlign`, `GridPlacement`,
+`GridAutoFlow`, `GridRepetitionCount`, and `GridTemplateAreas` no longer
+implement `From<_>` for their `taffy`/`parley` counterparts; the conversions
+are now `pub(crate)` inherent methods (`into_taffy`/`into_parley`).
+`TextWrapMode`, `WordBreak`, and `OverflowWrap` lose their `parley` `From`
+impls the same way. `ResolvedVerticalAlign::apply` is now `pub(crate)`.
+
+`takumi-raster`: dropped the unused `From<OutputFormat> for image::ImageFormat`
+impl, which pinned the `image` crate into the public API without being called
+anywhere.

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -128,13 +128,13 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
       font_family: style.font_family.to_parley(),
       letter_spacing: style.letter_spacing,
       word_spacing: style.word_spacing,
-      word_break: style.parent.word_break.into(),
+      word_break: style.parent.word_break.into_parley(),
       overflow_wrap: if style.parent.word_break == WordBreak::BreakWord {
         // When word-break is break-word, ignore the overflow-wrap property's value.
         // https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#break-word
         parley::OverflowWrap::Anywhere
       } else {
-        style.parent.overflow_wrap.into()
+        style.parent.overflow_wrap.into_parley()
       },
       brush: InlineBrush {
         source_span_id: None,
@@ -158,7 +158,7 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
         line_height_scales_with_text_fit: style.line_height_scales_with_text_fit,
         vertical_align: style.parent.vertical_align,
       },
-      text_wrap_mode: style.parent.resolved_text_wrap_mode().into(),
+      text_wrap_mode: style.parent.resolved_text_wrap_mode().into_parley(),
       font_width: style.parent.font_stretch.into(),
 
       locale: style.parent.lang,

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1618,7 +1618,7 @@ pub fn create_inline_layout<'c>(request: InlineLayoutRequest<'c>) -> BuiltInline
 
   built
     .layout
-    .align(style.parent.text_align.into(), Default::default());
+    .align(style.parent.text_align.into_parley(), Default::default());
   built
 }
 

--- a/takumi-core/src/style/properties/grid/grid_auto_flow.rs
+++ b/takumi-core/src/style/properties/grid/grid_auto_flow.rs
@@ -25,9 +25,9 @@ pub struct GridAutoFlow {
 
 impl MakeComputed for GridAutoFlow {}
 
-impl From<GridAutoFlow> for taffy::GridAutoFlow {
-  fn from(value: GridAutoFlow) -> Self {
-    match (value.direction, value.dense) {
+impl GridAutoFlow {
+  pub(crate) fn into_taffy(self) -> taffy::GridAutoFlow {
+    match (self.direction, self.dense) {
       (GridDirection::Row, false) => taffy::GridAutoFlow::Row,
       (GridDirection::Column, false) => taffy::GridAutoFlow::Column,
       (GridDirection::Row, true) => taffy::GridAutoFlow::RowDense,

--- a/takumi-core/src/style/properties/grid/grid_placement.rs
+++ b/takumi-core/src/style/properties/grid/grid_placement.rs
@@ -80,9 +80,9 @@ impl TailwindPropertyParser for GridPlacementSpan {
   }
 }
 
-impl From<GridPlacement> for taffy::GridPlacement {
-  fn from(placement: GridPlacement) -> Self {
-    match placement {
+impl GridPlacement {
+  pub(crate) fn into_taffy(self) -> taffy::GridPlacement {
+    match self {
       GridPlacement::Auto | GridPlacement::Named(_) => taffy::GridPlacement::Auto,
       GridPlacement::Line(line) => taffy::GridPlacement::Line(line.into()),
       GridPlacement::Span(GridPlacementSpan::Span(span)) => taffy::GridPlacement::Span(span),

--- a/takumi-core/src/style/properties/grid/grid_repetition_count.rs
+++ b/takumi-core/src/style/properties/grid/grid_repetition_count.rs
@@ -22,9 +22,9 @@ pub enum GridRepetitionCount {
   Count(u16),
 }
 
-impl From<GridRepetitionCount> for taffy::RepetitionCount {
-  fn from(repetition: GridRepetitionCount) -> Self {
-    match repetition {
+impl GridRepetitionCount {
+  pub(crate) fn into_taffy(self) -> taffy::RepetitionCount {
+    match self {
       GridRepetitionCount::Keyword(GridRepetitionKeyword::AutoFill) => {
         taffy::RepetitionCount::AutoFill
       }

--- a/takumi-core/src/style/properties/grid/grid_template_areas.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_areas.rs
@@ -17,14 +17,14 @@ pub struct GridTemplateAreas(pub Vec<Vec<String>>);
 
 impl MakeComputed for GridTemplateAreas {}
 
-impl From<GridTemplateAreas> for Vec<taffy::GridTemplateArea<String>> {
-  fn from(value: GridTemplateAreas) -> Self {
-    if value.0.is_empty() {
+impl GridTemplateAreas {
+  pub(crate) fn into_taffy(self) -> Vec<taffy::GridTemplateArea<String>> {
+    if self.0.is_empty() {
       return Vec::new();
     }
 
     let mut bounds: HashMap<&str, (usize, usize, usize, usize)> = HashMap::new();
-    for (r, row) in value.0.iter().enumerate() {
+    for (r, row) in self.0.iter().enumerate() {
       for (c, cell) in row.iter().enumerate() {
         if cell == "." {
           continue;

--- a/takumi-core/src/style/properties/grid/grid_template_component.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_component.rs
@@ -176,7 +176,7 @@ pub(crate) fn collect_components_and_names(
 
         track_components.push(taffy::GridTemplateComponent::Repeat(
           taffy::GridTemplateRepetition {
-            count: (*repetition).into(),
+            count: repetition.into_taffy(),
             tracks: track_sizes,
             line_names: inner_line_names,
           },

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -440,7 +440,7 @@ declare_enum_from_css_impl!(
   "border-box" => BoxSizing::BorderBox
 );
 
-impl_from_taffy_enum!(BoxSizing, taffy::BoxSizing, ContentBox, BorderBox);
+impl_from_taffy_enum!(BoxSizing, into_taffy -> taffy::BoxSizing, ContentBox, BorderBox);
 
 /// Text alignment options for text rendering.
 ///
@@ -474,7 +474,7 @@ declare_enum_from_css_impl!(
 );
 
 impl_from_taffy_enum!(
-  TextAlign, Alignment, Left, Right, Center, Justify, Start, End
+  TextAlign, into_parley -> Alignment, Left, Right, Center, Justify, Start, End
 );
 
 /// Defines whether an element creates a new stacking context.
@@ -561,11 +561,11 @@ declare_enum_from_css_impl!(
   "fixed" => Position::Fixed
 );
 
-impl From<Position> for taffy::Position {
-  fn from(value: Position) -> Self {
-    match value {
-      Position::Relative | Position::Static => Self::Relative,
-      Position::Absolute | Position::Fixed => Self::Absolute,
+impl Position {
+  pub(crate) fn into_taffy(self) -> taffy::Position {
+    match self {
+      Position::Relative | Position::Static => taffy::Position::Relative,
+      Position::Absolute | Position::Fixed => taffy::Position::Absolute,
     }
   }
 }
@@ -600,7 +600,7 @@ declare_enum_from_css_impl!(
   "rtl" => Direction::Rtl
 );
 
-impl_from_taffy_enum!(Direction, taffy::Direction, Ltr, Rtl);
+impl_from_taffy_enum!(Direction, into_taffy -> taffy::Direction, Ltr, Rtl);
 
 /// Defines whether an element should be placed along the left or right side of its container.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -735,7 +735,7 @@ declare_enum_from_css_impl!(
 
 impl_from_taffy_enum!(
   FlexDirection,
-  taffy::FlexDirection,
+  into_taffy -> taffy::FlexDirection,
   Row,
   Column,
   RowReverse,
@@ -818,9 +818,9 @@ impl TailwindPropertyParser for JustifyContent {
   }
 }
 
-impl From<JustifyContent> for Option<taffy::JustifyContent> {
-  fn from(value: JustifyContent) -> Self {
-    match value {
+impl JustifyContent {
+  pub(crate) fn into_taffy(self) -> Option<taffy::JustifyContent> {
+    match self {
       JustifyContent::Normal => None,
       JustifyContent::Start => Some(taffy::JustifyContent::START),
       JustifyContent::End => Some(taffy::JustifyContent::END),
@@ -914,9 +914,9 @@ impl Display {
   }
 }
 
-impl From<Display> for taffy::Display {
-  fn from(value: Display) -> Self {
-    match value {
+impl Display {
+  pub(crate) fn into_taffy(self) -> taffy::Display {
+    match self {
       Display::Flex | Display::InlineFlex => taffy::Display::Flex,
       Display::Grid | Display::InlineGrid => taffy::Display::Grid,
       Display::Block | Display::InlineBlock | Display::Inline => taffy::Display::Block,
@@ -977,9 +977,9 @@ declare_box_alignment_enum_impl!(
   }
 );
 
-impl From<AlignItems> for Option<taffy::AlignItems> {
-  fn from(value: AlignItems) -> Self {
-    match value {
+impl AlignItems {
+  pub(crate) fn into_taffy(self) -> Option<taffy::AlignItems> {
+    match self {
       AlignItems::Normal => None,
       AlignItems::Start => Some(taffy::AlignItems::START),
       AlignItems::End => Some(taffy::AlignItems::END),
@@ -1019,7 +1019,7 @@ declare_enum_from_css_impl!(
   "wrap-reverse" => FlexWrap::WrapReverse
 );
 
-impl_from_taffy_enum!(FlexWrap, taffy::FlexWrap, NoWrap, Wrap, WrapReverse);
+impl_from_taffy_enum!(FlexWrap, into_taffy -> taffy::FlexWrap, NoWrap, Wrap, WrapReverse);
 
 /// Controls text case transformation when rendering.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/takumi-core/src/style/properties/overflow.rs
+++ b/takumi-core/src/style/properties/overflow.rs
@@ -37,9 +37,9 @@ impl TailwindPropertyParser for Overflow {
   }
 }
 
-impl From<Overflow> for TaffyOverflow {
-  fn from(val: Overflow) -> Self {
-    match val {
+impl Overflow {
+  pub(crate) fn into_taffy(self) -> TaffyOverflow {
+    match self {
       Overflow::Visible => TaffyOverflow::Visible,
       Overflow::Clip => TaffyOverflow::Clip,
       Overflow::Hidden => TaffyOverflow::Hidden,

--- a/takumi-core/src/style/properties/overflow_wrap.rs
+++ b/takumi-core/src/style/properties/overflow_wrap.rs
@@ -53,8 +53,8 @@ impl ToCss for OverflowWrap {
   }
 }
 
-impl From<OverflowWrap> for parley::OverflowWrap {
-  fn from(value: OverflowWrap) -> Self {
-    value.0
+impl OverflowWrap {
+  pub(crate) fn into_parley(self) -> parley::OverflowWrap {
+    self.0
   }
 }

--- a/takumi-core/src/style/properties/text_wrap.rs
+++ b/takumi-core/src/style/properties/text_wrap.rs
@@ -86,9 +86,9 @@ pub enum TextWrapMode {
   NoWrap,
 }
 
-impl From<TextWrapMode> for parley::TextWrapMode {
-  fn from(value: TextWrapMode) -> Self {
-    match value {
+impl TextWrapMode {
+  pub(crate) fn into_parley(self) -> parley::TextWrapMode {
+    match self {
       TextWrapMode::Wrap => parley::TextWrapMode::Wrap,
       TextWrapMode::NoWrap => parley::TextWrapMode::NoWrap,
     }

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -754,12 +754,12 @@ impl ToCss for Arc<str> {
   }
 }
 
-/// Macro to implement From trait for Taffy enum conversions.
+/// Macro to implement a `pub(crate)` conversion method into a foreign (taffy/parley) enum.
 macro_rules! impl_from_taffy_enum {
-  ($from_ty:ty, $to_ty:ty, $($variant:ident),*) => {
-    impl From<$from_ty> for $to_ty {
-      fn from(value: $from_ty) -> Self {
-        match value {
+  ($from_ty:ty, $method:ident -> $to_ty:ty, $($variant:ident),*) => {
+    impl $from_ty {
+      pub(crate) fn $method(self) -> $to_ty {
+        match self {
           $(<$from_ty>::$variant => <$to_ty>::$variant,)*
         }
       }

--- a/takumi-core/src/style/properties/vertical_align.rs
+++ b/takumi-core/src/style/properties/vertical_align.rs
@@ -171,7 +171,7 @@ impl MakeComputed for VerticalAlign {
 
 impl ResolvedVerticalAlign {
   /// Writes the aligned `y` for a box on a line given its metrics.
-  pub fn apply(
+  pub(crate) fn apply(
     self,
     y: &mut f32,
     metrics: &LineMetrics,

--- a/takumi-core/src/style/properties/word_break.rs
+++ b/takumi-core/src/style/properties/word_break.rs
@@ -25,9 +25,9 @@ declare_enum_from_css_impl!(
   "break-word" => WordBreak::BreakWord,
 );
 
-impl From<WordBreak> for parley::WordBreak {
-  fn from(value: WordBreak) -> Self {
-    match value {
+impl WordBreak {
+  pub(crate) fn into_parley(self) -> parley::WordBreak {
+    match self {
       WordBreak::Normal | WordBreak::BreakWord => parley::WordBreak::Normal,
       WordBreak::BreakAll => parley::WordBreak::BreakAll,
       WordBreak::KeepAll => parley::WordBreak::KeepAll,

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -282,8 +282,8 @@ impl ComputedStyle {
     taffy::Style {
       float: self.float.resolve(self.direction),
       clear: self.clear.resolve(self.direction),
-      direction: self.direction.into(),
-      box_sizing: self.box_sizing.into(),
+      direction: self.direction.into_taffy(),
+      box_sizing: self.box_sizing.into_taffy(),
       size: Size {
         width: self.width,
         height: self.height,
@@ -322,14 +322,14 @@ impl ComputedStyle {
         left: self.margin_left,
       }
       .map(|margin| margin.resolve_to_length_percentage_auto(sizing)),
-      display: self.display.into(),
-      flex_direction: self.flex_direction.into(),
-      position: self.position.into(),
-      justify_content: self.justify_content.into(),
-      align_content: self.align_content.into(),
-      justify_items: self.justify_items.into(),
+      display: self.display.into_taffy(),
+      flex_direction: self.flex_direction.into_taffy(),
+      position: self.position.into_taffy(),
+      justify_content: self.justify_content.into_taffy(),
+      align_content: self.align_content.into_taffy(),
+      justify_items: self.justify_items.into_taffy(),
       flex_grow: self.flex_grow.map(|grow| grow.0).unwrap_or(0.0),
-      align_items: self.align_items.into(),
+      align_items: self.align_items.into_taffy(),
       gap: Size {
         width: self.column_gap.resolve_to_length_percentage(sizing),
         height: self.row_gap.resolve_to_length_percentage(sizing),
@@ -339,7 +339,7 @@ impl ComputedStyle {
         .unwrap_or(Length::Auto)
         .resolve_to_dimension(sizing),
       flex_shrink: self.flex_shrink.map(|shrink| shrink.0).unwrap_or(1.0),
-      flex_wrap: self.flex_wrap.into(),
+      flex_wrap: self.flex_wrap.into_taffy(),
       min_size: Size {
         width: self.min_width,
         height: self.min_height,
@@ -368,14 +368,14 @@ impl ComputedStyle {
             .map(|track| track.to_min_max(sizing))
             .collect()
         }),
-      grid_auto_flow: self.grid_auto_flow.into(),
+      grid_auto_flow: self.grid_auto_flow.into_taffy(),
       grid_column: Line {
-        start: self.grid_column_start.clone().into(),
-        end: self.grid_column_end.clone().into(),
+        start: self.grid_column_start.clone().into_taffy(),
+        end: self.grid_column_end.clone().into_taffy(),
       },
       grid_row: Line {
-        start: self.grid_row_start.clone().into(),
-        end: self.grid_row_end.clone().into(),
+        start: self.grid_row_start.clone().into_taffy(),
+        end: self.grid_row_end.clone().into_taffy(),
       },
       grid_template_columns,
       grid_template_rows,
@@ -386,11 +386,14 @@ impl ComputedStyle {
         .as_ref()
         .cloned()
         .unwrap_or_default()
-        .into(),
+        .into_taffy(),
       aspect_ratio: self.aspect_ratio.into(),
-      align_self: self.align_self.into(),
-      justify_self: self.justify_self.into(),
-      overflow: self.resolve_overflows().into_taffy().map(Into::into),
+      align_self: self.align_self.into_taffy(),
+      justify_self: self.justify_self.into_taffy(),
+      overflow: self
+        .resolve_overflows()
+        .into_taffy()
+        .map(Overflow::into_taffy),
       dummy: PhantomData,
       item_is_table: false,
       item_is_replaced: false,

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -5,7 +5,7 @@ use std::{
 
 use gif::{Encoder as GifEncoder, Frame as GifFrame, Repeat};
 use image::{
-  ExtendedColorType, ImageEncoder, ImageFormat, RgbaImage,
+  ExtendedColorType, ImageEncoder, RgbaImage,
   codecs::{ico::IcoEncoder, jpeg::JpegEncoder},
 };
 use png::{ColorType, DeflateCompression, Filter};
@@ -86,19 +86,6 @@ impl OutputFormat {
       OutputFormat::Png => "image/png",
       OutputFormat::Jpeg { .. } => "image/jpeg",
       OutputFormat::Ico => "image/x-icon",
-    }
-  }
-}
-
-impl From<OutputFormat> for ImageFormat {
-  fn from(format: OutputFormat) -> Self {
-    match format {
-      #[cfg(not(target_arch = "wasm32"))]
-      OutputFormat::WebP { .. } => Self::WebP,
-      OutputFormat::WebPLossless => Self::WebP,
-      OutputFormat::Png => Self::Png,
-      OutputFormat::Jpeg { .. } => Self::Jpeg,
-      OutputFormat::Ico => Self::Ico,
     }
   }
 }


### PR DESCRIPTION
## Why

Continuation of #915. The umbrella `takumi` crate's prelude glob-reexports all of `takumi_core::style::*`, so any foreign type in a public `style` signature is part of the 2.0 semver contract. Several `From<OurEnum> for taffy::*`/`parley::*` impls and one `pub fn` signature still leaked `taffy`/`parley` types this way. A parallel audit also found `takumi-raster::OutputFormat` leaking the `image` crate through a dead conversion.

## What

- `Position`, `Display`, `AlignItems`, `JustifyContent`, `BoxSizing`, `Direction`, `FlexDirection`, `FlexWrap`, `Overflow`, `TextAlign`, `GridPlacement`, `GridAutoFlow`, `GridRepetitionCount`, and `GridTemplateAreas` no longer implement `From<_>` for their `taffy` counterparts; conversions are now `pub(crate) fn into_taffy(self)` inherent methods.
- `TextWrapMode`, `WordBreak`, and `OverflowWrap` get the same treatment for `parley`, via `into_parley`.
- `impl_from_taffy_enum!` (the macro backing several of the above) now generates the inherent method instead of a public `From` impl.
- `ResolvedVerticalAlign::apply` is now `pub(crate)` (it took `&parley::layout::line::LineMetrics`).
- All call sites under `takumi-core/src/layout/` and `style/stylesheets_query.rs` updated to call the new methods explicitly.
- `takumi-raster`: removed the unused `From<OutputFormat> for image::ImageFormat` impl — it was never called and pinned the `image` crate into the public API for no reason.

`cargo public-api -p takumi-core` shows no `taffy::`/`parley::` in any `takumi_core::style::` signature (the only remaining `parley::`/`taffy::` mentions are outside `style` — `layout::tree`/`layout::inline`/`font_style`/`geometry` — or the unavoidable `parley::style::brush::Brush` blanket impls, both out of scope here). `cargo public-api -p takumi-raster` shows no `image::` types on `OutputFormat`.

Note: `takumi-core/src/error.rs`'s `impl From<SelectorParseErrorKind> for StyleSheetParseError` was investigated as a possible third leak, but it's required by `selectors::parser::Parser`'s associated-type bound (`type Error: From<SelectorParseErrorKind<'i>>`) — removing it breaks the build. It's in the same unavoidable bucket as the `Brush` blanket impls, so left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout and text handling conversions, helping grid, wrapping, alignment, and overflow behaviors stay consistent across the app.
  * Updated raster output handling to avoid unsupported image-format conversion paths.

* **Breaking Changes**
  * Several internal conversion APIs were removed or made crate-private, which may affect extensions or code built on top of these libraries.
  * Some previously exposed style and image-format conversions are no longer available publicly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->