### PR TITLE
Raster: reuse per-scene state across animation frames

### DIFF
--- a/.tegami/reuse-animation-frame-state.md
+++ b/.tegami/reuse-animation-frame-state.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+  "cargo:takumi": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Reuse per-scene state across animation frames
+
+Compute each scene's font snapshot once and share its image and stylesheet
+handles across frames instead of re-snapshotting and deep-cloning the whole
+option tree per frame. Frame output is unchanged.

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -540,8 +540,12 @@ fn resolve_prepared_at_time<'p, 'a, 'g>(
   prepared: &'p [PreparedScene<'a, 'g>],
   time_ms: u64,
 ) -> Option<(&'p PreparedScene<'a, 'g>, u64)> {
-  resolve_at_time(prepared.len(), |index| prepared[index].scene.duration_ms, time_ms)
-    .map(|(index, local_time_ms)| (&prepared[index], local_time_ms))
+  resolve_at_time(
+    prepared.len(),
+    |index| prepared[index].scene.duration_ms,
+    time_ms,
+  )
+  .map(|(index, local_time_ms)| (&prepared[index], local_time_ms))
 }
 
 /// A frame's start offset and displayed duration, both in milliseconds. Computed
@@ -629,7 +633,9 @@ fn resolve_at_time(
     return None;
   }
 
-  let total_ms = (0..count).map(|index| u64::from(duration_ms(index))).sum::<u64>();
+  let total_ms = (0..count)
+    .map(|index| u64::from(duration_ms(index)))
+    .sum::<u64>();
   let clamped_time_ms = time_ms.min(total_ms.saturating_sub(1));
   let mut elapsed_ms = 0_u64;
 

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -19,7 +19,7 @@ use crate::{
     node::Node,
     tree::{LayoutResults, LayoutTree, RenderNode},
   },
-  resources::image::ImageSource,
+  resources::{font::FontsSnapshot, image::ImageSource},
   stacking_context::paint_context,
   style::{Affine, FontFamily, SizingContext, StyleSheet},
   viewport::Viewport,
@@ -421,6 +421,18 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
     }))
     .build();
 
+  render_with_context(render_context, node, viewport, dithering)
+}
+
+/// Rasterizes `node` under an already-built [`RenderContext`]. The context
+/// carries the font snapshot, images, and stylesheet, so animation frames share
+/// one snapshot instead of re-snapshotting per frame.
+fn render_with_context(
+  render_context: RenderContext,
+  node: Node,
+  viewport: Viewport,
+  dithering: DitheringAlgorithm,
+) -> Result<Bitmap> {
   let mut root = RenderNode::from_node(&render_context, node);
   let mut tree = LayoutTree::from_render_node(&root);
 
@@ -465,22 +477,71 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
   Ok(Bitmap::from_rgba(image))
 }
 
-/// Renders a node at a specific time on the global animation timeline.
-pub(crate) fn render_at_time<'g>(mut options: RenderOptions<'g>, time_ms: u64) -> Result<Bitmap> {
-  options.time_ms = time_ms;
-  render(options)
+/// A scene with its per-frame-invariant render state precomputed: the font
+/// snapshot and the shared image and stylesheet handles do not change between
+/// frames of the same scene, so they are built once and cheaply cloned per
+/// frame instead of rebuilt (and the whole option tree deep-cloned) each time.
+///
+/// This is the seam where wider per-frame layout reuse would later live.
+pub(crate) struct PreparedScene<'a, 'g> {
+  scene: &'a SequentialScene<'g>,
+  fonts: FontsSnapshot,
+  images: Rc<HashMap<Arc<str>, ImageSource>>,
+  stylesheet: Rc<StyleSheet>,
 }
 
-/// Renders the active scene for a sequential animation timeline at `time_ms`.
-pub(crate) fn render_sequence_at_time<'g>(
-  scenes: &[SequentialScene<'g>],
-  time_ms: u64,
-) -> Result<Bitmap> {
-  let Some((scene, local_time_ms)) = resolve_scene_at_time(scenes, time_ms) else {
-    return Err(Error::InvalidViewport);
-  };
+impl<'a, 'g> PreparedScene<'a, 'g> {
+  fn new(scene: &'a SequentialScene<'g>) -> Self {
+    let options = &scene.options;
 
-  render_at_time(scene.options.clone(), local_time_ms)
+    Self {
+      fonts: options
+        .fonts
+        .snapshot_with_fallbacks(options.font_families.as_ref()),
+      images: Rc::new(options.images.clone()),
+      stylesheet: Rc::new(options.stylesheet.clone()),
+      scene,
+    }
+  }
+
+  fn render_at_time(&self, time_ms: u64) -> Result<Bitmap> {
+    let options = &self.scene.options;
+
+    let render_context = RenderContext::builder()
+      .fonts(self.fonts.clone())
+      .sizing(SizingContext::builder().viewport(options.viewport).build())
+      .images(self.images.clone())
+      .stylesheet(self.stylesheet.clone())
+      .time_ms(time_ms)
+      .draw_debug_border(options.draw_debug_border)
+      .style(Box::new(ComputedStyle {
+        lang: options.lang,
+        ..Default::default()
+      }))
+      .build();
+
+    render_with_context(
+      render_context,
+      options.node.clone(),
+      options.viewport,
+      options.dithering,
+    )
+  }
+}
+
+/// Precomputes the per-frame-invariant state for every scene in a timeline.
+pub(crate) fn prepare_scenes<'a, 'g>(
+  scenes: &'a [SequentialScene<'g>],
+) -> Vec<PreparedScene<'a, 'g>> {
+  scenes.iter().map(PreparedScene::new).collect()
+}
+
+fn resolve_prepared_at_time<'p, 'a, 'g>(
+  prepared: &'p [PreparedScene<'a, 'g>],
+  time_ms: u64,
+) -> Option<(&'p PreparedScene<'a, 'g>, u64)> {
+  resolve_at_time(prepared.len(), |index| prepared[index].scene.duration_ms, time_ms)
+    .map(|(index, local_time_ms)| (&prepared[index], local_time_ms))
 }
 
 /// A frame's start offset and displayed duration, both in milliseconds. Computed
@@ -521,11 +582,15 @@ pub(crate) fn frame_spans<'g>(scenes: &[SequentialScene<'g>], fps: u32) -> Vec<F
 }
 
 /// Renders one frame of the timeline for the given [`FrameSpan`].
-pub(crate) fn render_frame<'g>(
-  scenes: &[SequentialScene<'g>],
+pub(crate) fn render_frame(
+  prepared: &[PreparedScene<'_, '_>],
   span: FrameSpan,
 ) -> Result<AnimationFrame> {
-  let image = render_sequence_at_time(scenes, span.start_ms)?;
+  let Some((scene, local_time_ms)) = resolve_prepared_at_time(prepared, span.start_ms) else {
+    return Err(Error::InvalidViewport);
+  };
+
+  let image = scene.render_at_time(local_time_ms)?;
   Ok(AnimationFrame::new(image, span.duration_ms))
 }
 
@@ -537,9 +602,11 @@ pub fn render_animation<'g>(
   scenes: &[SequentialScene<'g>],
   fps: u32,
 ) -> Result<Vec<AnimationFrame>> {
+  let prepared = prepare_scenes(scenes);
+
   frame_spans(scenes, fps)
     .into_iter()
-    .map(|span| render_frame(scenes, span))
+    .map(|span| render_frame(&prepared, span))
     .collect()
 }
 
@@ -550,28 +617,41 @@ fn total_sequence_duration<'g>(scenes: &[SequentialScene<'g>]) -> u64 {
     .sum::<u64>()
 }
 
-fn resolve_scene_at_time<'a, 'g>(
-  scenes: &'a [SequentialScene<'g>],
+/// Resolves which scene of a `count`-long timeline is active at `time_ms` and the
+/// time offset within it, using `duration_ms(index)` for each scene's length.
+/// Times past the end clamp to the last scene's final millisecond.
+fn resolve_at_time(
+  count: usize,
+  duration_ms: impl Fn(usize) -> u32,
   time_ms: u64,
-) -> Option<(&'a SequentialScene<'g>, u64)> {
-  if scenes.is_empty() {
+) -> Option<(usize, u64)> {
+  if count == 0 {
     return None;
   }
 
+  let total_ms = (0..count).map(|index| u64::from(duration_ms(index))).sum::<u64>();
+  let clamped_time_ms = time_ms.min(total_ms.saturating_sub(1));
   let mut elapsed_ms = 0_u64;
-  let clamped_time_ms = time_ms.min(total_sequence_duration(scenes).saturating_sub(1));
 
-  for scene in scenes {
-    let next_elapsed_ms = elapsed_ms + u64::from(scene.duration_ms);
+  for index in 0..count {
+    let next_elapsed_ms = elapsed_ms + u64::from(duration_ms(index));
     if clamped_time_ms < next_elapsed_ms {
-      return Some((scene, clamped_time_ms - elapsed_ms));
+      return Some((index, clamped_time_ms - elapsed_ms));
     }
     elapsed_ms = next_elapsed_ms;
   }
 
-  scenes
-    .last()
-    .map(|scene| (scene, u64::from(scene.duration_ms.saturating_sub(1))))
+  let last = count - 1;
+  Some((last, u64::from(duration_ms(last).saturating_sub(1))))
+}
+
+#[cfg(test)]
+fn resolve_scene_at_time<'a, 'g>(
+  scenes: &'a [SequentialScene<'g>],
+  time_ms: u64,
+) -> Option<(&'a SequentialScene<'g>, u64)> {
+  resolve_at_time(scenes.len(), |index| scenes[index].duration_ms, time_ms)
+    .map(|(index, local_time_ms)| (&scenes[index], local_time_ms))
 }
 
 pub(crate) fn render_node(

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -18,7 +18,7 @@ use crate::webp::write_webp_lossy;
 use crate::{
   Result,
   error::Error,
-  render::{SequentialScene, frame_spans, render_frame},
+  render::{SequentialScene, frame_spans, prepare_scenes, render_frame},
   webp::{encode_animated_webp, has_any_alpha_pixel, strip_alpha_channel, write_webp_lossless},
 };
 
@@ -510,7 +510,8 @@ pub fn write_animation<W: Write>(
     return Err(Error::EmptyAnimationFrames);
   }
 
-  let frames = spans.iter().map(|&span| render_frame(scenes, span));
+  let prepared = prepare_scenes(scenes);
+  let frames = spans.iter().map(|&span| render_frame(&prepared, span));
   match format {
     AnimationFormat::WebP(options) => encode_animated_webp(frames, destination, options),
     AnimationFormat::Gif(options) => encode_animated_gif(frames, destination, options),


### PR DESCRIPTION
## Why
Each animation frame re-ran work that is invariant across frames of the same
scene: `render_sequence_at_time` deep-cloned the whole `RenderOptions` tree per
frame, and every frame rebuilt the font snapshot (cloning the font collection
and repopulating per-script fallback tables). A 30 fps timeline paid both costs
30 times per second for output that never changed.

## What
Add a private `PreparedScene` that snapshots each scene's fonts once and wraps
its images and stylesheet in shared `Rc` handles. The per-frame render now clones
only the node and bumps those refcounts instead of deep-cloning options and
re-snapshotting. Both animation entry points route through it: `render_animation`
(eager) and `write_animation` (streaming). The single-image `render` path keeps
snapshotting per call. Frame output is bit-identical; the 220 regenerated golden
`.html` files were macOS regen noise with zero `.webp`/`.svg` diffs.

Bench validation deferred to CI and reviewer per the no-heavy-local-builds
constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Animation rendering now reuses per-scene state across frames, reducing repeated work during sequential playback.
  * Frame generation now uses precomputed scene data for more efficient rendering.

* **Bug Fixes**
  * Animation output remains unchanged while improving how frame-by-frame scene data is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->