### PR TITLE
JS: harden remote fetches and stop `ImageResponse.ready` unhandled rejections

### DIFF
--- a/.tegami/bound-remote-fetches.md
+++ b/.tegami/bound-remote-fetches.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:@takumi-rs/helpers:
+    type: minor
+---
+
+### Bound remote fetches with byte caps and default timeouts
+
+Remote image, font, and Google Fonts CSS fetches now reject bodies past a byte
+cap (`maxBytes`, default 32 MiB; 2 MiB for CSS) and apply the 5 s timeout to
+every fetch, not just images. Set `timeout: 0` to disable it. A new `allowUrl`
+hook on `FetchOptions` skips URLs it rejects.

--- a/.tegami/image-response-ready-rejection.md
+++ b/.tegami/image-response-ready-rejection.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:takumi-js:
+    type: patch
+---
+
+### Mark `ImageResponse.ready` rejection as handled
+
+A failed render no longer crashes the process with an `unhandledRejection` when
+the caller never awaits `ready`. The failure still reaches the stream and a
+caller that does await `ready` still observes it.

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -11,7 +11,10 @@ icon: Wrench
 | Helper                           | Use                                                                                                                                           |
 | :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
 | `googleFonts(options)`           | Load Google Fonts families in one request; `render` keeps the subsets used. See [Fonts & text](/docs/typography-and-fonts#from-google-fonts). |
+| `fontFromUrl(url, options?)`     | Turn a font URL into a lazy `fonts` entry. `options` takes the [fetch limits](/docs/load-images#fetch-limits).                                |
 | `subsetFonts({ fonts, source })` | Trim font subsets to the codepoints `source` renders (what `render` does internally).                                                         |
+
+`googleFonts` and `prepareImages` accept the same [fetch limits](/docs/load-images#fetch-limits): `timeout` (default 5 s on every fetch), `maxBytes`, `allowUrl`, and a custom `fetch`.
 
 ## Building nodes
 

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -26,6 +26,33 @@ const image = await render(element, {
 
 A plain `Map` never evicts. If your URLs are high-cardinality (a different image per render), pass a bounded cache such as an LRU, or omit `fetchCache`.
 
+## Fetch limits
+
+Every remote fetch (images, fonts, Google Fonts CSS) is bounded. The group form of `images` takes the same options:
+
+| Option     | Default            | Use                                                            |
+| :--------- | :----------------- | :------------------------------------------------------------- |
+| `timeout`  | `5000` (ms)        | Abort a hanging host. `0` or negative disables it.             |
+| `maxBytes` | 32 MiB             | Reject a body past this size, by `content-length` or streamed. |
+| `allowUrl` | allow all          | Return `false` to block a URL, e.g. an SSRF allowlist.         |
+| `fetch`    | `globalThis.fetch` | Custom fetch implementation.                                   |
+
+```tsx twoslash
+import { render } from "takumi-js";
+
+const element = <img src="https://example.com/image.png" />;
+
+const image = await render(element, {
+  images: {
+    timeout: 3000,
+    maxBytes: 4 * 1024 * 1024,
+    allowUrl: (url) => new URL(url).hostname === "example.com",
+  },
+});
+```
+
+`allowUrl` only filters the URL string. Redirects and DNS are not inspected; keep a custom `fetch` for a stricter SSRF policy.
+
 ## Pre-fetched Images
 
 Provide images by key so the renderer doesn't have to fetch them itself. Each key can be used in any `src` field or in the `background-image` / `mask-image` CSS properties.

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,6 +1,6 @@
 import type { GoogleFontShapeFamilies, GoogleFontShapes } from "./google-fonts-catalog";
 import type { Node } from "./types";
-import { fetchOk, type FetchOptions } from "./utils";
+import { defaultMaxFetchBytes, fetchOk, type FetchOptions, readBodyLimited } from "./utils";
 
 const chromeUserAgent =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -121,11 +121,15 @@ function buildUrl(options: GoogleFontsOptions) {
   return url.toString();
 }
 
+const maxCssBytes = 2 * 1024 * 1024;
+
 function fetchCss(url: string, options: FetchOptions) {
   return fetchOk(url, {
     ...options,
     init: { headers: { "User-Agent": chromeUserAgent } },
-  }).then((r) => r.text());
+  })
+    .then((r) => readBodyLimited(r, options.maxBytes ?? maxCssBytes))
+    .then((buffer) => new TextDecoder().decode(buffer));
 }
 
 async function fetchCssCached(url: string, options: GoogleFontsOptions) {
@@ -180,7 +184,10 @@ function toSubset(face: SubsetFace, options: FetchOptions): FontSubset {
     weight: face.weight,
     style: face.style,
     ranges: face.ranges,
-    data: () => fetchOk(face.url, options).then((r) => r.arrayBuffer()),
+    data: () =>
+      fetchOk(face.url, options).then((r) =>
+        readBodyLimited(r, options.maxBytes ?? defaultMaxFetchBytes),
+      ),
   };
 }
 
@@ -349,10 +356,13 @@ export function subsetFonts<T>({
  * dedupe. Family name, weight, and style come from the font file. Lets `fonts` take a bare URL
  * string, e.g. `fonts: ["https://example.com/Inter.woff2"]`.
  */
-export function fontFromUrl(url: string) {
+export function fontFromUrl(url: string, options: FetchOptions = {}) {
   return {
     key: url,
-    data: () => fetchOk(url).then((r) => r.arrayBuffer()),
+    data: () =>
+      fetchOk(url, options).then((r) =>
+        readBodyLimited(r, options.maxBytes ?? defaultMaxFetchBytes),
+      ),
   };
 }
 

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 import type { Node } from "./types";
 
 const defaultFetchTimeout = 5000;
+export const defaultMaxFetchBytes = 32 * 1024 * 1024;
 const cssUrlPattern = /url\(\s*(['"]?)(.*?)\1\s*\)/g;
 
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
@@ -9,17 +10,25 @@ export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>
 export type FetchOptions = {
   /** Custom fetch implementation. @default globalThis.fetch */
   fetch?: FetchLike;
-  /** Abort the request after this many milliseconds. */
+  /** Abort the request after this many milliseconds; `0` or negative disables it. @default 5000 */
   timeout?: number;
   /** Caller abort signal, combined with the timeout. */
   signal?: AbortSignal;
+  /** Reject bodies larger than this many bytes. @default 33554432 (32 MiB) */
+  maxBytes?: number;
+  /** Return false to skip fetching a URL (e.g. SSRF allowlist). */
+  allowUrl?: (url: string) => boolean;
 };
 
 /** Fetches a URL, applying a timeout signal and throwing on a non-OK status. */
 export async function fetchOk(url: string, options: FetchOptions & { init?: RequestInit } = {}) {
+  if (options.allowUrl && !options.allowUrl(url)) {
+    throw new Error(`URL blocked by allowUrl policy: ${url}`);
+  }
+
   const fetchImpl = options.fetch ?? globalThis.fetch;
-  const timeoutSignal =
-    options.timeout === undefined ? undefined : AbortSignal.timeout(options.timeout);
+  const timeout = options.timeout ?? defaultFetchTimeout;
+  const timeoutSignal = timeout <= 0 ? undefined : AbortSignal.timeout(timeout);
   const signals = [options.signal, options.init?.signal, timeoutSignal].filter(
     (s): s is AbortSignal => s !== undefined,
   );
@@ -29,6 +38,44 @@ export async function fetchOk(url: string, options: FetchOptions & { init?: Requ
     throw new Error(`HTTP ${response.status} ${response.statusText} fetching ${url}`);
   }
   return response;
+}
+
+/** Reads a response body, rejecting once it exceeds `maxBytes` (by content-length or streamed size). */
+export async function readBodyLimited(response: Response, maxBytes: number): Promise<ArrayBuffer> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(`Response exceeds ${maxBytes} bytes (content-length ${declared})`);
+  }
+
+  const body = response.body;
+  if (!body) {
+    return response.arrayBuffer();
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new Error(`Response exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
 }
 
 function isRemoteUrl(value: string): boolean {
@@ -110,7 +157,7 @@ function fetchImageData(
   }
 
   const promise = fetchOk(url, options)
-    .then((response) => response.arrayBuffer())
+    .then((response) => readBodyLimited(response, options.maxBytes ?? defaultMaxFetchBytes))
     .catch((error) => {
       fetchCache?.delete(url);
       throw error;
@@ -146,8 +193,10 @@ export async function prepareImages<T extends { src: string } = FetchedImage>({
   sources = [],
   fetchCache,
   fetch,
-  timeout = defaultFetchTimeout,
+  timeout,
   signal,
+  maxBytes,
+  allowUrl,
   throwOnError = true,
 }: PrepareImagesOptions<T>): Promise<(T | FetchedImage)[]> {
   const nodes = Array.isArray(node) ? node : [node];
@@ -158,7 +207,7 @@ export async function prepareImages<T extends { src: string } = FetchedImage>({
   }
 
   const urls = [...new Set(nodes.flatMap(extractImageUrls))].filter((url) => !provided.has(url));
-  const fetchOptions: FetchOptions = { fetch, timeout, signal };
+  const fetchOptions: FetchOptions = { fetch, timeout, signal, maxBytes, allowUrl };
 
   const tasks = urls.map(
     async (src): Promise<FetchedImage> => ({

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, mock, test } from "bun:test";
+import { fontFromUrl } from "../src/fonts";
+import type { Node } from "../src/types";
+import { prepareImages } from "../src/utils";
+
+const tree = (...srcs: string[]): Node => ({
+  type: "container",
+  children: srcs.map((src) => ({ type: "image", src })),
+});
+
+const streamOf = (...chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
+  new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+describe("fetch byte caps", () => {
+  test("rejects an oversized content-length before reading the body", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(new Uint8Array(8), { headers: { "content-length": "1000" } })),
+    );
+
+    await expect(
+      prepareImages({ node: tree("https://example.com/big.png"), fetch: fetchMock, maxBytes: 100 }),
+    ).rejects.toThrow(/exceeds 100 bytes/);
+  });
+
+  test("rejects a streamed body that grows past maxBytes with no content-length", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(streamOf(new Uint8Array(60), new Uint8Array(60)))),
+    );
+
+    await expect(
+      prepareImages({
+        node: tree("https://example.com/stream.png"),
+        fetch: fetchMock,
+        maxBytes: 100,
+      }),
+    ).rejects.toThrow(/exceeds 100 bytes/);
+  });
+
+  test("resolves a body under the cap with the correct bytes", async () => {
+    const payload = new TextEncoder().encode("hello");
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
+
+    const images = await prepareImages({
+      node: tree("https://example.com/ok.png"),
+      fetch: fetchMock,
+      maxBytes: 100,
+    });
+
+    expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
+  });
+});
+
+describe("allowUrl policy", () => {
+  test("never calls fetch for a blocked url", async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(new Uint8Array())));
+
+    await expect(
+      prepareImages({
+        node: tree("https://blocked.example.com/a.png"),
+        fetch: fetchMock,
+        allowUrl: () => false,
+      }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("default fetch timeout", () => {
+  test("fontFromUrl rejects a hanging host within the timeout", async () => {
+    const fetchMock = mock(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    );
+
+    const loader = fontFromUrl("https://slow.example.com/font.woff2", {
+      fetch: fetchMock,
+      timeout: 50,
+    });
+
+    await expect(loader.data()).rejects.toThrow();
+  });
+});

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -145,7 +145,7 @@ async function collectImages(
   options?: PipelineOptions,
 ): Promise<ImageLoader[]> {
   const images = options?.images;
-  const { sources, fetchCache, fetch, timeout, cache } = Array.isArray(images)
+  const { sources, fetchCache, fetch, timeout, maxBytes, allowUrl, cache } = Array.isArray(images)
     ? { sources: images }
     : (images ?? {});
 
@@ -155,6 +155,8 @@ async function collectImages(
     fetchCache,
     fetch,
     timeout,
+    maxBytes,
+    allowUrl,
     signal: options?.signal,
   });
 

--- a/takumi-js/src/response/index.ts
+++ b/takumi-js/src/response/index.ts
@@ -33,6 +33,10 @@ function buildImageResponse(
     rejectReady = reject;
   });
 
+  // A rejection is also surfaced via controller.error; without this, callers
+  // that never await `ready` crash the process with an unhandledRejection.
+  ready.catch(() => {});
+
   const stream = new ReadableStream({
     async start(controller) {
       try {

--- a/takumi-js/tests/response.test.tsx
+++ b/takumi-js/tests/response.test.tsx
@@ -142,6 +142,30 @@ describe("ImageResponse", () => {
     expect(onError.mock.calls[0]?.[0]).toBe(error);
   });
 
+  test("does not emit an unhandledRejection when ready is never awaited", async () => {
+    const error = new Error("font load failed");
+
+    const rejections: unknown[] = [];
+    const handler = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", handler);
+
+    try {
+      const response = new ImageResponse(<div>Hello</div>, {
+        fonts: [{ key: "failing-font", data: () => Promise.reject(error) }],
+        onError() {},
+      });
+      await response.arrayBuffer().catch(() => {});
+      await Bun.sleep(50);
+
+      expect(rejections).toHaveLength(0);
+      await expect(response.ready).rejects.toThrow();
+    } finally {
+      process.off("unhandledRejection", handler);
+    }
+  });
+
   test("should not crash on social template with pre-wrap and emoji", async () => {
     const posts = [
       {


### PR DESCRIPTION
## Why

Two server-side robustness fixes for the JS packages:

- `ImageResponse.ready` is eagerly created but almost never awaited (it is the `next/og` drop-in). On a render failure the rejection had no handler, so Node emitted an `unhandledRejection` and crashed the process, even though the error already reaches the HTTP layer via `controller.error`.
- The helpers fetch author-influenced URLs (images, fonts, Google Fonts CSS). Bodies were read unbounded, only image fetches had a timeout, and there was no hook to restrict which URLs may be fetched.

## What

- `takumi-js`: attach a no-op `.catch` to the `ready` promise so the rejection is marked handled while awaiters still observe it. Regression test asserts no `unhandledRejection` fires when `ready` is never awaited.
- `@takumi-rs/helpers`: `readBodyLimited` caps every remote body (`maxBytes`, default 32 MiB; 2 MiB for CSS); `fetchOk` applies the 5 s timeout to all fetches (`timeout: 0` disables) and gains an `allowUrl` policy hook. Image, font-subset, `fontFromUrl`, and Google Fonts CSS paths all route through the bounded reader.
- `takumi-js` render plumbs `maxBytes`/`allowUrl` from the `images` group form into `prepareImages`.
- Docs: fetch limits section in Images & emoji, `fontFromUrl(url, options?)` in Helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote image, font, and Google Fonts CSS fetches are now guarded with byte caps and enforced timeouts (with configurable `timeout`/`maxBytes`), reducing runaway downloads and hangs.
  * Image responses no longer trigger unhandled rejection crashes when `ready` isn’t awaited.

* **Tests**
  * Added tests for byte-limit enforcement, `allowUrl` filtering, timeout behavior, and the `ready` rejection handling.

* **Documentation**
  * Updated helper and load-images docs with fetch-limit configuration details (`timeout`, `maxBytes`, `allowUrl`) and the new `fontFromUrl(url, options?)` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->