### PR TITLE
Docs: add AGENTS.md, align CONTRIBUTING gates, fix lefthook worktree README corruption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+Agent-facing facts for working in this repo. Human-oriented setup, PR
+checklist, and rationale live in `CONTRIBUTING.md`; read that too.
+
+## Build/test commands
+
+Rust:
+
+```bash
+CARGO_PROFILE_TEST_STRIP=debuginfo cargo test -q       # full suite (also test -p takumi for goldens)
+cargo clippy --all-targets --all-features -- -D warnings
+cargo machete                                            # unused deps
+```
+
+JS/TS, per package you touched:
+
+```bash
+(cd <package> && bun test --silent)
+bun run lint         # oxlint + oxfmt --check
+bun knip              # unused exports/deps
+bun publish-lint      # attw + publint (needs a built dist)
+```
+
+`takumi-image-response` has no test script; covered by
+`takumi-js/tests/response.test.tsx`.
+
+## Fixture rules
+
+`cargo test` REWRITES `takumi/tests/fixtures-generated/`. Diffs limited to
+`.html` are regen noise; discard them unless you intended the change. Diffs
+touching `.webp`/`.svg` are real render changes; review and commit them
+intentionally. CI fails the build if generated files change unexpectedly on
+a clean run.
+
+## Golden platform rule
+
+Goldens are Linux-canonical. Some fixtures render ±1-2px differently on
+macOS. Never re-baseline goldens from a macOS run. Pull the updated
+`.webp`/`.svg` files from the CI `changed-files` artifact instead.
+
+## Toolchain gotchas
+
+- Pre-commit hook (lefthook) needs `cargo-rdme` and `jq` on PATH; runs
+  `cargo fmt`, `cargo rdme --force`, `bun run lint:fix`. Rust steps are
+  glob-scoped to `*.rs`/`Cargo.toml`, so JS-only commits skip them.
+- In a linked git worktree, `LEFTHOOK=0 git commit ...` skips the hook if it
+  misbehaves. History: lefthook exported `GIT_DIR` without `GIT_WORK_TREE`
+  into the `cargo rdme` job, so `cd`-ing into a crate dir made git treat
+  that crate as repo root and `git add README.md` clobbered the root
+  README's index entry. The job now unsets both before running.
+- Docs playground (`docs/`) consumes `takumi-helpers/dist` (built), not
+  source. Rebuild helpers and clear `docs/.vite` for helper changes to show.
+- `takumi-napi` release build needs target-specific setup; no debug build
+  script exists. Use `cargo check -p takumi-napi` for fast local iteration.
+- `takumi-wasm` builds need `wasm-pack`; CI additionally pins a nightly
+  toolchain for `build-std`.
+
+## Changelogs
+
+```bash
+bun run tegami
+```
+
+Writes `.tegami/*.md` (frontmatter `packages: "npm:<pkg>"|"cargo:<crate>":
+<bump>` + `### Title` + body). All non-`takumi` crates are pre-1.0: a
+breaking change bumps `minor`, not `major`. Only `takumi` itself uses
+`major` for breaking changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ This guide covers local setup, development flow, testing/build commands, fixture
 
 - Rust `1.91+`
 - Bun (latest)
+- [`cargo-rdme`](https://github.com/orium/cargo-rdme) (`cargo install cargo-rdme`) and `jq`,
+  required by the pre-commit hook installed via `bun install`
 
 ## Local Setup
 
@@ -23,6 +25,9 @@ bun install
 ```
 
 This installs all workspace dependencies and sets up `lefthook`.
+The pre-commit hook runs `cargo fmt`, `cargo rdme`, and lint auto-fix; the Rust
+steps are glob-scoped to `*.rs`/`Cargo.toml` changes, so a JS-only commit skips
+them.
 
 ## Development Flow
 
@@ -60,15 +65,23 @@ Run workspace package tests (pick what you changed):
 (cd takumi-helpers && bun test --silent)
 (cd takumi-napi && bun test --silent)
 (cd takumi-wasm && bun test --silent)
-(cd takumi-image-response && bun test --silent)
 (cd takumi-template && bun test --silent)
 ```
 
-To match CI quality gates for Rust changes, also run:
+`takumi-image-response` has no test script; its logic is covered by
+`takumi-js/tests/response.test.tsx`.
+
+Fixture goldens are Linux-canonical: some render ±1-2px differently on macOS.
+Never re-baseline goldens from a macOS run. Pull the updated files from CI's
+`changed-files` artifact instead. See `AGENTS.md` for the full rule.
+
+To match CI quality gates, also run:
 
 ```bash
 cargo clippy --all-targets --all-features -- -D warnings
 cargo machete
+bun knip
+bun publish-lint
 ```
 
 ## Build Commands
@@ -77,14 +90,15 @@ Run build only for packages you touched:
 
 ```bash
 bun --filter ./takumi-helpers run build
-bun --filter ./takumi-napi run build:debug
+bun --filter ./takumi-napi run build
 bun --filter ./takumi-wasm run build:debug
 bun --filter ./takumi-image-response run build
 ```
 
 Notes:
 
-- `takumi-napi` release build needs target-specific setup; for local validation, `build:debug` is usually enough.
+- `takumi-napi` has no debug build script; `build` is always a full `--release`
+  napi build. For fast local iteration, use `cargo check -p takumi-napi`.
 - `takumi-wasm` build requires `wasm-pack`.
 
 ## Fixture Workflow (Rust Rendering)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,7 @@ pre-commit:
   piped: true
   jobs:
     - run: cargo fmt --all
+      glob: "*.rs"
       stage_fixed: true
 
     - run: |
@@ -9,8 +10,16 @@ pre-commit:
         cargo metadata --format-version 1 --no-deps \
           | jq -r '.packages[] | select(.publish != []) | select(any(.targets[]; .kind | index("lib"))) | .manifest_path | rtrimstr("/Cargo.toml")' \
           | while read -r dir; do
-              (cd "$dir" && cargo rdme --force && git add README.md) || exit 1
+              # unset: lefthook exports GIT_DIR (not GIT_WORK_TREE) into the job env.
+              # Per git's own GIT_DIR/GIT_WORK_TREE fallback rule, that makes `cd "$dir"`
+              # treat $dir as the repo toplevel, so `git add README.md` stages under the
+              # bare "README.md" path and clobbers the root README's index entry (only
+              # reproduces in linked worktrees; the primary checkout doesn't set GIT_DIR).
+              (cd "$dir" && unset GIT_DIR GIT_WORK_TREE && cargo rdme --force && git add README.md) || exit 1
             done
+      glob:
+        - "*.rs"
+        - "**/Cargo.toml"
 
     - run: bun run lint:fix
       stage_fixed: true


### PR DESCRIPTION
## Why

No AGENTS.md exists for agent-facing gotchas (golden platform rule, fixture regen semantics, toolchain quirks). CONTRIBUTING is stale: missing cargo-rdme/jq prerequisites, missing the knip/publish-lint CI gates, a phantom takumi-image-response test command, and a nonexistent takumi-napi build:debug script. Separately, the lefthook pre-commit hook corrupts the root README.md in git worktrees.

## What

- Add `AGENTS.md`: build/test commands, fixture regen rules, golden platform rule (Linux-canonical), toolchain gotchas, changelog workflow.
- Fix `CONTRIBUTING.md`: add cargo-rdme/jq prerequisites, add knip/publish-lint to the CI gate list, drop the phantom takumi-image-response test line, fix the takumi-napi build:debug line (script doesn't exist).
- Fix `lefthook.yml`:
  - glob-scope the Rust pre-commit jobs to `*.rs`/`Cargo.toml` so JS-only commits skip them.
  - Root-cause and fix the worktree README corruption: lefthook exports `GIT_DIR` (not `GIT_WORK_TREE`) into the job env, so `cd`-ing into a crate dir makes git treat that dir as the repo toplevel (per git's own GIT_DIR/GIT_WORK_TREE fallback rule) and `git add README.md` clobbers the root README's index entry instead of the crate's own README. Unsetting both before running `cargo rdme` fixes it. Verified: reproduced the corruption on unpatched config with a real commit, then confirmed a real commit against the patched config leaves README.md untouched.

No changeset: docs/tooling only, no published package behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor and agent guidance with clearer setup, testing, build, and changelog instructions.
  * Added notes about fixture/golden-file expectations, CI checks, and local hook behavior.

* **Chores**
  * Improved pre-commit hook coverage and reliability for Rust-related files.
  * Updated hook staging behavior to avoid issues in linked worktrees and keep generated README changes in the right place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->