### PR TITLE
Docs: fix stale Rust example in usage skill

### DIFF
--- a/.agents/skills/takumi-usage/SKILL.md
+++ b/.agents/skills/takumi-usage/SKILL.md
@@ -185,6 +185,11 @@ To build the node tree from HTML instead, enable the `from-html` feature and use
 use takumi::prelude::*;
 use takumi::{from_html, render};
 
+let mut fonts = Fonts::default();
+fonts.register(FontResource::new(include_bytes!(
+  "../../assets/fonts/geist/Geist[wght].woff2"
+)))?;
+
 let html = r#"<div style="background: red; width: 100%; height: 100%;"></div>"#;
 let node = from_html(html, FromHtmlOptions::default())?;
 

--- a/.agents/skills/takumi-usage/SKILL.md
+++ b/.agents/skills/takumi-usage/SKILL.md
@@ -155,17 +155,44 @@ Provides fine-grained control over font rendering features and variable layout c
 
 ## Rust Crate API (`takumi`)
 
-```rust
-use takumi::{render, RenderOptions, Node};
+<!-- keep in sync with the doctest in takumi/src/lib.rs -->
 
-fn main() {
-    let options = RenderOptions {
-        width: 800,
-        height: 600,
-        ..Default::default()
-    };
-    let html = r#"<div style="background: red; width: 100%; height: 100%;"></div>"#;
-    let node = Node::from_html(html, None).unwrap();
-    let bytes = render(&node, &options).unwrap();
-}
+```rust
+use takumi::prelude::*;
+use takumi::render;
+
+let node = Node::container([Node::text("Hello, world!").with_style(
+  Style::default().with(StyleDeclaration::font_size(Length::Px(32.0).into())),
+)]);
+
+let mut fonts = Fonts::default();
+fonts.register(FontResource::new(include_bytes!(
+  "../../assets/fonts/geist/Geist[wght].woff2"
+)))?;
+
+let options = RenderOptions::builder()
+  .viewport(Viewport::new((1200, 630)))
+  .node(node)
+  .fonts(&fonts)
+  .build();
+
+let image = render(options)?;
+```
+
+To build the node tree from HTML instead, enable the `from-html` feature and use `from_html`:
+
+```rust
+use takumi::prelude::*;
+use takumi::{from_html, render};
+
+let html = r#"<div style="background: red; width: 100%; height: 100%;"></div>"#;
+let node = from_html(html, FromHtmlOptions::default())?;
+
+let options = RenderOptions::builder()
+  .viewport(Viewport::new((1200, 630)))
+  .node(node)
+  .fonts(&fonts)
+  .build();
+
+let image = render(options)?;
 ```

--- a/takumi-core/Cargo.toml
+++ b/takumi-core/Cargo.toml
@@ -81,4 +81,7 @@ serde_json.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 

--- a/takumi-html/Cargo.toml
+++ b/takumi-html/Cargo.toml
@@ -21,4 +21,7 @@ version = "0.3.0"
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 

--- a/takumi-raster/Cargo.toml
+++ b/takumi-raster/Cargo.toml
@@ -60,4 +60,7 @@ serde_json.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 

--- a/takumi-svg/Cargo.toml
+++ b/takumi-svg/Cargo.toml
@@ -21,4 +21,7 @@ version = "0.3.0"
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 


### PR DESCRIPTION
## Why

`.agents/skills/takumi-usage/SKILL.md`'s Rust section showed a pre-2.0 API
(`RenderOptions { width, height, .. }` struct literal, `Node::from_html`,
`render(&node, &options)`) that no longer compiles against the 2.0 builder
API. Only the umbrella `takumi` crate had `[package.metadata.docs.rs]
all-features = true`, so docs.rs shows a partial surface for the published
sibling crates (`takumi-core`, `takumi-raster`, `takumi-svg`, `takumi-html`).

## What

- Rewrote the Rust snippet in SKILL.md to mirror the doctest in
  `takumi/src/lib.rs` (builder + `Viewport` + `fonts` + `render(options)?`),
  added an HTML-input variant using `from_html`/`FromHtmlOptions`, and a
  sync comment pointing back at the doctest. Verified by compiling both
  snippets in a scratch example against the real crate.
- Added `[package.metadata.docs.rs] all-features = true` to `takumi-core`,
  `takumi-raster`, `takumi-svg`, and `takumi-html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the Rust API usage example with clearer setup steps, including custom font registration, builder-based rendering options, and HTML-to-node rendering when available.
  * Updated documentation build settings so generated docs include all available features across the affected crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->