### PR TITLE
Raster: canvas mask fast paths and post-split cleanup

### DIFF
--- a/.tegami/canvas-mask-fast-paths.md
+++ b/.tegami/canvas-mask-fast-paths.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+  "cargo:takumi": patch
+  "npm:@takumi-rs/core": patch
+  "npm:@takumi-rs/wasm": patch
+---
+
+### Skip mask copies and per-pixel mask lookups in canvas fast paths
+
+Borrow the combined constraint mask directly when it already matches the
+canvas viewport instead of copying it per draw, and hoist mask lookups out of
+the per-pixel blit loops. Output is unchanged.

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -11,11 +11,10 @@ mod mask;
 mod paint_source;
 mod skia;
 
-use std::{mem::replace, sync::Arc};
+use std::{borrow::Cow, mem::replace, sync::Arc};
 
 pub(crate) use blit::{
-  composite_mask_source_to_pixmap, compute_overlay_bounds_for_canvas, overlay_image,
-  overlay_sampled_paint_source,
+  composite_mask_source_to_pixmap, overlay_image, overlay_sampled_paint_source,
 };
 pub(crate) use buffer_pool::BufferPool;
 pub(crate) use gradient::{
@@ -29,15 +28,17 @@ pub(crate) use mask::{
   CanvasViewport, MaskView, NodeMaskAction, attenuate_alpha_by_mask, intersect_alpha_masks,
   mask_index_from_coord, prepare_node_mask, render_mask,
 };
-use mask::{MaskStackEntry, materialize_mask};
-pub(crate) use paint_source::{PaintSource, SamplingFootprint, interpolate_with_footprint};
+use mask::{MaskStackEntry, resolve_mask};
+pub(crate) use paint_source::{
+  MaskCompositeColor, PaintSource, SamplingFootprint, interpolate_with_footprint,
+};
 use takumi_core::geometry::{Point, Size};
 use tiny_skia::{
   FilterQuality as TinyFilterQuality, Mask as TinyMask, Pixmap, PixmapMut, PixmapPaint, PixmapRef,
   Transform as TinyTransform,
 };
 
-use self::{paint_source::MaskCompositeColor, skia::to_tiny_blend_mode};
+use self::skia::to_tiny_blend_mode;
 use crate::{
   BackgroundTile, BorderProperties, Placement, Result,
   blend::*,
@@ -67,14 +68,6 @@ pub(crate) struct OverlayOptions {
   pub mode: BlendMode,
 }
 
-#[derive(Clone, Copy)]
-pub(crate) struct MaskSourceToPixmapOptions<'a> {
-  pub placement: Placement,
-  pub sampling: MaskSamplingOptions,
-  pub mode: BlendMode,
-  pub combined_mask: Option<MaskView<'a>>,
-}
-
 /// Borrowed view of the active paint destination: the pixmap, the canvas's
 /// combined constraint mask, and the scratch pool. Primitives take this instead
 /// of threading `(pixmap, mask, pool, size)` separately, so a materialized mask
@@ -85,7 +78,7 @@ pub(crate) struct DrawTarget<'a, 'p> {
   pub buffer_pool: &'a mut BufferPool,
 }
 
-impl DrawTarget<'_, '_> {
+impl<'a> DrawTarget<'a, '_> {
   pub(crate) fn size(&self) -> Size<u32> {
     Size {
       width: self.pixmap.width(),
@@ -93,11 +86,11 @@ impl DrawTarget<'_, '_> {
     }
   }
 
-  pub(crate) fn materialize_combined_mask(&mut self) -> Option<TinyMask> {
+  pub(crate) fn resolve_combined_mask(&mut self) -> Option<Cow<'a, TinyMask>> {
     let size = self.size();
     self
       .combined_mask
-      .and_then(|mask| materialize_mask(mask, size, self.buffer_pool))
+      .and_then(|mask| resolve_mask(mask, size, self.buffer_pool))
   }
 }
 
@@ -316,6 +309,7 @@ impl Canvas {
     mask: &[u8],
     placement: Placement,
     source: PaintSource<'_>,
+    color_mode: MaskCompositeColor,
     sampling: MaskSamplingOptions,
     mode: BlendMode,
   ) {
@@ -329,59 +323,7 @@ impl Canvas {
         composite::Options {
           placement,
           sampling,
-          color_mode: MaskCompositeColor::SourceOnly,
-          mode,
-          combined_mask: target.combined_mask,
-        },
-      );
-    });
-  }
-  pub(crate) fn composite_mask_source_over_color(
-    &mut self,
-    mask: &[u8],
-    placement: Placement,
-    source: PaintSource<'_>,
-    color: Color,
-    sampling: MaskSamplingOptions,
-    mode: BlendMode,
-  ) {
-    let placement = self.localize_placement(placement);
-    let sampling = self.localize_mask_sampling(sampling);
-    self.with_overlay_state(|target| {
-      composite::source(
-        target.pixmap,
-        mask,
-        source,
-        composite::Options {
-          placement,
-          sampling,
-          color_mode: MaskCompositeColor::SourceOverColor(premultiply_rgba(Rgba(color.0))),
-          mode,
-          combined_mask: target.combined_mask,
-        },
-      );
-    });
-  }
-  pub(crate) fn composite_mask_color_over_source(
-    &mut self,
-    mask: &[u8],
-    placement: Placement,
-    source: PaintSource<'_>,
-    color: Color,
-    sampling: MaskSamplingOptions,
-    mode: BlendMode,
-  ) {
-    let placement = self.localize_placement(placement);
-    let sampling = self.localize_mask_sampling(sampling);
-    self.with_overlay_state(|target| {
-      composite::source(
-        target.pixmap,
-        mask,
-        source,
-        composite::Options {
-          placement,
-          sampling,
-          color_mode: MaskCompositeColor::ColorOverSource(premultiply_rgba(Rgba(color.0))),
+          color_mode,
           mode,
           combined_mask: target.combined_mask,
         },
@@ -463,45 +405,39 @@ impl Canvas {
       y: translation.y - self.origin.y as f32,
     };
 
-    match tile {
+    self.with_overlay_state(|target| match tile {
       BackgroundTile::Linear(gradient) => {
-        self.with_overlay_state(|target| {
-          overlay_linear_gradient_tile(
-            target.pixmap,
-            gradient,
-            localized_translation,
-            mode,
-            target.combined_mask,
-          );
-        });
+        overlay_linear_gradient_tile(
+          target.pixmap,
+          gradient,
+          localized_translation,
+          mode,
+          target.combined_mask,
+        );
         true
       }
       BackgroundTile::Radial(gradient) => {
-        self.with_overlay_state(|target| {
-          overlay_radial_gradient_tile(
-            target.pixmap,
-            gradient,
-            localized_translation,
-            mode,
-            target.combined_mask,
-          );
-        });
+        overlay_radial_gradient_tile(
+          target.pixmap,
+          gradient,
+          localized_translation,
+          mode,
+          target.combined_mask,
+        );
         true
       }
       BackgroundTile::Conic(gradient) => {
-        self.with_overlay_state(|target| {
-          overlay_gradient_tile(
-            target.pixmap,
-            gradient,
-            localized_translation,
-            mode,
-            target.combined_mask,
-          );
-        });
+        overlay_gradient_tile(
+          target.pixmap,
+          gradient,
+          localized_translation,
+          mode,
+          target.combined_mask,
+        );
         true
       }
       _ => false,
-    }
+    })
   }
 
   fn with_overlay_state<R>(&mut self, f: impl FnOnce(&mut DrawTarget<'_, '_>) -> R) -> R {

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -6,9 +6,10 @@ use takumi_core::geometry::{Point, Size};
 use tiny_skia::{PixmapMut, PremultipliedColorU8};
 
 use super::{
-  DrawTarget, MaskSamplingOptions, MaskSourceToPixmapOptions, MaskView, OverlayOptions,
-  PaintSource, SamplingFootprint, SamplingOptions, composite,
+  DrawTarget, MaskSamplingOptions, MaskView, OverlayOptions, PaintSource, SamplingFootprint,
+  SamplingOptions, composite,
   composite::sampling_footprint,
+  mask::MaskRow,
   paint_source::{MaskCompositeColor, sample_paint_source},
   skia::{
     FillColorOptions, ImagePathFillOptions, try_draw_image_with_tiny_skia,
@@ -22,6 +23,19 @@ use crate::{
   style::{Affine, BlendMode, ImageScalingAlgorithm},
 };
 
+/// The clipped destination region of an overlay: `offset_*` is the overlay's
+/// top-left in canvas space, `x/y` bounds are the canvas-space pixel range to
+/// write.
+#[derive(Clone, Copy)]
+pub(crate) struct OverlayBounds {
+  pub offset_x: i32,
+  pub offset_y: i32,
+  pub x_min: i32,
+  pub x_max: i32,
+  pub y_min: i32,
+  pub y_max: i32,
+}
+
 #[inline(always)]
 pub(crate) fn compute_overlay_bounds_for_canvas(
   canvas_width: u32,
@@ -29,7 +43,7 @@ pub(crate) fn compute_overlay_bounds_for_canvas(
   offset: Point<f32>,
   width: u32,
   height: u32,
-) -> Option<(i32, i32, i32, i32, i32, i32)> {
+) -> Option<OverlayBounds> {
   if width == 0 || height == 0 {
     return None;
   }
@@ -38,34 +52,38 @@ pub(crate) fn compute_overlay_bounds_for_canvas(
   let offset_y = offset.y.trunc() as i32;
   let bottom_width = canvas_width as i32;
   let bottom_height = canvas_height as i32;
-  let dest_y_min = offset_y.max(0);
-  let dest_y_max = (offset_y + height as i32).min(bottom_height);
-  if dest_y_min >= dest_y_max {
+  let y_min = offset_y.max(0);
+  let y_max = (offset_y + height as i32).min(bottom_height);
+  if y_min >= y_max {
     return None;
   }
 
-  let dest_x_min = offset_x.max(0);
-  let dest_x_max = (offset_x + width as i32).min(bottom_width);
-  if dest_x_min >= dest_x_max {
+  let x_min = offset_x.max(0);
+  let x_max = (offset_x + width as i32).min(bottom_width);
+  if x_min >= x_max {
     return None;
   }
 
-  Some((
-    offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max,
-  ))
+  Some(OverlayBounds {
+    offset_x,
+    offset_y,
+    x_min,
+    x_max,
+    y_min,
+    y_max,
+  })
 }
 
 #[inline(always)]
-pub(crate) fn apply_combined_mask(
+pub(crate) fn apply_mask_row(
   src: [u8; 4],
-  combined_mask: Option<MaskView<'_>>,
-  dest_x: u32,
-  dest_y: u32,
+  row: Option<MaskRow<'_>>,
+  offset: usize,
 ) -> Option<[u8; 4]> {
-  let Some(mask) = combined_mask else {
+  let Some(row) = row else {
     return Some(src);
   };
-  let alpha = mask.alpha_at(dest_x, dest_y);
+  let alpha = row.alpha_at_offset(offset);
   if alpha == 0 {
     return None;
   }
@@ -95,7 +113,7 @@ fn blit_sampled_paint_source_translation(
 
   let canvas_width = pixmap.width();
   let canvas_height = pixmap.height();
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
+  let Some(bounds) =
     compute_overlay_bounds_for_canvas(canvas_width, canvas_height, offset, size.width, size.height)
   else {
     return;
@@ -103,12 +121,18 @@ fn blit_sampled_paint_source_translation(
 
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
   let footprint = sampling_footprint(sampling.logical_to_source);
-  for dest_y in dest_y_min..dest_y_max {
-    let src_y = (dest_y - offset_y) as f32;
+  for dest_y in bounds.y_min..bounds.y_max {
+    let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+    if mask_row.is_some_and(|row| row.is_empty()) {
+      continue;
+    }
+
+    let src_y = (dest_y - bounds.offset_y) as f32;
     let (mut sample_x, mut sample_y) = sampling
       .logical_to_source
-      .transform_point((dest_x_min - offset_x) as f32 + 0.5, src_y + 0.5);
-    for dest_x in dest_x_min..dest_x_max {
+      .transform_point((bounds.x_min - bounds.offset_x) as f32 + 0.5, src_y + 0.5);
+    let dst_row = dest_y as usize * canvas_width as usize;
+    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
       let src = sample_paint_source(source, sampling.algorithm, sample_x, sample_y, footprint)
         .unwrap_or([0, 0, 0, 0]);
       sample_x += sampling.logical_to_source.a;
@@ -117,14 +141,11 @@ fn blit_sampled_paint_source_translation(
         continue;
       }
 
-      let dest_x = dest_x as u32;
-      let dest_y = dest_y as u32;
-      let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y) else {
+      let Some(src) = apply_mask_row(src, mask_row, i) else {
         continue;
       };
 
-      let index = (dest_y * canvas_width + dest_x) as usize;
-      blend_premultiplied_pixel(&mut pixels[index], src, mode);
+      blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
     }
   }
 }
@@ -151,15 +172,13 @@ fn blit_paint_source_translation(
 
   let canvas_width = pixmap.width();
   let canvas_height = pixmap.height();
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_for_canvas(
-      canvas_width,
-      canvas_height,
-      offset,
-      source.width(),
-      source.height(),
-    )
-  else {
+  let Some(bounds) = compute_overlay_bounds_for_canvas(
+    canvas_width,
+    canvas_height,
+    offset,
+    source.width(),
+    source.height(),
+  ) else {
     return;
   };
 
@@ -169,13 +188,13 @@ fn blit_paint_source_translation(
       let source_pixels = source.pixels();
       let source_width = source.width();
       if mode == BlendMode::Normal && combined_mask.is_none() {
-        let copy_width = (dest_x_max - dest_x_min) as usize;
-        let src_x_start = (dest_x_min - offset_x) as usize;
-        for dest_y in dest_y_min..dest_y_max {
-          let src_y = (dest_y - offset_y) as usize;
+        let copy_width = (bounds.x_max - bounds.x_min) as usize;
+        let src_x_start = (bounds.x_min - bounds.offset_x) as usize;
+        for dest_y in bounds.y_min..bounds.y_max {
+          let src_y = (dest_y - bounds.offset_y) as usize;
           let src_start = src_y * source_width as usize + src_x_start;
           let src_end = src_start + copy_width;
-          let dst_start = (dest_y as u32 * canvas_width + dest_x_min as u32) as usize;
+          let dst_start = (dest_y as u32 * canvas_width + bounds.x_min as u32) as usize;
           let dst_end = dst_start + copy_width;
           let dst = bytemuck::cast_slice_mut(&mut pixels[dst_start..dst_end]);
           composite_premultiplied_over_span(dst, &source_pixels[src_start..src_end]);
@@ -183,19 +202,23 @@ fn blit_paint_source_translation(
         return;
       }
 
-      for dest_y in dest_y_min..dest_y_max {
-        let src_y = (dest_y - offset_y) as u32;
+      for dest_y in bounds.y_min..bounds.y_max {
+        let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+        if mask_row.is_some_and(|row| row.is_empty()) {
+          continue;
+        }
+
+        let src_y = (dest_y - bounds.offset_y) as u32;
         let dst_row = dest_y as usize * canvas_width as usize;
         let src_row = src_y as usize * source_width as usize;
-        for dest_x in dest_x_min..dest_x_max {
-          let src_x = (dest_x - offset_x) as u32;
+        for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+          let src_x = (dest_x - bounds.offset_x) as u32;
           let src = premultiplied_from_pixel(source_pixels[src_row + src_x as usize]);
           if src[3] == 0 {
             continue;
           }
 
-          let dest_x = dest_x as u32;
-          let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y as u32) else {
+          let Some(src) = apply_mask_row(src, mask_row, i) else {
             continue;
           };
 
@@ -204,11 +227,16 @@ fn blit_paint_source_translation(
       }
     }
     _ => {
-      for dest_y in dest_y_min..dest_y_max {
-        let src_y = (dest_y - offset_y) as f32;
+      for dest_y in bounds.y_min..bounds.y_max {
+        let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+        if mask_row.is_some_and(|row| row.is_empty()) {
+          continue;
+        }
+
+        let src_y = (dest_y - bounds.offset_y) as f32;
         let dst_row = dest_y as usize * canvas_width as usize;
-        for dest_x in dest_x_min..dest_x_max {
-          let src_x = (dest_x - offset_x) as f32;
+        for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+          let src_x = (dest_x - bounds.offset_x) as f32;
           let src = sample_paint_source(
             source,
             ImageScalingAlgorithm::Pixelated,
@@ -221,8 +249,7 @@ fn blit_paint_source_translation(
             continue;
           }
 
-          let dest_x = dest_x as u32;
-          let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y as u32) else {
+          let Some(src) = apply_mask_row(src, mask_row, i) else {
             continue;
           };
 
@@ -248,15 +275,13 @@ fn blit_solid_translation(
 
   let canvas_width = pixmap.width();
   let canvas_height = pixmap.height();
-  let Some((_offset_x, _offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_for_canvas(
-      canvas_width,
-      canvas_height,
-      offset,
-      source_width,
-      source_height,
-    )
-  else {
+  let Some(bounds) = compute_overlay_bounds_for_canvas(
+    canvas_width,
+    canvas_height,
+    offset,
+    source_width,
+    source_height,
+  ) else {
     return;
   };
 
@@ -264,9 +289,9 @@ fn blit_solid_translation(
 
   if mode == BlendMode::Normal && combined_mask.is_none() {
     let row_stride = canvas_width as usize * 4;
-    let x_byte_start = dest_x_min as usize * 4;
-    let x_byte_end = dest_x_max as usize * 4;
-    for dest_y in dest_y_min..dest_y_max {
+    let x_byte_start = bounds.x_min as usize * 4;
+    let x_byte_end = bounds.x_max as usize * 4;
+    for dest_y in bounds.y_min..bounds.y_max {
       let row_start = dest_y as usize * row_stride;
       let row = &mut data[row_start + x_byte_start..row_start + x_byte_end];
       if color[3] == u8::MAX {
@@ -283,11 +308,15 @@ fn blit_solid_translation(
   }
 
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(data);
-  for dest_y in dest_y_min..dest_y_max {
+  for dest_y in bounds.y_min..bounds.y_max {
+    let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+    if mask_row.is_some_and(|row| row.is_empty()) {
+      continue;
+    }
+
     let dst_row = dest_y as usize * canvas_width as usize;
-    for dest_x in dest_x_min..dest_x_max {
-      let dest_x = dest_x as u32;
-      let Some(src) = apply_combined_mask(color, combined_mask, dest_x, dest_y as u32) else {
+    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+      let Some(src) = apply_mask_row(color, mask_row, i) else {
         continue;
       };
 
@@ -300,18 +329,21 @@ pub(crate) fn composite_mask_source_to_pixmap(
   pixmap: &mut PixmapMut<'_>,
   mask: &[u8],
   source: PaintSource<'_>,
-  options: MaskSourceToPixmapOptions<'_>,
+  placement: Placement,
+  sampling: MaskSamplingOptions,
+  mode: BlendMode,
+  combined_mask: Option<MaskView<'_>>,
 ) {
   composite::source(
     pixmap,
     mask,
     source,
     composite::Options {
-      placement: options.placement,
-      sampling: options.sampling,
+      placement,
+      sampling,
       color_mode: MaskCompositeColor::SourceOnly,
-      mode: options.mode,
-      combined_mask: options.combined_mask,
+      mode,
+      combined_mask,
     },
   );
 }
@@ -417,41 +449,55 @@ pub(crate) fn overlay_image<'a, I: Into<PaintSource<'a>>>(
     return;
   }
 
+  composite_bordered_source(
+    target,
+    image,
+    content_size,
+    Affine::IDENTITY,
+    options.algorithm,
+    options,
+  );
+}
+
+/// Shared slow path for bordered/transformed overlays: renders the border mask
+/// and composites `source` through it, mapping canvas coordinates back to the
+/// source via `logical_to_source` (and the transform's inverse when the
+/// transform is not identity).
+fn composite_bordered_source(
+  target: &mut DrawTarget,
+  source: PaintSource<'_>,
+  size: Size<u32>,
+  logical_to_source: Affine,
+  algorithm: ImageScalingAlgorithm,
+  options: OverlayOptions,
+) {
   let mut paths = Vec::new();
   options
     .border
-    .append_mask_commands(&mut paths, content_size.map(|v| v as f32), Point::ZERO);
+    .append_mask_commands(&mut paths, size.map(|v| v as f32), Point::ZERO);
 
   let (mask, placement) = render_mask(&paths, Some(options.transform), None, target.buffer_pool);
-  let inverse = options.transform.invert();
-  if options.transform.is_identity() && placement.left >= 0 && placement.top >= 0 {
+  let canvas_to_source =
+    if options.transform.is_identity() && placement.left >= 0 && placement.top >= 0 {
+      Some(logical_to_source)
+    } else {
+      options
+        .transform
+        .invert()
+        .map(|inverse| logical_to_source * inverse)
+    };
+
+  if let Some(canvas_to_source) = canvas_to_source {
     composite::source(
       target.pixmap,
       &mask,
-      image,
+      source,
       composite::Options {
         placement,
         sampling: MaskSamplingOptions {
-          canvas_to_source: Affine::IDENTITY,
+          canvas_to_source,
           sample_bias: Point { x: 0.5, y: 0.5 },
-          algorithm: options.algorithm,
-        },
-        color_mode: MaskCompositeColor::SourceOnly,
-        mode: options.mode,
-        combined_mask: target.combined_mask,
-      },
-    );
-  } else if let Some(inverse) = inverse {
-    composite::source(
-      target.pixmap,
-      &mask,
-      image,
-      composite::Options {
-        placement,
-        sampling: MaskSamplingOptions {
-          canvas_to_source: inverse,
-          sample_bias: Point { x: 0.5, y: 0.5 },
-          algorithm: options.algorithm,
+          algorithm,
         },
         color_mode: MaskCompositeColor::SourceOnly,
         mode: options.mode,
@@ -503,51 +549,14 @@ pub(crate) fn overlay_sampled_paint_source(
     return;
   }
 
-  let mut paths = Vec::new();
-  options
-    .border
-    .append_mask_commands(&mut paths, size.map(|v| v as f32), Point::ZERO);
-  let (mask, placement) = render_mask(&paths, Some(options.transform), None, target.buffer_pool);
-
-  let inverse = options.transform.invert();
-  if options.transform.is_identity() && placement.left >= 0 && placement.top >= 0 {
-    composite::source(
-      target.pixmap,
-      &mask,
-      source,
-      composite::Options {
-        placement,
-        sampling: MaskSamplingOptions {
-          canvas_to_source: sampling.logical_to_source,
-          sample_bias: Point { x: 0.5, y: 0.5 },
-          algorithm: sampling.algorithm,
-        },
-        color_mode: MaskCompositeColor::SourceOnly,
-        mode: options.mode,
-        combined_mask: target.combined_mask,
-      },
-    );
-  } else if let Some(inverse) = inverse {
-    let combined_inverse = sampling.logical_to_source * inverse;
-    composite::source(
-      target.pixmap,
-      &mask,
-      source,
-      composite::Options {
-        placement,
-        sampling: MaskSamplingOptions {
-          canvas_to_source: combined_inverse,
-          sample_bias: Point { x: 0.5, y: 0.5 },
-          algorithm: sampling.algorithm,
-        },
-        color_mode: MaskCompositeColor::SourceOnly,
-        mode: options.mode,
-        combined_mask: target.combined_mask,
-      },
-    );
-  }
-
-  target.buffer_pool.release(mask);
+  composite_bordered_source(
+    target,
+    source,
+    size,
+    sampling.logical_to_source,
+    sampling.algorithm,
+    options,
+  );
 }
 
 #[cfg(test)]

--- a/takumi-raster/src/canvas/composite.rs
+++ b/takumi-raster/src/canvas/composite.rs
@@ -2,7 +2,8 @@ use takumi_core::geometry::Point;
 use tiny_skia::PixmapMut;
 
 use super::{
-  MaskSamplingOptions, MaskView, PaintSource, SamplingFootprint, compute_overlay_bounds_for_canvas,
+  MaskSamplingOptions, MaskView, PaintSource, SamplingFootprint,
+  blit::{OverlayBounds, compute_overlay_bounds_for_canvas},
   paint_source::{MaskCompositeColor, apply_mask_color_mode, sample_paint_source},
 };
 use crate::{
@@ -13,8 +14,7 @@ use crate::{
 
 #[derive(Clone, Copy)]
 struct DestRegion {
-  bounds: (i32, i32, i32, i32),
-  offset: (i32, i32),
+  bounds: OverlayBounds,
   canvas_width: usize,
   mask_stride: usize,
 }
@@ -42,24 +42,21 @@ pub(super) fn constant(
 
   let canvas_width = pixmap.width();
   let canvas_height = pixmap.height();
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_for_canvas(
-      canvas_width,
-      canvas_height,
-      Point {
-        x: placement.left as f32,
-        y: placement.top as f32,
-      },
-      placement.width,
-      placement.height,
-    )
-  else {
+  let Some(bounds) = compute_overlay_bounds_for_canvas(
+    canvas_width,
+    canvas_height,
+    Point {
+      x: placement.left as f32,
+      y: placement.top as f32,
+    },
+    placement.width,
+    placement.height,
+  ) else {
     return;
   };
 
   let region = DestRegion {
-    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    offset: (offset_x, offset_y),
+    bounds,
     canvas_width: canvas_width as usize,
     mask_stride: placement.width as usize,
   };
@@ -108,10 +105,8 @@ pub(super) fn source(
   ) else {
     return;
   };
-  let (offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max) = bounds;
   let region = DestRegion {
-    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    offset: (offset_x, offset_y),
+    bounds,
     canvas_width: canvas_width as usize,
     mask_stride: options.placement.width as usize,
   };
@@ -129,17 +124,16 @@ pub(super) fn source(
 #[inline]
 fn constant_normal(pixels: &mut [[u8; 4]], mask: &[u8], color: [u8; 4], region: DestRegion) {
   let DestRegion {
-    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    offset: (offset_x, offset_y),
+    bounds,
     canvas_width,
     mask_stride,
   } = region;
-  let span = (dest_x_max - dest_x_min) as usize;
+  let span = (bounds.x_max - bounds.x_min) as usize;
 
-  for dest_y in dest_y_min..dest_y_max {
-    let mask_y = (dest_y - offset_y) as usize;
-    let mask_x = (dest_x_min - offset_x) as usize;
-    let dst_row_start = dest_y as usize * canvas_width + dest_x_min as usize;
+  for dest_y in bounds.y_min..bounds.y_max {
+    let mask_y = (dest_y - bounds.offset_y) as usize;
+    let mask_x = (bounds.x_min - bounds.offset_x) as usize;
+    let dst_row_start = dest_y as usize * canvas_width + bounds.x_min as usize;
     let mask_row_start = mask_y * mask_stride + mask_x;
 
     let dst = &mut pixels[dst_row_start..dst_row_start + span];
@@ -167,18 +161,22 @@ fn constant_general(
   region: DestRegion,
 ) {
   let DestRegion {
-    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    offset: (offset_x, offset_y),
+    bounds,
     canvas_width,
     mask_stride,
   } = region;
 
-  for dest_y in dest_y_min..dest_y_max {
-    let mask_y = (dest_y - offset_y) as usize;
+  for dest_y in bounds.y_min..bounds.y_max {
+    let combined_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+    if combined_row.is_some_and(|row| row.is_empty()) {
+      continue;
+    }
+
+    let mask_y = (dest_y - bounds.offset_y) as usize;
     let dst_row = dest_y as usize * canvas_width;
     let mask_row = mask_y * mask_stride;
-    for dest_x in dest_x_min..dest_x_max {
-      let alpha = mask[mask_row + (dest_x - offset_x) as usize];
+    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+      let alpha = mask[mask_row + (dest_x - bounds.offset_x) as usize];
       if alpha == 0 {
         continue;
       }
@@ -186,8 +184,8 @@ fn constant_general(
       if src[3] == 0 {
         continue;
       }
-      if let Some(view) = combined_mask {
-        let extra = view.alpha_at(dest_x as u32, dest_y as u32);
+      if let Some(row) = combined_row {
+        let extra = row.alpha_at_offset(i);
         if extra == 0 {
           continue;
         }
@@ -217,8 +215,7 @@ fn try_translation_blit(
   };
 
   let DestRegion {
-    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    offset: (offset_x, offset_y),
+    bounds,
     canvas_width,
     mask_stride,
   } = region;
@@ -228,29 +225,29 @@ fn try_translation_blit(
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
   let sample_dx = transform.x as i32;
   let sample_dy = transform.y as i32;
-  let span = (dest_x_max - dest_x_min) as usize;
+  let span = (bounds.x_max - bounds.x_min) as usize;
 
-  for dest_y in dest_y_min..dest_y_max {
+  for dest_y in bounds.y_min..bounds.y_max {
     let src_y = dest_y + sample_dy;
     if src_y < 0 || src_y >= source_height {
       continue;
     }
-    let mask_y = (dest_y - offset_y) as usize;
-    let mask_x_start = (dest_x_min - offset_x) as usize;
+    let mask_y = (dest_y - bounds.offset_y) as usize;
+    let mask_x_start = (bounds.x_min - bounds.offset_x) as usize;
     let mask_row =
       &mask[mask_y * mask_stride + mask_x_start..mask_y * mask_stride + mask_x_start + span];
 
     let combined_row = options
       .combined_mask
       .as_ref()
-      .map(|view| view.row(dest_y, dest_x_min));
+      .map(|view| view.row(dest_y, bounds.x_min));
 
     let src_row_offset = src_y as usize * source_width as usize;
     let dst_row_offset = dest_y as usize * canvas_width;
     let dst_row = &mut pixels
-      [dst_row_offset + dest_x_min as usize..dst_row_offset + dest_x_min as usize + span];
+      [dst_row_offset + bounds.x_min as usize..dst_row_offset + bounds.x_min as usize + span];
 
-    let src_x_base = dest_x_min + sample_dx;
+    let src_x_base = bounds.x_min + sample_dx;
     for (i, (dst, &mask_alpha)) in dst_row.iter_mut().zip(mask_row).enumerate() {
       if mask_alpha == 0 {
         continue;
@@ -310,24 +307,30 @@ fn source_general(
   region: DestRegion,
 ) {
   let DestRegion {
-    bounds: (dest_x_min, dest_x_max, dest_y_min, dest_y_max),
-    offset: (offset_x, offset_y),
+    bounds,
     canvas_width,
     mask_stride,
   } = region;
   let footprint = sampling_footprint(options.sampling.canvas_to_source);
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
 
-  for dest_y in dest_y_min..dest_y_max {
-    let mask_y = (dest_y - offset_y) as usize;
+  for dest_y in bounds.y_min..bounds.y_max {
+    let combined_row = options
+      .combined_mask
+      .map(|view| view.row(dest_y, bounds.x_min));
+    if combined_row.is_some_and(|row| row.is_empty()) {
+      continue;
+    }
+
+    let mask_y = (dest_y - bounds.offset_y) as usize;
     let dst_row = dest_y as usize * canvas_width;
     let mask_row = mask_y * mask_stride;
     let (mut sample_x, mut sample_y) = options.sampling.canvas_to_source.transform_point(
-      dest_x_min as f32 + options.sampling.sample_bias.x,
+      bounds.x_min as f32 + options.sampling.sample_bias.x,
       dest_y as f32 + options.sampling.sample_bias.y,
     );
-    for dest_x in dest_x_min..dest_x_max {
-      let mask_alpha = mask[mask_row + (dest_x - offset_x) as usize];
+    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+      let mask_alpha = mask[mask_row + (dest_x - bounds.offset_x) as usize];
       let sampled = if mask_alpha == 0 {
         None
       } else {
@@ -352,8 +355,8 @@ fn source_general(
         continue;
       }
 
-      if let Some(view) = options.combined_mask {
-        let extra = view.alpha_at(dest_x as u32, dest_y as u32);
+      if let Some(row) = combined_row {
+        let extra = row.alpha_at_offset(i);
         if extra == 0 {
           continue;
         }

--- a/takumi-raster/src/canvas/gradient.rs
+++ b/takumi-raster/src/canvas/gradient.rs
@@ -11,7 +11,7 @@ use tiny_skia::PixmapMut;
 
 use super::{
   MaskView,
-  blit::{apply_combined_mask, compute_overlay_bounds_for_canvas},
+  blit::{apply_mask_row, compute_overlay_bounds_for_canvas},
 };
 use crate::{blend::*, style::BlendMode};
 
@@ -43,31 +43,33 @@ pub(crate) fn overlay_gradient_tile<T>(
     return;
   }
 
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_for_canvas(
-      bottom_width,
-      bottom_height,
-      offset,
-      top_size.width,
-      top_size.height,
-    )
-  else {
+  let Some(bounds) = compute_overlay_bounds_for_canvas(
+    bottom_width,
+    bottom_height,
+    offset,
+    top_size.width,
+    top_size.height,
+  ) else {
     return;
   };
 
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
-  for dest_y in dest_y_min..dest_y_max {
-    let src_y = (dest_y - offset_y) as u32;
+  for dest_y in bounds.y_min..bounds.y_max {
+    let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+    if mask_row.is_some_and(|row| row.is_empty()) {
+      continue;
+    }
+
+    let src_y = (dest_y - bounds.offset_y) as u32;
     let dst_row = dest_y as usize * bottom_width as usize;
-    for dest_x in dest_x_min..dest_x_max {
-      let src_x = (dest_x - offset_x) as u32;
+    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+      let src_x = (dest_x - bounds.offset_x) as u32;
       let src = premultiplied_from_pixel(gradient.sample_pixel(src_x, src_y));
       if src[3] == 0 {
         continue;
       }
 
-      let dest_x = dest_x as u32;
-      let Some(src) = apply_combined_mask(src, combined_mask, dest_x, dest_y as u32) else {
+      let Some(src) = apply_mask_row(src, mask_row, i) else {
         continue;
       };
 
@@ -83,15 +85,13 @@ fn try_overlay_linear_gradient_tile_fast_normal_unconstrained(
   gradient: &LinearGradientTile,
   offset: Point<f32>,
 ) -> bool {
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_for_canvas(
-      bottom_width,
-      bottom_height,
-      offset,
-      gradient.width(),
-      gradient.height(),
-    )
-  else {
+  let Some(bounds) = compute_overlay_bounds_for_canvas(
+    bottom_width,
+    bottom_height,
+    offset,
+    gradient.width(),
+    gradient.height(),
+  ) else {
     return true;
   };
 
@@ -100,15 +100,15 @@ fn try_overlay_linear_gradient_tile_fast_normal_unconstrained(
   };
 
   let row_stride = bottom_width as usize * 4;
-  let row_count = (dest_y_max - dest_y_min) as usize;
-  let segment_pixel_count = (dest_x_max - dest_x_min) as usize;
-  let dest_byte_start = dest_x_min as usize * 4;
+  let row_count = (bounds.y_max - bounds.y_min) as usize;
+  let segment_pixel_count = (bounds.x_max - bounds.x_min) as usize;
+  let dest_byte_start = bounds.x_min as usize * 4;
   let dest_byte_end = dest_byte_start + segment_pixel_count * 4;
-  let rows = &mut data[dest_y_min as usize * row_stride..dest_y_max as usize * row_stride];
+  let rows = &mut data[bounds.y_min as usize * row_stride..bounds.y_max as usize * row_stride];
 
   match fast_path.kind {
     LinearGradientFastPathKind::Horizontal => {
-      let src_x_start = (dest_x_min - offset_x) as usize;
+      let src_x_start = (bounds.x_min - bounds.offset_x) as usize;
       let src_x_end = src_x_start + segment_pixel_count;
       let src_pixels = &fast_path.axis_samples[src_x_start..src_x_end];
 
@@ -125,7 +125,7 @@ fn try_overlay_linear_gradient_tile_fast_normal_unconstrained(
       }
     }
     LinearGradientFastPathKind::Vertical => {
-      let src_y_start = (dest_y_min - offset_y) as usize;
+      let src_y_start = (bounds.y_min - bounds.offset_y) as usize;
       let src_pixels = &fast_path.axis_samples[src_y_start..src_y_start + row_count];
 
       for (row_offset, row) in rows.chunks_mut(row_stride).enumerate() {
@@ -202,15 +202,13 @@ fn try_overlay_radial_gradient_tile_fast_normal_unconstrained(
   gradient: &RadialGradientTile,
   offset: Point<f32>,
 ) -> bool {
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_for_canvas(
-      bottom_width,
-      bottom_height,
-      offset,
-      gradient.width(),
-      gradient.height(),
-    )
-  else {
+  let Some(bounds) = compute_overlay_bounds_for_canvas(
+    bottom_width,
+    bottom_height,
+    offset,
+    gradient.width(),
+    gradient.height(),
+  ) else {
     return true;
   };
 
@@ -228,18 +226,18 @@ fn try_overlay_radial_gradient_tile_fast_normal_unconstrained(
   }
 
   let row_stride = bottom_width as usize * 4;
-  for dest_y in dest_y_min..dest_y_max {
-    let src_y = (dest_y - offset_y) as u32;
-    let src_x_start = (dest_x_min - offset_x) as u32;
-    let src_x_end = (dest_x_max - offset_x) as u32;
+  for dest_y in bounds.y_min..bounds.y_max {
+    let src_y = (dest_y - bounds.offset_y) as u32;
+    let src_x_start = (bounds.x_min - bounds.offset_x) as u32;
+    let src_x_end = (bounds.x_max - bounds.offset_x) as u32;
     let Some((active_x_start, active_x_end)) =
       gradient.non_repeating_active_span(src_x_start, src_x_end, src_y)
     else {
       return false;
     };
 
-    let row_start = dest_y as usize * row_stride + dest_x_min as usize * 4;
-    let row_end = row_start + (dest_x_max - dest_x_min) as usize * 4;
+    let row_start = dest_y as usize * row_stride + bounds.x_min as usize * 4;
+    let row_end = row_start + (bounds.x_max - bounds.x_min) as usize * 4;
     let row = &mut data[row_start..row_end];
 
     let left_pixels = (active_x_start - src_x_start) as usize;

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use takumi_core::geometry::{
   ComputedLayout as Layout, Point, Rect, Size, transformed_rect_extents,
@@ -784,21 +784,6 @@ pub(crate) struct MaskView<'a> {
 
 impl<'a> MaskView<'a> {
   #[inline]
-  pub(crate) fn alpha_at(self, x: u32, y: u32) -> u8 {
-    let local_x = x as i32 + self.canvas_origin.x as i32 - self.origin.x as i32;
-    let local_y = y as i32 + self.canvas_origin.y as i32 - self.origin.y as i32;
-    if local_x < 0
-      || local_y < 0
-      || local_x >= self.mask.width() as i32
-      || local_y >= self.mask.height() as i32
-    {
-      return 0;
-    }
-
-    self.mask.data()[mask_index_from_coord(local_x as u32, local_y as u32, self.mask.width())]
-  }
-
-  #[inline]
   pub(crate) fn row(&self, canvas_y: i32, canvas_x_start: i32) -> MaskRow<'a> {
     let local_y = canvas_y + self.canvas_origin.y as i32 - self.origin.y as i32;
     let mask_width = self.mask.width() as i32;
@@ -841,6 +826,28 @@ impl<'a> MaskRow<'a> {
     }
     self.data[self.row_offset + local_x as usize]
   }
+
+  #[inline]
+  pub(crate) fn is_empty(&self) -> bool {
+    self.data.is_empty()
+  }
+}
+
+/// Resolves the combined constraint mask against the pixmap it clips: borrowed
+/// directly when the stored mask already matches the canvas viewport, cropped
+/// into a scratch buffer otherwise.
+pub(crate) fn resolve_mask<'a>(
+  mask: MaskView<'a>,
+  size: Size<u32>,
+  buffer_pool: &mut BufferPool,
+) -> Option<Cow<'a, TinyMask>> {
+  if mask.origin == mask.canvas_origin
+    && mask.mask.width() == size.width
+    && mask.mask.height() == size.height
+  {
+    return Some(Cow::Borrowed(mask.mask));
+  }
+  materialize_mask(mask, size, buffer_pool).map(Cow::Owned)
 }
 
 #[inline(always)]

--- a/takumi-raster/src/canvas/paint_source.rs
+++ b/takumi-raster/src/canvas/paint_source.rs
@@ -1,10 +1,11 @@
+use image::Rgba;
 use tiny_skia::{PixmapRef, PremultipliedColorU8};
 
 use crate::{
   BackgroundTile, ColorTile,
-  blend::premultiplied_from_pixel,
+  blend::{premultiplied_from_pixel, premultiply_rgba},
   canvas::{BufferPool, composite_premultiplied_over},
-  style::ImageScalingAlgorithm,
+  style::{Color, ImageScalingAlgorithm},
 };
 
 #[derive(Clone, Copy)]
@@ -159,10 +160,20 @@ impl<'a> From<&'a ColorTile> for PaintSource<'a> {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum MaskCompositeColor {
+pub(crate) enum MaskCompositeColor {
   SourceOnly,
   SourceOverColor([u8; 4]),
   ColorOverSource([u8; 4]),
+}
+
+impl MaskCompositeColor {
+  pub(crate) fn source_over_color(color: Color) -> Self {
+    Self::SourceOverColor(premultiply_rgba(Rgba(color.0)))
+  }
+
+  pub(crate) fn color_over_source(color: Color) -> Self {
+    Self::ColorOverSource(premultiply_rgba(Rgba(color.0)))
+  }
 }
 
 #[inline(always)]

--- a/takumi-raster/src/canvas/skia.rs
+++ b/takumi-raster/src/canvas/skia.rs
@@ -80,8 +80,8 @@ pub(crate) fn try_draw_image_with_tiny_skia(
     blend_mode,
     quality: to_tiny_filter_quality(algorithm),
   };
-  let materialized_mask = target.materialize_combined_mask();
-  let combined_mask = materialized_mask.as_ref();
+  let resolved_mask = target.resolve_combined_mask();
+  let combined_mask = resolved_mask.as_deref();
 
   image
     .with_pixmap_ref(target.buffer_pool, |source_pixmap| {
@@ -109,8 +109,8 @@ pub(crate) fn try_fill_color_with_tiny_skia(
   paint.set_color_rgba8(red, green, blue, alpha);
   paint.blend_mode = blend_mode;
   paint.anti_alias = true;
-  let materialized_mask = target.materialize_combined_mask();
-  let combined_mask = materialized_mask.as_ref();
+  let resolved_mask = target.resolve_combined_mask();
+  let combined_mask = resolved_mask.as_deref();
   target.pixmap.fill_path(
     &path,
     &paint,
@@ -132,8 +132,8 @@ pub(crate) fn try_fill_image_path_with_tiny_skia(
   let Some(path) = build_border_path(options.border, options.content_size) else {
     return false;
   };
-  let materialized_mask = target.materialize_combined_mask();
-  let combined_mask = materialized_mask.as_ref();
+  let resolved_mask = target.resolve_combined_mask();
+  let combined_mask = resolved_mask.as_deref();
 
   image
     .with_pixmap_ref(target.buffer_pool, |source_pixmap| {

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -7,8 +7,8 @@ use takumi_core::{
 };
 
 use crate::{
-  Canvas, Cap, DashPattern, Fill, MaskSamplingOptions, PaintSource, PathBuilder, Placement, Stroke,
-  Style, intersect_alpha_masks, render_mask,
+  Canvas, Cap, DashPattern, Fill, MaskCompositeColor, MaskSamplingOptions, PaintSource,
+  PathBuilder, Placement, Stroke, Style, intersect_alpha_masks, render_mask,
   style::{Affine, BlendMode, BorderStyle, Color, ImageScalingAlgorithm},
 };
 
@@ -628,11 +628,11 @@ fn paint_mask_with_inverse(
     let Some(inverse) = inverse else {
       return;
     };
-    canvas.composite_mask_source_over_color(
+    canvas.composite_mask_source(
       mask,
       placement,
       clip_image,
-      color,
+      MaskCompositeColor::source_over_color(color),
       MaskSamplingOptions {
         canvas_to_source: inverse,
         sample_bias: Point::ZERO,

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -5,7 +5,7 @@ use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 use tiny_skia::Pixmap;
 
 use crate::{
-  BorderProperties, Canvas, ColorTile, Command, MaskSamplingOptions, MaskSourceToPixmapOptions,
+  BorderProperties, Canvas, ColorTile, Command, MaskCompositeColor, MaskSamplingOptions,
   PaintSource, Placement, Result, SamplingOptions, SizedFontStyle, Stroke,
   composite_mask_source_to_pixmap, draw_outset_shadow,
   layout::inline::ShapedRun,
@@ -173,24 +173,22 @@ pub(crate) fn draw_glyph_clip_image(
         &mut bottom_pixmap,
         &mask,
         clip_image,
-        MaskSourceToPixmapOptions {
-          placement: Placement {
-            left: 0,
-            top: 0,
-            width: bitmap.placement.width,
-            height: bitmap.placement.height,
-          },
-          sampling: MaskSamplingOptions {
-            canvas_to_source: Affine::translation(
-              inline_offset.x + bitmap.placement.left as f32,
-              inline_offset.y - bitmap.placement.top as f32,
-            ),
-            sample_bias: Point::ZERO,
-            algorithm: ImageScalingAlgorithm::Pixelated,
-          },
-          mode: BlendMode::Normal,
-          combined_mask: None,
+        Placement {
+          left: 0,
+          top: 0,
+          width: bitmap.placement.width,
+          height: bitmap.placement.height,
         },
+        MaskSamplingOptions {
+          canvas_to_source: Affine::translation(
+            inline_offset.x + bitmap.placement.left as f32,
+            inline_offset.y - bitmap.placement.top as f32,
+          ),
+          sample_bias: Point::ZERO,
+          algorithm: ImageScalingAlgorithm::Pixelated,
+        },
+        BlendMode::Normal,
+        None,
       );
 
       canvas.overlay_sampled_pixmap(
@@ -241,6 +239,7 @@ pub(crate) fn draw_glyph_clip_image(
             cached_mask,
             placement,
             clip_image,
+            MaskCompositeColor::SourceOnly,
             sampling,
             BlendMode::Normal,
           );
@@ -252,7 +251,14 @@ pub(crate) fn draw_glyph_clip_image(
           None,
           &mut canvas.buffer_pool,
         );
-        canvas.composite_mask_source(&mask, placement, clip_image, sampling, BlendMode::Normal);
+        canvas.composite_mask_source(
+          &mask,
+          placement,
+          clip_image,
+          MaskCompositeColor::SourceOnly,
+          sampling,
+          BlendMode::Normal,
+        );
         canvas.buffer_pool.release(mask);
       }
 
@@ -361,11 +367,11 @@ fn draw_text_stroke_clip_image(ctx: &mut GlyphPaintCtx<'_, '_>, clip_image: Pain
     &mut ctx.canvas.buffer_pool,
   );
 
-  ctx.canvas.composite_mask_color_over_source(
+  ctx.canvas.composite_mask_source(
     &stroke_mask,
     stroke_placement,
     clip_image,
-    ctx.style.text_stroke_color,
+    MaskCompositeColor::color_over_source(ctx.style.text_stroke_color),
     MaskSamplingOptions {
       canvas_to_source: Affine::translation(ctx.inline_offset.x, ctx.inline_offset.y) * inverse,
       sample_bias: Point::ZERO,
@@ -404,6 +410,7 @@ fn draw_text_embolden_clip_image(
     &stroke_mask,
     stroke_placement,
     clip_image,
+    MaskCompositeColor::SourceOnly,
     MaskSamplingOptions {
       canvas_to_source: Affine::translation(ctx.inline_offset.x, ctx.inline_offset.y) * inverse,
       sample_bias: Point::ZERO,


### PR DESCRIPTION
Stacked on #933. Perf and simplification pass over the freshly split canvas modules.

Perf:
- Resolve the combined constraint mask as `Cow<TinyMask>`: borrowed directly when it already matches the canvas viewport (the common root-canvas case), materialized into a scratch buffer only when a subcanvas offset requires cropping. Previously every masked tiny-skia draw copied the full canvas-sized mask and leaked the buffer out of the pool.
- Hoist combined-mask lookups out of the per-pixel loops in blit, gradient, and composite paths via `MaskRow` (one bounds branch per pixel instead of four plus signed arithmetic), and skip rows the mask fully clips.

Simplification:
- Fold `composite_mask_source`/`_over_color`/`_color_over_source` into one method taking `MaskCompositeColor`.
- Share the bordered-overlay slow path between `overlay_image` and `overlay_sampled_paint_source` (`composite_bordered_source`).
- Return a named `OverlayBounds` struct instead of a 6-tuple; `composite::DestRegion` now embeds it.
- Drop the single-caller `MaskSourceToPixmapOptions` indirection and the now-unused `MaskView::alpha_at`.

Checks: `cargo test -p takumi-raster` 69 passed, `cargo test -p takumi` 280 passed with zero `.webp`/`.svg` golden diffs (html regen noise discarded), `cargo clippy -p takumi-raster --tests` clean, `cargo fmt` clean. Bench validation deferred to CI per operator constraint.

https://claude.ai/code/session_01WDrwWBjQfCYyYPcmuoMoGF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved canvas rendering speed by reducing unnecessary mask work, especially in fast-path drawing and clipping cases.
  * Optimized gradient, border, text, and image rendering to reuse mask information more efficiently.

* **Bug Fixes**
  * Kept rendering output unchanged while refining how masks are applied across canvas operations.
  * Improved consistency in compositing for masked shapes, images, and text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->