### PR TITLE
Crate: refactor `font_families` and `lang` option type

### DIFF
--- a/.tegami/node-from-html copy.md
+++ b/.tegami/node-from-html copy.md
@@ -1,0 +1,9 @@
+---
+packages:
+  cargo:takumi-core: major
+  cargo:takumi: major
+---
+
+### Refactor `font_families` and `lang` option type
+
+Now both option takes resolved value instead of raw strings.

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -161,6 +161,10 @@ pub enum Error {
   /// The layout engine was asked for a node id it does not know.
   #[error("Invalid layout node id: {0}")]
   InvalidLayoutNode(u64),
+
+  /// An invalid BCP-47 language tag was supplied to a node's `lang` attribute.
+  #[error("Invalid language tag: {0}")]
+  InvalidLanguageTag(String),
 }
 
 impl Error {

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -173,7 +173,7 @@ impl<'s> From<&'s SizedFontStyle<'s>> for TextStyle<'s, 's, InlineBrush> {
       text_wrap_mode: style.parent.resolved_text_wrap_mode().into_parley(),
       font_width: style.parent.font_stretch.into_parlance(),
 
-      locale: style.parent.lang.as_ref().map(Lang::to_parlance),
+      locale: style.parent.lang.map(Lang::into_parlance),
       has_underline: false,
       underline_offset: None,
       underline_size: None,

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -6,7 +6,7 @@ use crate::{
   geometry::{AvailableSpace, Size},
   layout::node::{ImageData, ImageSourceInput, Node, NodeStyleLayers},
   resources::image::{ImageError, ImageResult, ImageSource, is_svg_like},
-  style::{Lang, Length, Style, StyleDeclaration},
+  style::{Length, Style, StyleDeclaration},
 };
 
 pub(crate) fn image_url(image: &ImageData) -> Option<&str> {
@@ -39,7 +39,6 @@ pub(crate) fn take_image_style_layers(
     author_tw: node.metadata.tw.take(),
     inline: node.metadata.style.take(),
     dir: node.metadata.dir.take(),
-    lang: node.metadata.lang.take().map(|tag| Lang::parse(&tag)),
   }
 }
 

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -48,8 +48,8 @@ pub(crate) struct NodeMetadata {
   pub tw: Option<TailwindValues>,
   /// The text direction for this node.
   pub dir: Option<Direction>,
-  /// The BCP-47 language tag for this node, from the `lang` attribute.
-  pub lang: Option<Box<str>>,
+  /// The BCP-47 language tag for this node, equivalent to the `lang` attribute.
+  pub lang: Option<Lang>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -371,8 +371,8 @@ impl Node {
   }
 
   /// Sets the BCP-47 language tag and returns the updated node.
-  pub fn with_lang(mut self, lang: impl Into<Box<str>>) -> Self {
-    self.metadata.lang = Some(lang.into());
+  pub fn with_lang(mut self, lang: Lang) -> Self {
+    self.metadata.lang = Some(lang);
     self
   }
 
@@ -424,7 +424,7 @@ impl Node {
       attrs.push(format!("dir=\"{}\"", dir_str));
     }
     if let Some(lang) = &self.metadata.lang {
-      attrs.push(format!("lang=\"{}\"", escape_attr(lang)));
+      attrs.push(format!("lang=\"{}\"", escape_attr(lang.as_str())));
     }
     if let Some(attributes) = &self.metadata.attributes {
       for (k, v) in attributes {
@@ -521,7 +521,6 @@ impl Node {
       author_tw: self.metadata.tw.take(),
       inline: self.metadata.style.take(),
       dir: self.metadata.dir.take(),
-      lang: self.metadata.lang.take().map(|tag| Lang::parse(&tag)),
     }
   }
 
@@ -635,10 +634,6 @@ pub(crate) struct NodeStyleLayers {
   /// Inline style attached directly to the element.
   pub(crate) inline: Option<Style>,
   pub(crate) dir: Option<Direction>,
-  /// Resolved `lang` attribute, applied to the computed style after inheritance.
-  /// `None` means absent (inherit the parent). `Some(None)` means present but empty
-  /// or invalid, which per HTML clears the language to unknown.
-  pub(crate) lang: Option<Option<Lang>>,
 }
 
 impl MatchableNode for Node {

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1174,7 +1174,6 @@ impl RenderNode {
         .map(NodeMatchedDeclarations::element)
         .unwrap_or(&default_matched);
       let layers = node.take_style_layers();
-      let node_lang = layers.lang.clone();
       let style_layers = build_style_layers(layers, matched, parent_context.sizing.viewport);
       let inherited_parent = registered_custom_property_parent_style(
         &parent_context.style,
@@ -1182,9 +1181,6 @@ impl RenderNode {
         parent_context.sizing.viewport,
       );
       let mut style = style_layers.inherit(&inherited_parent);
-      if let Some(resolved) = node_lang {
-        style.lang = resolved;
-      }
 
       // On the root element, `parent_root_font_size` is `None` so `rem` inside
       // its own `font-size` falls back to `viewport.font_size`, per CSS Values 4
@@ -2363,48 +2359,5 @@ mod tests {
       resolved.custom_properties.get("--move"),
       Some(&"red".to_owned()) // syntax validation is skipped, so any value is accepted
     );
-  }
-
-  #[test]
-  fn lang_resolves_and_inherits_to_descendants() {
-    use crate::{
-      context::RenderContext,
-      layout::{node::Node, tree::RenderNode},
-      resources::font::Fonts,
-      style::{Lang, SizingContext},
-    };
-
-    let fonts = Fonts::default();
-    let context = RenderContext::builder()
-      .fonts(fonts.snapshot())
-      .sizing(
-        SizingContext::builder()
-          .viewport(Viewport::default())
-          .build(),
-      )
-      .build();
-
-    let tree = RenderNode::from_node(
-      &context,
-      Node::container([
-        Node::container([Node::text("inherits")]),
-        Node::container([Node::text("overrides")]).with_lang("ja"),
-        // `lang=""` is present-but-empty: HTML treats it as unknown, clearing the
-        // inherited value rather than falling through to the parent.
-        Node::container([Node::text("clears")]).with_lang(""),
-      ])
-      .with_lang("zh-Hant"),
-    );
-
-    let zh = Lang::parse("zh-Hant");
-    let ja = Lang::parse("ja");
-    assert!(zh.is_some() && ja.is_some());
-
-    assert_eq!(tree.context.style.lang, zh);
-
-    let children = tree.children.as_deref().expect("block children");
-    assert_eq!(children[0].context.style.lang, zh);
-    assert_eq!(children[1].context.style.lang, ja);
-    assert_eq!(children[2].context.style.lang, None);
   }
 }

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -9,7 +9,8 @@ use std::{
 
 use image::{Rgba, RgbaImage};
 use parley::{
-  GenericFamily as ParleyGenericFamily, GlyphRun, LayoutContext, TextStyle, TreeBuilder,
+  FontFamilyName, GenericFamily as ParleyGenericFamily, GlyphRun, LayoutContext, TextStyle,
+  TreeBuilder,
   fontique::{
     Attributes, Blob, Collection, CollectionOptions, FallbackKey, FontInfoOverride, FontStyle,
     FontWeight, FontWidth, QueryFamily, QueryStatus, Script, ScriptExt,
@@ -33,7 +34,7 @@ use crate::{
   geometry::{PathCommand as Command, Point},
   layout::inline::{InlineBrush, InlineLayout},
   resources::{image_buffer::ImageBuffer, image_decoder::decode_png},
-  style::FontStyle as CssFontStyle,
+  style::{FontFamily, FontStyle as CssFontStyle},
 };
 
 /// A resolved glyph, either an embedded bitmap or a vector outline.
@@ -753,15 +754,19 @@ impl Fonts {
   }
 
   /// Render-local snapshot whose fallback bucket carries the given families.
-  pub fn snapshot_with_fallbacks(&self, fallbacks: Option<&[String]>) -> FontsSnapshot {
+  pub fn snapshot_with_fallbacks(&self, fallbacks: Option<&FontFamily>) -> FontsSnapshot {
     let mut cloned = self.inner.clone();
 
     if let Some(names) = fallbacks {
       // A name may be a logical subset family; expand it to its registered subset names so
       // the fallback bucket carries the whole stack, matching `font-family` expansion.
       let mut family_ids = Vec::new();
-      for name in names {
-        match self.groups.get(name) {
+      for name in names.names() {
+        let FontFamilyName::Named(literal_name) = name else {
+          continue;
+        };
+
+        match self.groups.get(&*literal_name) {
           Some(subsets) => {
             family_ids.extend(
               subsets
@@ -769,7 +774,7 @@ impl Fonts {
                 .filter_map(|n| cloned.collection.family_id(n)),
             );
           }
-          None => family_ids.extend(cloned.collection.family_id(name)),
+          None => family_ids.extend(cloned.collection.family_id(&*literal_name)),
         }
       }
 

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -774,7 +774,7 @@ impl Fonts {
                 .filter_map(|n| cloned.collection.family_id(n)),
             );
           }
-          None => family_ids.extend(cloned.collection.family_id(&*literal_name)),
+          None => family_ids.extend(cloned.collection.family_id(&literal_name)),
         }
       }
 

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -3,10 +3,11 @@ use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
 use cssparser::{Parser, ParserInput, RuleBodyParser, Token, match_ignore_ascii_case};
 use parley::Language;
 use paste::paste;
-use serde::de::IgnoredAny;
+use serde::{Deserialize, de::Error as DeError, de::IgnoredAny};
 use smallvec::{SmallVec, smallvec};
 
 use crate::{
+  Error,
   error::StyleDeclarationBlockParseError,
   style::{
     CssInput, CssValueSeed, SizingContext,
@@ -48,29 +49,41 @@ struct DeferredDeclaration {
 
 /// A resolved BCP-47 language tag (the canonicalized `language[-Script][-REGION]`
 /// prefix), inherited from the `lang` attribute. Drives locale-aware shaping
-/// (Han unification, line-breaking). Has no CSS property; set via
-/// [`ComputedStyle::set_lang`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Lang(Box<str>);
+/// (Han unification, line-breaking).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Lang(parley::Language);
+
+impl<'de> Deserialize<'de> for Lang {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let tag = Cow::<str>::deserialize(deserializer)?;
+    Lang::parse(&tag).map_err(|_| {
+      D::Error::invalid_type(
+        serde::de::Unexpected::Str(&tag),
+        &"a valid BCP-47 language tag",
+      )
+    })
+  }
+}
 
 impl Lang {
   /// Parses a BCP-47 tag string, canonicalizing language/script/region casing.
   /// Returns `None` if the tag has no valid `language[-Script][-REGION]` prefix.
-  pub fn parse(tag: &str) -> Option<Self> {
+  pub fn parse(tag: &str) -> crate::Result<Self> {
     Language::parse(tag)
-      .ok()
-      .map(|language| Self(language.as_str().into()))
+      .map(Self)
+      .map_err(|_| Error::InvalidLanguageTag(tag.to_string()))
   }
 
   /// The canonical string form (`language[-Script][-REGION]`).
   pub fn as_str(&self) -> &str {
-    &self.0
+    self.0.as_str()
   }
 
   pub(crate) fn to_parlance(&self) -> Language {
-    // `self.0` is always the canonical string form of a successful `Language::parse`,
-    // so this never actually falls back to `UND`.
-    Language::parse(&self.0).unwrap_or(Language::UND)
+    self.0
   }
 }
 
@@ -715,7 +728,7 @@ macro_rules! define_style {
             } else {
               parent.registered_custom_properties.clone()
             },
-            lang: parent.lang.clone(),
+            lang: parent.lang,
             $($longhand: define_inherited_default!(parent.$longhand, define_style!(@default $($longhand_default)?) $(, $longhand_inherit)?),)*
           }
         }
@@ -723,13 +736,6 @@ macro_rules! define_style {
         /// Resolves relative units against the sizing context.
         pub(crate) fn make_computed_values(&mut self, sizing: &SizingContext) {
           $(self.$longhand.make_computed(sizing);)*
-        }
-
-        /// Sets the BCP-47 language from a tag string (e.g. `"en"`, `"zh-Hant"`),
-        /// parsed into the shaping engine's representation. Unrecognized tags are
-        /// ignored. Drives locale-aware shaping and line-breaking.
-        pub fn set_lang(&mut self, tag: Option<&str>) {
-          self.lang = tag.and_then(Lang::parse);
         }
 
         pub(crate) fn apply_interpolated_properties(

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -82,7 +82,7 @@ impl Lang {
     self.0.as_str()
   }
 
-  pub(crate) fn to_parlance(&self) -> Language {
+  pub(crate) fn into_parlance(self) -> Language {
     self.0
   }
 }

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1251,23 +1251,3 @@ fn test_border_radius_calc_infinity_parses_from_stylesheet_declaration() {
     style.border_top_left_radius.x
   );
 }
-
-#[test]
-fn set_lang_parses_valid_tag_and_ignores_invalid() {
-  let mut style = ComputedStyle::default();
-  assert!(style.lang.is_none());
-
-  style.set_lang(Some("zh-Hant"));
-  assert!(style.lang.is_some(), "valid BCP-47 tag should parse");
-
-  style.set_lang(Some("123"));
-  assert!(
-    style.lang.is_none(),
-    "invalid tag should clear the language"
-  );
-
-  style.set_lang(Some("en"));
-  assert!(style.lang.is_some());
-  style.set_lang(None);
-  assert!(style.lang.is_none(), "None should clear the language");
-}

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -28,7 +28,7 @@ use html5ever::{
 use markup5ever_rcdom::{Handle, NodeData, RcDom, SerializableHandle};
 use takumi_core::{
   layout::node::{ImageData, ImageSourceInput, Node, NodeKind},
-  style::{Direction, FromCssStr, Style, StyleDeclarationBlock, tw::TailwindValues},
+  style::{Direction, FromCssStr, Lang, Style, StyleDeclarationBlock, tw::TailwindValues},
 };
 use typed_builder::TypedBuilder;
 
@@ -479,9 +479,13 @@ fn apply_metadata(
     match name {
       "class" => node = node.with_class_name(value),
       "id" => node = node.with_id(value),
-      "lang" => node = node.with_lang(value),
+      "lang" => {
+        if let Ok(lang) = Lang::parse(value) {
+          node = node.with_lang(lang);
+        }
+      }
       "dir" => {
-        if let Some(dir) = parse_direction(value) {
+        if let Ok(dir) = Direction::from_css_str(value) {
           node = node.with_dir(dir);
         }
       }
@@ -519,10 +523,6 @@ fn attribute(handle: &Handle, name: &str) -> Option<String> {
 
 fn dimension(handle: &Handle, name: &str) -> Option<f32> {
   attribute(handle, name).and_then(|value| value.parse().ok())
-}
-
-fn parse_direction(value: &str) -> Option<Direction> {
-  Direction::from_css_str(value).ok()
 }
 
 /// Serialize an element including its own tag (outer HTML), used to round-trip

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, mem::take, sync::Arc};
 use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
-  style::StyleSheet,
+  style::{FontFamily, Lang, StyleSheet},
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::measure;
@@ -23,8 +23,8 @@ pub struct MeasureTask {
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: StyleSheet,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
-  pub(crate) font_families: Option<Vec<String>>,
-  pub(crate) lang: Option<Arc<str>>,
+  pub(crate) font_families: Option<FontFamily>,
+  pub(crate) lang: Option<Lang>,
 }
 
 impl MeasureTask {
@@ -62,8 +62,13 @@ impl MeasureTask {
           ))
         })
         .collect::<Result<_>>()?,
-      font_families: options.font_families,
-      lang: options.lang.map(Arc::from),
+      font_families: options.font_families.map(FontFamily::from_names),
+      lang: options
+        .lang
+        .as_deref()
+        .map(Lang::parse)
+        .transpose()
+        .map_err(map_error)?,
     })
   }
 }

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, mem::take, sync::Arc};
 use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
-  style::KeyframesRule,
+  style::{FontFamily, KeyframesRule, Lang},
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{
@@ -12,7 +12,7 @@ use takumi_raster::{
 };
 
 use crate::{
-  buffer_from_object, deserialize_with_tracing, parse_stylesheet,
+  buffer_from_object, deserialize_with_tracing, map_error, parse_stylesheet,
   renderer::{
     AnimationOutputFormat, ImageCacheMode, ImageSource, RenderAnimationOptions, RendererState,
     decode_images, deserialize_keyframes, webp_lossless,
@@ -30,8 +30,8 @@ pub struct RenderAnimationTask {
   pub(crate) stylesheets: Option<Vec<String>>,
   pub(crate) keyframes: Vec<KeyframesRule>,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
-  pub(crate) font_families: Option<Vec<String>>,
-  pub(crate) lang: Option<Arc<str>>,
+  pub(crate) font_families: Option<FontFamily>,
+  pub(crate) lang: Option<Lang>,
   pub(crate) fps: u32,
 }
 
@@ -103,8 +103,12 @@ impl RenderAnimationTask {
           ))
         })
         .collect::<Result<_>>()?,
-      font_families,
-      lang: lang.map(Arc::from),
+      font_families: font_families.map(FontFamily::from_names),
+      lang: lang
+        .as_deref()
+        .map(Lang::parse)
+        .transpose()
+        .map_err(map_error)?,
       fps,
     })
   }

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -139,7 +139,7 @@ impl Task for RenderAnimationTask {
                 .node(node)
                 .fonts(&fonts)
                 .font_families(self.font_families.clone())
-                .lang(self.lang.clone())
+                .lang(self.lang)
                 .draw_debug_border(self.draw_debug_border)
                 .build(),
             )

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, mem::take, sync::Arc};
 use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
-  style::StyleSheet,
+  style::{FontFamily, Lang, StyleSheet},
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{DitheringAlgorithm, render, write_image};
@@ -28,8 +28,8 @@ pub struct RenderTask {
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: StyleSheet,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
-  pub(crate) font_families: Option<Vec<String>>,
-  pub(crate) lang: Option<Arc<str>>,
+  pub(crate) font_families: Option<FontFamily>,
+  pub(crate) lang: Option<Lang>,
 }
 
 impl RenderTask {
@@ -72,8 +72,13 @@ impl RenderTask {
           ))
         })
         .collect::<Result<_>>()?,
-      font_families: options.font_families,
-      lang: options.lang.map(Arc::from),
+      font_families: options.font_families.map(FontFamily::from_names),
+      lang: options
+        .lang
+        .as_deref()
+        .map(Lang::parse)
+        .transpose()
+        .map_err(map_error)?,
     })
   }
 }

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -1,7 +1,11 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
-use takumi_core::{layout::node::Node, style::StyleSheet, viewport::Viewport};
+use takumi_core::{
+  layout::node::Node,
+  style::{FontFamily, Lang, StyleSheet},
+  viewport::Viewport,
+};
 
 use crate::{
   buffer_from_object, map_error, parse_stylesheet,
@@ -17,8 +21,8 @@ pub struct SvgRenderTask {
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: StyleSheet,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
-  pub(crate) font_families: Option<Vec<String>>,
-  pub(crate) lang: Option<Arc<str>>,
+  pub(crate) font_families: Option<FontFamily>,
+  pub(crate) lang: Option<Lang>,
 }
 
 impl SvgRenderTask {
@@ -51,8 +55,11 @@ impl SvgRenderTask {
           ))
         })
         .collect::<Result<_>>()?,
-      font_families: options.font_families,
-      lang: options.lang.map(Arc::from),
+      font_families: options.font_families.map(FontFamily::from_names),
+      lang: options
+        .lang
+        .map(|lang| Lang::parse(&lang).map_err(map_error))
+        .transpose()?,
     })
   }
 }

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use takumi_core::{
   geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Size},
   scene::build_stacking_contexts,
+  style::{ComputedStyle, Lang},
 };
 use typed_builder::TypedBuilder;
 
@@ -20,23 +21,9 @@ use crate::{
   },
   resources::image::ImageSource,
   stacking_context::paint_context,
-  style::{Affine, ComputedStyle, FontFamily, SizingContext, StyleSheet},
+  style::{Affine, FontFamily, SizingContext, StyleSheet},
   viewport::Viewport,
 };
-
-/// Root computed style carrying the render-level `lang` and `fontFamilies` defaults,
-/// inherited by every node that does not set its own.
-fn root_style(lang: Option<&str>, font_families: Option<&[String]>) -> Box<ComputedStyle> {
-  let mut style = ComputedStyle {
-    font_family: font_families.map_or_else(FontFamily::default, |names| {
-      FontFamily::from_names(names.iter().cloned())
-    }),
-    ..Default::default()
-  };
-  style.set_lang(lang);
-
-  Box::new(style)
-}
 
 #[derive(Clone, TypedBuilder)]
 /// Options for rendering a node. Construct using [`RenderOptions::builder`] to avoid breaking changes.
@@ -65,11 +52,11 @@ pub struct RenderOptions<'g> {
   /// Per-render font fallback chain (family names in order). `None` uses all
   /// registered families in registration order.
   #[builder(default)]
-  pub(crate) font_families: Option<Vec<String>>,
+  pub(crate) font_families: Option<FontFamily>,
   /// Default BCP-47 language tag applied to the root, inherited by nodes without
   /// their own `lang`. Drives locale-aware shaping and line-breaking.
   #[builder(default)]
-  pub(crate) lang: Option<Arc<str>>,
+  pub(crate) lang: Option<Lang>,
 }
 
 impl<'g> RenderOptions<'g> {
@@ -177,13 +164,16 @@ pub fn measure<'g>(options: RenderOptions<'g>) -> Result<MeasuredNode> {
   } = options;
 
   let render_context = RenderContext::builder()
-    .fonts(fonts.snapshot_with_fallbacks(font_families.as_deref()))
+    .fonts(fonts.snapshot_with_fallbacks(font_families.as_ref()))
     .sizing(SizingContext::builder().viewport(viewport).build())
     .images(Rc::new(images))
     .stylesheet(stylesheet.into())
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
-    .style(root_style(lang.as_deref(), font_families.as_deref()))
+    .style(Box::new(ComputedStyle {
+      lang,
+      ..Default::default()
+    }))
     .build();
 
   let mut root = RenderNode::from_node(&render_context, node);
@@ -419,13 +409,16 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
   } = options;
 
   let render_context = RenderContext::builder()
-    .fonts(fonts.snapshot_with_fallbacks(font_families.as_deref()))
+    .fonts(fonts.snapshot_with_fallbacks(font_families.as_ref()))
     .sizing(SizingContext::builder().viewport(viewport).build())
     .images(Rc::new(images))
     .stylesheet(stylesheet.into())
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
-    .style(root_style(lang.as_deref(), font_families.as_deref()))
+    .style(Box::new(ComputedStyle {
+      lang,
+      ..Default::default()
+    }))
     .build();
 
   let mut root = RenderNode::from_node(&render_context, node);

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -18,8 +18,8 @@ use takumi_core::{
   shadow::SizedShadow,
   style::{
     Affine, BackgroundClip, BackgroundImage, BackgroundOrigin, BasicShape, BlendMode, BorderStyle,
-    Color, ComputedStyle, FillRule, Isolation, Length, Overflow, ShapeRadius, Sides, SizingContext,
-    SpacePair, StyleSheet, ToCss,
+    Color, ComputedStyle, FillRule, FontFamily, Isolation, Lang, Length, Overflow, ShapeRadius,
+    Sides, SizingContext, SpacePair, StyleSheet, ToCss,
   },
   viewport::Viewport,
 };
@@ -57,11 +57,11 @@ pub struct SvgOptions<'g> {
   /// Per-render font fallback chain (family names in order). `None` uses all
   /// registered families in registration order.
   #[builder(default)]
-  pub(crate) font_families: Option<Vec<String>>,
+  pub(crate) font_families: Option<FontFamily>,
   /// Default BCP-47 language tag applied to the root, inherited by nodes without
   /// their own `lang`. Drives locale-aware shaping and line-breaking.
   #[builder(default)]
-  pub(crate) lang: Option<Arc<str>>,
+  pub(crate) lang: Option<Lang>,
 }
 
 /// Renders a node tree to a vector SVG string.
@@ -72,16 +72,17 @@ pub fn render(options: SvgOptions<'_>) -> Result<String> {
     .fonts(
       options
         .fonts
-        .snapshot_with_fallbacks(options.font_families.as_deref()),
+        .snapshot_with_fallbacks(options.font_families.as_ref()),
     )
     .sizing(SizingContext::builder().viewport(viewport).build())
     .images(Rc::new(options.images))
     .stylesheet(options.stylesheet.into())
     .time_ms(options.time_ms)
     .style({
-      let mut style = ComputedStyle::default();
-      style.set_lang(options.lang.as_deref());
-      Box::new(style)
+      Box::new(ComputedStyle {
+        lang: options.lang,
+        ..Default::default()
+      })
     })
     .build();
 

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -14,7 +14,7 @@ use takumi_core::{
     font::{FontOverride, FontResource, GenericFamily, RegisteredFamily},
     image::{ImageCache, ImageSource as LoadedImageSource},
   },
-  style::{KeyframesRule, StyleSheet},
+  style::{FontFamily, KeyframesRule, Lang, StyleSheet},
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{
@@ -195,6 +195,11 @@ impl Renderer {
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
 
+    let lang = options
+      .lang
+      .map(|lang| Lang::parse(&lang).map_err(map_error))
+      .transpose()?;
+
     let render_options = takumi_raster::RenderOptions::builder()
       .viewport(
         Viewport::new((options.width, options.height)).with_device_pixel_ratio(
@@ -210,8 +215,8 @@ impl Renderer {
       .dithering(dithering)
       .node(node)
       .fonts(fonts)
-      .font_families(options.font_families)
-      .lang(options.lang.map(Arc::from))
+      .font_families(options.font_families.map(FontFamily::from_names))
+      .lang(lang)
       .build();
 
     let image = render(render_options).map_err(map_error)?;
@@ -252,6 +257,11 @@ impl Renderer {
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
     let state = self.read_state()?;
 
+    let lang = options
+      .lang
+      .map(|lang| Lang::parse(&lang).map_err(map_error))
+      .transpose()?;
+
     let svg = takumi_svg::render(
       takumi_svg::SvgOptions::builder()
         .viewport(Viewport::new((options.width, options.height)))
@@ -260,8 +270,8 @@ impl Renderer {
         .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
         .node(node)
         .fonts(&state)
-        .font_families(options.font_families)
-        .lang(options.lang.map(Arc::from))
+        .font_families(options.font_families.map(FontFamily::from_names))
+        .lang(lang)
         .build(),
     )
     .map_err(map_error)?;
@@ -282,6 +292,11 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
+    let lang = options
+      .lang
+      .map(|lang| Lang::parse(&lang).map_err(map_error))
+      .transpose()?;
+
     let images = self.images_map(options.images.as_deref())?;
     let stylesheet =
       self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
@@ -301,8 +316,8 @@ impl Renderer {
       .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
       .node(node)
       .fonts(&state)
-      .font_families(options.font_families)
-      .lang(options.lang.map(Arc::from))
+      .font_families(options.font_families.map(FontFamily::from_names))
+      .lang(lang)
       .build();
 
     let layout = measure(render_options).map_err(map_error)?;
@@ -361,8 +376,12 @@ impl Renderer {
       font_families,
       lang,
     } = from_value(options.into()).map_err(map_error)?;
+
+    let lang = lang
+      .map(|lang| Lang::parse(&lang).map_err(map_error))
+      .transpose()?;
+
     let images = self.images_map(images.as_deref())?;
-    let lang = lang.map(Arc::from);
 
     if scenes.is_empty() {
       return Err(JsValue::from_str("Expected at least one animation scene"));
@@ -389,8 +408,8 @@ impl Renderer {
               .stylesheet(stylesheet.clone())
               .node(scene.node)
               .fonts(&state)
-              .font_families(font_families.clone())
-              .lang(lang.clone())
+              .font_families(font_families.clone().map(FontFamily::from_names))
+              .lang(lang)
               .draw_debug_border(draw_debug_border)
               .build(),
           )

--- a/takumi/tests/fixtures/lang.rs
+++ b/takumi/tests/fixtures/lang.rs
@@ -9,34 +9,41 @@ const SAMPLE: &str = "直 骨 今 海 真 令 説 器";
 
 const FONT: &str = "CJK Locl Test";
 
-fn lang_row(lang: &'static str) -> Node {
-  Node::container([
-    Node::text(format!("{lang}: ")).with_style(
+fn lang_row(lang: Lang) -> Result<Node> {
+  Ok(
+    Node::container([
+      Node::text(format!("{}: ", lang.as_str())).with_style(
+        Style::default()
+          .with(StyleDeclaration::font_family(
+            FontFamily::from_css_str("Geist").unwrap(),
+          ))
+          .with(StyleDeclaration::font_size(FontSize::Length(Px(40.0)))),
+      ),
+      Node::text(SAMPLE).with_lang(lang).with_style(
+        Style::default()
+          .with(StyleDeclaration::font_family(
+            FontFamily::from_css_str(FONT).unwrap(),
+          ))
+          .with(StyleDeclaration::font_size(FontSize::Length(Px(40.0)))),
+      ),
+    ])
+    .with_style(
       Style::default()
-        .with(StyleDeclaration::font_family(
-          FontFamily::from_css_str("Geist").unwrap(),
-        ))
-        .with(StyleDeclaration::font_size(FontSize::Length(Px(40.0)))),
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::align_items(AlignItems::Center))
+        .with_gap(SpacePair::from_pair(Px(12.0).into(), Px(12.0).into())),
     ),
-    Node::text(SAMPLE).with_lang(lang).with_style(
-      Style::default()
-        .with(StyleDeclaration::font_family(
-          FontFamily::from_css_str(FONT).unwrap(),
-        ))
-        .with(StyleDeclaration::font_size(FontSize::Length(Px(40.0)))),
-    ),
-  ])
-  .with_style(
-    Style::default()
-      .with(StyleDeclaration::display(Display::Flex))
-      .with(StyleDeclaration::align_items(AlignItems::Center))
-      .with_gap(SpacePair::from_pair(Px(12.0).into(), Px(12.0).into())),
   )
 }
 
 #[test]
-fn test_lang_han_unification() {
-  let container = Node::container(["ja", "zh", "ko"].map(lang_row)).with_style(
+fn test_lang_han_unification() -> Result<()> {
+  let rows = ["ja", "zh", "ko"]
+    .iter()
+    .map(|lang| Lang::parse(lang).and_then(lang_row))
+    .collect::<Result<Vec<_>>>()?;
+
+  let container = Node::container(rows).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Flex))
       .with(StyleDeclaration::flex_direction(FlexDirection::Column))
@@ -50,5 +57,5 @@ fn test_lang_han_unification() {
       .with_gap(SpacePair::from_pair(Px(32.0).into(), Px(32.0).into())),
   );
 
-  run_fixture_test(container, "lang_han_unification");
+  Ok(run_fixture_test(container, "lang_han_unification"))
 }

--- a/takumi/tests/fixtures/lang.rs
+++ b/takumi/tests/fixtures/lang.rs
@@ -57,5 +57,7 @@ fn test_lang_han_unification() -> Result<()> {
       .with_gap(SpacePair::from_pair(Px(32.0).into(), Px(32.0).into())),
   );
 
-  Ok(run_fixture_test(container, "lang_han_unification"))
+  run_fixture_test(container, "lang_han_unification");
+
+  Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `lang` and `font-family` options now use stricter typed handling across rendering and HTML input.
  * Invalid language tags are validated and surfaced as errors.

* **Bug Fixes**
  * Improved `lang` behavior consistency in layout and computed style propagation.
  * `dir` parsing now validates directly before applying.
  * Image nodes no longer apply language-related style layering.

* **Breaking Changes**
  * Font fallback snapshot APIs and render options now accept typed `FontFamily` / `Lang` inputs instead of raw strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->