### PR TITLE
NAPI: add concurrent render tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,212 +1,25 @@
-<div align="center">
-  <img src="./assets/images/takumi.svg" alt="Takumi" width="64" />
+# takumi-svg
 
-# Takumi
+<!-- cargo-rdme start -->
 
-**A Rust rendering engine that turns JSX, HTML, and node trees into images. No headless browser required.**
+Vector SVG output for takumi.
 
-Render OpenGraph cards, animated GIFs, video frames, and vector SVG from Node.js, Cloudflare Workers, browsers, or any Rust application.
-Drop-in compatible with `next/og`.
+[`render`] turns a node tree into real SVG (`<rect>`, `<path>`,
+`<linearGradient>`/`<radialGradient>`, `<filter>`, `<clipPath>`, glyph-outline
+`<path>`s, embedded `<image>`) instead of wrapping a rasterized bitmap in a
+`data:` URL. [`quick_xml`] builds the document, so every attribute and value
+is escaped.
 
-[![npm version](https://img.shields.io/npm/v/takumi-js?label=takumi-js)](https://www.npmjs.com/package/takumi-js)
-[![crates.io](https://img.shields.io/crates/v/takumi?label=takumi)](https://crates.io/crates/takumi)
-[![npm downloads](https://img.shields.io/npm/dm/%40takumi-rs%2Fcore?label=downloads)](https://www.npmjs.com/package/@takumi-rs/core)
-[![license](https://img.shields.io/badge/license-MIT%20%2F%20Apache--2.0-blue)](#license)
+Coverage:
 
-[Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground) · [Showcase](https://takumi.kane.tw/showcase)
+- Backgrounds, borders, border-radius (backgrounds and clip).
+- Linear and radial gradients; conic via a wedge-path approximation.
+- Box-shadow.
+- Text: glyph outlines, decorations, text-shadow, `-webkit-text-stroke`.
+- Bitmap and emoji glyphs, images.
+- Clip-path, overflow, opacity.
+- Filter and backdrop-filter (`<filter>` chains; the backdrop is the scene
+  replayed up to the element).
+- Affine transforms.
 
-</div>
-
-## Why Takumi
-
-Takumi is a rendering pipeline built in Rust for one job: **turning markup and CSS into pixels**. It parses CSS, lays out the tree, shapes text, composites layers, and encodes the output inside a single binary. A headless-Chromium setup spends around **300 MB of RAM** and a browser cold start on the same OG card; Takumi spends **a function call**.
-
-**One engine, every deployment target:**
-
-- **Node.js** loads the native binding
-- **Cloudflare Workers and browsers** load the WASM build
-- **Rust applications** embed the `takumi` crate
-
-Prebuilt binaries ship for macOS, Linux (glibc and musl), and Windows, on x64 and ARM64.
-
-**CSS support reaches past the usual OG-image subset:**
-
-- CSS Grid, block, inline, float
-- `::before`, `::after`, `:is()`, `:where()`
-- masks, `clip-path`, `backdrop-filter`, blend modes
-- `background-clip: text`, conic gradients
-- RTL text
-- Tailwind v4 utilities, including arbitrary values
-
-## Quick Start
-
-```bash
-bun i takumi-js
-```
-
-### Static image
-
-```tsx
-import { render } from "takumi-js";
-import { writeFile } from "node:fs/promises";
-
-const image = await render(
-  <div tw="w-full h-full flex items-center justify-center bg-gradient-to-b from-blue-100 to-red-50">
-    <h1 tw="text-6xl font-bold">Hello from Takumi</h1>
-  </div>,
-  { width: 1200, height: 630 },
-);
-
-await writeFile("./output.png", image);
-```
-
-### API route (`next/og`-compatible)
-
-```tsx
-import { ImageResponse } from "takumi-js/response";
-
-export function GET() {
-  return new ImageResponse(
-    <div tw="w-full h-full flex items-center justify-center bg-gradient-to-b from-blue-100 to-red-50">
-      <h1 tw="text-6xl font-bold">Hello from Takumi</h1>
-    </div>,
-    { width: 1200, height: 630 },
-  );
-}
-```
-
-### Animated WebP
-
-```tsx
-import { renderAnimation } from "takumi-js";
-import { writeFile } from "node:fs/promises";
-
-const animation = await renderAnimation({
-  width: 400,
-  height: 400,
-  fps: 30,
-  format: "webp",
-  scenes: [
-    {
-      durationMs: 1000,
-      node: (
-        <div tw="w-full h-full flex items-center justify-center">
-          <div tw="w-32 h-32 bg-blue-500 animate-spin rounded-lg" />
-        </div>
-      ),
-    },
-  ],
-});
-
-await writeFile("./output.webp", animation);
-```
-
-### Vector SVG
-
-```tsx
-import { renderSvg } from "takumi-js";
-import { writeFile } from "node:fs/promises";
-
-const svg = await renderSvg(
-  <div tw="w-full h-full flex items-center justify-center bg-gradient-to-b from-blue-100 to-red-50">
-    <h1 tw="text-6xl font-bold">Hello from Takumi</h1>
-  </div>,
-  { width: 1200, height: 630 },
-);
-
-await writeFile("./output.svg", svg);
-```
-
-### Rust
-
-```bash
-cargo add takumi
-```
-
-Start from the [Rust example](./example/rust).
-
-## Comparison
-
-| Feature                            | `next/og` (Satori) |                            Takumi                             |
-| :--------------------------------- | :----------------: | :-----------------------------------------------------------: |
-| **Runtime**                        |    Node / Edge     |        Node, Edge, CF Workers, Browser, **Rust crate**        |
-| **Template input**                 |    JSX / React     |     JSX, HTML strings, JSON node trees from any language      |
-| **Layout**                         |      Flexbox       |          Flexbox, **CSS Grid**, block, inline, float          |
-| **Selectors**                      |      Limited       | Complex selectors, `:is()`, `:where()`, `::before`, `::after` |
-| **`backdrop-filter`, blend modes** |         ✗          |                              ✅                               |
-| **Animated output**                |         ✗          |             **WebP / APNG / GIF / video frames**              |
-| **Vector SVG output**              |     ✅ Native      |            ✅ **Plus raster and animated output**             |
-| **Headless browser**               |         ✗          |                               ✗                               |
-| **`ImageResponse` API**            |     ✅ Native      |                       ✅ **Compatible**                       |
-
-Compare rendering output across providers at [image-bench.kane.tw](https://image-bench.kane.tw).
-
-## Who's Using Takumi
-
-- [Dcard](https://dcard.tw) renders post share images
-- [TanStack](https://tanstack.com) renders OG images for its docs
-- [Fumadocs](https://fumadocs.dev) generates its docs OG images
-- [Nuxt OG Image](https://nuxtseo.com/docs/og-image/renderers/takumi) ships Takumi as a built-in renderer
-- [Luma](https://lu.ma) renders event share images
-- [shiki-image](https://github.com/pi0/shiki-image) turns syntax-highlighted code into images
-
-More projects in the [showcase](https://takumi.kane.tw/showcase). Takumi is part of the [Vercel OSS Program](https://vercel.com/oss).
-
-## Core Architecture
-
-Takumi converts any template into a **node tree** with three node kinds: `container`, `image`, and `text`. That tree runs through:
-
-1. **Layout** via [taffy](https://github.com/DioxusLabs/taffy): Flexbox, Grid, block, float, `calc()`, absolute positioning, z-index
-2. **Text shaping** via [parley](https://github.com/linebender/parley) and [skrifa](https://github.com/googlefonts/fontations/tree/main/skrifa): WOFF/WOFF2 fonts, emoji, RTL, multi-span inline blocks
-3. **Compositing**: stacking contexts, blend modes, filters, transforms, SVG via [resvg](https://github.com/linebender/resvg)
-4. **Output**: PNG, JPEG, WebP, ICO for statics; GIF, APNG, WebP for animations; raw RGBA frames for video pipelines
-
-The input contract is a node tree, so any template system that serializes to HTML or JSON can feed it: React, Svelte, Vue, plain strings, or your own serializer in any language.
-
-A **time axis** threads through the pipeline: the renderer takes a timestamp, so a PNG is the tree at `t=0` and a GIF is the same tree sampled across `t`. CSS `@keyframes`, the `animation` shorthand, and Tailwind animation utilities (`animate-spin`, `animate-bounce`, arbitrary values) all resolve at render time.
-
-The same layout drives a second backend: `renderSvg()` (Rust `render_svg`, behind the `svg-backend` feature) emits a real `<svg>` document built from `<rect>`, `<path>`, gradients, and glyph outlines, so you can ship scalable vector output instead of pixels. If you reached for [satori](https://github.com/vercel/satori) to get SVG, this is the drop-in path.
-
-```mermaid
-flowchart LR
-    A[Templates] --> N[Node Tree] --> P[Rendering Pipeline]
-    C[Stylesheets] --> P
-    R[Resources] --> P
-    D(Time Axis) -.-> P
-
-    P --> F[(Raw Pixels)]
-    P --> S[Vector SVG]
-
-    F --> G[PNG / JPEG / WebP / ICO]
-    F --> H[GIF / APNG]
-    F --> I[Video frames]
-```
-
-## Showcase
-
-|                                 Takumi OG image [(source)](./example/twitter-images/components/og-image.tsx)                                 |                Package OG card [(source)](./example/twitter-images/components/package-og-image.tsx)                 |
-| :------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------: |
-|                                       ![Takumi OG Image](./example/twitter-images/output/og-image.png)                                       |                      ![Package OG Image](./example/twitter-images/output/package-og-image.png)                      |
-|                        **Prisma-style API card** [(source)](./example/twitter-images/components/prisma-og-image.tsx)                         |              **X-style social post** [(source)](./example/twitter-images/components/x-post-image.tsx)               |
-|                                   ![Prisma OG Image](./example/twitter-images/output/prisma-og-image.png)                                    |                       ![X-style Post Image](./example/twitter-images/output/x-post-image.png)                       |
-|                             **Keyframe Animation** [(source)](./example/ffmpeg-keyframe-animation/src/index.tsx)                             |                                **[shiki-image](https://github.com/pi0/shiki-image)**                                |
-| [![Keyframe Animation](./example/ffmpeg-keyframe-animation/output/thumbnail.webp)](./example/ffmpeg-keyframe-animation/output/animation.mp4) | ![Shiki Image Example](https://raw.githubusercontent.com/pi0/shiki-image/refs/heads/main/test/.snapshot/image.webp) |
-
-**More examples:** [Next.js](./example/nextjs), [Cloudflare Workers](./example/cloudflare-workers), [TanStack Start](./example/tanstack-start), [Svelte](./example/svelte), [Rust](./example/rust), [ffmpeg keyframe animation](./example/ffmpeg-keyframe-animation)
-
-- [(Unofficial) Takumi Playground](https://takumi-playground.kapadiya.net/)
-
-## Contributing
-
-Read [CONTRIBUTING.md](./CONTRIBUTING.md). Covers local setup, test commands, fixture workflow, and changelog process.
-
-We welcome bug reports, feature requests, doc improvements, and new example integrations.
-
-## License
-
-MIT or Apache-2.0
-
-<br/>
-<a href="https://vercel.com/oss">
-  <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge.svg" />
-</a>
+<!-- cargo-rdme end -->

--- a/README.md
+++ b/README.md
@@ -1,25 +1,212 @@
-# takumi-svg
+<div align="center">
+  <img src="./assets/images/takumi.svg" alt="Takumi" width="64" />
 
-<!-- cargo-rdme start -->
+# Takumi
 
-Vector SVG output for takumi.
+**A Rust rendering engine that turns JSX, HTML, and node trees into images. No headless browser required.**
 
-[`render`] turns a node tree into real SVG (`<rect>`, `<path>`,
-`<linearGradient>`/`<radialGradient>`, `<filter>`, `<clipPath>`, glyph-outline
-`<path>`s, embedded `<image>`) instead of wrapping a rasterized bitmap in a
-`data:` URL. [`quick_xml`] builds the document, so every attribute and value
-is escaped.
+Render OpenGraph cards, animated GIFs, video frames, and vector SVG from Node.js, Cloudflare Workers, browsers, or any Rust application.
+Drop-in compatible with `next/og`.
 
-Coverage:
+[![npm version](https://img.shields.io/npm/v/takumi-js?label=takumi-js)](https://www.npmjs.com/package/takumi-js)
+[![crates.io](https://img.shields.io/crates/v/takumi?label=takumi)](https://crates.io/crates/takumi)
+[![npm downloads](https://img.shields.io/npm/dm/%40takumi-rs%2Fcore?label=downloads)](https://www.npmjs.com/package/@takumi-rs/core)
+[![license](https://img.shields.io/badge/license-MIT%20%2F%20Apache--2.0-blue)](#license)
 
-- Backgrounds, borders, border-radius (backgrounds and clip).
-- Linear and radial gradients; conic via a wedge-path approximation.
-- Box-shadow.
-- Text: glyph outlines, decorations, text-shadow, `-webkit-text-stroke`.
-- Bitmap and emoji glyphs, images.
-- Clip-path, overflow, opacity.
-- Filter and backdrop-filter (`<filter>` chains; the backdrop is the scene
-  replayed up to the element).
-- Affine transforms.
+[Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground) · [Showcase](https://takumi.kane.tw/showcase)
 
-<!-- cargo-rdme end -->
+</div>
+
+## Why Takumi
+
+Takumi is a rendering pipeline built in Rust for one job: **turning markup and CSS into pixels**. It parses CSS, lays out the tree, shapes text, composites layers, and encodes the output inside a single binary. A headless-Chromium setup spends around **300 MB of RAM** and a browser cold start on the same OG card; Takumi spends **a function call**.
+
+**One engine, every deployment target:**
+
+- **Node.js** loads the native binding
+- **Cloudflare Workers and browsers** load the WASM build
+- **Rust applications** embed the `takumi` crate
+
+Prebuilt binaries ship for macOS, Linux (glibc and musl), and Windows, on x64 and ARM64.
+
+**CSS support reaches past the usual OG-image subset:**
+
+- CSS Grid, block, inline, float
+- `::before`, `::after`, `:is()`, `:where()`
+- masks, `clip-path`, `backdrop-filter`, blend modes
+- `background-clip: text`, conic gradients
+- RTL text
+- Tailwind v4 utilities, including arbitrary values
+
+## Quick Start
+
+```bash
+bun i takumi-js
+```
+
+### Static image
+
+```tsx
+import { render } from "takumi-js";
+import { writeFile } from "node:fs/promises";
+
+const image = await render(
+  <div tw="w-full h-full flex items-center justify-center bg-gradient-to-b from-blue-100 to-red-50">
+    <h1 tw="text-6xl font-bold">Hello from Takumi</h1>
+  </div>,
+  { width: 1200, height: 630 },
+);
+
+await writeFile("./output.png", image);
+```
+
+### API route (`next/og`-compatible)
+
+```tsx
+import { ImageResponse } from "takumi-js/response";
+
+export function GET() {
+  return new ImageResponse(
+    <div tw="w-full h-full flex items-center justify-center bg-gradient-to-b from-blue-100 to-red-50">
+      <h1 tw="text-6xl font-bold">Hello from Takumi</h1>
+    </div>,
+    { width: 1200, height: 630 },
+  );
+}
+```
+
+### Animated WebP
+
+```tsx
+import { renderAnimation } from "takumi-js";
+import { writeFile } from "node:fs/promises";
+
+const animation = await renderAnimation({
+  width: 400,
+  height: 400,
+  fps: 30,
+  format: "webp",
+  scenes: [
+    {
+      durationMs: 1000,
+      node: (
+        <div tw="w-full h-full flex items-center justify-center">
+          <div tw="w-32 h-32 bg-blue-500 animate-spin rounded-lg" />
+        </div>
+      ),
+    },
+  ],
+});
+
+await writeFile("./output.webp", animation);
+```
+
+### Vector SVG
+
+```tsx
+import { renderSvg } from "takumi-js";
+import { writeFile } from "node:fs/promises";
+
+const svg = await renderSvg(
+  <div tw="w-full h-full flex items-center justify-center bg-gradient-to-b from-blue-100 to-red-50">
+    <h1 tw="text-6xl font-bold">Hello from Takumi</h1>
+  </div>,
+  { width: 1200, height: 630 },
+);
+
+await writeFile("./output.svg", svg);
+```
+
+### Rust
+
+```bash
+cargo add takumi
+```
+
+Start from the [Rust example](./example/rust).
+
+## Comparison
+
+| Feature                            | `next/og` (Satori) |                            Takumi                             |
+| :--------------------------------- | :----------------: | :-----------------------------------------------------------: |
+| **Runtime**                        |    Node / Edge     |        Node, Edge, CF Workers, Browser, **Rust crate**        |
+| **Template input**                 |    JSX / React     |     JSX, HTML strings, JSON node trees from any language      |
+| **Layout**                         |      Flexbox       |          Flexbox, **CSS Grid**, block, inline, float          |
+| **Selectors**                      |      Limited       | Complex selectors, `:is()`, `:where()`, `::before`, `::after` |
+| **`backdrop-filter`, blend modes** |         ✗          |                              ✅                               |
+| **Animated output**                |         ✗          |             **WebP / APNG / GIF / video frames**              |
+| **Vector SVG output**              |     ✅ Native      |            ✅ **Plus raster and animated output**             |
+| **Headless browser**               |         ✗          |                               ✗                               |
+| **`ImageResponse` API**            |     ✅ Native      |                       ✅ **Compatible**                       |
+
+Compare rendering output across providers at [image-bench.kane.tw](https://image-bench.kane.tw).
+
+## Who's Using Takumi
+
+- [Dcard](https://dcard.tw) renders post share images
+- [TanStack](https://tanstack.com) renders OG images for its docs
+- [Fumadocs](https://fumadocs.dev) generates its docs OG images
+- [Nuxt OG Image](https://nuxtseo.com/docs/og-image/renderers/takumi) ships Takumi as a built-in renderer
+- [Luma](https://lu.ma) renders event share images
+- [shiki-image](https://github.com/pi0/shiki-image) turns syntax-highlighted code into images
+
+More projects in the [showcase](https://takumi.kane.tw/showcase). Takumi is part of the [Vercel OSS Program](https://vercel.com/oss).
+
+## Core Architecture
+
+Takumi converts any template into a **node tree** with three node kinds: `container`, `image`, and `text`. That tree runs through:
+
+1. **Layout** via [taffy](https://github.com/DioxusLabs/taffy): Flexbox, Grid, block, float, `calc()`, absolute positioning, z-index
+2. **Text shaping** via [parley](https://github.com/linebender/parley) and [skrifa](https://github.com/googlefonts/fontations/tree/main/skrifa): WOFF/WOFF2 fonts, emoji, RTL, multi-span inline blocks
+3. **Compositing**: stacking contexts, blend modes, filters, transforms, SVG via [resvg](https://github.com/linebender/resvg)
+4. **Output**: PNG, JPEG, WebP, ICO for statics; GIF, APNG, WebP for animations; raw RGBA frames for video pipelines
+
+The input contract is a node tree, so any template system that serializes to HTML or JSON can feed it: React, Svelte, Vue, plain strings, or your own serializer in any language.
+
+A **time axis** threads through the pipeline: the renderer takes a timestamp, so a PNG is the tree at `t=0` and a GIF is the same tree sampled across `t`. CSS `@keyframes`, the `animation` shorthand, and Tailwind animation utilities (`animate-spin`, `animate-bounce`, arbitrary values) all resolve at render time.
+
+The same layout drives a second backend: `renderSvg()` (Rust `render_svg`, behind the `svg-backend` feature) emits a real `<svg>` document built from `<rect>`, `<path>`, gradients, and glyph outlines, so you can ship scalable vector output instead of pixels. If you reached for [satori](https://github.com/vercel/satori) to get SVG, this is the drop-in path.
+
+```mermaid
+flowchart LR
+    A[Templates] --> N[Node Tree] --> P[Rendering Pipeline]
+    C[Stylesheets] --> P
+    R[Resources] --> P
+    D(Time Axis) -.-> P
+
+    P --> F[(Raw Pixels)]
+    P --> S[Vector SVG]
+
+    F --> G[PNG / JPEG / WebP / ICO]
+    F --> H[GIF / APNG]
+    F --> I[Video frames]
+```
+
+## Showcase
+
+|                                 Takumi OG image [(source)](./example/twitter-images/components/og-image.tsx)                                 |                Package OG card [(source)](./example/twitter-images/components/package-og-image.tsx)                 |
+| :------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------: |
+|                                       ![Takumi OG Image](./example/twitter-images/output/og-image.png)                                       |                      ![Package OG Image](./example/twitter-images/output/package-og-image.png)                      |
+|                        **Prisma-style API card** [(source)](./example/twitter-images/components/prisma-og-image.tsx)                         |              **X-style social post** [(source)](./example/twitter-images/components/x-post-image.tsx)               |
+|                                   ![Prisma OG Image](./example/twitter-images/output/prisma-og-image.png)                                    |                       ![X-style Post Image](./example/twitter-images/output/x-post-image.png)                       |
+|                             **Keyframe Animation** [(source)](./example/ffmpeg-keyframe-animation/src/index.tsx)                             |                                **[shiki-image](https://github.com/pi0/shiki-image)**                                |
+| [![Keyframe Animation](./example/ffmpeg-keyframe-animation/output/thumbnail.webp)](./example/ffmpeg-keyframe-animation/output/animation.mp4) | ![Shiki Image Example](https://raw.githubusercontent.com/pi0/shiki-image/refs/heads/main/test/.snapshot/image.webp) |
+
+**More examples:** [Next.js](./example/nextjs), [Cloudflare Workers](./example/cloudflare-workers), [TanStack Start](./example/tanstack-start), [Svelte](./example/svelte), [Rust](./example/rust), [ffmpeg keyframe animation](./example/ffmpeg-keyframe-animation)
+
+- [(Unofficial) Takumi Playground](https://takumi-playground.kapadiya.net/)
+
+## Contributing
+
+Read [CONTRIBUTING.md](./CONTRIBUTING.md). Covers local setup, test commands, fixture workflow, and changelog process.
+
+We welcome bug reports, feature requests, doc improvements, and new example integrations.
+
+## License
+
+MIT or Apache-2.0
+
+<br/>
+<a href="https://vercel.com/oss">
+  <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge.svg" />
+</a>

--- a/takumi-napi/tests/concurrent-render.test.ts
+++ b/takumi-napi/tests/concurrent-render.test.ts
@@ -43,24 +43,27 @@ test("concurrent static renders resolve to distinct valid PNGs", async () => {
 });
 
 test("interleaved concurrent render and measure calls all resolve", async () => {
-  const tasks = Array.from({ length: 16 }, (_, i) =>
-    i % 2 === 0
-      ? renderer.render(textNode(i), { width: 400, height: 100, format: "png" })
-      : renderer.measure(textNode(i), { width: 400, height: 100 }),
+  const renders = Array.from({ length: 8 }, (_, i) =>
+    renderer.render(textNode(i * 2), { width: 400, height: 100, format: "png" }),
+  );
+  const measures = Array.from({ length: 8 }, (_, i) =>
+    renderer.measure(textNode(i * 2 + 1), { width: 400, height: 100 }),
   );
 
-  const results = await Promise.all(tasks);
+  const [renderResults, measureResults] = await Promise.all([
+    Promise.all(renders),
+    Promise.all(measures),
+  ]);
 
-  results.forEach((result, i) => {
-    if (i % 2 === 0) {
-      expect(result).toBeInstanceOf(Buffer);
-      expect((result as Buffer).length).toBeGreaterThan(0);
-    } else {
-      const measured = result as Awaited<ReturnType<typeof renderer.measure>>;
-      expect(Number.isFinite(measured.width)).toBe(true);
-      expect(Number.isFinite(measured.height)).toBe(true);
-    }
-  });
+  for (const result of renderResults) {
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+  }
+
+  for (const measured of measureResults) {
+    expect(Number.isFinite(measured.width)).toBe(true);
+    expect(Number.isFinite(measured.height)).toBe(true);
+  }
 });
 
 test("concurrent animation and static render calls all resolve", async () => {

--- a/takumi-napi/tests/concurrent-render.test.ts
+++ b/takumi-napi/tests/concurrent-render.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test";
+import { Renderer } from "../src/export";
+
+const fontData = await Bun.file(
+  new URL("../../assets/fonts/geist/Geist[wght].woff2", import.meta.url),
+).arrayBuffer();
+
+const renderer = new Renderer();
+
+await renderer.registerFont({
+  name: "Geist Concurrent",
+  data: fontData,
+  weight: 400,
+  style: "normal",
+});
+
+function textNode(index: number) {
+  return {
+    type: "text" as const,
+    text: `concurrent render ${index}`,
+    style: {
+      color: "#111827",
+      backgroundColor: `rgb(${index * 8}, ${255 - index * 8}, 128)`,
+      fontSize: 32,
+    },
+  };
+}
+
+test("concurrent static renders resolve to distinct valid PNGs", async () => {
+  const results = await Promise.all(
+    Array.from({ length: 16 }, (_, i) =>
+      renderer.render(textNode(i), { width: 400, height: 100, format: "png" }),
+    ),
+  );
+
+  for (const result of results) {
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+  }
+});
+
+test("interleaved concurrent render and measure calls all resolve", async () => {
+  const tasks = Array.from({ length: 16 }, (_, i) =>
+    i % 2 === 0
+      ? renderer.render(textNode(i), { width: 400, height: 100, format: "png" })
+      : renderer.measure(textNode(i), { width: 400, height: 100 }),
+  );
+
+  const results = await Promise.all(tasks);
+
+  results.forEach((result, i) => {
+    if (i % 2 === 0) {
+      expect(result).toBeInstanceOf(Buffer);
+      expect((result as Buffer).length).toBeGreaterThan(0);
+    } else {
+      const measured = result as Awaited<ReturnType<typeof renderer.measure>>;
+      expect(Number.isFinite(measured.width)).toBe(true);
+      expect(Number.isFinite(measured.height)).toBe(true);
+    }
+  });
+});
+
+test("concurrent animation and static render calls all resolve", async () => {
+  const scene = (index: number) => ({
+    node: textNode(index),
+    durationMs: 200,
+  });
+
+  const animationTasks = [
+    renderer.renderAnimation({
+      scenes: [scene(0), scene(1)],
+      width: 200,
+      height: 100,
+      fps: 2,
+      format: "gif" as const,
+    }),
+    renderer.renderAnimation({
+      scenes: [scene(2), scene(3), scene(4)],
+      width: 200,
+      height: 100,
+      fps: 2,
+      format: "webp" as const,
+    }),
+  ];
+
+  const staticTasks = Array.from({ length: 4 }, (_, i) =>
+    renderer.render(textNode(i + 10), { width: 200, height: 100, format: "png" }),
+  );
+
+  const [gif, webp, ...staticResults] = await Promise.all([...animationTasks, ...staticTasks]);
+
+  expect(gif.length).toBeGreaterThan(0);
+  expect(gif.subarray(0, 6).toString("ascii")).toMatch(/^GIF8[79]a$/);
+
+  expect(webp.length).toBeGreaterThan(0);
+  expect(webp.subarray(0, 4).toString("ascii")).toBe("RIFF");
+  expect(webp.subarray(8, 12).toString("ascii")).toBe("WEBP");
+
+  for (const result of staticResults) {
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBeGreaterThan(0);
+  }
+});
+
+test("concurrent renders of the same node are byte-identical to a serial render", async () => {
+  const node = textNode(42);
+  const options = { width: 400, height: 100, format: "png" as const };
+
+  const concurrent = await Promise.all(
+    Array.from({ length: 8 }, () => renderer.render(node, options)),
+  );
+
+  const serial = await renderer.render(node, options);
+
+  for (const result of concurrent) {
+    expect(Buffer.compare(result, serial)).toBe(0);
+  }
+});


### PR DESCRIPTION
## Why

`takumi-napi` runs render/measure/renderAnimation through async N-API tasks and a custom rayon thread pool, with a promised-safe concurrent design (ArcSwap fonts). The only existing concurrency test exercises `registerFont`; nothing exercised concurrent `render`/`measure`/`renderAnimation`, so a data race, worker panic, or teardown deadlock in those paths had no test to catch it.

## What

Adds `takumi-napi/tests/concurrent-render.test.ts` with four tests on one shared `Renderer`:

- 16 concurrent `render` calls, each asserted as a valid nonempty PNG
- 8 interleaved `render`/`measure` calls in one `Promise.all`
- 2 concurrent `renderAnimation` calls (gif/webp) alongside 4 static `render` calls
- 8 concurrent renders of the same node compared byte-for-byte against a serial render (determinism probe)

All four pass, verified across 3 consecutive full-suite runs (`bun test --silent`, 55/55 pass each time); no concurrency bug surfaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Bun test suite to validate concurrent rendering with a shared renderer.
  * Confirmed multiple simultaneous PNG renders return non-empty valid image buffers.
  * Verified that interleaved render and measure calls behave correctly under concurrency.
  * Added coverage for concurrent animated outputs alongside static renders, including basic GIF/WebP header checks.
  * Ensured concurrent renders of identical content produce identical byte-for-byte PNG results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
