### PR TITLE
Crate: fix decode/gradient/shadow panics and buffer-pool UB

### DIFF
--- a/.tegami/buffer-pool-capacity-invariant.md
+++ b/.tegami/buffer-pool-capacity-invariant.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+  "cargo:takumi": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Fix buffer pool bucket capacity invariant
+
+Release now buckets a buffer by the floor power of two its capacity guarantees,
+and `acquire_dirty` reserves before `set_len`. A pooled buffer can no longer be
+lengthened past its allocation.

--- a/.tegami/gradient-lut-stop-clamp.md
+++ b/.tegami/gradient-lut-stop-clamp.md
@@ -1,0 +1,12 @@
+---
+packages:
+  "cargo:takumi-core": patch
+  "cargo:takumi": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Fix gradient stop snapping panic for oversized stop lists
+
+Gradients with more color stops than the LUT can hold no longer panic. The
+sample-index clamp and normalization passes stay within LUT bounds.

--- a/.tegami/image-decode-limits.md
+++ b/.tegami/image-decode-limits.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-core": patch
+  "cargo:takumi": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Cap image decode dimensions and GIF frame volume
+
+Decoders reject images beyond 8192x8192 (via `image::Limits` for PNG and JPEG,
+dimension checks for WebP) and GIFs beyond a total-frame pixel budget, stopping
+decode-bomb OOM.

--- a/.tegami/shadow-blur-size-overflow.md
+++ b/.tegami/shadow-blur-size-overflow.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+  "cargo:takumi": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Guard shadow and blur buffer sizing against overflow
+
+Extreme blur radii could overflow the `u32` shadow-buffer area and panic or
+over-allocate. Sizing now uses saturating math and skips shadows above a 256
+Mi-pixel budget.

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -113,6 +113,15 @@ function OgImage() {
 }
 ```
 
+## Decode limits
+
+Takumi rejects oversized images at decode time. The limits guard server renders against decode bombs: small files that declare huge dimensions to force multi-gigabyte allocations.
+
+| Input        | Limit                                       |
+| ------------ | ------------------------------------------- |
+| Image        | **8192×8192** pixels                        |
+| Animated GIF | 4× the image budget, summed over all frames |
+
 ## Emoji
 
 ### Dynamic fetching

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use image::{
-  AnimationDecoder, DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, RgbaImage,
+  AnimationDecoder, DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits,
+  RgbaImage,
   codecs::{gif::GifDecoder, jpeg::JpegDecoder, png::PngDecoder},
   error::{DecodingError, ImageFormatHint, UnsupportedError, UnsupportedErrorKind},
 };
@@ -17,6 +18,34 @@ use crate::resources::image_buffer::ImageBuffer;
 
 const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 const JPEG_SIGNATURE: [u8; 3] = [0xFF, 0xD8, 0xFF];
+
+/// Maximum decoded image edge length; also the width/height limit fed to the
+/// `image` crate decoders.
+const MAX_IMAGE_DIMENSION: u32 = 8192;
+/// Decoded images above this pixel count are rejected (RGBA cost = 4x).
+/// 8192 x 8192 — far above any sane OG-image asset, far below OOM territory.
+const MAX_IMAGE_PIXELS: u64 = MAX_IMAGE_DIMENSION as u64 * MAX_IMAGE_DIMENSION as u64;
+/// Total pixels across all GIF frames (frame budget for animations).
+const MAX_GIF_TOTAL_PIXELS: u64 = 4 * MAX_IMAGE_PIXELS;
+
+/// Rejects decoded images whose pixel count exceeds [`MAX_IMAGE_PIXELS`].
+fn check_pixel_budget(width: u32, height: u32) -> ImageResult<()> {
+  if width as u64 * height as u64 > MAX_IMAGE_PIXELS {
+    return Err(pixel_budget_error(width, height));
+  }
+
+  Ok(())
+}
+
+fn pixel_budget_error(width: u32, height: u32) -> ImageError {
+  ImageError::Decoding(DecodingError::new(
+    ImageFormatHint::Unknown,
+    IoError::new(
+      ErrorKind::InvalidData,
+      format!("image dimensions {width}x{height} exceed the decode budget"),
+    ),
+  ))
+}
 
 pub(crate) struct DecodedGifFrame {
   pub(crate) buffer: Arc<ImageBuffer>,
@@ -76,9 +105,13 @@ enum DetectedImageFormat {
 }
 
 fn decode_with_image_crate(
-  decoder: impl ImageDecoder,
+  mut decoder: impl ImageDecoder,
   format: ImageFormat,
 ) -> ImageResult<ImageBuffer> {
+  let mut limits = Limits::default();
+  limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+  limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+  decoder.set_limits(limits)?;
   rgba_to_buffer(DynamicImage::from_decoder(decoder)?.to_rgba8(), format)
 }
 
@@ -92,10 +125,23 @@ fn decode_jpeg(bytes: &[u8]) -> ImageResult<ImageBuffer> {
 
 fn decode_gif(bytes: &[u8]) -> ImageResult<DecodedGif> {
   let decoder = GifDecoder::new(Cursor::new(bytes))?;
-  let frames = decoder.into_frames().collect_frames()?;
-  let mut decoded_frames = Vec::with_capacity(frames.len());
+  let mut decoded_frames = Vec::new();
+  let mut total_pixels: u64 = 0;
+  let mut first_frame = true;
 
-  for frame in frames {
+  for frame in decoder.into_frames() {
+    let frame = frame?;
+    let (width, height) = frame.buffer().dimensions();
+    if first_frame {
+      check_pixel_budget(width, height)?;
+      first_frame = false;
+    }
+
+    total_pixels += width as u64 * height as u64;
+    if total_pixels > MAX_GIF_TOTAL_PIXELS {
+      return Err(pixel_budget_error(width, height));
+    }
+
     let (numerator, denominator) = frame.delay().numer_denom_ms();
     let frame_delay_ms = numerator.checked_div(denominator).unwrap_or(numerator);
     let duration_ms = frame_delay_ms.max(1);
@@ -115,6 +161,7 @@ fn decode_gif(bytes: &[u8]) -> ImageResult<DecodedGif> {
 fn decode_webp(bytes: &[u8]) -> ImageResult<ImageBuffer> {
   let mut decoder = WebPDecoder::new(Cursor::new(bytes)).map_err(webp_decode_error)?;
   let (width, height) = decoder.dimensions();
+  check_pixel_budget(width, height)?;
   let has_alpha = decoder.has_alpha();
   let channel_count = if has_alpha { 4 } else { 3 };
   let mut image_data = vec![0; width as usize * height as usize * channel_count];
@@ -161,6 +208,13 @@ fn decode_webp(bytes: &[u8]) -> ImageResult<ImageBuffer> {
     return Err(webp_decode_error(WebPError::InvalidEncodedData));
   }
 
+  if let Err(error) = check_pixel_budget(width as u32, height as u32) {
+    unsafe {
+      WebPFree(decoded_ptr.cast());
+    }
+    return Err(error);
+  }
+
   let pixel_count = (width as usize)
     .checked_mul(height as usize)
     .and_then(|pixels| pixels.checked_mul(4))
@@ -201,4 +255,28 @@ fn invalid_buffer_error() -> ImageError {
 
 fn webp_decode_error(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> ImageError {
   ImageError::Decoding(DecodingError::new(ImageFormat::WebP.into(), error))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn check_pixel_budget_accepts_budget_edge() {
+    assert!(check_pixel_budget(MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION).is_ok());
+    assert!(check_pixel_budget(1, 1).is_ok());
+  }
+
+  #[test]
+  fn check_pixel_budget_rejects_oversized() {
+    assert!(check_pixel_budget(MAX_IMAGE_DIMENSION + 1, MAX_IMAGE_DIMENSION + 1).is_err());
+    assert!(check_pixel_budget(100_000, 100_000).is_err());
+  }
+
+  #[test]
+  fn decode_png_accepts_small_valid_image() {
+    let bytes = include_bytes!("../../../assets/images/yeecord.png");
+    let decoded = decode_image(bytes).expect("small PNG decodes within budget");
+    assert!(matches!(decoded, DecodedImage::Buffer(_)));
+  }
 }

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -12,7 +12,7 @@ use image::{
 #[cfg(target_arch = "wasm32")]
 use image_webp::WebPDecoder;
 #[cfg(not(target_arch = "wasm32"))]
-use libwebp_sys::{WebPDecodeRGBA, WebPFree};
+use libwebp_sys::{WebPDecodeRGBA, WebPFree, WebPGetInfo};
 
 use crate::resources::image_buffer::ImageBuffer;
 
@@ -104,14 +104,18 @@ enum DetectedImageFormat {
   WebP,
 }
 
+fn decode_limits() -> Limits {
+  let mut limits = Limits::default();
+  limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+  limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+  limits
+}
+
 fn decode_with_image_crate(
   mut decoder: impl ImageDecoder,
   format: ImageFormat,
 ) -> ImageResult<ImageBuffer> {
-  let mut limits = Limits::default();
-  limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
-  limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
-  decoder.set_limits(limits)?;
+  decoder.set_limits(decode_limits())?;
   rgba_to_buffer(DynamicImage::from_decoder(decoder)?.to_rgba8(), format)
 }
 
@@ -124,18 +128,15 @@ fn decode_jpeg(bytes: &[u8]) -> ImageResult<ImageBuffer> {
 }
 
 fn decode_gif(bytes: &[u8]) -> ImageResult<DecodedGif> {
-  let decoder = GifDecoder::new(Cursor::new(bytes))?;
+  let mut decoder = GifDecoder::new(Cursor::new(bytes))?;
+  decoder.set_limits(decode_limits())?;
+
   let mut decoded_frames = Vec::new();
   let mut total_pixels: u64 = 0;
-  let mut first_frame = true;
 
   for frame in decoder.into_frames() {
     let frame = frame?;
     let (width, height) = frame.buffer().dimensions();
-    if first_frame {
-      check_pixel_budget(width, height)?;
-      first_frame = false;
-    }
 
     total_pixels += width as u64 * height as u64;
     if total_pixels > MAX_GIF_TOTAL_PIXELS {
@@ -191,6 +192,17 @@ fn decode_webp(bytes: &[u8]) -> ImageResult<ImageBuffer> {
 
   let mut width = 0;
   let mut height = 0;
+  let header_ok = unsafe {
+    // SAFETY: `bytes.as_ptr()` is valid for `bytes.len()` bytes for the duration of the call.
+    WebPGetInfo(bytes.as_ptr(), bytes.len(), &mut width, &mut height)
+  };
+
+  if header_ok == 0 || width <= 0 || height <= 0 {
+    return Err(webp_decode_error(WebPError::InvalidEncodedData));
+  }
+
+  check_pixel_budget(width as u32, height as u32)?;
+
   let decoded_ptr = unsafe {
     // SAFETY: `bytes.as_ptr()` is valid for `bytes.len()` bytes for the duration of the call,
     // and libwebp returns either a null pointer or an owned RGBA buffer freed with `WebPFree`.
@@ -206,13 +218,6 @@ fn decode_webp(bytes: &[u8]) -> ImageResult<ImageBuffer> {
       WebPFree(decoded_ptr.cast());
     }
     return Err(webp_decode_error(WebPError::InvalidEncodedData));
-  }
-
-  if let Err(error) = check_pixel_budget(width as u32, height as u32) {
-    unsafe {
-      WebPFree(decoded_ptr.cast());
-    }
-    return Err(error);
   }
 
   let pixel_count = (width as usize)

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -470,14 +470,21 @@ fn assign_stop_sample_indices(
       let stop_index = i + offset;
       let lower_bound = stop_index.min(max_index);
       let upper_bound = max_index.saturating_sub(stop_count - 1 - stop_index);
-      *slot = logical_index.clamp(lower_bound, upper_bound);
+      *slot = if lower_bound <= upper_bound {
+        logical_index.clamp(lower_bound, upper_bound)
+      } else {
+        // More stops than LUT slots: uniqueness is impossible; stay in range.
+        logical_index.min(max_index)
+      };
     }
 
     i = run_end;
   }
 
   for i in 1..stop_count {
-    indices[i] = indices[i].max(indices[i - 1].saturating_add(1));
+    indices[i] = indices[i]
+      .max(indices[i - 1].saturating_add(1))
+      .min(max_index);
   }
 
   for i in (0..stop_count.saturating_sub(1)).rev() {
@@ -1057,5 +1064,41 @@ mod tests {
   fn test_interpolate_rgba_uses_premultiplied_alpha() {
     let mixed = interpolate_rgba(Color([255, 255, 255, 255]), Color([0, 0, 0, 0]), 0.5);
     assert_eq!(mixed, Color([255, 255, 255, 128]));
+  }
+
+  fn evenly_spaced_stops(count: usize, axis_length: f32) -> Vec<ResolvedGradientStop> {
+    (0..count)
+      .map(|i| ResolvedGradientStop {
+        color: Color([255, 0, 0, 255]),
+        position: axis_length * i as f32 / (count - 1) as f32,
+      })
+      .collect()
+  }
+
+  #[test]
+  fn assign_stop_sample_indices_survives_more_stops_than_lut() {
+    let stops = evenly_spaced_stops(9000, 256.0);
+    let indices = assign_stop_sample_indices(&stops, 256.0, 8193);
+
+    assert_eq!(indices.len(), 9000);
+    assert!(indices.iter().all(|&idx| idx < 8193));
+  }
+
+  #[test]
+  fn snap_stop_samples_survives_more_stops_than_lut() {
+    let stops = evenly_spaced_stops(9000, 256.0);
+    let mut lut = vec![PremultipliedColorU8::TRANSPARENT; 8193];
+    snap_stop_samples(&mut lut, &stops, 256.0);
+  }
+
+  #[test]
+  fn assign_stop_sample_indices_in_range_is_strictly_increasing() {
+    let stops = evenly_spaced_stops(5, 512.0);
+    let indices = assign_stop_sample_indices(&stops, 512.0, 512);
+
+    assert!(indices.iter().all(|&idx| idx < 512));
+    for pair in indices.windows(2) {
+      assert!(pair[0] < pair[1]);
+    }
   }
 }

--- a/takumi-raster/src/canvas/buffer_pool.rs
+++ b/takumi-raster/src/canvas/buffer_pool.rs
@@ -34,6 +34,9 @@ fn bucket_index_clamped(capacity: usize) -> usize {
 /// Bucket whose guarantee (`capacity >= 2^i`) this capacity satisfies.
 #[inline]
 fn release_bucket_index(capacity: usize) -> usize {
+  if capacity == 0 {
+    return 0;
+  }
   let raw = (usize::BITS - 1 - capacity.leading_zeros()) as usize; // floor(log2)
   raw.min(BUCKET_COUNT - 1)
 }

--- a/takumi-raster/src/canvas/buffer_pool.rs
+++ b/takumi-raster/src/canvas/buffer_pool.rs
@@ -31,6 +31,13 @@ fn bucket_index_clamped(capacity: usize) -> usize {
   raw.min(BUCKET_COUNT - 1)
 }
 
+/// Bucket whose guarantee (`capacity >= 2^i`) this capacity satisfies.
+#[inline]
+fn release_bucket_index(capacity: usize) -> usize {
+  let raw = (usize::BITS - 1 - capacity.leading_zeros()) as usize; // floor(log2)
+  raw.min(BUCKET_COUNT - 1)
+}
+
 #[inline]
 fn pop_from_bucket<T>(pools: &mut [Vec<Vec<T>>; BUCKET_COUNT], index: usize) -> Option<Vec<T>> {
   pools[index..].iter_mut().find_map(Vec::pop)
@@ -66,6 +73,9 @@ impl BufferPool {
       None => Vec::with_capacity(allocate_capacity(index, capacity)),
     };
     buf.clear();
+    if buf.capacity() < capacity {
+      buf.reserve_exact(capacity);
+    }
     unsafe {
       buf.set_len(capacity);
     }
@@ -78,7 +88,7 @@ impl BufferPool {
       return;
     }
     self.current_size += cap;
-    self.pools[bucket_index_clamped(cap)].push(buffer);
+    self.pools[release_bucket_index(cap)].push(buffer);
   }
 
   pub(crate) fn acquire_u32(&mut self, capacity: usize) -> Vec<u32> {
@@ -104,6 +114,46 @@ impl BufferPool {
       return;
     }
     self.current_size += cap_bytes;
-    self.u32_pools[bucket_index_clamped(cap)].push(buffer);
+    self.u32_pools[release_bucket_index(cap)].push(buffer);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn release_undersized_then_acquire_dirty_larger() {
+    let mut pool = BufferPool::default();
+    let buf = vec![0u8; 3000];
+    pool.release(buf);
+
+    let mut acquired = pool.acquire_dirty(4000);
+    assert_eq!(acquired.len(), 4000);
+    assert!(acquired.capacity() >= 4000);
+    acquired.fill(0xAB);
+    assert!(acquired.iter().all(|&b| b == 0xAB));
+  }
+
+  #[test]
+  fn release_buckets_by_floor_power_of_two() {
+    let mut pool = BufferPool::default();
+    let buf = vec![0u8; 3000];
+    pool.release(buf);
+
+    let acquired = pool.acquire_dirty(2048);
+    assert_eq!(acquired.len(), 2048);
+    assert!(acquired.capacity() >= 2048);
+  }
+
+  #[test]
+  fn release_u32_undersized_then_acquire_larger() {
+    let mut pool = BufferPool::default();
+    let buf = vec![0u32; 3000];
+    pool.release_u32(buf);
+
+    let acquired = pool.acquire_u32(4000);
+    assert_eq!(acquired.len(), 4000);
+    assert!(acquired.capacity() >= 4000);
   }
 }

--- a/takumi-raster/src/components/blur.rs
+++ b/takumi-raster/src/components/blur.rs
@@ -89,7 +89,7 @@ pub(crate) fn apply_blur(
 
   match format {
     BlurFormat::Alpha { data, .. } => {
-      let mut temp_image = pool.acquire_dirty((width * height) as usize);
+      let mut temp_image = pool.acquire_dirty(width as usize * height as usize);
       let temp_data = &mut *temp_image;
 
       for _ in 0..3 {

--- a/takumi-raster/src/components/shadow.rs
+++ b/takumi-raster/src/components/shadow.rs
@@ -8,6 +8,16 @@ use crate::{
   style::{Affine, BlendMode, ImageScalingAlgorithm, Sides},
 };
 
+/// Shadow buffers above this pixel count are skipped rather than allocated.
+pub(crate) const MAX_SHADOW_AREA: u64 = 1 << 28; // 256 Mi single-channel bytes
+
+/// Guards shadow buffer sizing against `u32` overflow from huge blur radii.
+#[inline]
+pub(crate) fn checked_shadow_area(width: u32, height: u32) -> Option<usize> {
+  let area = width as u64 * height as u64;
+  (area > 0 && area <= MAX_SHADOW_AREA).then_some(area as usize)
+}
+
 /// Draws the outset mask of the shadow.
 pub(crate) fn draw_outset_shadow(
   shadow: &SizedShadow,
@@ -35,11 +45,14 @@ pub(crate) fn draw_outset_shadow(
     0.0
   };
 
-  let shadow_width = placement.width + (blur_padding * 2.0) as u32;
-  let shadow_height = placement.height + (blur_padding * 2.0) as u32;
-  let mut shadow_alpha = canvas
-    .buffer_pool
-    .acquire((shadow_width * shadow_height) as usize);
+  let total_padding = (blur_padding * 2.0).min(u32::MAX as f32) as u32;
+  let shadow_width = placement.width.saturating_add(total_padding);
+  let shadow_height = placement.height.saturating_add(total_padding);
+  let Some(area) = checked_shadow_area(shadow_width, shadow_height) else {
+    canvas.buffer_pool.release(mask);
+    return Ok(());
+  };
+  let mut shadow_alpha = canvas.buffer_pool.acquire(area);
 
   let padding = blur_padding as u32;
   for y in 0..placement.height {
@@ -215,4 +228,29 @@ pub(crate) fn draw_inset_shadow(
   buffer_pool.release(shadow_alpha);
 
   Ok((data, width, height))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn checked_shadow_area_accepts_sane_dimensions() {
+    assert_eq!(checked_shadow_area(1024, 1024), Some(1024 * 1024));
+    assert_eq!(checked_shadow_area(16384, 16384), Some(1 << 28));
+  }
+
+  #[test]
+  fn checked_shadow_area_rejects_zero() {
+    assert_eq!(checked_shadow_area(0, 1024), None);
+    assert_eq!(checked_shadow_area(1024, 0), None);
+  }
+
+  #[test]
+  fn checked_shadow_area_rejects_extreme_blur_radius() {
+    // `box-shadow: 0 0 100000px` on a large node produces ~1.5M px dimensions;
+    // the u32 product would wrap, but the u64 guard rejects it without panic.
+    assert_eq!(checked_shadow_area(1_500_000, 1_500_000), None);
+    assert_eq!(checked_shadow_area(u32::MAX, u32::MAX), None);
+  }
 }

--- a/takumi-raster/src/components/shadow.rs
+++ b/takumi-raster/src/components/shadow.rs
@@ -45,7 +45,7 @@ pub(crate) fn draw_outset_shadow(
     0.0
   };
 
-  let total_padding = (blur_padding * 2.0).min(u32::MAX as f32) as u32;
+  let total_padding = (blur_padding * 2.0) as u32;
   let shadow_width = placement.width.saturating_add(total_padding);
   let shadow_height = placement.height.saturating_add(total_padding);
   let Some(area) = checked_shadow_area(shadow_width, shadow_height) else {

--- a/takumi-raster/src/filter.rs
+++ b/takumi-raster/src/filter.rs
@@ -7,7 +7,8 @@ use tiny_skia::{Mask as TinyMask, PixmapMut};
 
 use crate::{
   BlurFormat, BlurType, BorderProperties, BufferPool, Canvas, Placement, RenderContext, Result,
-  SizedShadow, apply_blur, apply_blur_rgba_bytes, fast_div_255, intersect_alpha_masks, render_mask,
+  SizedShadow, apply_blur, apply_blur_rgba_bytes, checked_shadow_area, fast_div_255,
+  intersect_alpha_masks, render_mask,
   style::{
     Affine, Color, Filter, FilterCategory, LUMA_WEIGHTS, PercentageNumber, SEPIA_WEIGHTS,
     SizingContext, TransferChannel, TransferTable,
@@ -562,10 +563,17 @@ fn apply_drop_shadow_filter(
     return Ok(());
   }
 
-  let shadow_width = source_bounds.width + 2 * padding;
-  let shadow_height = source_bounds.height + 2 * padding;
+  let shadow_width = source_bounds
+    .width
+    .saturating_add(padding.saturating_mul(2));
+  let shadow_height = source_bounds
+    .height
+    .saturating_add(padding.saturating_mul(2));
 
-  let mut shadow_alpha = buffer_pool.acquire_dirty((shadow_width * shadow_height) as usize);
+  let Some(area) = checked_shadow_area(shadow_width, shadow_height) else {
+    return Ok(());
+  };
+  let mut shadow_alpha = buffer_pool.acquire_dirty(area);
   shadow_alpha.fill(0);
 
   for y in 0..source_bounds.height {


### PR DESCRIPTION
## Why

Four render paths crash, hit undefined behavior, or over-allocate on hostile or degenerate input reachable from user CSS and author-influenced image URLs.

## What

- **Buffer pool bucket invariant**: an externally sized buffer released into the pool could later be `set_len` past its allocation (heap OOB write, UB). Release now buckets by the floor power of two the capacity guarantees, and `acquire_dirty` reserves before `set_len`.
- **Gradient stop snapping**: a gradient with more color stops than the LUT can hold panicked (`clamp` with `min > max`, then out-of-bounds indexing). The clamp is order-safe and the normalization passes stay within LUT bounds.
- **Shadow and blur sizing**: huge blur radii overflowed the `u32` shadow-buffer area, panicking or attempting a multi-GB allocation. Sizing uses saturating math and skips shadows above a 256 Mi-pixel budget.
- **Image decode limits**: decoders reject images beyond 8192x8192 (via `image::Limits` for PNG/JPEG, dimension checks for WebP) and GIFs beyond a total-frame pixel budget, stopping decode-bomb OOM. Documented in the images page.

Each fix ships with unit tests. Rendering output is unchanged for valid input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pixel-budget protections to reject oversized images and decode-bomb GIFs, and capped decode dimensions to 8192×8192.
  * Fixed gradient color-stop LUT handling to prevent panics when stop counts exceed LUT capacity.
  * Improved blur and shadow/drop-shadow rendering by using overflow-safe sizing and rejecting unsafe/extreme shadow allocations.
  * Updated buffer pool behavior so released/dirty buffers use consistent power-of-two bucketing and aren’t grown beyond their allocation.
* **Documentation**
  * Documented the new image decode limits, including the GIF frame budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->