### PR TITLE
JS: add managed render functions to the wasm entry

### DIFF
--- a/.tegami/wasm-entry-managed-render.md
+++ b/.tegami/wasm-entry-managed-render.md
@@ -1,0 +1,11 @@
+---
+packages:
+  npm:takumi-js: minor
+---
+
+### Add managed render functions to `takumi-js/wasm`
+
+`takumi-js/wasm` now exports `render`, `renderSvg`, and `renderAnimation`
+pinned to the WASM backend, using the binary `@takumi-rs/wasm/auto` resolves.
+The backend cache keeps separate slots for auto and forced-WASM loads, and the
+shared renderer is cached per backend, so mixing both entries stays correct.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -20,6 +20,8 @@ npm i takumi-js
 
 `takumi-js` bundles both bindings: the native renderer (`@takumi-rs/core`) and the WebAssembly one (`@takumi-rs/wasm`). It picks the right one at runtime — native on Node.js, WebAssembly on Cloudflare Workers, Vercel Edge, Deno, and the browser. No extra install.
 
+To pin the WebAssembly backend instead, import the same functions from `takumi-js/wasm`. That entry never resolves the native addon, so use it when a bundler or deploy target chokes on the `.node` binary.
+
 ## Render an image
 
 `render` takes JSX and returns image bytes. A default sans-serif font is built in, so text works without loading a font.

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -12,7 +12,7 @@ These practices keep Takumi fast as your node trees grow.
 
 The `Renderer` holds Takumi's caches. Reuse one instance across renders instead of constructing a new one each time.
 
-[`ImageResponse`](/docs/image-response) manages an internal renderer, or pass your own through the `renderer` option. See [Typography & Fonts](/docs/typography-and-fonts) and [Load Images](/docs/load-images).
+`render`, `renderSvg`, `renderAnimation`, and [`ImageResponse`](/docs/image-response) already do this: they create one shared renderer per backend on first use and keep it across calls, retrying if a load failed. Pass your own through the `renderer` option only when you need a separate instance. See [Typography & Fonts](/docs/typography-and-fonts) and [Load Images](/docs/load-images).
 
 ### Preload Frequently Used Images
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -23,7 +23,7 @@ Pass the fonts a render needs through `fonts`. An entry takes one of three forms
 | Raw bytes  | A `Uint8Array`, `ArrayBuffer`, or `Buffer`, registered directly.                 |
 | Descriptor | `{ name, data, weight, style }`. The fields override what the file reports.      |
 
-A reused renderer decodes each file once. `fonts` also takes a promise of the list, so async helpers like `googleFonts` pass straight through without `await`.
+A reused renderer decodes each file once. Entries dedupe by URL, buffer, or `name`/`weight`/`style`, so the same `fonts` list on every render costs nothing after the first; skip tracking registrations yourself. `fonts` also takes a promise of the list, so async helpers like `googleFonts` pass straight through without `await`.
 
 ```tsx twoslash
 import { ImageResponse } from "takumi-js/response";

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -1,26 +1,37 @@
 import { loadBackend } from "#backend";
 import type { BackendModule } from "./backend/types";
 
-type Imports = Awaited<ReturnType<typeof loadBackend>>;
+export type Imports = Awaited<ReturnType<typeof loadBackend>>;
 
-let importPromise: Promise<Imports> | null = null;
+let backendPromise: Promise<Imports> | null = null;
+let wasmPromise: Promise<Imports> | null = null;
 
 /**
- * Resolves the rendering backend once and caches it. With no `module`, the
- * `#backend` import conditions pick it (napi on Node/Bun, WASM elsewhere). An
- * explicit `module` is a WASM binary, so it forces WASM — the escape hatch for a
- * Node target that can't load the native addon. A failed load clears the cache.
+ * Resolves the rendering backend and caches it, one slot per strategy. With no
+ * `module`, the `#backend` import conditions pick it (napi on Node/Bun, WASM
+ * elsewhere). An explicit `module` is a WASM binary, so it forces WASM — the
+ * escape hatch for a target that can't load the native addon. The slots are
+ * separate so a forced-WASM call never gets a previously cached napi backend
+ * (and vice versa). A failed load clears its slot.
  */
 export function getImports(module?: BackendModule): Promise<Imports> {
-  importPromise ??= (
-    module === undefined
-      ? loadBackend()
-      : import("./backend/wasm-init").then(({ initWasm }) => initWasm(module))
-  ).catch((error) => {
-    importPromise = null;
+  if (module === undefined) {
+    backendPromise ??= loadBackend().catch((error) => {
+      backendPromise = null;
 
-    throw error;
-  });
+      throw error;
+    });
 
-  return importPromise;
+    return backendPromise;
+  }
+
+  wasmPromise ??= import("./backend/wasm-init")
+    .then(({ initWasm }) => initWasm(module))
+    .catch((error) => {
+      wasmPromise = null;
+
+      throw error;
+    });
+
+  return wasmPromise;
 }

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -3,7 +3,8 @@ import type * as wasm from "@takumi-rs/wasm";
 import { extractEmojis, type EmojiType } from "@takumi-rs/helpers/emoji";
 import { prepareImages, type FetchOptions, type ImageFetchCache } from "@takumi-rs/helpers";
 import { fromJsx, type FromJsxOptions } from "@takumi-rs/helpers/jsx";
-import { getImports } from "./import";
+import { getImports, type Imports } from "./import";
+import type { BackendModule } from "./backend/types";
 import type { ReactNode } from "react";
 import type { Node, ReactElementLike } from "@takumi-rs/helpers";
 import { fromHtml } from "@takumi-rs/helpers/html";
@@ -43,7 +44,7 @@ type ManagedRendererOptions = {
   /**
    * @description The WebAssembly module to use for the renderer. If not provided, the default resolving strategy will be used.
    */
-  module?: wasm.InitInput | Promise<wasm.InitInput> | { default: wasm.InitInput };
+  module?: BackendModule;
 };
 
 /**
@@ -93,7 +94,7 @@ type PipelineOptions = Partial<SharedRenderExtras> &
     stylesheets?: string[];
   };
 
-let globalRenderer: Renderer | undefined;
+const globalRenderers = new WeakMap<Imports, Renderer>();
 
 export type RenderInput = ReactNode | ReactElementLike | Node | string;
 
@@ -120,14 +121,21 @@ async function transformElement(element: RenderInput, options?: PipelineOptions)
   return fromJsx(element, options?.jsx);
 }
 
-/** Resolves the renderer to use: a caller-supplied one, or the shared global. */
+/** Resolves the renderer to use: a caller-supplied one, or the backend's shared global. */
 async function resolveRenderer(options?: PipelineOptions): Promise<Renderer> {
   if (options && "renderer" in options && options.renderer) {
     return options.renderer;
   }
 
   const imports = await getImports(options?.module);
-  return (globalRenderer ??= new imports.Renderer());
+  let renderer = globalRenderers.get(imports);
+
+  if (!renderer) {
+    renderer = new imports.Renderer();
+    globalRenderers.set(imports, renderer);
+  }
+
+  return renderer;
 }
 
 /** Transforms an input into a node tree and extracts its emojis. */

--- a/takumi-js/src/wasm/index.ts
+++ b/takumi-js/src/wasm/index.ts
@@ -1,3 +1,56 @@
+import autoModule from "@takumi-rs/wasm/auto";
+import {
+  render as renderManaged,
+  renderAnimation as renderAnimationManaged,
+  renderSvg as renderSvgManaged,
+  type RenderAnimationOptions,
+  type RenderInput,
+  type RenderOptions,
+  type RenderSvgOptions,
+} from "../render";
+
 export { default } from "@takumi-rs/wasm/auto";
 export { default as init } from "@takumi-rs/wasm";
 export * from "@takumi-rs/wasm";
+
+export type { RenderAnimationOptions, RenderInput, RenderOptions, RenderSvgOptions };
+
+type ManagedOptions = RenderOptions | RenderSvgOptions | RenderAnimationOptions;
+
+/** Whether the caller already picked a backend, via `renderer` or `module`. */
+function hasBackend(options?: ManagedOptions): boolean {
+  return (
+    !!options &&
+    (("renderer" in options && !!options.renderer) || ("module" in options && !!options.module))
+  );
+}
+
+/**
+ * {@link renderManaged | render} pinned to the WASM backend: never resolves the
+ * native addon, and loads the binary `@takumi-rs/wasm/auto` picks for the host
+ * bundler. Same managed pipeline as the main entry: shared renderer, `fonts`
+ * dedupe, image fetching, emoji extraction.
+ *
+ * @example
+ * ```tsx
+ * import { render } from "takumi-js/wasm";
+ *
+ * const png = await render(<div tw="p-4">Hello</div>, { width: 1200, height: 630 });
+ * ```
+ */
+export function render(element: RenderInput, options?: RenderOptions) {
+  return renderManaged(element, hasBackend(options) ? options : { ...options, module: autoModule });
+}
+
+/** {@link renderSvgManaged | renderSvg} pinned to the WASM backend. */
+export function renderSvg(element: RenderInput, options?: RenderSvgOptions) {
+  return renderSvgManaged(
+    element,
+    hasBackend(options) ? options : { ...options, module: autoModule },
+  );
+}
+
+/** {@link renderAnimationManaged | renderAnimation} pinned to the WASM backend. */
+export function renderAnimation(options: RenderAnimationOptions) {
+  return renderAnimationManaged(hasBackend(options) ? options : { ...options, module: autoModule });
+}

--- a/takumi-js/tests/wasm-entry.test.ts
+++ b/takumi-js/tests/wasm-entry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { render, renderSvg } from "../src/wasm";
+import type { Node } from "@takumi-rs/helpers";
+
+const node: Node = {
+  type: "container",
+  width: 8,
+  height: 8,
+  children: [{ type: "text", text: "wasm" }],
+};
+
+// On Bun the main entry's `#backend` condition picks napi, so output here
+// proves the entry actually forced the WASM backend.
+describe("takumi-js/wasm", () => {
+  test("render() uses the bundled WASM binary", async () => {
+    const png = await render(node, { width: 8, height: 8 });
+
+    expect(png.subarray(0, 4)).toEqual(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+  });
+
+  test("renderSvg() shares the managed WASM renderer", async () => {
+    const svg = await renderSvg(node, { width: 8, height: 8 });
+
+    expect(svg).toStartWith("<svg");
+  });
+
+  test("does not poison the main entry's backend slot", async () => {
+    const { render: renderAuto } = await import("../src");
+    const png = await renderAuto(node, { width: 8, height: 8 });
+
+    expect(png.subarray(0, 4)).toEqual(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+  });
+});


### PR DESCRIPTION
## Why
Downstream users who need the WASM backend (edge deploys, bundlers that mishandle the native `.node` addon) end up hand-rolling what the package already does: init `@takumi-rs/wasm/auto`, cache a renderer across requests, and dedupe font registrations with their own key set. sveltekit-og's takumi integration is a live example — it reimplements the internal init dance and carries a font-dedupe bug the built-in `FontRegistry` doesn't have.

## What
- `takumi-js/wasm` exports managed `render`/`renderSvg`/`renderAnimation` pinned to the WASM backend via `@takumi-rs/wasm/auto`, on top of the existing raw re-exports.
- `getImports` caches auto and forced-WASM backends in separate slots, so a forced call never receives a cached napi backend; the shared renderer is now cached per backend.
- `module` option widened to `BackendModule` (accepts the function/promise loader forms `getImports` already handled).
- Docs: pinning WASM by import path, the managed renderer lifecycle, and `fonts` dedupe semantics.
- Bun test covering the wasm entry and slot isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WASM-specific rendering entry points for PNG, SVG, and animation output.
  * Added documentation for selecting the WASM backend in bundler and deployment environments.
  * Rendering now reuses separate renderer instances for each backend while preserving custom renderer options.

* **Bug Fixes**
  * Improved backend isolation so native and WASM rendering selections do not interfere with each other.
  * Added safer retry behavior when backend loading fails.

* **Documentation**
  * Clarified renderer reuse and font registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->