### PR TITLE
Core: fix inline SVG data URIs and null style values

### DIFF
--- a/.tegami/data-uri-svg-hash.md
+++ b/.tegami/data-uri-svg-hash.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Fix inline SVG data URIs truncated at `#`
+
+Percent-escape `#` in data URI bodies so inline SVGs are not cut off at the first fragment delimiter.

--- a/.tegami/null-style-values.md
+++ b/.tegami/null-style-values.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Ignore null style values
+
+Skip `null` and `undefined` style declarations instead of failing to deserialize the style.

--- a/takumi-core/src/layout/node/image.rs
+++ b/takumi-core/src/layout/node/image.rs
@@ -184,7 +184,15 @@ fn resolve_style_size_axis(
 const DATA_URI_PREFIX: &str = "data:";
 
 fn parse_data_uri_image(src: &str) -> ImageResult {
-  let url = DataUrl::process(src).map_err(|_| ImageError::InvalidDataUriFormat)?;
+  // An unescaped `#` (common in inline SVG: `fill="#fff"`, `url(#filter)`) is a URL
+  // fragment delimiter and would truncate the body.
+  let escaped = src.split_once(',').and_then(|(header, body)| {
+    body
+      .contains('#')
+      .then(|| format!("{header},{}", body.replace('#', "%23")))
+  });
+  let url = DataUrl::process(escaped.as_deref().unwrap_or(src))
+    .map_err(|_| ImageError::InvalidDataUriFormat)?;
   let (data, _) = url
     .decode_to_vec()
     .map_err(|_| ImageError::InvalidDataUriFormat)?;
@@ -220,6 +228,8 @@ mod tests {
   use serde_json::from_value;
   use taffy::{Dimension, Size as TaffySize, Style};
 
+  #[cfg(feature = "svg")]
+  use super::parse_data_uri_image;
   use super::{image_url, measure_image_node};
   use crate::{
     Fonts,
@@ -230,6 +240,17 @@ mod tests {
     style::SizingContext,
     viewport::Viewport,
   };
+
+  #[cfg(feature = "svg")]
+  #[test]
+  fn parse_data_uri_svg_with_unescaped_hash() {
+    let source = parse_data_uri_image(
+      "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><rect width='10' height='10' fill='#f00'/></svg>",
+    )
+    .unwrap();
+
+    assert_matches!(source, ImageSource::Svg(_));
+  }
 
   #[test]
   fn deserialize_image_src_from_string() -> std::result::Result<(), serde_json::Error> {

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -10,7 +10,7 @@ use crate::{
   Error,
   error::StyleDeclarationBlockParseError,
   style::{
-    CssInput, CssValueSeed, SizingContext,
+    CssInput, CssUnexpected, CssValueSeed, SizingContext,
     properties::*,
     selector::{PropertyRule, StyleDeclarationParser},
     unexpected_token,
@@ -515,6 +515,12 @@ macro_rules! define_style {
                 }
 
                 let css_input = map.next_value_seed(CssValueSeed)?;
+
+                // `undefined` / `null` values are how JS callers express "no declaration".
+                if matches!(css_input, CssInput::Unexpected(CssUnexpected::Unit)) {
+                  continue;
+                }
+
                 if matches!(property, PropertyId::Custom) {
                   if !matches!(css_input, CssInput::Unexpected(_)) {
                     style.declarations.push(

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -84,6 +84,16 @@ fn test_deserialize_numeric_opacity_preserves_fraction() -> Result<(), serde_jso
   Ok(())
 }
 
+#[test]
+fn test_deserialize_skips_null_declarations() -> Result<(), serde_json::Error> {
+  let style = from_value::<Style>(json!({ "color": null, "opacity": 0.3 }))?;
+  let computed = style.inherit(&ComputedStyle::default());
+
+  assert_eq!(computed.opacity, PercentageNumber(0.3));
+  assert_eq!(computed.color, ComputedStyle::default().color);
+  Ok(())
+}
+
 fn feature_tags(features: &[FontFeature]) -> Vec<(String, u16)> {
   features
     .iter()


### PR DESCRIPTION
## Why

- `background-image: url(data:image/svg+xml,<svg …fill='#fff'…>)` never rendered: an unescaped `#` is a URL fragment delimiter, so the SVG body was cut off at the first one.
- `style={{ color: cond ? "red" : undefined }}` — the idiomatic JSX conditional — failed to deserialize instead of being treated as an absent declaration.

## What

- `parse_data_uri_image` percent-escapes `#` in the data URI body before handing it to the URL parser.
- The `Style` deserializer skips declarations whose value is `null` or `undefined`, covering the napi, wasm, and JSON paths at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline SVG data URIs containing `#` characters so they render correctly instead of being truncated.
  * Updated style handling to ignore `null` and undefined declarations while preserving valid styles.

* **Documentation**
  * Added documentation covering SVG data URI encoding and ignored null style values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->