### PR TITLE
Docs: add Nitro integration page

### DIFF
--- a/docs/content/docs/integration/meta.json
+++ b/docs/content/docs/integration/meta.json
@@ -1,5 +1,5 @@
 {
   "defaultOpen": true,
   "icon": "ToyBrick",
-  "pages": ["nextjs", "fumapress", "nuxt", "sveltekit", "tanstack-start", "astro"]
+  "pages": ["nextjs", "fumapress", "nuxt", "sveltekit", "tanstack-start", "nitro", "astro"]
 }

--- a/docs/content/docs/integration/nitro.mdx
+++ b/docs/content/docs/integration/nitro.mdx
@@ -1,0 +1,64 @@
+---
+title: Nitro
+description: Use Takumi to render your React components on the server.
+---
+
+<Steps>
+  <Step>
+    ### Install Takumi
+
+    Nitro does not ship React, so install it alongside for JSX.
+
+    ```npm
+    npm i takumi-js react
+    ```
+
+  </Step>
+  <Step>
+    ### Create a server route
+
+    Nitro handlers can return a `Response`, so return an `ImageResponse` directly.
+
+    ```tsx title="routes/og.png.tsx"
+    import { defineHandler } from "nitro";
+    import ImageResponse from "takumi-js/response";
+
+    export default defineHandler((event) => {
+      const url = new URL(event.req.url);
+      const title = url.searchParams.get("title") ?? "Takumi + Nitro";
+      const description =
+        url.searchParams.get("description") ?? "Render OG images from a Nitro route.";
+
+      return new ImageResponse(
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            padding: "64px",
+            backgroundImage: "linear-gradient(to bottom right, #fff1f2, #fecdd3)",
+          }}
+        >
+          <p style={{ fontSize: 72, fontWeight: 700, color: "#111827" }}>{title}</p>
+          <p style={{ fontSize: 42, fontWeight: 500, color: "#4b5563" }}>{description}</p>
+        </div>,
+        {
+          width: 1200,
+          height: 630,
+        },
+      );
+    });
+    ```
+
+  </Step>
+  <Step>
+    ### Request the endpoint
+
+    Visit `/og.png?title=Hello&description=From%20Nitro`.
+
+    Takumi picks the render backend from the deployment target: native bindings on the Node preset, WebAssembly on edge presets. No config is needed.
+
+  </Step>
+</Steps>

--- a/docs/content/docs/integration/nitro.mdx
+++ b/docs/content/docs/integration/nitro.mdx
@@ -1,26 +1,25 @@
 ---
 title: Nitro
-description: Use Takumi to render your React components on the server.
+description: Render OG images from a Nitro server route.
 ---
 
 <Steps>
   <Step>
     ### Install Takumi
 
-    Nitro does not ship React, so install it alongside for JSX.
-
     ```npm
-    npm i takumi-js react
+    npm i takumi-js
     ```
 
   </Step>
   <Step>
     ### Create a server route
 
-    Nitro handlers can return a `Response`, so return an `ImageResponse` directly.
+    Build the node tree with [helpers](/docs/helpers), so no JSX setup is needed. Nitro handlers can return a `Response`, so return an `ImageResponse` directly.
 
-    ```tsx title="routes/og.png.tsx"
+    ```ts title="routes/og.png.ts"
     import { defineHandler } from "nitro";
+    import { container, text } from "takumi-js/helpers";
     import ImageResponse from "takumi-js/response";
 
     export default defineHandler((event) => {
@@ -30,8 +29,8 @@ description: Use Takumi to render your React components on the server.
         url.searchParams.get("description") ?? "Render OG images from a Nitro route.";
 
       return new ImageResponse(
-        <div
-          style={{
+        container({
+          style: {
             width: "100%",
             height: "100%",
             display: "flex",
@@ -39,11 +38,12 @@ description: Use Takumi to render your React components on the server.
             justifyContent: "center",
             padding: "64px",
             backgroundImage: "linear-gradient(to bottom right, #fff1f2, #fecdd3)",
-          }}
-        >
-          <p style={{ fontSize: 72, fontWeight: 700, color: "#111827" }}>{title}</p>
-          <p style={{ fontSize: 42, fontWeight: 500, color: "#4b5563" }}>{description}</p>
-        </div>,
+          },
+          children: [
+            text(title, { fontSize: 72, fontWeight: 700, color: "#111827" }),
+            text(description, { fontSize: 42, fontWeight: 500, color: "#4b5563" }),
+          ],
+        }),
         {
           width: 1200,
           height: 630,


### PR DESCRIPTION
## Why
Nitro deploys the same handler across Node and edge targets, and Takumi already resolves the right backend for each, but the docs had no page showing the setup.

## What
Add `integration/nitro.mdx`: install `takumi-js`, build the tree with `container`/`text` helpers (no React or JSX setup), return an `ImageResponse` from a `defineHandler` route, note that backend selection needs no config. Register the page in `meta.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Nitro” to the integrations documentation index.
  * Introduced a new Nitro integration guide with step-by-step setup: installing Takumi, creating a Nitro server route that generates JSX-based `ImageResponse`, and using `/og.png` with query parameters.
  * Documented how the render backend is automatically selected based on the Nitro deployment target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->