### PR TITLE
Core: seal the parlance font model out of the public style API

### DIFF
--- a/.tegami/seal-style-parlance-leaks.md
+++ b/.tegami/seal-style-parlance-leaks.md
@@ -1,0 +1,24 @@
+---
+packages:
+  cargo:takumi-core: minor
+---
+
+### Seal the `parlance` font model out of the public `style` API
+
+`#916` grepped only `parley::`, so it missed `parlance` (the parley font
+model) leaking through `style`. This follow-up seals it:
+
+`FontFeature`, `FontVariation`, and `Tag` are now takumi-owned structs,
+replacing `parlance::tag::{FontFeature, FontVariation, Tag}` in
+`ComputedStyle::font_feature_settings`/`font_variation_settings`.
+`FontWeight::Absolute` holds a plain `f32` instead of
+`parlance::font::FontWeight`. `ComputedStyle::lang` is now `Option<Lang>`, a
+takumi-owned BCP-47 tag, instead of `Option<parlance::language::Language>`.
+`FontStretch`, `FontStyle`, `FontWeight`, `FontFamily`, and
+`resources::font::GenericFamily` lose their `From<_>`/`Into<_>` impls
+targeting `parlance` types; the conversions are now `pub(crate)` inherent
+methods (`into_parlance`/`to_parlance`/`from_parlance_generic`) called only
+at the shaping boundary.
+
+Also dropped two unused `From<FontFamily> for parlance::FontFamily` impls
+with no callers in the crate.

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -15,7 +15,7 @@ use crate::{
   layout::inline::InlineBrush,
   shadow::SizedShadow,
   style::{
-    BorderStyle, Color, ComputedStyle, Display, FontFamily, FontSynthesis, Length,
+    BorderStyle, Color, ComputedStyle, Display, FontFamily, FontSynthesis, Lang, Length,
     SizedTextDecorationThickness, SizingContext, WordBreak,
   },
 };
@@ -119,12 +119,24 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
     TextStyle {
       font_size: style.sizing.font_size,
       line_height: style.line_height,
-      font_weight: style.parent.font_weight.into(),
-      font_style: style.parent.font_style.into(),
-      font_variations: FontVariations::List(Cow::Borrowed(
-        style.parent.font_variation_settings.as_ref(),
+      font_weight: style.parent.font_weight.into_parlance(),
+      font_style: style.parent.font_style.into_parlance(),
+      font_variations: FontVariations::List(Cow::Owned(
+        style
+          .parent
+          .font_variation_settings
+          .iter()
+          .map(|variation| variation.into_parlance())
+          .collect(),
       )),
-      font_features: FontFeatures::List(style.parent.resolved_font_features()),
+      font_features: FontFeatures::List(Cow::Owned(
+        style
+          .parent
+          .resolved_font_features()
+          .iter()
+          .map(|feature| feature.into_parlance())
+          .collect(),
+      )),
       font_family: style.font_family.to_parley(),
       letter_spacing: style.letter_spacing,
       word_spacing: style.word_spacing,
@@ -159,9 +171,9 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
         vertical_align: style.parent.vertical_align,
       },
       text_wrap_mode: style.parent.resolved_text_wrap_mode().into_parley(),
-      font_width: style.parent.font_stretch.into(),
+      font_width: style.parent.font_stretch.into_parlance(),
 
-      locale: style.parent.lang,
+      locale: style.parent.lang.as_ref().map(Lang::to_parlance),
       has_underline: false,
       underline_offset: None,
       underline_size: None,

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -1,5 +1,4 @@
 use data_url::DataUrl;
-use parley::Language;
 use taffy::{CompactLength, MaybeResolve};
 
 use crate::{
@@ -7,7 +6,7 @@ use crate::{
   geometry::{AvailableSpace, Size},
   layout::node::{ImageData, ImageSourceInput, Node, NodeStyleLayers},
   resources::image::{ImageError, ImageResult, ImageSource, is_svg_like},
-  style::{Length, Style, StyleDeclaration},
+  style::{Lang, Length, Style, StyleDeclaration},
 };
 
 pub(crate) fn image_url(image: &ImageData) -> Option<&str> {
@@ -40,11 +39,7 @@ pub(crate) fn take_image_style_layers(
     author_tw: node.metadata.tw.take(),
     inline: node.metadata.style.take(),
     dir: node.metadata.dir.take(),
-    lang: node
-      .metadata
-      .lang
-      .take()
-      .map(|tag| Language::parse(&tag).ok()),
+    lang: node.metadata.lang.take().map(|tag| Lang::parse(&tag)),
   }
 }
 

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -4,7 +4,6 @@ mod text;
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use parley::Language;
 use serde::Deserialize;
 
 pub use self::image::resolve_image;
@@ -25,7 +24,7 @@ use crate::{
     image::{ImageResult, ImageSource},
     image_buffer::ImageBuffer,
   },
-  style::{Direction, Style, StyleDeclaration, ToCss, tw::TailwindValues},
+  style::{Direction, Lang, Style, StyleDeclaration, ToCss, tw::TailwindValues},
   viewport::Viewport,
 };
 
@@ -522,11 +521,7 @@ impl Node {
       author_tw: self.metadata.tw.take(),
       inline: self.metadata.style.take(),
       dir: self.metadata.dir.take(),
-      lang: self
-        .metadata
-        .lang
-        .take()
-        .map(|tag| Language::parse(&tag).ok()),
+      lang: self.metadata.lang.take().map(|tag| Lang::parse(&tag)),
     }
   }
 
@@ -643,7 +638,7 @@ pub(crate) struct NodeStyleLayers {
   /// Resolved `lang` attribute, applied to the computed style after inheritance.
   /// `None` means absent (inherit the parent). `Some(None)` means present but empty
   /// or invalid, which per HTML clears the language to unknown.
-  pub(crate) lang: Option<Option<Language>>,
+  pub(crate) lang: Option<Option<Lang>>,
 }
 
 impl MatchableNode for Node {

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -158,9 +158,9 @@ fn resolve_normal_line_height(
     return 0.0;
   }
   let attributes = Attributes {
-    width: style.font_stretch.into(),
-    style: style.font_style.into(),
-    weight: style.font_weight.into(),
+    width: style.font_stretch.into_parlance(),
+    style: style.font_style.into_parlance(),
+    weight: style.font_weight.into_parlance(),
   };
   let font_family = context.expand_font_family(&style.font_family);
 
@@ -1174,7 +1174,7 @@ impl RenderNode {
         .map(NodeMatchedDeclarations::element)
         .unwrap_or(&default_matched);
       let layers = node.take_style_layers();
-      let node_lang = layers.lang;
+      let node_lang = layers.lang.clone();
       let style_layers = build_style_layers(layers, matched, parent_context.sizing.viewport);
       let inherited_parent = registered_custom_property_parent_style(
         &parent_context.style,
@@ -2367,13 +2367,11 @@ mod tests {
 
   #[test]
   fn lang_resolves_and_inherits_to_descendants() {
-    use parley::Language;
-
     use crate::{
       context::RenderContext,
       layout::{node::Node, tree::RenderNode},
       resources::font::Fonts,
-      style::SizingContext,
+      style::{Lang, SizingContext},
     };
 
     let fonts = Fonts::default();
@@ -2398,8 +2396,8 @@ mod tests {
       .with_lang("zh-Hant"),
     );
 
-    let zh = Language::parse("zh-Hant").ok();
-    let ja = Language::parse("ja").ok();
+    let zh = Lang::parse("zh-Hant");
+    let ja = Lang::parse("ja");
     assert!(zh.is_some() && ja.is_some());
 
     assert_eq!(tree.context.style.lang, zh);

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -941,7 +941,7 @@ impl Fonts {
         self
           .inner
           .collection
-          .append_generic_families(generic_family.into(), once(family));
+          .append_generic_families(generic_family.into_parlance(), once(family));
       }
     }
 
@@ -1076,11 +1076,9 @@ impl GenericFamily {
   pub const MATH: Self = Self(ParleyGenericFamily::Math);
   /// `fangsong`
   pub const FANG_SONG: Self = Self(ParleyGenericFamily::FangSong);
-}
 
-impl From<GenericFamily> for ParleyGenericFamily {
-  fn from(value: GenericFamily) -> Self {
-    value.0
+  pub(crate) fn into_parlance(self) -> ParleyGenericFamily {
+    self.0
   }
 }
 
@@ -1120,7 +1118,7 @@ impl FontOverride {
     FontInfoOverride {
       family_name: self.family_name.as_deref(),
       width: self.width.map(FontWidth::from_percentage),
-      style: self.style.map(Into::into),
+      style: self.style.map(CssFontStyle::into_parlance),
       weight: self.weight.map(FontWeight::new),
       axes: (!axes.is_empty()).then_some(axes),
     }

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, cmp::Ordering};
 
-use parley::{FontFeature, FontVariation};
 use serde::Deserialize;
 use typed_builder::TypedBuilder;
 

--- a/takumi-core/src/style/properties/font_family.rs
+++ b/takumi-core/src/style/properties/font_family.rs
@@ -1,7 +1,7 @@
 use std::{fmt, string::ToString};
 
 use cssparser::{Parser, match_ignore_ascii_case};
-use parley::{FontFamily as ParleyFontFamily, FontFamilyName, GenericFamily};
+use parley::{FontFamilyName, GenericFamily};
 
 use crate::style::{
   CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
@@ -45,6 +45,10 @@ impl FontFamily {
       FontFamilyToken::Generic(generic) => FontFamilyName::Generic(*generic),
     })
   }
+
+  pub(crate) fn from_parlance_generic(generic: GenericFamily) -> Self {
+    Self(Box::new([FontFamilyToken::Generic(generic)]))
+  }
 }
 
 impl<'i> FromCss<'i> for FontFamilyToken {
@@ -86,9 +90,9 @@ impl<'i> FromCss<'i> for FontFamily {
 impl TailwindPropertyParser for FontFamily {
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
-      "sans" => Some(GenericFamily::SansSerif.into()),
-      "serif" => Some(GenericFamily::Serif.into()),
-      "mono" => Some(GenericFamily::Monospace.into()),
+      "sans" => Some(FontFamily::from_parlance_generic(GenericFamily::SansSerif)),
+      "serif" => Some(FontFamily::from_parlance_generic(GenericFamily::Serif)),
+      "mono" => Some(FontFamily::from_parlance_generic(GenericFamily::Monospace)),
       _ => None,
     }
   }
@@ -96,34 +100,7 @@ impl TailwindPropertyParser for FontFamily {
 
 impl Default for FontFamily {
   fn default() -> Self {
-    GenericFamily::SansSerif.into()
-  }
-}
-
-impl<'a> From<FontFamily> for ParleyFontFamily<'a> {
-  fn from(family: FontFamily) -> Self {
-    ParleyFontFamily::List(
-      family
-        .0
-        .into_iter()
-        .map(|token| match token {
-          FontFamilyToken::Owned(name) => FontFamilyName::Named(name.into()),
-          FontFamilyToken::Generic(generic) => FontFamilyName::Generic(generic),
-        })
-        .collect(),
-    )
-  }
-}
-
-impl<'a> From<&'a FontFamily> for ParleyFontFamily<'a> {
-  fn from(family: &'a FontFamily) -> Self {
-    ParleyFontFamily::List(family.names().collect())
-  }
-}
-
-impl From<GenericFamily> for FontFamily {
-  fn from(generic: GenericFamily) -> Self {
-    Self(Box::new([FontFamilyToken::Generic(generic)]))
+    FontFamily::from_parlance_generic(GenericFamily::SansSerif)
   }
 }
 

--- a/takumi-core/src/style/properties/font_feature_settings.rs
+++ b/takumi-core/src/style/properties/font_feature_settings.rs
@@ -1,11 +1,47 @@
 use std::fmt;
 
 use cssparser::{Parser, Token};
-use parley::{FontFeature, setting::Tag};
 
 use crate::style::{
   CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token,
 };
+
+/// A 4-byte OpenType tag (for example `wght`, `liga`).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct Tag([u8; 4]);
+
+impl Tag {
+  /// Creates a tag from a 4-byte array.
+  pub const fn new(bytes: &[u8; 4]) -> Self {
+    Self(*bytes)
+  }
+
+  /// Returns this tag as 4 bytes.
+  pub const fn to_bytes(self) -> [u8; 4] {
+    self.0
+  }
+
+  /// Parses a tag from a 4-character ASCII string, matching the OpenType tag grammar
+  /// (printable ASCII or space in every position).
+  fn parse(s: &str) -> Option<Self> {
+    let bytes = s.as_bytes();
+    if bytes.len() != 4 || !bytes.iter().all(|b| b.is_ascii_graphic() || *b == b' ') {
+      return None;
+    }
+    Some(Self([bytes[0], bytes[1], bytes[2], bytes[3]]))
+  }
+
+  pub(crate) fn into_parlance(self) -> parley::setting::Tag {
+    parley::setting::Tag::from_bytes(self.0)
+  }
+}
+
+impl fmt::Display for Tag {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let s = std::str::from_utf8(&self.0).unwrap_or("????");
+    f.write_str(s)
+  }
+}
 
 pub(crate) fn parse_opentype_tag<'i, T: FromCss<'i>>(
   input: &mut Parser<'i, '_>,
@@ -21,6 +57,29 @@ pub(crate) fn parse_opentype_tag<'i, T: FromCss<'i>>(
   }
   Tag::parse(tag_name)
     .ok_or_else(|| unexpected_token!(T, location, &Token::QuotedString(tag_name.clone())))
+}
+
+/// An OpenType font feature setting (tag + value) from CSS `font-feature-settings`.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct FontFeature {
+  /// The OpenType tag for this setting.
+  pub tag: Tag,
+  /// The feature value.
+  pub value: u16,
+}
+
+impl FontFeature {
+  /// Creates a new feature setting.
+  pub const fn new(tag: Tag, value: u16) -> Self {
+    Self { tag, value }
+  }
+
+  pub(crate) fn into_parlance(self) -> parley::FontFeature {
+    parley::FontFeature {
+      tag: self.tag.into_parlance(),
+      value: self.value,
+    }
+  }
 }
 
 /// Controls OpenType font features via CSS font-feature-settings property.
@@ -70,7 +129,7 @@ impl<'i> FromCss<'i> for FontFeatureSettings {
   ];
 }
 
-impl ToCss for parley::FontFeature {
+impl ToCss for FontFeature {
   // An empty `font-feature-settings` list is the keyword `normal`.
   const EMPTY_LIST_KEYWORD: Option<&'static str> = Some("normal");
 

--- a/takumi-core/src/style/properties/font_stretch.rs
+++ b/takumi-core/src/style/properties/font_stretch.rs
@@ -80,11 +80,9 @@ impl FontStretch {
   pub(crate) fn from_percentage(value: f32) -> Self {
     Self(FontWidth::from_percentage(value.max(0.0) * 100.0))
   }
-}
 
-impl From<FontStretch> for FontWidth {
-  fn from(value: FontStretch) -> Self {
-    value.0
+  pub(crate) fn into_parlance(self) -> FontWidth {
+    self.0
   }
 }
 

--- a/takumi-core/src/style/properties/font_style.rs
+++ b/takumi-core/src/style/properties/font_style.rs
@@ -51,9 +51,9 @@ impl FontStyle {
   }
 }
 
-impl From<FontStyle> for ParleyFontStyle {
-  fn from(value: FontStyle) -> Self {
-    value.0
+impl FontStyle {
+  pub(crate) fn into_parlance(self) -> ParleyFontStyle {
+    self.0
   }
 }
 

--- a/takumi-core/src/style/properties/font_variant.rs
+++ b/takumi-core/src/style/properties/font_variant.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
-use parley::{FontFeature, setting::Tag};
 
 use crate::style::{
-  Animatable, CssToken, FromCss, MakeComputed, ParseResult, ToCss, unexpected_token,
+  Animatable, CssToken, FontFeature, FromCss, MakeComputed, ParseResult, Tag, ToCss,
+  unexpected_token,
 };
 
 /// Tri-state for one `font-variant-ligatures` group.

--- a/takumi-core/src/style/properties/font_variation_settings.rs
+++ b/takumi-core/src/style/properties/font_variation_settings.rs
@@ -1,10 +1,32 @@
 use std::fmt;
 
 use cssparser::Parser;
-use parley::FontVariation;
 
-use super::font_feature_settings::parse_opentype_tag;
+use super::font_feature_settings::{Tag, parse_opentype_tag};
 use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss};
+
+/// An OpenType font variation setting (tag + value) from CSS `font-variation-settings`.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct FontVariation {
+  /// The OpenType tag for this setting.
+  pub tag: Tag,
+  /// The variation value.
+  pub value: f32,
+}
+
+impl FontVariation {
+  /// Creates a new variation setting.
+  pub const fn new(tag: Tag, value: f32) -> Self {
+    Self { tag, value }
+  }
+
+  pub(crate) fn into_parlance(self) -> parley::FontVariation {
+    parley::FontVariation {
+      tag: self.tag.into_parlance(),
+      value: self.value,
+    }
+  }
+}
 
 /// Controls variable font axis values via CSS font-variation-settings property.
 ///
@@ -39,7 +61,7 @@ impl<'i> FromCss<'i> for FontVariationSettings {
   ];
 }
 
-impl ToCss for parley::FontVariation {
+impl ToCss for FontVariation {
   // An empty `font-variation-settings` list is the keyword `normal`.
   const EMPTY_LIST_KEYWORD: Option<&'static str> = Some("normal");
 

--- a/takumi-core/src/style/properties/font_weight.rs
+++ b/takumi-core/src/style/properties/font_weight.rs
@@ -11,8 +11,8 @@ use crate::style::{
 /// Represents font weight value.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FontWeight {
-  /// An absolute numeric weight.
-  Absolute(ParleyFontWeight),
+  /// An absolute numeric weight (CSS `font-weight`, typically 1-1000).
+  Absolute(f32),
   /// One step bolder than the inherited weight, resolved against the parent.
   Bolder,
   /// One step lighter than the inherited weight, resolved against the parent.
@@ -119,7 +119,7 @@ impl FontWeight {
   /// inheritance to step from the parent weight.
   pub fn value(self) -> f32 {
     match self {
-      Self::Absolute(weight) => weight.value(),
+      Self::Absolute(weight) => weight,
       Self::Bolder => bolder(400.0),
       Self::Lighter => lighter(400.0),
     }
@@ -134,17 +134,15 @@ impl FontWeight {
       absolute => absolute,
     }
   }
-}
 
-impl From<FontWeight> for ParleyFontWeight {
-  fn from(value: FontWeight) -> Self {
-    ParleyFontWeight::new(value.value())
+  pub(crate) fn into_parlance(self) -> ParleyFontWeight {
+    ParleyFontWeight::new(self.value())
   }
 }
 
 impl From<f32> for FontWeight {
   fn from(value: f32) -> Self {
-    FontWeight::Absolute(ParleyFontWeight::new(value))
+    FontWeight::Absolute(value)
   }
 }
 
@@ -153,7 +151,7 @@ impl ToCss for FontWeight {
     match self {
       Self::Bolder => dest.write_str("bolder"),
       Self::Lighter => dest.write_str("lighter"),
-      Self::Absolute(weight) => write!(dest, "{}", weight.value()),
+      Self::Absolute(weight) => write!(dest, "{weight}"),
     }
   }
 }

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -87,13 +87,15 @@ pub use filter::{
 pub use flex::*;
 pub use flex_grow::*;
 pub use font_family::*;
-pub(crate) use font_feature_settings::*;
+pub(crate) use font_feature_settings::FontFeatureSettings;
+pub use font_feature_settings::{FontFeature, Tag};
 pub use font_size::*;
 pub use font_stretch::*;
 pub use font_style::*;
 pub use font_synthesis::*;
 pub use font_variant::*;
-pub(crate) use font_variation_settings::*;
+pub use font_variation_settings::FontVariation;
+pub(crate) use font_variation_settings::FontVariationSettings;
 pub use font_weight::*;
 pub use gap::*;
 pub use grid::*;

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -46,6 +46,34 @@ struct DeferredDeclaration {
   specified_value: String,
 }
 
+/// A resolved BCP-47 language tag (the canonicalized `language[-Script][-REGION]`
+/// prefix), inherited from the `lang` attribute. Drives locale-aware shaping
+/// (Han unification, line-breaking). Has no CSS property; set via
+/// [`ComputedStyle::set_lang`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Lang(Box<str>);
+
+impl Lang {
+  /// Parses a BCP-47 tag string, canonicalizing language/script/region casing.
+  /// Returns `None` if the tag has no valid `language[-Script][-REGION]` prefix.
+  pub fn parse(tag: &str) -> Option<Self> {
+    Language::parse(tag)
+      .ok()
+      .map(|language| Self(language.as_str().into()))
+  }
+
+  /// The canonical string form (`language[-Script][-REGION]`).
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+
+  pub(crate) fn to_parlance(&self) -> Language {
+    // `self.0` is always the canonical string form of a successful `Language::parse`,
+    // so this never actually falls back to `UND`.
+    Language::parse(&self.0).unwrap_or(Language::UND)
+  }
+}
+
 #[derive(Clone, Copy)]
 struct InterpolationContext<'a> {
   progress: f32,
@@ -632,7 +660,7 @@ macro_rules! define_style {
         /// Resolved BCP-47 language, inherited from the `lang` attribute. Drives
         /// locale-aware shaping (Han unification, line-breaking). Has no CSS property.
         /// Set from a tag string via [`ComputedStyle::set_lang`].
-        pub lang: Option<Language>,
+        pub lang: Option<Lang>,
         $(
           #[doc = concat!("Computed `", stringify!($longhand), "` value.")]
           pub $longhand: $longhand_ty,
@@ -687,7 +715,7 @@ macro_rules! define_style {
             } else {
               parent.registered_custom_properties.clone()
             },
-            lang: parent.lang,
+            lang: parent.lang.clone(),
             $($longhand: define_inherited_default!(parent.$longhand, define_style!(@default $($longhand_default)?) $(, $longhand_inherit)?),)*
           }
         }
@@ -701,7 +729,7 @@ macro_rules! define_style {
         /// parsed into the shaping engine's representation. Unrecognized tags are
         /// ignored. Drives locale-aware shaping and line-breaking.
         pub fn set_lang(&mut self, tag: Option<&str>) {
-          self.lang = tag.and_then(|tag| Language::parse(tag).ok());
+          self.lang = tag.and_then(Lang::parse);
         }
 
         pub(crate) fn apply_interpolated_properties(

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, marker::PhantomData};
 
-use parley::FontFeature;
 use taffy::{Line, Rect, Size};
 
 use super::ComputedStyle;

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, rc::Rc, str::FromStr};
 
 use cssparser::{Parser, ParserInput};
-use parley::FontFeature;
 use serde_json::{from_value, json};
 
 use super::{

--- a/takumi/tests/fixtures/animation.rs
+++ b/takumi/tests/fixtures/animation.rs
@@ -1,6 +1,5 @@
 use std::f32::consts::PI;
 
-use parley::GenericFamily;
 use takumi::{
   prelude::{Length::*, *},
   render_animation,
@@ -55,7 +54,7 @@ fn bouncing_text_label() -> Node {
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::font_size(Px(56.0).into()))
       .with(StyleDeclaration::font_family(
-        GenericFamily::Monospace.into(),
+        FontFamily::from_css_str("monospace").expect("valid generic family"),
       ))
       .with(StyleDeclaration::font_weight(FontWeight::from(700.0)))
       .with(StyleDeclaration::color(ColorInput::Value(Color([

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -1,4 +1,3 @@
-use parley::{FontVariation, setting::Tag};
 use serde_json::{from_value, json};
 use takumi::prelude::{Length::*, *};
 
@@ -48,10 +47,7 @@ fn text_typography_variable_width() {
         Style::default()
           .with(StyleDeclaration::display(Display::Flex))
           .with(StyleDeclaration::font_variation_settings(Box::new([
-            FontVariation {
-              tag: Tag::from_bytes(*b"wdth"),
-              value: *width,
-            },
+            FontVariation::new(Tag::new(b"wdth"), *width),
           ]))),
       )
     })


### PR DESCRIPTION
## Why
#916 sealed the `taffy`/`parley` leaks out of the public `style` API, but its verify step only grepped `parley::`, missing `parlance` entirely — the parley font-model fork. `parlance::*` types (feature/variation settings, `FontWeight`, `Language`, font family/generic-family conversions) still leaked through `ComputedStyle`, `StyleDeclaration`, and several `From` impls, pinning a foreign crate into the stable `style` API surface.

## What
- `FontFeature`, `FontVariation`, and `Tag` are now takumi-owned structs (were `parlance::tag::{FontFeature, FontVariation, Tag}`), so `ComputedStyle::font_feature_settings`/`font_variation_settings` and `StyleDeclaration::FontFeatureSettings`/`FontVariationSettings` no longer expose a foreign type. `ToCss`/`FromCss` behavior is unchanged.
- `FontWeight::Absolute` now holds a plain `f32` instead of `parlance::font::FontWeight`.
- `ComputedStyle::lang` is now `Option<Lang>`, a takumi-owned BCP-47 tag wrapper, instead of `Option<parlance::language::Language>`.
- `FontStretch`, `FontStyle`, `FontWeight`, `FontFamily`, and `resources::font::GenericFamily` lose their public `From`/`Into` impls targeting `parlance` types; conversions are now `pub(crate)` inherent methods (`into_parlance`/`to_parlance`/`from_parlance_generic`), called only where style meets the shaper (`font_style.rs`, `layout/tree.rs`, `resources/font.rs`).
- Dropped two unused `From<FontFamily> for parlance::FontFamily` impls with no callers in the crate (same treatment #916 gave the unused `image::ImageFormat` impl).

Verify gate — `takumi_core::style::*` and `resources::font::GenericFamily` grepped for both `parlance::` and `parley::`, zero matches except the unavoidable `parley::style::brush::Brush` blanket impls:

```
$ cargo public-api -p takumi-core 2>/dev/null | grep -E "takumi_core::style::|resources::font" | grep -E "parlance::|parley::" | grep -v "parley::style::brush::Brush"
(no output)
```

`cargo build`/`clippy --all-targets` clean across the workspace. `cargo test -p takumi -p takumi-core` green; no golden `.webp`/`.svg` fixture drift (only the expected `.html`-only regen noise, discarded), confirming the parlance round-trip is byte-identical to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app-owned support for font features, font variations, and language tags.
  * Improved handling of font weight, font family, and locale values in styles.

* **Bug Fixes**
  * Fixed style data leaking external font types through public APIs.
  * Preserved language inheritance and parsing behavior across nested content.

* **Refactor**
  * Simplified internal style conversions and reduced reliance on external font/type wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->