### PR TITLE
JS: fall back to the WASM backend in a WebContainer

### DIFF
--- a/.tegami/webcontainer-wasm-fallback.md
+++ b/.tegami/webcontainer-wasm-fallback.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:takumi-js:
+    type: patch
+---
+
+### Fall back to the WASM backend in a WebContainer
+
+Unbundled runs (e.g. `nitro dev` externalizing the package) resolve `#backend`
+with Node's default conditions, so the native addon wins even when the host set
+`unwasm`. The node backend now detects `process.versions.webcontainer` and loads
+the WASM backend instead.

--- a/takumi-js/src/backend/node.ts
+++ b/takumi-js/src/backend/node.ts
@@ -3,10 +3,19 @@ import type { LoadBackend } from "./types";
 // Dynamic import so bundlers don't inline the native addon — its `.node` binary
 // must resolve from node_modules at runtime, which a bundled-in copy breaks.
 // Selected by the `node`/`bun` condition, so it never reaches a worker/edge bundle.
-export const loadBackend: LoadBackend = () =>
+const loadNative: LoadBackend = () =>
   import("@takumi-rs/core").catch((cause) => {
     throw new Error(
       "Failed to load the native @takumi-rs/core backend. On a runtime without the native addon, pass a `module` (a WASM binary) to render with the WASM backend instead.",
       { cause },
     );
   });
+
+// WebContainer can't load native addons, and unbundled runs (e.g. `nitro dev`
+// externalizing this package) resolve `#backend` with Node's default conditions,
+// so the `node` condition lands here even when the host set `unwasm`. Detect it
+// (the same signal Next.js and SvelteKit use) and reroute to the WASM backend.
+export const loadBackend: LoadBackend = (module) =>
+  typeof process !== "undefined" && process.versions?.webcontainer
+    ? import("./wasm").then((backend) => backend.loadBackend(module))
+    : loadNative(module);


### PR DESCRIPTION
## Why
takumi-js 2.0.3 still loads the napi backend on StackBlitz. Nitro sets the `unwasm` condition, but only its bundler sees it — `nitro dev` externalizes the package, so Node resolves `#backend` with its default conditions and the `node` key wins. A WebContainer can't load the native addon, so the render fails.

## What
The node backend checks `process.versions.webcontainer` (the signal Next.js, SvelteKit, and Angular CLI use) and reroutes to the WASM backend, which loads its binary from node_modules via `readFileSync`. Everything else keeps the condition-based selection. Verified by rendering under a loader hook that blocks `@takumi-rs/core`: with the flag the WASM path renders; without it the native path is attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility in WebContainer environments by automatically using the WebAssembly backend when the native backend is unavailable or unsuitable.
  * Enhanced backend loading errors with clearer failure details.

* **Documentation**
  * Added guidance for configuring and using the WebAssembly fallback in unbundled WebContainer runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->