### PR TITLE
JS: share the Renderer facade between the napi and wasm bindings

### DIFF
--- a/.tegami/share-renderer-facade.md
+++ b/.tegami/share-renderer-facade.md
@@ -1,0 +1,17 @@
+---
+packages:
+  npm:@takumi-rs/helpers:
+    type: minor
+  npm:@takumi-rs/core:
+    type: minor
+  npm:@takumi-rs/wasm:
+    type: minor
+---
+
+### Share the renderer facade between the napi and wasm bindings
+
+The napi and wasm `Renderer` wrappers now build on a shared `prepareRenderInput`
+helper in `@takumi-rs/helpers/renderer`, so their option types and render bodies
+live in one place. Both backends check `signal` before and after resolving
+fonts and images: on native, an already-aborted signal now throws before any
+resource fetch.

--- a/takumi-helpers/src/renderer.ts
+++ b/takumi-helpers/src/renderer.ts
@@ -1,4 +1,5 @@
-import { fontFromUrl } from "./fonts";
+import { fontFromUrl, subsetFonts } from "./fonts";
+import type { Node } from "./types";
 
 /**
  * Shared wrapper primitives for the `@takumi-rs/core` (napi) and `@takumi-rs/wasm` renderer
@@ -101,6 +102,25 @@ export type RenderExtras = {
   signal?: AbortSignal;
   images?: ImagesInput;
 };
+
+/** Public `render`/`measure` options for a backend whose binding options are {@link TInternal}. */
+export type BackendRenderOptions<TInternal> = Omit<
+  TInternal,
+  "images" | "format" | "quality" | "lossless"
+> &
+  OutputFormatOptions &
+  RenderExtras;
+
+/** Public `renderAnimation` options for a backend whose binding options are {@link TInternal}. */
+export type BackendAnimationOptions<TInternal> = Omit<
+  TInternal,
+  "images" | "format" | "quality" | "lossless"
+> &
+  AnimationOutputFormatOptions &
+  RenderExtras;
+
+/** Public `renderSvg` options for a backend whose binding options are {@link TInternal}. */
+export type BackendSvgOptions<TInternal> = Omit<TInternal, "images"> & RenderExtras;
 
 function isBuffer(data: unknown): data is ByteBuf {
   return (
@@ -241,4 +261,40 @@ export class FontRegistry<TFamily extends RegisteredFamilyLike> {
       fontFamilies: fontFamilies ?? registeredFamilies,
     };
   }
+}
+
+/** The binding options {@link prepareRenderInput} yields: extras stripped, resolved resources merged in. */
+export type ResolvedRenderOptions<TOptions> = Omit<
+  TOptions,
+  keyof RenderExtras | "fontFamilies"
+> & {
+  images?: ImageSource[];
+  fontFamilies?: string[];
+};
+
+/**
+ * Shared body for every backend render entry point: subsets and registers `fonts` against `source`,
+ * resolves `images`/`fontFamilies`, and enforces one abort policy: `signal` is checked before and
+ * after the (network-bound) resource resolution. Returns the binding options plus the `signal` for
+ * the backend to forward into a native call when it supports cancellation.
+ */
+export async function prepareRenderInput<
+  TOptions extends RenderExtras & { fontFamilies?: string[] },
+  TFamily extends RegisteredFamilyLike,
+>(
+  registry: FontRegistry<TFamily>,
+  options: TOptions,
+  source: string | Node | Node[],
+): Promise<{ options: ResolvedRenderOptions<TOptions>; signal: AbortSignal | undefined }> {
+  const { fonts, fontFamilies, signal, images, ...rest } = options;
+  signal?.throwIfAborted();
+
+  const resolved = await registry.resolveResources(
+    fonts && subsetFonts({ fonts, source }),
+    images,
+    fontFamilies,
+  );
+  signal?.throwIfAborted();
+
+  return { options: { ...rest, ...resolved }, signal };
 }

--- a/takumi-helpers/tests/renderer-facade.test.ts
+++ b/takumi-helpers/tests/renderer-facade.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { FontRegistry, prepareRenderInput } from "../src/renderer";
+import type { Font, FontLoader } from "../src/renderer";
+import type { Node } from "../src/types";
+
+const bytes = () => new Uint8Array([1, 2, 3]);
+const textNode = (text: string): Node => ({ type: "text", text });
+
+const rangedFont = (name: string, ranges: [number, number][]): FontLoader => ({
+  name,
+  ranges,
+  data: () => bytes(),
+});
+
+const registry = () => {
+  const registerInner = mock((font: Font) => [
+    { name: "name" in font && font.name ? font.name : "Fam" },
+  ]);
+  return { registerInner, fonts: new FontRegistry(registerInner) };
+};
+
+/** Mirrors the per-backend `Renderer` wiring so the shared body is exercised through all methods. */
+const stub = () => {
+  const { registerInner, fonts } = registry();
+  const inner = {
+    render: mock((_node: Node, _options: unknown, _signal?: AbortSignal) => "png"),
+    renderSvg: mock((_node: Node, _options: unknown, _signal?: AbortSignal) => "svg"),
+    measure: mock((_node: Node, _options: unknown, _signal?: AbortSignal) => "measured"),
+    renderAnimation: mock((_options: unknown, _signal?: AbortSignal) => "anim"),
+  };
+  return {
+    inner,
+    registerInner,
+    async render(node: Node, options?: { signal?: AbortSignal; fonts?: FontLoader[] }) {
+      const { options: opts, signal } = await prepareRenderInput(fonts, options ?? {}, node);
+      return inner.render(node, opts, signal);
+    },
+    async renderSvg(node: Node, options?: { signal?: AbortSignal; fonts?: FontLoader[] }) {
+      const { options: opts, signal } = await prepareRenderInput(fonts, options ?? {}, node);
+      return inner.renderSvg(node, opts, signal);
+    },
+    async measure(node: Node, options?: { signal?: AbortSignal; fonts?: FontLoader[] }) {
+      const { options: opts, signal } = await prepareRenderInput(fonts, options ?? {}, node);
+      return inner.measure(node, opts, signal);
+    },
+    async renderAnimation(options: {
+      scenes: { node: Node }[];
+      signal?: AbortSignal;
+      fonts?: FontLoader[];
+    }) {
+      const nodes = options.scenes.map((scene) => scene.node);
+      const { options: opts, signal } = await prepareRenderInput(fonts, options, nodes);
+      return inner.renderAnimation(opts, signal);
+    },
+  };
+};
+
+describe("prepareRenderInput abort policy", () => {
+  test("a pre-aborted signal rejects before resources resolve", async () => {
+    const { fonts } = registry();
+    const resolve = spyOn(fonts, "resolveResources");
+
+    await expect(
+      prepareRenderInput(fonts, { signal: AbortSignal.abort() }, textNode("A")),
+    ).rejects.toThrow();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  test("a signal aborted during resolution rejects after resources resolve", async () => {
+    const { fonts } = registry();
+    const resolve = spyOn(fonts, "resolveResources");
+    const controller = new AbortController();
+    const font: FontLoader = {
+      name: "Fam",
+      ranges: [[0x41, 0x5a]],
+      data: () => {
+        controller.abort();
+        return bytes();
+      },
+    };
+
+    await expect(
+      prepareRenderInput(fonts, { fonts: [font], signal: controller.signal }, textNode("A")),
+    ).rejects.toThrow();
+    expect(resolve).toHaveBeenCalled();
+  });
+});
+
+describe("prepareRenderInput resource forwarding", () => {
+  test("fonts, images and fontFamilies reach resolveResources", async () => {
+    const { fonts } = registry();
+    const resolve = spyOn(fonts, "resolveResources");
+    const font = rangedFont("Fam", [[0x41, 0x5a]]);
+    const images = [{ src: "a", data: bytes() }];
+
+    await prepareRenderInput(
+      fonts,
+      { fonts: [font], images, fontFamilies: ["Explicit"] },
+      textNode("A"),
+    );
+
+    expect(resolve).toHaveBeenCalledWith([font], images, ["Explicit"]);
+  });
+
+  test("source drives font subsetting", async () => {
+    const { fonts } = registry();
+    const resolve = spyOn(fonts, "resolveResources");
+    const font = rangedFont("Fam", [[0x41, 0x5a]]);
+
+    await prepareRenderInput(fonts, { fonts: [font] }, textNode("0"));
+
+    expect(resolve).toHaveBeenCalledWith([], undefined, undefined);
+  });
+});
+
+describe("shared Renderer body", () => {
+  test("every method forwards resolved resources to its inner call", async () => {
+    const backend = stub();
+    const font = rangedFont("Fam", [[0x41, 0x5a]]);
+    const node = textNode("A");
+
+    await backend.render(node, { fonts: [font] });
+    await backend.renderSvg(node, { fonts: [font] });
+    await backend.measure(node, { fonts: [font] });
+
+    for (const call of [backend.inner.render, backend.inner.renderSvg, backend.inner.measure]) {
+      expect(call).toHaveBeenCalledWith(node, { fontFamilies: ["Fam"] }, undefined);
+    }
+  });
+
+  test("a pre-aborted signal keeps the inner call from running", async () => {
+    const backend = stub();
+
+    await expect(backend.render(textNode("A"), { signal: AbortSignal.abort() })).rejects.toThrow();
+    expect(backend.inner.render).not.toHaveBeenCalled();
+  });
+
+  test("renderAnimation subsets fonts across every scene node", async () => {
+    const backend = stub();
+    const fontA = rangedFont("A", [[0x41, 0x41]]);
+    const fontB = rangedFont("B", [[0x42, 0x42]]);
+
+    const scenes = [{ node: textNode("A") }, { node: textNode("B") }];
+    await backend.renderAnimation({ scenes, fonts: [fontA, fontB] });
+
+    expect(backend.inner.renderAnimation).toHaveBeenCalledWith(
+      { scenes, fontFamilies: ["A", "B"] },
+      undefined,
+    );
+  });
+});

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -8,13 +8,12 @@ import type {
 export type * from "../index";
 import { Renderer as RendererInternal } from "../index";
 
-import { subsetFonts } from "@takumi-rs/helpers";
-import { FontRegistry } from "@takumi-rs/helpers/renderer";
+import { FontRegistry, prepareRenderInput } from "@takumi-rs/helpers/renderer";
 import type {
-  AnimationOutputFormatOptions,
+  BackendAnimationOptions,
+  BackendRenderOptions,
+  BackendSvgOptions,
   FontLoader,
-  ImagesInput,
-  OutputFormatOptions,
 } from "@takumi-rs/helpers/renderer";
 
 export type {
@@ -25,79 +24,33 @@ export type {
   OutputFormatOptions,
 } from "@takumi-rs/helpers/renderer";
 
-export type RenderOptions = Omit<
-  RenderOptionsInternal,
-  "images" | "format" | "quality" | "lossless"
-> &
-  OutputFormatOptions & {
-    fonts?: FontLoader[];
-    signal?: AbortSignal;
-    images?: ImagesInput;
-  };
-
-export type RenderAnimationOptions = Omit<
-  RenderAnimationOptionsInternal,
-  "images" | "format" | "quality" | "lossless"
-> &
-  AnimationOutputFormatOptions & {
-    fonts?: FontLoader[];
-    signal?: AbortSignal;
-    images?: ImagesInput;
-  };
-
-export type SvgRenderOptions = Omit<SvgRenderOptionsInternal, "images"> & {
-  fonts?: FontLoader[];
-  signal?: AbortSignal;
-  images?: ImagesInput;
-};
+export type RenderOptions = BackendRenderOptions<RenderOptionsInternal>;
+export type RenderAnimationOptions = BackendAnimationOptions<RenderAnimationOptionsInternal>;
+export type SvgRenderOptions = BackendSvgOptions<SvgRenderOptionsInternal>;
 
 export class Renderer {
   private inner = new RendererInternal();
   private fonts = new FontRegistry<RegisteredFamily>((font) => this.inner.registerFont(font));
 
   async render(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-
-    return this.inner.render(node, { ...rest, ...resolved }, signal);
+    const { options: opts, signal } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.render(node, opts, signal);
   }
 
   async renderSvg(node: Node, options?: SvgRenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-
-    return this.inner.renderSvg(node, { ...rest, ...resolved }, signal);
+    const { options: opts, signal } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.renderSvg(node, opts, signal);
   }
 
   async measure(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-
-    return this.inner.measure(node, { ...rest, ...resolved }, signal);
+    const { options: opts, signal } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.measure(node, opts, signal);
   }
 
   async renderAnimation(options: RenderAnimationOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options;
     const nodes = options.scenes.map((scene) => scene.node);
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: nodes }),
-      images,
-      fontFamilies,
-    );
-
-    return this.inner.renderAnimation({ ...rest, ...resolved }, signal);
+    const { options: opts, signal } = await prepareRenderInput(this.fonts, options, nodes);
+    return this.inner.renderAnimation(opts, signal);
   }
 
   registerFont(font: FontLoader) {

--- a/takumi-wasm/src/export.ts
+++ b/takumi-wasm/src/export.ts
@@ -10,13 +10,12 @@ import {
 export * from "../pkg/takumi_wasm";
 export { default } from "../pkg/takumi_wasm";
 
-import { subsetFonts } from "@takumi-rs/helpers";
-import { FontRegistry } from "@takumi-rs/helpers/renderer";
+import { FontRegistry, prepareRenderInput } from "@takumi-rs/helpers/renderer";
 import type {
-  AnimationOutputFormatOptions,
+  BackendAnimationOptions,
+  BackendRenderOptions,
+  BackendSvgOptions,
   FontLoader,
-  ImagesInput,
-  OutputFormatOptions,
 } from "@takumi-rs/helpers/renderer";
 
 export type {
@@ -27,100 +26,38 @@ export type {
   OutputFormatOptions,
 } from "@takumi-rs/helpers/renderer";
 
-export type RenderOptions = Omit<
-  RenderOptionsInternal,
-  "images" | "format" | "quality" | "lossless"
-> &
-  OutputFormatOptions & {
-    fonts?: FontLoader[];
-    signal?: AbortSignal;
-    images?: ImagesInput;
-  };
-
-export type RenderAnimationOptions = Omit<
-  RenderAnimationOptionsInternal,
-  "images" | "format" | "quality" | "lossless"
-> &
-  AnimationOutputFormatOptions & {
-    fonts?: FontLoader[];
-    signal?: AbortSignal;
-    images?: ImagesInput;
-  };
-
-export type SvgRenderOptions = Omit<SvgRenderOptionsInternal, "images"> & {
-  fonts?: FontLoader[];
-  signal?: AbortSignal;
-  images?: ImagesInput;
-};
+export type RenderOptions = BackendRenderOptions<RenderOptionsInternal>;
+export type RenderAnimationOptions = BackendAnimationOptions<RenderAnimationOptionsInternal>;
+export type SvgRenderOptions = BackendSvgOptions<SvgRenderOptionsInternal>;
 
 export class Renderer {
   private inner = new RendererInternal();
   private fonts = new FontRegistry<RegisteredFamily>((font) => this.inner.registerFont(font));
 
   async render(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    signal?.throwIfAborted();
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-    signal?.throwIfAborted();
-
-    return this.inner.render(node, { ...rest, ...resolved });
+    const { options: opts } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.render(node, opts);
   }
 
   async renderAsDataUrl(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    signal?.throwIfAborted();
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-    signal?.throwIfAborted();
-
-    return this.inner.renderAsDataUrl(node, { ...rest, ...resolved });
+    const { options: opts } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.renderAsDataUrl(node, opts);
   }
 
   async renderSvg(node: Node, options?: SvgRenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    signal?.throwIfAborted();
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-    signal?.throwIfAborted();
-
-    return this.inner.renderSvg(node, { ...rest, ...resolved });
+    const { options: opts } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.renderSvg(node, opts);
   }
 
   async measure(node: Node, options?: RenderOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options ?? {};
-    signal?.throwIfAborted();
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: node }),
-      images,
-      fontFamilies,
-    );
-    signal?.throwIfAborted();
-
-    return this.inner.measure(node, { ...rest, ...resolved });
+    const { options: opts } = await prepareRenderInput(this.fonts, options ?? {}, node);
+    return this.inner.measure(node, opts);
   }
 
   async renderAnimation(options: RenderAnimationOptions) {
-    const { fonts, fontFamilies, signal, images, ...rest } = options;
-    signal?.throwIfAborted();
     const nodes = options.scenes.map((scene) => scene.node);
-    const resolved = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: nodes }),
-      images,
-      fontFamilies,
-    );
-    signal?.throwIfAborted();
-
-    return this.inner.renderAnimation({ ...rest, ...resolved });
+    const { options: opts } = await prepareRenderInput(this.fonts, options, nodes);
+    return this.inner.renderAnimation(opts);
   }
 
   registerFont(font: FontLoader) {


### PR DESCRIPTION
## Why
The `@takumi-rs/core` (napi) and `@takumi-rs/wasm` `Renderer` wrappers held byte-identical option types and four near-identical async methods, so every option had to be written twice. They had already drifted on cancellation: napi forwarded `signal` to the native call but never guarded the network-bound resource resolution, while wasm guarded around resolution but could not forward. Same public API, different abort behavior per backend.

## What
Add `prepareRenderInput` and the `BackendRenderOptions`/`BackendAnimationOptions`/`BackendSvgOptions` types to `@takumi-rs/helpers/renderer`. Both bindings now derive their option types from these and route every render method through the shared body, which checks `signal` before and after resolving fonts and images and returns it for the backend to forward when it can (napi does, wasm has no native signal). On native, an already-aborted signal now throws before any resource fetch. wasm keeps its `renderAsDataUrl` and `free`. New facade and abort-regression tests cover the shared body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared rendering input handling now powers both native and web builds, keeping behavior aligned across backends.
  * Rendering now supports more consistent cancellation checks during resource loading.

* **Bug Fixes**
  * Improved abort handling so cancelled renders stop earlier and avoid unnecessary resource fetching.
  * Standardized font, image, and scene resource resolution across render, image, SVG, and animation flows.

* **Refactor**
  * Consolidated rendering option handling and input preparation into a single shared path.
  * Simplified backend-specific rendering methods by reusing common prepared inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->