### PR TITLE
Core: add font routing and CSS property round-trip tests

### DIFF
--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -258,3 +258,66 @@ impl<'s> SizedFontStyle<'s> {
     }
   }
 }
+
+// Weight/stretch/style nearest-match face selection lives in parley's fontique query engine,
+// not in this file; the one testable seam owned by this module is `ExpandedFontFamily::expand`.
+#[cfg(test)]
+mod tests {
+  use std::collections::{BTreeSet, HashMap};
+
+  use parley::{FontFamilyName, GenericFamily};
+
+  use super::ExpandedFontFamily;
+  use crate::style::{FontFamily, FromCssStr};
+
+  fn names(expanded: &ExpandedFontFamily) -> Vec<String> {
+    expanded
+      .iter()
+      .map(|name| match name {
+        FontFamilyName::Named(name) => name.into_owned(),
+        FontFamilyName::Generic(generic) => format!("{generic:?}"),
+      })
+      .collect()
+  }
+
+  #[test]
+  fn names_not_in_groups_pass_through_unchanged() {
+    let family = FontFamily::from_css_str("Geist, serif").unwrap();
+    let expanded = ExpandedFontFamily::expand(&family, &HashMap::new());
+
+    assert_eq!(expanded.0.len(), 2);
+    assert_eq!(
+      names(&expanded),
+      vec!["Geist".to_string(), "Serif".to_string()]
+    );
+  }
+
+  #[test]
+  fn logical_subset_group_expands_to_its_registered_subsets_in_order() {
+    let family = FontFamily::from_css_str("Logical").unwrap();
+    let mut groups = HashMap::new();
+    groups.insert(
+      "Logical".to_string(),
+      BTreeSet::from(["Subset A".to_string(), "Subset B".to_string()]),
+    );
+
+    let expanded = ExpandedFontFamily::expand(&family, &groups);
+
+    assert_eq!(
+      names(&expanded),
+      vec!["Subset A".to_string(), "Subset B".to_string()]
+    );
+  }
+
+  #[test]
+  fn generic_family_tokens_pass_through_expansion() {
+    let family = FontFamily::from_css_str("monospace").unwrap();
+    let expanded = ExpandedFontFamily::expand(&family, &HashMap::new());
+
+    assert_eq!(expanded.0.len(), 1);
+    assert!(matches!(
+      expanded.iter().next(),
+      Some(FontFamilyName::Generic(GenericFamily::Monospace))
+    ));
+  }
+}

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -1192,3 +1192,133 @@ impl<'a> FontResource<'a> {
     })
   }
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+  use std::{fs::File, io::Read, path::Path};
+
+  use super::*;
+  use crate::style::FromCssStr;
+
+  fn read_font_asset(relative: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    let mut bytes = Vec::new();
+    let mut file = File::open(&path)
+      .unwrap_or_else(|error| panic!("failed to open test font {}: {error}", path.display()));
+    file
+      .read_to_end(&mut bytes)
+      .unwrap_or_else(|error| panic!("failed to read test font {}: {error}", path.display()));
+    bytes
+  }
+
+  fn geist_bytes() -> Vec<u8> {
+    read_font_asset("../assets/fonts/geist/Geist[wght].woff2")
+  }
+
+  fn geist_mono_bytes() -> Vec<u8> {
+    read_font_asset("../assets/fonts/geist/GeistMono[wght].woff2")
+  }
+
+  fn register_named(fonts: &mut Fonts, bytes: Vec<u8>, family_name: &str) -> Vec<RegisteredFamily> {
+    fonts
+      .register(FontResource::new(bytes).override_info(FontOverride {
+        family_name: Some(family_name.into()),
+        ..Default::default()
+      }))
+      .unwrap()
+  }
+
+  #[test]
+  fn register_returns_family_with_at_least_one_face() {
+    let mut fonts = Fonts::default();
+    let families = register_named(&mut fonts, geist_bytes(), "Geist Test");
+
+    assert_eq!(families.len(), 1);
+    assert_eq!(families[0].name, "Geist Test");
+    assert!(!families[0].faces.is_empty());
+  }
+
+  #[test]
+  fn registering_same_bytes_twice_is_idempotent_in_order() {
+    let mut fonts = Fonts::default();
+    register_named(&mut fonts, geist_bytes(), "Geist Test");
+    register_named(&mut fonts, geist_bytes(), "Geist Test");
+
+    // Registration order dedups by name: registering the same family name twice does not
+    // produce a second entry in `order`, so default fallback selection stays stable.
+    assert_eq!(
+      fonts
+        .order
+        .iter()
+        .filter(|name| *name == "Geist Test")
+        .count(),
+      1
+    );
+  }
+
+  #[test]
+  fn font_override_family_name_renames_family() {
+    let mut fonts = Fonts::default();
+    let families = register_named(&mut fonts, geist_bytes(), "Renamed Family");
+
+    assert_eq!(families[0].name, "Renamed Family");
+    assert!(fonts.order.contains(&"Renamed Family".to_string()));
+  }
+
+  #[test]
+  fn subset_of_groups_multiple_families_under_logical_name() {
+    let mut fonts = Fonts::default();
+    fonts
+      .register(
+        FontResource::new(geist_bytes())
+          .override_info(FontOverride {
+            family_name: Some("Subset A".into()),
+            ..Default::default()
+          })
+          .subset_of("Logical"),
+      )
+      .unwrap();
+    fonts
+      .register(
+        FontResource::new(geist_mono_bytes())
+          .override_info(FontOverride {
+            family_name: Some("Subset B".into()),
+            ..Default::default()
+          })
+          .subset_of("Logical"),
+      )
+      .unwrap();
+
+    let subsets = fonts.groups.get("Logical").expect("logical group present");
+    assert_eq!(
+      subsets,
+      &BTreeSet::from(["Subset A".to_string(), "Subset B".to_string()])
+    );
+
+    let snapshot =
+      fonts.snapshot_with_fallbacks(Some(&FontFamily::from_css_str("Logical").unwrap()));
+    assert_eq!(snapshot.groups.get("Logical"), Some(subsets));
+  }
+
+  #[test]
+  fn registration_order_defines_default_fallbacks() {
+    let mut fonts = Fonts::default();
+    register_named(&mut fonts, geist_bytes(), "B Family");
+    register_named(&mut fonts, geist_mono_bytes(), "A Family");
+
+    assert_eq!(
+      fonts.order,
+      vec!["B Family".to_string(), "A Family".to_string()]
+    );
+  }
+
+  #[test]
+  fn unknown_family_in_fallbacks_does_not_panic() {
+    let fonts = Fonts::default();
+    let unknown = FontFamily::from_css_str("Never Registered").unwrap();
+
+    // Must not panic: an unresolved name simply yields an empty fallback bucket.
+    let _snapshot = fonts.snapshot_with_fallbacks(Some(&unknown));
+  }
+}

--- a/takumi-core/src/style/properties/background_position.rs
+++ b/takumi-core/src/style/properties/background_position.rs
@@ -298,3 +298,75 @@ impl ToCss for PositionValue {
     self.0.to_css(dest)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_position_value() {
+    for (css, expected) in [
+      (
+        "10px 20px",
+        PositionValue(SpacePair::from_pair(
+          PositionComponent::Length(Length::Px(10.0)),
+          PositionComponent::Length(Length::Px(20.0)),
+        )),
+      ),
+      (
+        "left top",
+        PositionValue(SpacePair::from_pair(
+          PositionComponent::KeywordX(PositionKeywordX::Left),
+          PositionComponent::KeywordY(PositionKeywordY::Top),
+        )),
+      ),
+      (
+        "top",
+        PositionValue(SpacePair::from_pair(
+          PositionComponent::KeywordX(PositionKeywordX::Center),
+          PositionComponent::KeywordY(PositionKeywordY::Top),
+        )),
+      ),
+      ("center", PositionValue::center()),
+    ] {
+      assert_eq!(
+        PositionValue::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_position_value_round_trip() {
+    for css in ["10px 20px", "left top", "top"] {
+      let parsed = PositionValue::from_css_str(css).unwrap();
+      let reparsed = PositionValue::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_position_value_center_does_not_round_trip() {
+    let parsed = PositionValue::from_css_str("center").unwrap();
+    assert_eq!(parsed, PositionValue::center());
+    let reparsed = PositionValue::from_css_str(&parsed.to_css_string()).unwrap();
+    // TODO: looks wrong: "center" serializes to "center center", and reparsing always reads
+    // the ambiguous second "center" as KeywordX (PositionComponent::from_css keyword order),
+    // so the y-axis silently becomes KeywordX instead of KeywordY.
+    assert_eq!(
+      reparsed,
+      PositionValue(SpacePair::from_pair(
+        PositionComponent::KeywordX(PositionKeywordX::Center),
+        PositionComponent::KeywordX(PositionKeywordX::Center),
+      ))
+    );
+  }
+
+  #[test]
+  fn test_parse_position_value_invalid() {
+    assert!(PositionValue::from_css_str("diagonal").is_err());
+    assert!(PositionValue::from_css_str("\"foo\"").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -192,3 +192,61 @@ impl ToCss for BackgroundRepeat {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_background_repeat() {
+    for (css, expected) in [
+      (
+        "repeat-x",
+        BackgroundRepeat(
+          BackgroundRepeatStyle::Repeat,
+          BackgroundRepeatStyle::NoRepeat,
+        ),
+      ),
+      (
+        "repeat-y",
+        BackgroundRepeat(
+          BackgroundRepeatStyle::NoRepeat,
+          BackgroundRepeatStyle::Repeat,
+        ),
+      ),
+      (
+        "repeat no-repeat",
+        BackgroundRepeat(
+          BackgroundRepeatStyle::Repeat,
+          BackgroundRepeatStyle::NoRepeat,
+        ),
+      ),
+      (
+        "space",
+        BackgroundRepeat(BackgroundRepeatStyle::Space, BackgroundRepeatStyle::Space),
+      ),
+    ] {
+      assert_eq!(
+        BackgroundRepeat::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_background_repeat_round_trip() {
+    for css in ["repeat-x", "repeat-y", "repeat no-repeat", "space", "round"] {
+      let parsed = BackgroundRepeat::from_css_str(css).unwrap();
+      let reparsed = BackgroundRepeat::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_background_repeat_invalid() {
+    assert!(BackgroundRepeat::from_css_str("123").is_err());
+    assert!(BackgroundRepeat::from_css_str("bogus").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/blend_mode.rs
+++ b/takumi-core/src/style/properties/blend_mode.rs
@@ -93,3 +93,52 @@ impl Animatable for BlendMode {
     ListInterpolationStrategy::RepeatToLcm
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::ToCss;
+
+  #[test]
+  fn test_parse_blend_mode() {
+    for (css, expected) in [
+      ("normal", BlendMode::Normal),
+      ("multiply", BlendMode::Multiply),
+      ("plus-lighter", BlendMode::PlusLighter),
+      ("color-dodge", BlendMode::ColorDodge),
+    ] {
+      assert_eq!(
+        BlendMode::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_parse_blend_modes_list() {
+    assert_eq!(
+      BlendModes::from_css_str("screen, overlay"),
+      Ok(Box::new([BlendMode::Screen, BlendMode::Overlay]) as BlendModes)
+    );
+  }
+
+  #[test]
+  fn test_blend_mode_round_trip() {
+    for css in ["normal", "multiply", "plus-lighter"] {
+      let parsed = BlendMode::from_css_str(css).unwrap();
+      let reparsed = BlendMode::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+
+    let parsed = BlendModes::from_css_str("screen, overlay").unwrap();
+    let reparsed = BlendModes::from_css_str(&parsed.to_css_string()).unwrap();
+    assert_eq!(parsed, reparsed);
+  }
+
+  #[test]
+  fn test_parse_blend_mode_invalid() {
+    assert!(BlendMode::from_css_str("bogus").is_err());
+    assert!(BlendMode::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/box_alignment.rs
+++ b/takumi-core/src/style/properties/box_alignment.rs
@@ -74,3 +74,61 @@ where
 
   Ok((first, second))
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_place_items() {
+    for (css, expected) in [
+      (
+        "start end",
+        PlaceItems {
+          align: AlignItems::Start,
+          justify: AlignItems::End,
+        },
+      ),
+      (
+        "center",
+        PlaceItems {
+          align: AlignItems::Center,
+          justify: AlignItems::Center,
+        },
+      ),
+      (
+        "safe start",
+        PlaceItems {
+          align: AlignItems::SafeStart,
+          justify: AlignItems::SafeStart,
+        },
+      ),
+    ] {
+      assert_eq!(
+        PlaceItems::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_parse_place_content() {
+    assert_eq!(
+      PlaceContent::from_css_str("start end"),
+      Ok(PlaceContent {
+        align: JustifyContent::Start,
+        justify: JustifyContent::End,
+      })
+    );
+  }
+
+  // PlaceItems/PlaceContent/PlaceSelf have no ToCss impl, so no round-trip test.
+
+  #[test]
+  fn test_parse_place_items_invalid() {
+    assert!(PlaceItems::from_css_str("bogus").is_err());
+    assert!(PlaceItems::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/flex_grow.rs
+++ b/takumi-core/src/style/properties/flex_grow.rs
@@ -49,3 +49,39 @@ impl ToCss for FlexGrow {
     write!(dest, "{}", self.0)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_flex_grow() {
+    for (css, expected) in [
+      ("0", FlexGrow(0.0)),
+      ("1.5", FlexGrow(1.5)),
+      ("-2", FlexGrow(-2.0)),
+    ] {
+      assert_eq!(
+        FlexGrow::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_flex_grow_round_trip() {
+    for css in ["0", "1.5", "-2"] {
+      let parsed = FlexGrow::from_css_str(css).unwrap();
+      let reparsed = FlexGrow::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_flex_grow_invalid() {
+    assert!(FlexGrow::from_css_str("auto").is_err());
+    assert!(FlexGrow::from_css_str("\"foo\"").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/font_style.rs
+++ b/takumi-core/src/style/properties/font_style.rs
@@ -69,3 +69,40 @@ impl ToCss for FontStyle {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_font_style() {
+    for (css, expected) in [
+      ("normal", FontStyle::normal()),
+      ("italic", FontStyle::italic()),
+      ("oblique", FontStyle(ParleyFontStyle::Oblique(None))),
+      ("oblique 10deg", FontStyle::oblique(10.0)),
+    ] {
+      assert_eq!(
+        FontStyle::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_style_round_trip() {
+    for css in ["normal", "italic", "oblique", "oblique 10deg"] {
+      let parsed = FontStyle::from_css_str(css).unwrap();
+      let reparsed = FontStyle::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_style_invalid() {
+    assert!(FontStyle::from_css_str("bogus").is_err());
+    assert!(FontStyle::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/font_synthesis.rs
+++ b/takumi-core/src/style/properties/font_synthesis.rs
@@ -74,3 +74,57 @@ declare_enum_from_css_impl!(
   "auto" => FontSynthesic::Auto,
   "none" => FontSynthesic::None,
 );
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_font_synthesis() {
+    for (css, expected) in [
+      (
+        "none",
+        FontSynthesis {
+          weight: FontSynthesic::None,
+          style: FontSynthesic::None,
+        },
+      ),
+      (
+        "weight",
+        FontSynthesis {
+          weight: FontSynthesic::Auto,
+          style: FontSynthesic::None,
+        },
+      ),
+      (
+        "style",
+        FontSynthesis {
+          weight: FontSynthesic::None,
+          style: FontSynthesic::Auto,
+        },
+      ),
+      (
+        "weight style",
+        FontSynthesis {
+          weight: FontSynthesic::Auto,
+          style: FontSynthesic::Auto,
+        },
+      ),
+    ] {
+      assert_eq!(
+        FontSynthesis::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  // FontSynthesis has no ToCss impl, so no round-trip test.
+
+  #[test]
+  fn test_parse_font_synthesis_invalid() {
+    assert!(FontSynthesis::from_css_str("auto").is_err());
+    assert!(FontSynthesis::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/font_variant.rs
+++ b/takumi-core/src/style/properties/font_variant.rs
@@ -648,3 +648,208 @@ const VARIANT_TOKEN_LISTS: &[&[CssToken]] = &[
 
 const VARIANT_TOKENS: [CssToken; CssToken::merged_len(VARIANT_TOKEN_LISTS)] =
   CssToken::merge_lists(VARIANT_TOKEN_LISTS);
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_font_variant_ligatures() {
+    for (css, expected) in [
+      ("normal", FontVariantLigatures::default()),
+      ("none", FontVariantLigatures::none()),
+      (
+        "common-ligatures no-discretionary-ligatures",
+        FontVariantLigatures {
+          common: LigatureState::Enabled,
+          discretionary: LigatureState::Disabled,
+          historical: LigatureState::Normal,
+          contextual: LigatureState::Normal,
+        },
+      ),
+    ] {
+      assert_eq!(
+        FontVariantLigatures::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_variant_ligatures_round_trip() {
+    for css in [
+      "normal",
+      "none",
+      "common-ligatures no-discretionary-ligatures",
+    ] {
+      let parsed = FontVariantLigatures::from_css_str(css).unwrap();
+      let reparsed = FontVariantLigatures::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_variant_ligatures_invalid() {
+    assert!(FontVariantLigatures::from_css_str("bogus").is_err());
+    assert!(FontVariantLigatures::from_css_str("123").is_err());
+  }
+
+  #[test]
+  fn test_parse_font_variant_numeric() {
+    for (css, expected) in [
+      ("normal", FontVariantNumeric::default()),
+      (
+        "lining-nums tabular-nums ordinal",
+        FontVariantNumeric {
+          figure: NumericFigure::Lining,
+          spacing: NumericSpacing::Tabular,
+          fraction: NumericFraction::Normal,
+          ordinal: true,
+          slashed_zero: false,
+        },
+      ),
+      (
+        "oldstyle-nums diagonal-fractions slashed-zero",
+        FontVariantNumeric {
+          figure: NumericFigure::Oldstyle,
+          spacing: NumericSpacing::Normal,
+          fraction: NumericFraction::Diagonal,
+          ordinal: false,
+          slashed_zero: true,
+        },
+      ),
+    ] {
+      assert_eq!(
+        FontVariantNumeric::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_variant_numeric_round_trip() {
+    for css in ["normal", "lining-nums tabular-nums ordinal"] {
+      let parsed = FontVariantNumeric::from_css_str(css).unwrap();
+      let reparsed = FontVariantNumeric::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_variant_numeric_invalid() {
+    assert!(FontVariantNumeric::from_css_str("bogus").is_err());
+  }
+
+  #[test]
+  fn test_parse_font_variant_east_asian() {
+    for (css, expected) in [
+      ("normal", FontVariantEastAsian::default()),
+      (
+        "jis78 full-width ruby",
+        FontVariantEastAsian {
+          form: EastAsianForm::Jis78,
+          width: EastAsianWidth::Full,
+          ruby: true,
+        },
+      ),
+    ] {
+      assert_eq!(
+        FontVariantEastAsian::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_variant_east_asian_round_trip() {
+    for css in ["normal", "jis78 full-width ruby"] {
+      let parsed = FontVariantEastAsian::from_css_str(css).unwrap();
+      let reparsed = FontVariantEastAsian::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_variant_east_asian_invalid() {
+    assert!(FontVariantEastAsian::from_css_str("bogus").is_err());
+  }
+
+  #[test]
+  fn test_parse_font_variant_caps() {
+    for (css, expected) in [
+      ("normal", FontVariantCaps::Normal),
+      ("small-caps", FontVariantCaps::SmallCaps),
+      ("all-small-caps", FontVariantCaps::AllSmallCaps),
+      ("titling-caps", FontVariantCaps::TitlingCaps),
+    ] {
+      assert_eq!(
+        FontVariantCaps::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_variant_caps_round_trip() {
+    for css in ["normal", "small-caps", "all-small-caps", "titling-caps"] {
+      let parsed = FontVariantCaps::from_css_str(css).unwrap();
+      let reparsed = FontVariantCaps::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_variant_caps_invalid() {
+    assert!(FontVariantCaps::from_css_str("bogus").is_err());
+    assert!(FontVariantCaps::from_css_str("123").is_err());
+  }
+
+  #[test]
+  fn test_parse_font_variant_position() {
+    for (css, expected) in [
+      ("normal", FontVariantPosition::Normal),
+      ("sub", FontVariantPosition::Sub),
+      ("super", FontVariantPosition::Super),
+    ] {
+      assert_eq!(
+        FontVariantPosition::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_variant_position_round_trip() {
+    for css in ["normal", "sub", "super"] {
+      let parsed = FontVariantPosition::from_css_str(css).unwrap();
+      let reparsed = FontVariantPosition::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_variant_position_invalid() {
+    assert!(FontVariantPosition::from_css_str("bogus").is_err());
+  }
+
+  #[test]
+  fn test_parse_font_variant_shorthand() {
+    let value = FontVariant::from_css_str("small-caps sub common-ligatures").unwrap();
+    assert_eq!(value.caps, FontVariantCaps::SmallCaps);
+    assert_eq!(value.position, FontVariantPosition::Sub);
+    assert_eq!(value.ligatures.common, LigatureState::Enabled);
+  }
+
+  // FontVariant (the shorthand struct) has no ToCss impl, so no round-trip test.
+
+  #[test]
+  fn test_parse_font_variant_shorthand_invalid() {
+    assert!(FontVariant::from_css_str("bogus").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/font_variation_settings.rs
+++ b/takumi-core/src/style/properties/font_variation_settings.rs
@@ -69,3 +69,48 @@ impl ToCss for FontVariation {
     write!(dest, "\"{}\" {}", self.tag, self.value)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_font_variation_settings() {
+    for (css, expected) in [
+      ("normal", Box::new([]) as FontVariationSettings),
+      (
+        "\"wght\" 400",
+        Box::new([FontVariation::new(Tag::new(b"wght"), 400.0)]),
+      ),
+      (
+        "\"wght\" 400, \"slnt\" -10",
+        Box::new([
+          FontVariation::new(Tag::new(b"wght"), 400.0),
+          FontVariation::new(Tag::new(b"slnt"), -10.0),
+        ]),
+      ),
+    ] {
+      assert_eq!(
+        FontVariationSettings::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_font_variation_settings_round_trip() {
+    for css in ["normal", "\"wght\" 400", "\"wght\" 400, \"slnt\" -10"] {
+      let parsed = FontVariationSettings::from_css_str(css).unwrap();
+      let reparsed = FontVariationSettings::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_font_variation_settings_invalid() {
+    assert!(FontVariationSettings::from_css_str("123").is_err());
+    assert!(FontVariationSettings::from_css_str("wght 400").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/line_clamp.rs
+++ b/takumi-core/src/style/properties/line_clamp.rs
@@ -149,3 +149,76 @@ impl TailwindPropertyParser for LineClamp {
     Some(Self::clamp(Some(count), BlockEllipsis::Auto))
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_block_ellipsis() {
+    for (css, expected) in [
+      ("none", BlockEllipsis::None),
+      ("auto", BlockEllipsis::Auto),
+      ("\"foo\"", BlockEllipsis::String("foo".to_string())),
+    ] {
+      assert_eq!(
+        BlockEllipsis::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_block_ellipsis_round_trip() {
+    for css in ["none", "auto", "\"foo\""] {
+      let parsed = BlockEllipsis::from_css_str(css).unwrap();
+      let reparsed = BlockEllipsis::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_block_ellipsis_invalid() {
+    assert!(BlockEllipsis::from_css_str("123").is_err());
+  }
+
+  #[test]
+  fn test_parse_line_clamp() {
+    for (css, expected) in [
+      ("none", LineClamp::default()),
+      (
+        "3",
+        LineClamp {
+          max_lines: Some(3),
+          block_ellipsis: BlockEllipsis::Auto,
+          line_continue: Continue::Collapse,
+        },
+      ),
+      (
+        "2 \"foo\"",
+        LineClamp {
+          max_lines: Some(2),
+          block_ellipsis: BlockEllipsis::String("foo".to_string()),
+          line_continue: Continue::Collapse,
+        },
+      ),
+      ("0", LineClamp::default()),
+    ] {
+      assert_eq!(
+        LineClamp::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  // LineClamp has no ToCss impl, so no round-trip test.
+
+  #[test]
+  fn test_parse_line_clamp_invalid() {
+    assert!(LineClamp::from_css_str("bogus").is_err());
+    assert!(LineClamp::from_css_str("1.5").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/order.rs
+++ b/takumi-core/src/style/properties/order.rs
@@ -26,3 +26,31 @@ impl ToCss for Order {
     write!(dest, "{}", self.0)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_order() {
+    for (css, expected) in [("0", Order(0)), ("5", Order(5)), ("-3", Order(-3))] {
+      assert_eq!(Order::from_css_str(css), Ok(expected), "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_order_round_trip() {
+    for css in ["0", "5", "-3"] {
+      let parsed = Order::from_css_str(css).unwrap();
+      let reparsed = Order::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_order_invalid() {
+    assert!(Order::from_css_str("1.5").is_err());
+    assert!(Order::from_css_str("auto").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/overflow_wrap.rs
+++ b/takumi-core/src/style/properties/overflow_wrap.rs
@@ -58,3 +58,38 @@ impl OverflowWrap {
     self.0
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_parse_overflow_wrap() {
+    for (css, expected) in [
+      ("normal", OverflowWrap(parley::OverflowWrap::Normal)),
+      ("anywhere", OverflowWrap(parley::OverflowWrap::Anywhere)),
+      ("break-word", OverflowWrap(parley::OverflowWrap::BreakWord)),
+    ] {
+      assert_eq!(
+        OverflowWrap::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_overflow_wrap_round_trip() {
+    for css in ["normal", "anywhere", "break-word"] {
+      let parsed = OverflowWrap::from_css_str(css).unwrap();
+      let reparsed = OverflowWrap::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_overflow_wrap_invalid() {
+    assert!(OverflowWrap::from_css_str("bogus").is_err());
+    assert!(OverflowWrap::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/percentage_number.rs
+++ b/takumi-core/src/style/properties/percentage_number.rs
@@ -82,3 +82,40 @@ impl ToCss for PercentageNumber {
     write!(dest, "{}", self.0)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_percentage_number() {
+    for (css, expected) in [
+      ("0.5", PercentageNumber(0.5)),
+      ("50%", PercentageNumber(0.5)),
+      ("1", PercentageNumber(1.0)),
+      ("100%", PercentageNumber(1.0)),
+    ] {
+      assert_eq!(
+        PercentageNumber::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_percentage_number_round_trip() {
+    for css in ["0.5", "50%", "1"] {
+      let parsed = PercentageNumber::from_css_str(css).unwrap();
+      let reparsed = PercentageNumber::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_percentage_number_invalid() {
+    assert!(PercentageNumber::from_css_str("auto").is_err());
+    assert!(PercentageNumber::from_css_str("\"foo\"").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/space_pair.rs
+++ b/takumi-core/src/style/properties/space_pair.rs
@@ -95,3 +95,42 @@ impl<T: Copy + ToCss> ToCss for SpacePair<T> {
     self.y.to_css(dest)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_space_pair_length() {
+    for (css, expected) in [
+      ("10px", SpacePair::from_single(Length::Px(10.0))),
+      (
+        "10px 20px",
+        SpacePair::from_pair(Length::Px(10.0), Length::Px(20.0)),
+      ),
+      ("auto", SpacePair::from_single(Length::Auto)),
+    ] {
+      assert_eq!(
+        SpacePair::<Length>::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_space_pair_length_round_trip() {
+    for css in ["10px", "10px 20px", "auto"] {
+      let parsed = SpacePair::<Length>::from_css_str(css).unwrap();
+      let reparsed = SpacePair::<Length>::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_space_pair_length_invalid() {
+    assert!(SpacePair::<Length>::from_css_str("10xyz").is_err());
+    assert!(SpacePair::<Length>::from_css_str("\"foo\"").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/text_fit.rs
+++ b/takumi-core/src/style/properties/text_fit.rs
@@ -118,3 +118,60 @@ impl ToCss for TextFit {
     Ok(())
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_text_fit() {
+    for (css, expected) in [
+      ("none", TextFit::builder().build()),
+      (
+        "grow per-line",
+        TextFit::builder()
+          .mode(TextFitMode::Grow)
+          .target(TextFitTarget::PerLine)
+          .build(),
+      ),
+      (
+        "shrink 50%",
+        TextFit::builder()
+          .mode(TextFitMode::Shrink)
+          .limit(Some(0.5))
+          .build(),
+      ),
+      (
+        "grow per-line-all 75%",
+        TextFit::builder()
+          .mode(TextFitMode::Grow)
+          .target(TextFitTarget::PerLineAll)
+          .limit(Some(0.75))
+          .build(),
+      ),
+    ] {
+      assert_eq!(TextFit::from_css_str(css), Ok(expected), "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_text_fit_round_trip() {
+    for css in [
+      "none",
+      "grow per-line",
+      "shrink 50%",
+      "grow per-line-all 75%",
+    ] {
+      let parsed = TextFit::from_css_str(css).unwrap();
+      let reparsed = TextFit::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_text_fit_invalid() {
+    assert!(TextFit::from_css_str("bogus").is_err());
+    assert!(TextFit::from_css_str("50%").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/text_overflow.rs
+++ b/takumi-core/src/style/properties/text_overflow.rs
@@ -50,3 +50,39 @@ impl ToCss for TextOverflow {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::FromCssStr;
+
+  #[test]
+  fn test_parse_text_overflow() {
+    for (css, expected) in [
+      ("clip", TextOverflow::Clip),
+      ("ellipsis", TextOverflow::Ellipsis),
+      ("\"foo\"", TextOverflow::Custom("foo".to_string())),
+      ("bar", TextOverflow::Custom("bar".to_string())),
+    ] {
+      assert_eq!(
+        TextOverflow::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_text_overflow_round_trip() {
+    for css in ["clip", "ellipsis", "\"foo\"", "bar"] {
+      let parsed = TextOverflow::from_css_str(css).unwrap();
+      let reparsed = TextOverflow::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_text_overflow_invalid() {
+    assert!(TextOverflow::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/text_stroke.rs
+++ b/takumi-core/src/style/properties/text_stroke.rs
@@ -37,3 +37,50 @@ impl MakeComputed for TextStroke {
     self.width.make_computed(sizing);
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::{Color, FromCssStr};
+
+  #[test]
+  fn test_parse_text_stroke() {
+    for (css, expected) in [
+      (
+        "2px",
+        TextStroke {
+          width: Length::Px(2.0),
+          color: None,
+        },
+      ),
+      (
+        "2px red",
+        TextStroke {
+          width: Length::Px(2.0),
+          color: Some(ColorInput::Value(Color::from_rgb(0xff0000))),
+        },
+      ),
+      (
+        "1em",
+        TextStroke {
+          width: Length::Em(1.0),
+          color: None,
+        },
+      ),
+    ] {
+      assert_eq!(
+        TextStroke::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  // TextStroke has no ToCss impl, so no round-trip test.
+
+  #[test]
+  fn test_parse_text_stroke_invalid() {
+    assert!(TextStroke::from_css_str("bogus").is_err());
+    assert!(TextStroke::from_css_str("\"2px\"").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/text_wrap.rs
+++ b/takumi-core/src/style/properties/text_wrap.rs
@@ -120,3 +120,64 @@ declare_enum_from_css_impl!(
   "balance" => TextWrapStyle::Balance,
   "pretty" => TextWrapStyle::Pretty,
 );
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::{FromCssStr, ToCss};
+
+  #[test]
+  fn test_parse_text_wrap() {
+    for (css, expected) in [
+      (
+        "wrap",
+        TextWrap {
+          mode: TextWrapMode::Wrap,
+          style: TextWrapStyle::Auto,
+        },
+      ),
+      (
+        "balance",
+        TextWrap {
+          mode: TextWrapMode::Wrap,
+          style: TextWrapStyle::Balance,
+        },
+      ),
+      (
+        "nowrap pretty",
+        TextWrap {
+          mode: TextWrapMode::NoWrap,
+          style: TextWrapStyle::Pretty,
+        },
+      ),
+    ] {
+      assert_eq!(
+        TextWrap::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  // TextWrap (the shorthand struct) has no ToCss impl, so no round-trip test on it. Its
+  // sub-enums do though.
+  #[test]
+  fn test_text_wrap_sub_enums_round_trip() {
+    for css in ["wrap", "nowrap"] {
+      let parsed = TextWrapMode::from_css_str(css).unwrap();
+      let reparsed = TextWrapMode::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+    for css in ["auto", "balance", "pretty"] {
+      let parsed = TextWrapStyle::from_css_str(css).unwrap();
+      let reparsed = TextWrapStyle::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_text_wrap_invalid() {
+    assert!(TextWrap::from_css_str("bogus").is_err());
+    assert!(TextWrap::from_css_str("123").is_err());
+  }
+}

--- a/takumi-core/src/style/properties/word_break.rs
+++ b/takumi-core/src/style/properties/word_break.rs
@@ -34,3 +34,40 @@ impl WordBreak {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::{FromCssStr, ToCss};
+
+  #[test]
+  fn test_parse_word_break() {
+    for (css, expected) in [
+      ("normal", WordBreak::Normal),
+      ("break-all", WordBreak::BreakAll),
+      ("keep-all", WordBreak::KeepAll),
+      ("break-word", WordBreak::BreakWord),
+    ] {
+      assert_eq!(
+        WordBreak::from_css_str(css),
+        Ok(expected),
+        "failed for {css}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_word_break_round_trip() {
+    for css in ["normal", "break-all", "keep-all", "break-word"] {
+      let parsed = WordBreak::from_css_str(css).unwrap();
+      let reparsed = WordBreak::from_css_str(&parsed.to_css_string()).unwrap();
+      assert_eq!(parsed, reparsed, "failed for {css}");
+    }
+  }
+
+  #[test]
+  fn test_parse_word_break_invalid() {
+    assert!(WordBreak::from_css_str("bogus").is_err());
+    assert!(WordBreak::from_css_str("123").is_err());
+  }
+}


### PR DESCRIPTION
## Why

Font routing (registration, subset-group expansion, fallback ordering) and 19 CSS property parsers had no unit tests; the only gate was the pixel-golden diff, which cannot catch wrong-font or wrong-parse regressions that still draw glyphs.

## What

- Characterization tests for `Fonts`: registration outcomes, `FontOverride` renaming, `subset_of` grouping, registration-order default fallbacks, unknown-family snapshots. Plus `ExpandedFontFamily::expand` coverage in `font_style.rs`.
- Table-driven parse, round-trip (`parse(to_css(x)) == x`), and invalid-first-token tests for the 19 untested property modules under `style/properties/`.
- Pins one round-trip asymmetry without fixing it: `PositionValue` "center" serializes to "center center" and reparses with the second keyword as `KeywordX` (TODO in `background_position.rs`).

Tests only, no production changes, no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for font handling and CSS property parsing/serialization across many style values.
  * Added checks for round-tripping, invalid inputs, shorthand parsing, and fallback behavior to improve confidence in text, font, and layout-related features.
  * Verified font family expansion, registration order, and named font overrides behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->