### PR TITLE
Core: decode GIF frames on the raw gif decoder

### DIFF
--- a/.tegami/gif-raw-decoder.md
+++ b/.tegami/gif-raw-decoder.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Decode GIF frames on the raw `gif` decoder
+
+Composite frames on one reused canvas instead of the `image` crate's per-frame allocations; skipped frames no longer allocate or premultiply.

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -609,6 +609,34 @@ mod tests {
   }
 
   #[test]
+  fn gif_compositing_matches_image_crate_for_interlaced_frames() {
+    let mut striped = Vec::new();
+    for row in 0..8_u8 {
+      let shade = row * 32;
+      striped.extend(rgba_patch(8, 1, [shade, 255 - shade, row, 255]));
+    }
+    let mut interlaced = test_frame(8, 8, (0, 0), striped, DisposalMethod::Keep, 1);
+    interlaced.interlaced = true;
+
+    let bytes = encode_test_gif(
+      8,
+      8,
+      &[
+        test_frame(
+          8,
+          8,
+          (0, 0),
+          rgba_patch(8, 8, [255, 0, 0, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+        interlaced,
+      ],
+    );
+    assert_matches_reference(&bytes);
+  }
+
+  #[test]
   fn gif_zero_delay_clamps_to_one_ms_like_image_crate() {
     let bytes = encode_test_gif(
       2,

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -127,7 +127,6 @@ fn gif_decode_error(error: gif::DecodingError) -> ImageError {
   ImageError::Decoding(DecodingError::new(ImageFormat::Gif.into(), error))
 }
 
-/// Reads the GIF header and validates the logical screen dimensions.
 fn gif_decoder(bytes: &[u8]) -> ImageResult<GifDecoder<Cursor<&[u8]>>> {
   let mut options = DecodeOptions::new();
   options.set_color_output(ColorOutput::RGBA);
@@ -165,7 +164,6 @@ fn blit_frame(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect, pixels: 
   }
 }
 
-/// Clears the canvas rect to transparent (`Background` disposal).
 fn clear_rect(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect) {
   for row in 0..rect.rows(canvas_width, canvas.len()) {
     let dst_row = ((rect.top + row) * canvas_width + rect.left) as usize * 4;
@@ -258,7 +256,6 @@ pub(crate) fn decode_gif_frames(
     }
 
     // The emitted frame is the canvas after compositing, before disposal.
-    // Skipped frames only update the canvas: no clone, no premultiply.
     let keep = current >= skip;
     let last_needed = keep && limit.is_some_and(|limit| pushed + 1 >= limit);
     let composited = if last_needed {
@@ -428,8 +425,6 @@ mod tests {
     decode_image(bytes).expect("small PNG decodes within budget");
   }
 
-  /// A solid-color RGBA frame patch; `alpha: 0` pixels punch through to the
-  /// canvas below.
   fn rgba_patch(width: u16, height: u16, rgba: [u8; 4]) -> Vec<u8> {
     rgba.repeat(width as usize * height as usize)
   }
@@ -460,7 +455,6 @@ mod tests {
     bytes
   }
 
-  /// Reference decode through the `image` crate's compositing.
   fn reference_frames(bytes: &[u8]) -> Vec<(Vec<u8>, u32)> {
     use image::AnimationDecoder;
 

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -1,12 +1,13 @@
 use std::{
   io::{Cursor, Error as IoError, ErrorKind},
+  mem::take,
   sync::Arc,
 };
 
+use gif::{ColorOutput, DecodeOptions, Decoder as GifDecoder, DisposalMethod};
 use image::{
-  AnimationDecoder, DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits,
-  RgbaImage,
-  codecs::{gif::GifDecoder, jpeg::JpegDecoder, png::PngDecoder},
+  DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits, RgbaImage,
+  codecs::{jpeg::JpegDecoder, png::PngDecoder},
   error::{DecodingError, ImageFormatHint, UnsupportedError, UnsupportedErrorKind},
 };
 #[cfg(target_arch = "wasm32")]
@@ -122,11 +123,75 @@ fn decode_jpeg(bytes: &[u8]) -> ImageResult<ImageBuffer> {
   decode_with_image_crate(JpegDecoder::new(Cursor::new(bytes))?, ImageFormat::Jpeg)
 }
 
+fn gif_decode_error(error: gif::DecodingError) -> ImageError {
+  ImageError::Decoding(DecodingError::new(ImageFormat::Gif.into(), error))
+}
+
+/// Reads the GIF header and validates the logical screen dimensions.
+fn gif_decoder(bytes: &[u8]) -> ImageResult<GifDecoder<Cursor<&[u8]>>> {
+  let mut options = DecodeOptions::new();
+  options.set_color_output(ColorOutput::RGBA);
+
+  let decoder = options
+    .read_info(Cursor::new(bytes))
+    .map_err(gif_decode_error)?;
+  let (width, height) = (decoder.width() as u32, decoder.height() as u32);
+  if width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION {
+    return Err(pixel_budget_error(width, height));
+  }
+
+  Ok(decoder)
+}
+
 /// GIF logical screen dimensions from the header; decodes no frame.
 pub(crate) fn gif_dimensions(bytes: &[u8]) -> ImageResult<(u32, u32)> {
-  let mut decoder = GifDecoder::new(Cursor::new(bytes))?;
-  decoder.set_limits(decode_limits())?;
-  Ok(decoder.dimensions())
+  let decoder = gif_decoder(bytes)?;
+  Ok((decoder.width() as u32, decoder.height() as u32))
+}
+
+/// Overwrites the canvas rect with the frame's non-transparent pixels
+/// (straight-alpha RGBA; GIF alpha is 0 or 255).
+fn blit_frame(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect, pixels: &[u8]) {
+  for row in 0..rect.rows(canvas_width, canvas.len()) {
+    let src_row = (row * rect.width) as usize * 4;
+    let dst_row = ((rect.top + row) * canvas_width + rect.left) as usize * 4;
+    for col in 0..rect.cols(canvas_width) as usize {
+      let src = src_row + col * 4;
+      if pixels[src + 3] != 0 {
+        let dst = dst_row + col * 4;
+        canvas[dst..dst + 4].copy_from_slice(&pixels[src..src + 4]);
+      }
+    }
+  }
+}
+
+/// Clears the canvas rect to transparent (`Background` disposal).
+fn clear_rect(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect) {
+  for row in 0..rect.rows(canvas_width, canvas.len()) {
+    let dst_row = ((rect.top + row) * canvas_width + rect.left) as usize * 4;
+    let cols = rect.cols(canvas_width) as usize;
+    canvas[dst_row..dst_row + cols * 4].fill(0);
+  }
+}
+
+/// A GIF frame's placement rect, clamped to the canvas at use sites.
+#[derive(Clone, Copy)]
+struct GifFrameRect {
+  left: u32,
+  top: u32,
+  width: u32,
+  height: u32,
+}
+
+impl GifFrameRect {
+  fn cols(self, canvas_width: u32) -> u32 {
+    self.width.min(canvas_width.saturating_sub(self.left))
+  }
+
+  fn rows(self, canvas_width: u32, canvas_len: usize) -> u32 {
+    let canvas_height = (canvas_len / 4) as u32 / canvas_width.max(1);
+    self.height.min(canvas_height.saturating_sub(self.top))
+  }
 }
 
 /// Decodes GIF frames in stream order, passing each frame past the first
@@ -134,60 +199,104 @@ pub(crate) fn gif_dimensions(bytes: &[u8]) -> ImageResult<(u32, u32)> {
 /// ended. A mid-stream decode error or a blown [`MAX_GIF_TOTAL_PIXELS`] budget
 /// truncates the timeline (reported as ended); only a stream with no decodable
 /// first frame errors.
+///
+/// Compositing matches the `image` crate (and browsers): frames blend over a
+/// transparent canvas, `Keep` persists the composited result, `Background`
+/// clears the frame rect, `Previous` restores the pre-frame canvas.
 pub(crate) fn decode_gif_frames(
   bytes: &[u8],
   skip: usize,
   limit: Option<usize>,
   mut push: impl FnMut(DecodedGifFrame),
 ) -> ImageResult<bool> {
-  let mut decoder = GifDecoder::new(Cursor::new(bytes))?;
-  decoder.set_limits(decode_limits())?;
+  let mut decoder = gif_decoder(bytes)?;
+  let (width, height) = (decoder.width() as u32, decoder.height() as u32);
 
+  // GIF alpha is 0 or 255, so the canvas is valid premultiplied RGBA as-is:
+  // blits copy opaque pixels (premultiply is identity) and cleared pixels are
+  // all-zero. Emitted frames skip the premultiply pass entirely.
+  let mut canvas = vec![0_u8; width as usize * height as usize * 4];
+  let mut scratch = Vec::new();
   let mut total_pixels: u64 = 0;
   let mut pushed = 0_usize;
-  let mut frames = decoder.into_frames();
   let mut index = 0_usize;
 
   loop {
-    // Check before pulling the next frame: `next()` decodes its pixels.
     if limit.is_some_and(|limit| pushed >= limit) {
       return Ok(false);
     }
 
-    let Some(frame) = frames.next() else {
-      break;
+    let frame = match decoder.next_frame_info() {
+      Ok(Some(frame)) => frame,
+      Ok(None) => break,
+      Err(error) if index == 0 => return Err(gif_decode_error(error)),
+      Err(_) => return Ok(true),
     };
     let current = index;
     index += 1;
-
-    let frame = match frame {
-      Ok(frame) => frame,
-      Err(error) if current == 0 => return Err(error),
-      Err(_) => return Ok(true),
-    };
-    let (width, height) = frame.buffer().dimensions();
 
     total_pixels += width as u64 * height as u64;
     if total_pixels > MAX_GIF_TOTAL_PIXELS {
       return Ok(true);
     }
 
-    // Skipped frames still decode (compositing needs them) but avoid the
-    // premultiply pass and buffer allocation.
-    if current < skip {
-      continue;
+    let rect = GifFrameRect {
+      left: frame.left as u32,
+      top: frame.top as u32,
+      width: frame.width as u32,
+      height: frame.height as u32,
+    };
+    let dispose = frame.dispose;
+    let duration_ms = (frame.delay as u32 * 10).max(1);
+
+    scratch.resize(decoder.buffer_size(), 0);
+    if let Err(error) = decoder.read_into_buffer(&mut scratch) {
+      if current == 0 {
+        return Err(gif_decode_error(error));
+      }
+      return Ok(true);
     }
 
-    let (numerator, denominator) = frame.delay().numer_denom_ms();
-    let frame_delay_ms = numerator.checked_div(denominator).unwrap_or(numerator);
-    let duration_ms = frame_delay_ms.max(1);
-    let buffer = Arc::new(rgba_to_buffer(frame.into_buffer(), ImageFormat::Gif)?);
+    // The emitted frame is the canvas after compositing, before disposal.
+    // Skipped frames only update the canvas: no clone, no premultiply.
+    let keep = current >= skip;
+    let last_needed = keep && limit.is_some_and(|limit| pushed + 1 >= limit);
+    let composited = if last_needed {
+      // The canvas is never read again: emit it without cloning.
+      blit_frame(&mut canvas, width, rect, &scratch);
+      Some(take(&mut canvas))
+    } else {
+      match dispose {
+        DisposalMethod::Any | DisposalMethod::Keep => {
+          blit_frame(&mut canvas, width, rect, &scratch);
+          keep.then(|| canvas.clone())
+        }
+        DisposalMethod::Background | DisposalMethod::Previous => {
+          let composited = keep.then(|| {
+            let mut out = canvas.clone();
+            blit_frame(&mut out, width, rect, &scratch);
+            out
+          });
+          if matches!(dispose, DisposalMethod::Background) {
+            clear_rect(&mut canvas, width, rect);
+          }
+          composited
+        }
+      }
+    };
 
-    push(DecodedGifFrame {
-      buffer,
-      duration_ms,
-    });
-    pushed += 1;
+    if let Some(composited) = composited {
+      let buffer = ImageBuffer::from_premultiplied_rgba(composited, width, height)
+        .ok_or_else(invalid_buffer_error)?;
+      push(DecodedGifFrame {
+        buffer: Arc::new(buffer),
+        duration_ms,
+      });
+      pushed += 1;
+      if limit.is_some_and(|limit| pushed >= limit) {
+        return Ok(false);
+      }
+    }
   }
 
   Ok(true)
@@ -317,5 +426,260 @@ mod tests {
   fn decode_png_accepts_small_valid_image() {
     let bytes = include_bytes!("../../../assets/images/yeecord.png");
     decode_image(bytes).expect("small PNG decodes within budget");
+  }
+
+  /// A solid-color RGBA frame patch; `alpha: 0` pixels punch through to the
+  /// canvas below.
+  fn rgba_patch(width: u16, height: u16, rgba: [u8; 4]) -> Vec<u8> {
+    rgba.repeat(width as usize * height as usize)
+  }
+
+  fn test_frame(
+    width: u16,
+    height: u16,
+    (left, top): (u16, u16),
+    mut pixels: Vec<u8>,
+    dispose: DisposalMethod,
+    delay: u16,
+  ) -> gif::Frame<'static> {
+    let mut frame = gif::Frame::from_rgba_speed(width, height, &mut pixels, 10);
+    frame.left = left;
+    frame.top = top;
+    frame.dispose = dispose;
+    frame.delay = delay;
+    frame
+  }
+
+  fn encode_test_gif(width: u16, height: u16, frames: &[gif::Frame<'static>]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut encoder = gif::Encoder::new(&mut bytes, width, height, &[]).unwrap();
+    for frame in frames {
+      encoder.write_frame(frame).unwrap();
+    }
+    drop(encoder);
+    bytes
+  }
+
+  /// Reference decode through the `image` crate's compositing.
+  fn reference_frames(bytes: &[u8]) -> Vec<(Vec<u8>, u32)> {
+    use image::AnimationDecoder;
+
+    let decoder = image::codecs::gif::GifDecoder::new(Cursor::new(bytes)).unwrap();
+    decoder
+      .into_frames()
+      .map(|frame| {
+        let frame = frame.unwrap();
+        let (numerator, denominator) = frame.delay().numer_denom_ms();
+        let duration_ms = numerator
+          .checked_div(denominator)
+          .unwrap_or(numerator)
+          .max(1);
+        let buffer = rgba_to_buffer(frame.into_buffer(), ImageFormat::Gif).unwrap();
+        (buffer.data().to_vec(), duration_ms)
+      })
+      .collect()
+  }
+
+  fn our_frames(bytes: &[u8], skip: usize) -> Vec<(Vec<u8>, u32)> {
+    let mut frames = Vec::new();
+    let ended = decode_gif_frames(bytes, skip, None, |frame| {
+      frames.push((frame.buffer.data().to_vec(), frame.duration_ms));
+    })
+    .unwrap();
+    assert!(ended);
+    frames
+  }
+
+  fn assert_matches_reference(bytes: &[u8]) {
+    let reference = reference_frames(bytes);
+    assert_eq!(our_frames(bytes, 0), reference);
+    assert_eq!(our_frames(bytes, 1), reference[1..]);
+  }
+
+  #[test]
+  fn gif_compositing_matches_image_crate_for_keep_disposal() {
+    let bytes = encode_test_gif(
+      4,
+      4,
+      &[
+        test_frame(
+          4,
+          4,
+          (0, 0),
+          rgba_patch(4, 4, [255, 0, 0, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+        test_frame(
+          2,
+          2,
+          (1, 1),
+          rgba_patch(2, 2, [0, 255, 0, 255]),
+          DisposalMethod::Keep,
+          2,
+        ),
+        test_frame(
+          2,
+          2,
+          (2, 2),
+          rgba_patch(2, 2, [0, 0, 255, 255]),
+          DisposalMethod::Keep,
+          3,
+        ),
+      ],
+    );
+    assert_matches_reference(&bytes);
+  }
+
+  #[test]
+  fn gif_compositing_matches_image_crate_for_transparent_patches() {
+    let mut patch = rgba_patch(2, 2, [0, 255, 0, 255]);
+    patch[4..8].fill(0);
+
+    let bytes = encode_test_gif(
+      4,
+      4,
+      &[
+        test_frame(
+          4,
+          4,
+          (0, 0),
+          rgba_patch(4, 4, [255, 0, 0, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+        test_frame(2, 2, (1, 1), patch, DisposalMethod::Keep, 1),
+      ],
+    );
+    assert_matches_reference(&bytes);
+  }
+
+  #[test]
+  fn gif_compositing_matches_image_crate_for_background_disposal() {
+    let bytes = encode_test_gif(
+      4,
+      4,
+      &[
+        test_frame(
+          4,
+          4,
+          (0, 0),
+          rgba_patch(4, 4, [255, 0, 0, 255]),
+          DisposalMethod::Background,
+          1,
+        ),
+        test_frame(
+          2,
+          2,
+          (1, 1),
+          rgba_patch(2, 2, [0, 255, 0, 255]),
+          DisposalMethod::Background,
+          1,
+        ),
+        test_frame(
+          2,
+          2,
+          (2, 2),
+          rgba_patch(2, 2, [0, 0, 255, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+      ],
+    );
+    assert_matches_reference(&bytes);
+  }
+
+  #[test]
+  fn gif_compositing_matches_image_crate_for_previous_disposal() {
+    let bytes = encode_test_gif(
+      4,
+      4,
+      &[
+        test_frame(
+          4,
+          4,
+          (0, 0),
+          rgba_patch(4, 4, [255, 0, 0, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+        test_frame(
+          2,
+          2,
+          (1, 1),
+          rgba_patch(2, 2, [0, 255, 0, 255]),
+          DisposalMethod::Previous,
+          1,
+        ),
+        test_frame(
+          2,
+          2,
+          (2, 2),
+          rgba_patch(2, 2, [0, 0, 255, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+      ],
+    );
+    assert_matches_reference(&bytes);
+  }
+
+  #[test]
+  fn gif_zero_delay_clamps_to_one_ms_like_image_crate() {
+    let bytes = encode_test_gif(
+      2,
+      2,
+      &[
+        test_frame(
+          2,
+          2,
+          (0, 0),
+          rgba_patch(2, 2, [255, 0, 0, 255]),
+          DisposalMethod::Keep,
+          0,
+        ),
+        test_frame(
+          2,
+          2,
+          (0, 0),
+          rgba_patch(2, 2, [0, 255, 0, 255]),
+          DisposalMethod::Keep,
+          0,
+        ),
+      ],
+    );
+    assert_matches_reference(&bytes);
+    assert!(our_frames(&bytes, 0).iter().all(|(_, ms)| *ms == 1));
+  }
+
+  #[test]
+  fn gif_limit_stops_before_decoding_later_frames() {
+    let bytes = encode_test_gif(
+      2,
+      2,
+      &[
+        test_frame(
+          2,
+          2,
+          (0, 0),
+          rgba_patch(2, 2, [255, 0, 0, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+        test_frame(
+          2,
+          2,
+          (0, 0),
+          rgba_patch(2, 2, [0, 255, 0, 255]),
+          DisposalMethod::Keep,
+          1,
+        ),
+      ],
+    );
+
+    let mut frames = Vec::new();
+    let ended = decode_gif_frames(&bytes, 0, Some(1), |frame| frames.push(frame)).unwrap();
+    assert!(!ended);
+    assert_eq!(frames.len(), 1);
   }
 }

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -15,7 +15,7 @@ use image_webp::WebPDecoder;
 #[cfg(not(target_arch = "wasm32"))]
 use libwebp_sys::{WebPDecodeRGBA, WebPFree, WebPGetInfo};
 
-use crate::resources::image_buffer::ImageBuffer;
+use crate::{geometry::Rect, resources::image_buffer::ImageBuffer};
 
 const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 const JPEG_SIGNATURE: [u8; 3] = [0xFF, 0xD8, 0xFF];
@@ -148,13 +148,23 @@ pub(crate) fn gif_dimensions(bytes: &[u8]) -> ImageResult<(u32, u32)> {
   Ok((decoder.width() as u32, decoder.height() as u32))
 }
 
+/// Rows and columns of the rect that fall inside the canvas, plus the rect's
+/// unclamped pixel stride.
+fn clamped_span(rect: Rect<u32>, canvas_width: u32, canvas_height: u32) -> (u32, usize, usize) {
+  let rows = rect.bottom.min(canvas_height).saturating_sub(rect.top);
+  let cols = rect.right.min(canvas_width).saturating_sub(rect.left) as usize;
+  let stride = (rect.right - rect.left) as usize;
+  (rows, cols, stride)
+}
+
 /// Overwrites the canvas rect with the frame's non-transparent pixels
 /// (straight-alpha RGBA; GIF alpha is 0 or 255).
-fn blit_frame(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect, pixels: &[u8]) {
-  for row in 0..rect.rows(canvas_width, canvas.len()) {
-    let src_row = (row * rect.width) as usize * 4;
-    let dst_row = ((rect.top + row) * canvas_width + rect.left) as usize * 4;
-    for col in 0..rect.cols(canvas_width) as usize {
+fn blit_frame(canvas: &mut [u8], canvas_size: (u32, u32), rect: Rect<u32>, pixels: &[u8]) {
+  let (rows, cols, stride) = clamped_span(rect, canvas_size.0, canvas_size.1);
+  for row in 0..rows {
+    let src_row = row as usize * stride * 4;
+    let dst_row = ((rect.top + row) * canvas_size.0 + rect.left) as usize * 4;
+    for col in 0..cols {
       let src = src_row + col * 4;
       if pixels[src + 3] != 0 {
         let dst = dst_row + col * 4;
@@ -164,31 +174,11 @@ fn blit_frame(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect, pixels: 
   }
 }
 
-fn clear_rect(canvas: &mut [u8], canvas_width: u32, rect: GifFrameRect) {
-  for row in 0..rect.rows(canvas_width, canvas.len()) {
-    let dst_row = ((rect.top + row) * canvas_width + rect.left) as usize * 4;
-    let cols = rect.cols(canvas_width) as usize;
+fn clear_rect(canvas: &mut [u8], canvas_size: (u32, u32), rect: Rect<u32>) {
+  let (rows, cols, _) = clamped_span(rect, canvas_size.0, canvas_size.1);
+  for row in 0..rows {
+    let dst_row = ((rect.top + row) * canvas_size.0 + rect.left) as usize * 4;
     canvas[dst_row..dst_row + cols * 4].fill(0);
-  }
-}
-
-/// A GIF frame's placement rect, clamped to the canvas at use sites.
-#[derive(Clone, Copy)]
-struct GifFrameRect {
-  left: u32,
-  top: u32,
-  width: u32,
-  height: u32,
-}
-
-impl GifFrameRect {
-  fn cols(self, canvas_width: u32) -> u32 {
-    self.width.min(canvas_width.saturating_sub(self.left))
-  }
-
-  fn rows(self, canvas_width: u32, canvas_len: usize) -> u32 {
-    let canvas_height = (canvas_len / 4) as u32 / canvas_width.max(1);
-    self.height.min(canvas_height.saturating_sub(self.top))
   }
 }
 
@@ -238,11 +228,11 @@ pub(crate) fn decode_gif_frames(
       return Ok(true);
     }
 
-    let rect = GifFrameRect {
+    let rect = Rect {
       left: frame.left as u32,
       top: frame.top as u32,
-      width: frame.width as u32,
-      height: frame.height as u32,
+      right: frame.left as u32 + frame.width as u32,
+      bottom: frame.top as u32 + frame.height as u32,
     };
     let dispose = frame.dispose;
     let duration_ms = (frame.delay as u32 * 10).max(1);
@@ -260,22 +250,22 @@ pub(crate) fn decode_gif_frames(
     let last_needed = keep && limit.is_some_and(|limit| pushed + 1 >= limit);
     let composited = if last_needed {
       // The canvas is never read again: emit it without cloning.
-      blit_frame(&mut canvas, width, rect, &scratch);
+      blit_frame(&mut canvas, (width, height), rect, &scratch);
       Some(take(&mut canvas))
     } else {
       match dispose {
         DisposalMethod::Any | DisposalMethod::Keep => {
-          blit_frame(&mut canvas, width, rect, &scratch);
+          blit_frame(&mut canvas, (width, height), rect, &scratch);
           keep.then(|| canvas.clone())
         }
         DisposalMethod::Background | DisposalMethod::Previous => {
           let composited = keep.then(|| {
             let mut out = canvas.clone();
-            blit_frame(&mut out, width, rect, &scratch);
+            blit_frame(&mut out, (width, height), rect, &scratch);
             out
           });
           if matches!(dispose, DisposalMethod::Background) {
-            clear_rect(&mut canvas, width, rect);
+            clear_rect(&mut canvas, (width, height), rect);
           }
           composited
         }


### PR DESCRIPTION
## Why

GIF decoding went through the `image` crate's frame iterator, which allocates a rect buffer and a full composited canvas for every frame. The lazy path from #958 made that visible: frames it skips still paid both allocations plus a premultiply pass, only to be dropped.

## What

- Decode on the `gif` crate directly: one reused canvas accumulates frame patches, one reused scratch buffer receives each frame's rect.
- Skipped frames update the canvas in place: no allocation, no premultiply.
- Kept frames clone the canvas once; the final requested frame moves it instead. GIF alpha is 0 or 255, so the canvas doubles as premultiplied RGBA and emitted frames skip the premultiply pass.
- Compositing (blend, `Keep`/`Background`/`Previous` disposal, rect clamping, delay clamping) replicates the `image` crate; differential tests decode the same bytes through both paths and assert byte-identical frames across disposal modes, transparency, and partial rects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GIF playback by switching to a more accurate raw decoder with correct frame disposal compositing.
  * Corrected frame timing to respect GIF delays, clamping very short delays to a minimum 1ms.
  * Improved behavior when streaming GIFs and frames fail, including clearer “ended” outcomes.
  * Enhanced performance and stability when skipping/limiting frames during decoding.
* **Documentation**
  * Added documentation for the GIF “raw” decoder behavior.
* **Tests**
  * Updated GIF decoding tests to verify buffer output and durations across disposal methods and timing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->