### PR TITLE
NAPI: drop unused @types/react-dom; JS: fix README hard break

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -275,7 +275,6 @@
         "@napi-rs/cli": "3.7.2",
         "@types/bun": "catalog:",
         "@types/react": "catalog:",
-        "@types/react-dom": "catalog:",
         "csstype": "catalog:",
         "lucide-react": "catalog:",
         "mitata": "^1.0.34",

--- a/takumi-js/README.md
+++ b/takumi-js/README.md
@@ -3,7 +3,8 @@
 
 # takumi-js
 
-**Render JSX to SVG or images. Drop-in next/og replacement.**  
+**Render JSX to SVG or images. Drop-in next/og replacement.**
+
 OG cards, banners, and lightweight animations from one Rust engine, no headless browser required.
 
 [Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground)

--- a/takumi-js/README.md
+++ b/takumi-js/README.md
@@ -3,7 +3,7 @@
 
 # takumi-js
 
-**Render JSX to SVG or images. Drop-in next/og replacement.**
+**Render JSX to SVG or images. Drop-in next/og replacement.**  
 OG cards, banners, and lightweight animations from one Rust engine, no headless browser required.
 
 [Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground)

--- a/takumi-napi/README.md
+++ b/takumi-napi/README.md
@@ -3,7 +3,8 @@
 
 # @takumi-rs/core
 
-**Native Node.js bindings for [Takumi](https://github.com/kane50613/takumi), a Rust image rendering engine.**  
+**Native Node.js bindings for [Takumi](https://github.com/kane50613/takumi), a Rust image rendering engine.**
+
 The high-performance N-API runtime that turns node trees into OG cards, banners, and animations, no headless browser required.
 
 [Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground)

--- a/takumi-napi/package.json
+++ b/takumi-napi/package.json
@@ -76,7 +76,6 @@
     "@napi-rs/cli": "3.7.2",
     "@types/bun": "catalog:",
     "@types/react": "catalog:",
-    "@types/react-dom": "catalog:",
     "csstype": "catalog:",
     "lucide-react": "catalog:",
     "mitata": "^1.0.34",

--- a/takumi-wasm/README.md
+++ b/takumi-wasm/README.md
@@ -3,7 +3,8 @@
 
 # @takumi-rs/wasm
 
-**WebAssembly bindings for [Takumi](https://github.com/kane50613/takumi), a Rust image rendering engine.**  
+**WebAssembly bindings for [Takumi](https://github.com/kane50613/takumi), a Rust image rendering engine.**
+
 Render OG cards, banners, and animations on Cloudflare Workers, edge runtimes, and browsers, no headless browser required.
 
 [Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground)


### PR DESCRIPTION
## Why
`bun run knip` fails on an unused `@types/react-dom` in takumi-napi, and the package README taglines cram the bold intro and subtitle into one paragraph (core/wasm via a trailing hard break, takumi-js via a soft wrap that merges them into one line on npm). The root README separates them with a blank line.

## What
Remove the devDependency and put a blank line after the tagline in the takumi-js, @takumi-rs/core, and @takumi-rs/wasm READMEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed introductory taglines in the package READMEs, clarifying “Render JSX to SVG or images” and “Native Node.js bindings for Takumi,” with minor formatting/whitespace normalization (including line-break behavior) while keeping meaning the same.

* **Chores**
  * Updated development dependency type definitions in the native package to adjust the set of included React/Bun-related type packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->