### PR TITLE
Helpers: resolve hooks with an installed dispatcher, render Preact trees

### DIFF
--- a/.tegami/hook-dispatcher-preact.md
+++ b/.tegami/hook-dispatcher-preact.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:@takumi-rs/helpers:
+    type: minor
+---
+
+### Resolve hooks without react-dom and render Preact trees
+
+`fromJsx` installs a server-semantics hook dispatcher instead of falling back
+to `react-dom/server`, handles context providers and consumers natively, and
+renders Preact subtrees through `preact-render-to-string`. The `react-dom`
+peer dependency is gone; `preact` and `preact-render-to-string` are new
+optional peers.

--- a/bun.lock
+++ b/bun.lock
@@ -222,6 +222,8 @@
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "lucide-react": "catalog:",
+        "preact": "^10.28.2",
+        "preact-render-to-string": "^6.6.4",
         "react": "catalog:",
         "react-dom": "catalog:",
         "tsdown": "catalog:",
@@ -229,12 +231,14 @@
         "unrun": "catalog:",
       },
       "peerDependencies": {
+        "preact": "^10.0.0",
+        "preact-render-to-string": "^6.0.0",
         "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
       },
       "optionalPeers": [
+        "preact",
+        "preact-render-to-string",
         "react",
-        "react-dom",
       ],
     },
     "takumi-image-response": {
@@ -2052,6 +2056,10 @@
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "preact": ["preact@10.29.7", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.7.0", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q=="],
 
     "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -42,6 +42,8 @@ Length and color shorthands return CSS strings. `vw`/`vh` are viewport width/hei
 | `fromJsx(element, options?)` | `takumi-js/helpers/jsx`  | Convert JSX or a React element to `{ node, stylesheets }`. |
 | `fromHtml(html)`             | `takumi-js/helpers/html` | Convert an HTML string to `{ node, stylesheets }`.         |
 
+`fromJsx` resolves hooks and context itself: components using `useState`, `useContext`, or `use()` render with server semantics (initial state, no effects), without loading `react-dom`. Preact trees render through `preact-render-to-string` when it is installed.
+
 ## Images & emoji
 
 | Helper                           | Import                    | Use                                                                                               |

--- a/takumi-helpers/package.json
+++ b/takumi-helpers/package.json
@@ -99,6 +99,8 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "lucide-react": "catalog:",
+    "preact": "^10.28.2",
+    "preact-render-to-string": "^6.6.4",
     "react": "catalog:",
     "react-dom": "catalog:",
     "tsdown": "catalog:",
@@ -106,11 +108,15 @@
     "unrun": "catalog:"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "preact": "^10.0.0",
+    "preact-render-to-string": "^6.0.0",
+    "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
-    "react-dom": {
+    "preact": {
+      "optional": true
+    },
+    "preact-render-to-string": {
       "optional": true
     },
     "react": {

--- a/takumi-helpers/src/jsx/dispatcher.ts
+++ b/takumi-helpers/src/jsx/dispatcher.ts
@@ -1,0 +1,178 @@
+import type { ReactNode } from "react";
+
+/**
+ * Hooks read the active dispatcher from React's shared internals; only a
+ * renderer installs one. Installing a minimal server-semantics dispatcher
+ * (initial state, no effects) around synchronous component calls resolves hooks
+ * without react-dom/server, the same way react-ssr-prepass does:
+ * https://github.com/FormidableLabs/react-ssr-prepass
+ */
+
+// React 19 and 18 internals keys; both shapes are feature-detected below.
+const CLIENT_INTERNALS = "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE";
+const SECRET_INTERNALS = "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED";
+
+export interface RenderEnv {
+  contexts: ReadonlyMap<unknown, unknown>;
+  ids: { current: number };
+}
+
+interface DispatcherSlot {
+  get(): unknown;
+  set(value: unknown): void;
+}
+
+interface TrackedThenable extends PromiseLike<unknown> {
+  status?: string;
+  value?: unknown;
+  reason?: unknown;
+}
+
+let slotPromise: Promise<DispatcherSlot | null> | undefined;
+
+export function getProperty(object: unknown, key: string): unknown {
+  return typeof object === "object" && object !== null && key in object
+    ? (object as Record<string, unknown>)[key]
+    : undefined;
+}
+
+function isThenable(value: unknown): value is TrackedThenable {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
+}
+
+function resolveSlot(react: unknown): DispatcherSlot | null {
+  const client = getProperty(react, CLIENT_INTERNALS);
+  if (typeof client === "object" && client !== null && "H" in client) {
+    const internals = client as { H: unknown };
+
+    return {
+      get: () => internals.H,
+      set: (value) => {
+        internals.H = value;
+      },
+    };
+  }
+
+  const dispatcherRef = getProperty(getProperty(react, SECRET_INTERNALS), "ReactCurrentDispatcher");
+  if (typeof dispatcherRef === "object" && dispatcherRef !== null && "current" in dispatcherRef) {
+    const ref = dispatcherRef as { current: unknown };
+
+    return {
+      get: () => ref.current,
+      set: (value) => {
+        ref.current = value;
+      },
+    };
+  }
+
+  return null;
+}
+
+function getSlot(): Promise<DispatcherSlot | null> {
+  slotPromise ??= import("react")
+    .then((module) => resolveSlot(module.default ?? module))
+    .catch(() => null);
+
+  return slotPromise;
+}
+
+export function readContext(env: RenderEnv, context: unknown): unknown {
+  return env.contexts.has(context)
+    ? env.contexts.get(context)
+    : getProperty(context, "_currentValue");
+}
+
+const noop = () => {};
+
+function createDispatcher(env: RenderEnv): Record<string, unknown> {
+  const read = (context: unknown) => readContext(env, context);
+
+  return {
+    readContext: read,
+    useContext: read,
+    use: (usable: unknown): unknown => {
+      if (isThenable(usable)) {
+        if (usable.status === "fulfilled") return usable.value;
+        if (usable.status === "rejected") throw usable.reason;
+        throw usable;
+      }
+
+      return read(usable);
+    },
+    useState: (initial: unknown) => [typeof initial === "function" ? initial() : initial, noop],
+    useReducer: (_reducer: unknown, initialArg: unknown, init?: (arg: unknown) => unknown) => [
+      init ? init(initialArg) : initialArg,
+      noop,
+    ],
+    useMemo: (factory: () => unknown) => factory(),
+    useCallback: (callback: unknown) => callback,
+    useRef: (initial: unknown) => ({ current: initial }),
+    useEffect: noop,
+    useLayoutEffect: noop,
+    useInsertionEffect: noop,
+    useImperativeHandle: noop,
+    useDebugValue: noop,
+    useDeferredValue: (value: unknown) => value,
+    useTransition: () => [false, noop],
+    useOptimistic: (state: unknown) => [state, noop],
+    useActionState: (_action: unknown, initial: unknown) => [initial, noop, false],
+    useSyncExternalStore: (
+      _subscribe: unknown,
+      getSnapshot: () => unknown,
+      getServerSnapshot?: () => unknown,
+    ) => (getServerSnapshot ?? getSnapshot)(),
+    useId: () => `:t${env.ids.current++}:`,
+    useCacheRefresh: () => noop,
+    useHostTransitionStatus: () => ({ pending: false, data: null, method: null, action: null }),
+  };
+}
+
+// Bounds `use()` replays; a component creating a fresh promise every render
+// would otherwise replay forever (React warns on the same pattern).
+const MAX_THENABLE_REPLAYS = 64;
+
+/**
+ * Calls a function component with the dispatcher installed, replaying the call
+ * when `use()` throws a pending thenable. Without React (or with unrecognized
+ * internals) the component is called bare, so hook-free components still work.
+ */
+export async function callWithDispatcher(
+  component: (props: unknown) => ReactNode,
+  props: unknown,
+  env: RenderEnv,
+): Promise<ReactNode> {
+  const slot = await getSlot();
+  if (!slot) return component(props);
+
+  for (let replays = 0; ; replays++) {
+    const previous = slot.get();
+    slot.set(createDispatcher(env));
+
+    try {
+      return component(props);
+    } catch (thrown) {
+      if (!isThenable(thrown) || replays >= MAX_THENABLE_REPLAYS) throw thrown;
+
+      await settleThenable(thrown);
+    } finally {
+      slot.set(previous);
+    }
+  }
+}
+
+// Stamps resolution onto the thenable (React's own convention) so the replayed
+// `use()` can read it synchronously.
+async function settleThenable(thenable: TrackedThenable): Promise<void> {
+  try {
+    thenable.value = await thenable;
+    thenable.status = "fulfilled";
+  } catch (reason) {
+    thenable.reason = reason;
+    thenable.status = "rejected";
+  }
+}

--- a/takumi-helpers/src/jsx/dispatcher.ts
+++ b/takumi-helpers/src/jsx/dispatcher.ts
@@ -89,8 +89,12 @@ export function readContext(env: RenderEnv, context: unknown): unknown {
 
 const noop = () => {};
 
-function createDispatcher(env: RenderEnv): Record<string, unknown> {
+function createDispatcher(env: RenderEnv, callId: number): Record<string, unknown> {
   const read = (context: unknown) => readContext(env, context);
+
+  // Fresh per dispatcher, so a `use()` replay hands out the same IDs; callId
+  // keeps them unique across components sharing the traversal counter.
+  let localId = 0;
 
   return {
     readContext: read,
@@ -126,7 +130,7 @@ function createDispatcher(env: RenderEnv): Record<string, unknown> {
       getSnapshot: () => unknown,
       getServerSnapshot?: () => unknown,
     ) => (getServerSnapshot ?? getSnapshot)(),
-    useId: () => `:t${env.ids.current++}:`,
+    useId: () => `:t${callId}-${localId++}:`,
     useCacheRefresh: () => noop,
     useHostTransitionStatus: () => ({ pending: false, data: null, method: null, action: null }),
   };
@@ -149,19 +153,24 @@ export async function callWithDispatcher(
   const slot = await getSlot();
   if (!slot) return component(props);
 
+  const callId = env.ids.current++;
+
   for (let replays = 0; ; replays++) {
     const previous = slot.get();
-    slot.set(createDispatcher(env));
+    slot.set(createDispatcher(env, callId));
 
+    let thrown: unknown;
     try {
       return component(props);
-    } catch (thrown) {
-      if (!isThenable(thrown) || replays >= MAX_THENABLE_REPLAYS) throw thrown;
-
-      await settleThenable(thrown);
+    } catch (error) {
+      thrown = error;
     } finally {
       slot.set(previous);
     }
+
+    if (!isThenable(thrown) || replays >= MAX_THENABLE_REPLAYS) throw thrown;
+
+    await settleThenable(thrown);
   }
 }
 

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -4,6 +4,7 @@ import type { Node, NodeMetadata, ReactElementLike } from "../types";
 import { extractAttributes, getPresets, type HtmlProps } from "./metadata";
 export type { HtmlProps } from "./metadata";
 import { fromStaticMarkup, type FromStaticMarkupOptions } from "../html/markup";
+import { callWithDispatcher, getProperty, readContext, type RenderEnv } from "./dispatcher";
 import { defaultStylePresets } from "./style-presets";
 import { serializeSvg } from "./svg";
 import {
@@ -41,7 +42,7 @@ export interface FromJsxOptions {
   tailwindClassesProperty?: string;
 }
 
-interface ResolvedFromJsxOptions {
+interface ResolvedFromJsxOptions extends RenderEnv {
   defaultStyles: typeof defaultStylePresets | false;
   presets?: typeof defaultStylePresets;
   tailwindClassesProperty: string;
@@ -61,30 +62,6 @@ function emptyTraversalResult(): FromJsxTraversalResult {
   return { nodes: [], stylesheets: [] };
 }
 
-type ReactModuleLike = {
-  default?: ReactModuleLike;
-  Fragment?: unknown;
-  createElement: (
-    type: unknown,
-    props: Record<string, unknown> | null,
-    ...children: unknown[]
-  ) => ReactNode;
-};
-
-type ReactDomServerModule = {
-  default?: ReactDomServerModule;
-  renderToStaticMarkup: (node: ReactNode) => string;
-};
-
-const INVALID_HOOK_PATTERNS = [
-  /Invalid hook call\./,
-  /Cannot read properties of null \(reading 'use[A-Z][A-Za-z]+'\)/,
-  /null is not an object \(evaluating 'dispatcher\.use[A-Z][A-Za-z]+'\)/,
-];
-
-let reactDomServerPromise: Promise<ReactDomServerModule | null> | undefined;
-let reactModulePromise: Promise<ReactModuleLike | null> | undefined;
-
 export async function fromJsx(
   element: ReactNode | ReactElementLike,
   options?: FromJsxOptions,
@@ -93,19 +70,10 @@ export async function fromJsx(
     defaultStyles: resolveDefaultStyles(options),
     presets: getPresets(options?.defaultStyles),
     tailwindClassesProperty: options?.tailwindClassesProperty ?? "tw",
+    contexts: new Map<unknown, unknown>(),
+    ids: { current: 0 },
   } satisfies ResolvedFromJsxOptions;
-  const result = await fromJsxInternal(element, resolvedOptions).catch(async (error) => {
-    if (!shouldFallbackToReactDomServer(error)) {
-      throw error;
-    }
-
-    const fallbackResult = await renderWithReactDomServer(element, resolvedOptions);
-    if (fallbackResult) {
-      return fallbackResult;
-    }
-
-    return fromJsxInternal(element, resolvedOptions);
-  });
+  const result = await fromJsxInternal(element, resolvedOptions);
   const nodes = result.nodes;
 
   let node: Node;
@@ -168,49 +136,67 @@ function resolveDefaultStyles(options?: FromJsxOptions): typeof defaultStylePres
   return defaultStylePresets;
 }
 
-function containsReactContextProvider(element: ReactNode | ReactElementLike): boolean {
-  if (!isValidElement(element)) {
-    return false;
+const REACT_CONTEXT_TYPE = Symbol.for("react.context");
+const REACT_PROVIDER_TYPE = Symbol.for("react.provider");
+const REACT_CONSUMER_TYPE = Symbol.for("react.consumer");
+
+/**
+ * Handles context provider/consumer elements natively: providers push their
+ * value onto the traversal's context map (read back by the dispatcher's
+ * `useContext`), consumers call their render prop with the current value.
+ * A `react.context` element type is a provider on React 19 and a legacy
+ * consumer on 18; the render-prop children shape disambiguates.
+ */
+function tryHandleContextElement(
+  element: ReactElementLike,
+  options: ResolvedFromJsxOptions,
+): Promise<FromJsxTraversalResult> | undefined {
+  const type = element.type;
+  if (typeof type !== "object" || type === null) return;
+
+  const tag = getProperty(type, "$$typeof");
+
+  if (tag === REACT_PROVIDER_TYPE) {
+    return collectChildrenWithContext(element, getProperty(type, "_context"), options);
   }
 
-  if (typeof element.type !== "object" || element.type === null || !("$$typeof" in element.type)) {
-    return false;
+  if (tag === REACT_CONSUMER_TYPE) {
+    return renderConsumer(element, getProperty(type, "_context") ?? type, options);
   }
 
-  return (
-    element.type.$$typeof === Symbol.for("react.context") ||
-    element.type.$$typeof === Symbol.for("react.provider")
-  );
-}
-
-function shouldFallbackToReactDomServer(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return INVALID_HOOK_PATTERNS.some((pattern) => pattern.test(error.message));
-}
-
-async function runWithSuppressedInvalidHookWarning<T>(callback: () => Promise<T>): Promise<T> {
-  const originalConsoleError = console.error;
-
-  console.error = (...args: unknown[]) => {
-    const [firstArg] = args;
-    if (
-      typeof firstArg === "string" &&
-      INVALID_HOOK_PATTERNS.some((pattern) => pattern.test(firstArg))
-    ) {
-      return;
+  if (tag === REACT_CONTEXT_TYPE) {
+    if (typeof getElementChildren(element) === "function") {
+      return renderConsumer(element, type, options);
     }
 
-    originalConsoleError(...args);
-  };
-
-  try {
-    return await callback();
-  } finally {
-    console.error = originalConsoleError;
+    return collectChildrenWithContext(element, type, options);
   }
+}
+
+function collectChildrenWithContext(
+  element: ReactElementLike,
+  context: unknown,
+  options: ResolvedFromJsxOptions,
+): Promise<FromJsxTraversalResult> {
+  const contexts = new Map(options.contexts);
+  contexts.set(context, getProperty(element.props, "value"));
+
+  return collectChildren(element, { ...options, contexts });
+}
+
+function isRenderProp(value: unknown): value is (value: unknown) => ReactNode {
+  return typeof value === "function";
+}
+
+function renderConsumer(
+  element: ReactElementLike,
+  context: unknown,
+  options: ResolvedFromJsxOptions,
+): Promise<FromJsxTraversalResult> {
+  const children = getElementChildren(element);
+  if (!isRenderProp(children)) return collectChildren(element, options);
+
+  return fromJsxInternal(children(readContext(options, context)), options);
 }
 
 async function renderFunctionComponent(
@@ -218,7 +204,7 @@ async function renderFunctionComponent(
   props: unknown,
   options: ResolvedFromJsxOptions,
 ): Promise<FromJsxTraversalResult> {
-  return runWithSuppressedInvalidHookWarning(() => fromJsxInternal(component(props), options));
+  return fromJsxInternal(await callWithDispatcher(component, props, options), options);
 }
 
 function tryHandleComponentWrapper(
@@ -261,64 +247,45 @@ function getElementChildren(element: ReactElementLike): ReactNode | undefined {
   }
 }
 
-function isReactModuleLike(module: unknown): module is ReactModuleLike {
-  return (
-    typeof module === "object" &&
-    module !== null &&
-    "createElement" in module &&
-    typeof module.createElement === "function"
-  );
+/**
+ * Preact vnodes stamp an own `constructor: undefined` (its JSON-injection
+ * guard), which no React element or plain element literal has.
+ */
+function isPreactVNode(element: ReactElementLike): boolean {
+  return element.constructor === undefined;
 }
 
-function isReactDomServerModule(module: unknown): module is ReactDomServerModule {
-  return (
-    typeof module === "object" &&
-    module !== null &&
-    "renderToStaticMarkup" in module &&
-    typeof module.renderToStaticMarkup === "function"
-  );
-}
+let preactRenderPromise: Promise<((vnode: unknown) => string) | null> | undefined;
 
-async function getReactModule(): Promise<ReactModuleLike | null> {
-  reactModulePromise ??= import("react")
+function getPreactRender(): Promise<((vnode: unknown) => string) | null> {
+  return (preactRenderPromise ??= import("preact-render-to-string")
     .then((module) => {
-      const resolvedModule = (module.default ?? module) as unknown;
-      return isReactModuleLike(resolvedModule) ? resolvedModule : null;
-    })
-    .catch(() => null);
+      for (const render of [module.renderToStaticMarkup, module.renderToString, module.default]) {
+        // Parameter widening at the module boundary; the vnode handed in is
+        // always a Preact one.
+        if (typeof render === "function") return render as (vnode: unknown) => string;
+      }
 
-  return reactModulePromise;
+      return null;
+    })
+    .catch(() => null));
 }
 
-async function getReactDomServerModule(): Promise<ReactDomServerModule | null> {
-  reactDomServerPromise ??= import("react-dom/server")
-    .then((module) => {
-      const resolvedModule = (module.default ?? module) as unknown;
-      return isReactDomServerModule(resolvedModule) ? resolvedModule : null;
-    })
-    .catch(() => null);
-
-  return reactDomServerPromise;
-}
-
-async function renderWithReactDomServer(
-  element: ReactNode | ReactElementLike,
+/**
+ * Preact hooks live on Preact's mangled internals, which are not stable enough
+ * to shim the way the React dispatcher is; its own renderer is ~4 kB, so a
+ * Preact subtree renders through preact-render-to-string into the markup path.
+ * Without it installed, the caller falls through to native traversal, which
+ * still handles hook-free trees.
+ */
+async function renderWithPreact(
+  element: ReactElementLike,
   options: ResolvedFromJsxOptions,
 ): Promise<FromJsxTraversalResult | null> {
-  const [reactModule, reactDomServerModule] = await Promise.all([
-    getReactModule(),
-    getReactDomServerModule(),
-  ]);
+  const render = await getPreactRender();
+  if (!render) return null;
 
-  if (!reactModule || !reactDomServerModule) {
-    return null;
-  }
-
-  const markup = reactDomServerModule.renderToStaticMarkup(
-    reactModule.createElement(reactModule.Fragment ?? undefined, null, element),
-  );
-
-  return fromStaticMarkup(markup, {
+  return fromStaticMarkup(render(element), {
     defaultStyles: options.defaultStyles,
     tailwindClassesProperty: options.tailwindClassesProperty,
   } satisfies FromStaticMarkupOptions);
@@ -420,14 +387,15 @@ async function processReactElement(
   element: ReactElementLike,
   options: ResolvedFromJsxOptions,
 ): Promise<FromJsxTraversalResult> {
-  if (containsReactContextProvider(element)) {
-    const fallbackResult = await renderWithReactDomServer(element, options);
-    if (fallbackResult) {
-      return fallbackResult;
+  if (isPreactVNode(element)) {
+    const preactResult = await renderWithPreact(element, options);
+    if (preactResult) {
+      return preactResult;
     }
-
-    return collectChildren(element, options);
   }
+
+  const contextResult = tryHandleContextElement(element, options);
+  if (contextResult !== undefined) return contextResult;
 
   if (isFunctionComponent(element.type)) {
     return renderFunctionComponent(element.type, element.props, options);

--- a/takumi-helpers/tests/jsx/hooks-dispatcher.test.tsx
+++ b/takumi-helpers/tests/jsx/hooks-dispatcher.test.tsx
@@ -54,8 +54,25 @@ describe("hook resolution through the installed dispatcher", () => {
 
     const [a, b] = await Promise.all([fromJsx(<Component />), fromJsx(<Component />)]);
 
-    expect(a.node).toMatchObject({ type: "text", text: ":t0: :t1:" });
+    expect(a.node).toMatchObject({ type: "text", text: ":t0-0: :t0-1:" });
     expect(a.node).toEqual(b.node);
+  });
+
+  test("useId is stable across use() replays", async () => {
+    const pending = new Promise<string>((resolve) => setTimeout(() => resolve("late"), 1));
+    const Component = () => {
+      const id = useId();
+
+      return (
+        <p>
+          {id} {use(pending)}
+        </p>
+      );
+    };
+
+    const { node } = await fromJsx(<Component />);
+
+    expect(node).toMatchObject({ type: "text", text: ":t0-0: late" });
   });
 
   test("use() suspends on a pending promise and replays", async () => {

--- a/takumi-helpers/tests/jsx/hooks-dispatcher.test.tsx
+++ b/takumi-helpers/tests/jsx/hooks-dispatcher.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createContext,
+  use,
+  useContext,
+  useId,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { fromJsx } from "../../src/jsx";
+
+describe("hook resolution through the installed dispatcher", () => {
+  test("resolves state, memo, ref, reducer, and store hooks", async () => {
+    const Component = () => {
+      const [count] = useState(() => 3);
+      const doubled = useMemo(() => count * 2, [count]);
+      const ref = useRef("ref");
+      const [word] = useReducer((state: string) => state, "reduced");
+      const stored = useSyncExternalStore(
+        () => () => {},
+        () => "client",
+        () => "server",
+      );
+
+      return (
+        <p>
+          {count} {doubled} {ref.current} {word} {stored}
+        </p>
+      );
+    };
+
+    const { node } = await fromJsx(<Component />);
+
+    expect(node).toMatchObject({
+      type: "text",
+      text: "3 6 ref reduced server",
+    });
+  });
+
+  test("useId is deterministic per render", async () => {
+    const Component = () => {
+      const first = useId();
+      const second = useId();
+
+      return (
+        <p>
+          {first} {second}
+        </p>
+      );
+    };
+
+    const [a, b] = await Promise.all([fromJsx(<Component />), fromJsx(<Component />)]);
+
+    expect(a.node).toMatchObject({ type: "text", text: ":t0: :t1:" });
+    expect(a.node).toEqual(b.node);
+  });
+
+  test("use() suspends on a pending promise and replays", async () => {
+    const value = Promise.resolve("resolved");
+    const Component = () => <p>{use(value)}</p>;
+
+    const { node } = await fromJsx(<Component />);
+
+    expect(node).toMatchObject({ type: "text", text: "resolved" });
+  });
+
+  test("useContext reads nested provider values natively", async () => {
+    const Greeting = createContext("default");
+
+    const Inner = () => <p>{useContext(Greeting)}</p>;
+
+    const { node } = await fromJsx(
+      <div>
+        <Inner />
+        <Greeting.Provider value="outer">
+          <Inner />
+          <Greeting.Provider value="inner">
+            <Inner />
+          </Greeting.Provider>
+        </Greeting.Provider>
+      </div>,
+    );
+
+    expect(node).toMatchObject({
+      type: "container",
+      children: [
+        { type: "text", text: "default" },
+        { type: "text", text: "outer" },
+        { type: "text", text: "inner" },
+      ],
+    });
+  });
+
+  test("consumer render prop receives the provided value", async () => {
+    const Greeting = createContext("default");
+
+    const { node } = await fromJsx(
+      <Greeting.Provider value="provided">
+        <Greeting.Consumer>{(value) => <p>{value}</p>}</Greeting.Consumer>
+      </Greeting.Provider>,
+    );
+
+    expect(node).toMatchObject({ type: "text", text: "provided" });
+  });
+
+  test("hooks and context compose across component boundaries", async () => {
+    const Theme = createContext("light");
+
+    const Label = ({ suffix }: { suffix: string }) => {
+      const theme = use(Theme);
+      const label = useMemo(() => `${theme}-${suffix}`, [theme, suffix]);
+
+      return <p tw="font-bold">{label}</p>;
+    };
+
+    const { node } = await fromJsx(
+      <Theme.Provider value="dark">
+        <Label suffix="mode" />
+      </Theme.Provider>,
+    );
+
+    expect(node).toMatchObject({
+      type: "text",
+      text: "dark-mode",
+      tw: "font-bold",
+    });
+  });
+});

--- a/takumi-helpers/tests/jsx/preact.test.ts
+++ b/takumi-helpers/tests/jsx/preact.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { h } from "preact";
+import { useMemo, useState } from "preact/hooks";
+import { fromJsx } from "../../src/jsx";
+import type { ReactElementLike } from "../../src/types";
+
+function asElement(vnode: unknown): ReactElementLike {
+  return vnode as ReactElementLike;
+}
+
+describe("preact trees render through preact-render-to-string", () => {
+  test("resolves preact hooks", async () => {
+    const Counter = () => {
+      const [count] = useState(7);
+      const label = useMemo(() => `count ${count}`, [count]);
+
+      return h("p", { tw: "font-bold" }, label);
+    };
+
+    const { node } = await fromJsx(asElement(h("div", null, h(Counter, null))));
+
+    expect(node).toMatchObject({
+      type: "container",
+      tagName: "div",
+      children: [
+        {
+          type: "text",
+          text: "count 7",
+          tw: "font-bold",
+        },
+      ],
+    });
+  });
+
+  test("keeps inline styles from preact host elements", async () => {
+    const { node } = await fromJsx(
+      asElement(h("div", { style: { backgroundColor: "red" } }, "styled")),
+    );
+
+    expect(node).toMatchObject({
+      type: "text",
+      text: "styled",
+      style: expect.objectContaining({ backgroundColor: "red" }),
+    });
+  });
+});


### PR DESCRIPTION
## Why
Components using hooks or context forced `fromJsx` through `renderToStaticMarkup`, so `react-dom/server` (~500 kB) landed in any bundle that includes the helpers, and Preact trees crashed on their first hook.

## What
- `src/jsx/dispatcher.ts` installs a minimal server-semantics dispatcher (initial state, no effects, `use()` with pending-thenable replay) into React's shared internals around each synchronous component call — the react-ssr-prepass approach. React 19 and 18 internals are feature-detected; without React, hook-free components still render bare.
- Context providers and consumers are handled natively with an immutable per-traversal context map, replacing the `react-dom/server` fallback entirely. The error-sniffing fallback machinery is deleted; `react-dom` no longer appears anywhere in dist.
- Preact vnodes (detected by their own `constructor: undefined` stamp) render through `preact-render-to-string` when installed, falling back to native traversal otherwise. `preact` and `preact-render-to-string` join as optional peers; the `react-dom` peer is removed.
- New tests cover hook resolution, `useId` determinism, `use()` replay, nested providers, consumer render props, and Preact hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `fromJsx` server rendering to resolve React hooks and nested context with server-like semantics, including deterministic `useId` and replaying resolved `use()` values.
  * Added server-side rendering support for Preact trees, including Preact hook execution and preservation of inline `style` props.
* **Documentation**
  * Updated “Parsing templates” guidance for `fromJsx` to reflect server semantics and optional Preact rendering.
* **Tests**
  * Added Bun test coverage for hook dispatching behavior and Preact JSX rendering.
* **Compatibility**
  * Updated peer dependencies to prefer optional Preact packages instead of `react-dom`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->