### PR TITLE
Docs: update pnpm native binding hoist guidance

### DIFF
--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -34,11 +34,20 @@ If the issue persists, file an issue on [our GitHub repository](https://github.c
   <Accordion title="Cannot find native binding">
 This happens when the `@takumi-rs/core` package failed to find the native binding.
 
-If you are using package manager with virtual store such as `pnpm` or `yarn`, add the following to your `.npmrc` file and re-run `pnpm i` to allow hoisting of the native binary.
+If you are using package manager with virtual store such as `pnpm` or `yarn`, allow it to hoist the native binary. The following examples are for pnpm; after updating the configuration, re-run `pnpm i`.
+
+```yaml title="pnpm-workspace.yaml"
+publicHoistPattern:
+  - "@takumi-rs/core-*"
+```
+
+With pnpm versions earlier than 10.5.0, add the equivalent setting to `.npmrc` instead:
 
 ```text title=".npmrc"
 public-hoist-pattern[]=@takumi-rs/core-*
 ```
+
+For other package managers, refer to their docs for hoist config instructions.
 
   </Accordion>
   <Accordion title="TypeError: fetch failed">


### PR DESCRIPTION
From pnpm v11 onwards, [only auth/registry settings are read from `.npmrc`](https://pnpm.io/ja/blog/releases/11.0#npmrc-is-authregistry-only), so `pnpm-workspace.yaml` is recommended.
We have specified that settings can also be configured in `.npmrc` for older versions of pnpm.

The reason v10.5.0 is specified is that it is the version where it became possible to include the config in `pnpm-workspace.yaml`.
https://github.com/pnpm/pnpm/releases/tag/v10.5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for resolving “Cannot find native binding” errors.
  * Added pnpm workspace hoisting configuration examples, including instructions for older pnpm versions.
  * Clarified that users of other package managers should consult their respective hoisting configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->