### PR TITLE
Core: stream PNG decode at draw size

### DIFF
--- a/.tegami/png-streaming-decode.md
+++ b/.tegami/png-streaming-decode.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Stream PNG decode at draw size
+
+Non-interlaced PNGs decode row-by-row through a streaming resampler, so downscaling never materializes the full-size buffer. Output is byte-identical to decode-then-resize.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -25,8 +25,8 @@ use crate::{
   resources::{
     image_buffer::ImageBuffer,
     image_decoder::{
-      DecodedGifFrame, bitmap_dimensions, decode_gif_frames, decode_image, gif_dimensions, is_gif,
-      resize_buffer,
+      DecodedGifFrame, bitmap_dimensions, decode_bitmap_scaled, decode_gif_frames, decode_image,
+      gif_dimensions, is_gif,
     },
   },
   style::{ImageScalingAlgorithm, IntrinsicSizing, SizingContext},
@@ -286,14 +286,9 @@ impl EncodedBitmap {
     height: u32,
     algorithm: ImageScalingAlgorithm,
   ) -> Result<Arc<ImageBuffer>, ImageError> {
-    let decoded = decode_image(&self.bytes).map_err(ImageError::decode)?;
-    if width >= decoded.width() && height >= decoded.height() {
-      return Ok(Arc::new(decoded));
-    }
-
-    let resized =
-      resize_buffer(&decoded, width, height, algorithm).ok_or(ImageError::MismatchedBufferSize)?;
-    Ok(Arc::new(resized))
+    decode_bitmap_scaled(&self.bytes, width, height, algorithm)
+      .map(Arc::new)
+      .map_err(ImageError::decode)
   }
 }
 

--- a/takumi-core/src/resources/image_buffer.rs
+++ b/takumi-core/src/resources/image_buffer.rs
@@ -121,7 +121,7 @@ fn has_opaque_alpha(raw: &[u8]) -> bool {
 }
 
 #[inline(always)]
-fn premultiply_rgba_in_place(raw: &mut [u8]) {
+pub(crate) fn premultiply_rgba_in_place(raw: &mut [u8]) {
   for pixel in raw.chunks_exact_mut(4) {
     let alpha = pixel[3];
     if alpha == u8::MAX {

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -9,7 +9,6 @@ use image::{
   DynamicImage, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits, RgbaImage,
   codecs::{jpeg::JpegDecoder, png::PngDecoder},
   error::{DecodingError, ImageFormatHint, UnsupportedError, UnsupportedErrorKind},
-  imageops::{self, FilterType},
 };
 #[cfg(target_arch = "wasm32")]
 use image_webp::WebPDecoder;
@@ -144,15 +143,6 @@ pub(crate) fn bitmap_dimensions(bytes: &[u8]) -> Option<ImageResult<(u32, u32)>>
   Some(dimensions)
 }
 
-/// The filter each [`ImageScalingAlgorithm`] documents.
-fn resize_filter(algorithm: ImageScalingAlgorithm) -> FilterType {
-  match algorithm {
-    ImageScalingAlgorithm::Smooth => FilterType::Lanczos3,
-    ImageScalingAlgorithm::Pixelated => FilterType::Nearest,
-    _ => FilterType::CatmullRom,
-  }
-}
-
 /// Downscales a decoded (premultiplied) buffer; linear filtering of
 /// premultiplied RGBA is alpha-correct.
 pub(crate) fn resize_buffer(
@@ -161,9 +151,15 @@ pub(crate) fn resize_buffer(
   height: u32,
   algorithm: ImageScalingAlgorithm,
 ) -> Option<ImageBuffer> {
-  let image = RgbaImage::from_raw(buffer.width(), buffer.height(), buffer.data().to_vec())?;
-  let resized = imageops::resize(&image, width, height, resize_filter(algorithm));
-  ImageBuffer::from_premultiplied_rgba(resized.into_raw(), width, height)
+  let mut resampler = StreamResampler::new(
+    (buffer.width(), buffer.height()),
+    (width, height),
+    algorithm,
+  );
+  for row in buffer.data().chunks_exact(buffer.width() as usize * 4) {
+    resampler.push_row(row);
+  }
+  resampler.finish()
 }
 
 /// Decodes bitmap bytes scaled to cover `width` x `height`, never upscaling.

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -15,8 +15,16 @@ use image::{
 use image_webp::WebPDecoder;
 #[cfg(not(target_arch = "wasm32"))]
 use libwebp_sys::{WebPDecodeRGBA, WebPFree, WebPGetInfo};
+use png::{BitDepth, ColorType, Decoder as PngRowDecoder, Transformations};
 
-use crate::{geometry::Rect, resources::image_buffer::ImageBuffer, style::ImageScalingAlgorithm};
+use crate::{
+  geometry::Rect,
+  resources::{
+    image_buffer::{ImageBuffer, premultiply_rgba_in_place},
+    image_resampler::StreamResampler,
+  },
+  style::ImageScalingAlgorithm,
+};
 
 const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 const JPEG_SIGNATURE: [u8; 3] = [0xFF, 0xD8, 0xFF];
@@ -156,6 +164,99 @@ pub(crate) fn resize_buffer(
   let image = RgbaImage::from_raw(buffer.width(), buffer.height(), buffer.data().to_vec())?;
   let resized = imageops::resize(&image, width, height, resize_filter(algorithm));
   ImageBuffer::from_premultiplied_rgba(resized.into_raw(), width, height)
+}
+
+/// Decodes bitmap bytes scaled to cover `width` x `height`, never upscaling.
+/// Non-interlaced PNGs stream row-by-row through the resampler without a
+/// full-size buffer; everything else decodes fully and resizes.
+pub(crate) fn decode_bitmap_scaled(
+  bytes: &[u8],
+  width: u32,
+  height: u32,
+  algorithm: ImageScalingAlgorithm,
+) -> ImageResult<ImageBuffer> {
+  if let Some(streamed) = decode_png_scaled(bytes, width, height, algorithm) {
+    return streamed;
+  }
+
+  let decoded = decode_image(bytes)?;
+  if width >= decoded.width() && height >= decoded.height() {
+    return Ok(decoded);
+  }
+
+  resize_buffer(&decoded, width, height, algorithm).ok_or_else(invalid_buffer_error)
+}
+
+fn png_decode_error(error: png::DecodingError) -> ImageError {
+  ImageError::Decoding(DecodingError::new(ImageFormat::Png.into(), error))
+}
+
+/// Streams a non-interlaced PNG through [`StreamResampler`]. `None` means the
+/// input isn't eligible (not a PNG, interlaced, unsupported layout, or no
+/// downscale) and the caller should decode fully; errors after eligibility are
+/// real decode failures.
+fn decode_png_scaled(
+  bytes: &[u8],
+  width: u32,
+  height: u32,
+  algorithm: ImageScalingAlgorithm,
+) -> Option<ImageResult<ImageBuffer>> {
+  if !bytes.starts_with(&PNG_SIGNATURE) {
+    return None;
+  }
+
+  let mut decoder = PngRowDecoder::new(Cursor::new(bytes));
+  decoder.set_transformations(
+    Transformations::EXPAND | Transformations::STRIP_16 | Transformations::ALPHA,
+  );
+  let mut reader = decoder.read_info().ok()?;
+
+  let info = reader.info();
+  let (native_width, native_height) = (info.width, info.height);
+  if info.interlaced
+    || native_width == 0
+    || native_height == 0
+    || native_width > MAX_IMAGE_DIMENSION
+    || native_height > MAX_IMAGE_DIMENSION
+    || (width >= native_width && height >= native_height)
+  {
+    return None;
+  }
+
+  let channels = match reader.output_color_type() {
+    (ColorType::Rgba, BitDepth::Eight) => 4,
+    (ColorType::GrayscaleAlpha, BitDepth::Eight) => 2,
+    _ => return None,
+  };
+
+  let mut resampler =
+    StreamResampler::new((native_width, native_height), (width, height), algorithm);
+  let mut rgba_row = vec![0_u8; native_width as usize * 4];
+
+  loop {
+    let row = match reader.next_row() {
+      Ok(Some(row)) => row,
+      Ok(None) => break,
+      Err(error) => return Some(Err(png_decode_error(error))),
+    };
+
+    match channels {
+      4 => rgba_row.copy_from_slice(row.data()),
+      _ => {
+        for (rgba, pixel) in rgba_row.chunks_exact_mut(4).zip(row.data().chunks_exact(2)) {
+          rgba[0] = pixel[0];
+          rgba[1] = pixel[0];
+          rgba[2] = pixel[0];
+          rgba[3] = pixel[1];
+        }
+      }
+    }
+
+    premultiply_rgba_in_place(&mut rgba_row);
+    resampler.push_row(&rgba_row);
+  }
+
+  Some(resampler.finish().ok_or_else(invalid_buffer_error))
 }
 
 fn gif_decode_error(error: gif::DecodingError) -> ImageError {
@@ -472,6 +573,54 @@ mod tests {
   fn decode_png_accepts_small_valid_image() {
     let bytes = include_bytes!("../../../assets/images/yeecord.png");
     decode_image(bytes).expect("small PNG decodes within budget");
+  }
+
+  fn assert_streamed_matches_full(bytes: &[u8], width: u32, height: u32) {
+    for algorithm in [
+      ImageScalingAlgorithm::Auto,
+      ImageScalingAlgorithm::Smooth,
+      ImageScalingAlgorithm::Pixelated,
+    ] {
+      let streamed = decode_bitmap_scaled(bytes, width, height, algorithm).unwrap();
+      let full = decode_image(bytes).unwrap();
+      let resized = resize_buffer(&full, width, height, algorithm).unwrap();
+      assert_eq!(streamed.data(), resized.data(), "{algorithm:?}");
+    }
+  }
+
+  #[test]
+  fn png_streaming_matches_full_decode_for_rgba() {
+    let mut image = RgbaImage::new(40, 30);
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+      *pixel = image::Rgba([(x * 6) as u8, (y * 8) as u8, ((x + y) * 3) as u8, 200]);
+    }
+    let mut bytes = Vec::new();
+    image
+      .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+      .unwrap();
+
+    assert_streamed_matches_full(&bytes, 13, 9);
+  }
+
+  #[test]
+  fn png_streaming_matches_full_decode_for_grayscale_alpha() {
+    let mut image = image::GrayAlphaImage::new(32, 24);
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+      *pixel = image::LumaA([(x * 8) as u8, (255 - y * 4) as u8]);
+    }
+    let mut bytes = Vec::new();
+    image
+      .write_to(&mut Cursor::new(&mut bytes), ImageFormat::Png)
+      .unwrap();
+
+    assert_streamed_matches_full(&bytes, 11, 7);
+  }
+
+  #[test]
+  fn real_png_streaming_matches_full_decode() {
+    let bytes = include_bytes!("../../../assets/images/yeecord.png");
+    let full = decode_image(bytes).unwrap();
+    assert_streamed_matches_full(bytes, full.width() / 3, full.height() / 3);
   }
 
   fn rgba_patch(width: u16, height: u16, rgba: [u8; 4]) -> Vec<u8> {

--- a/takumi-core/src/resources/image_resampler.rs
+++ b/takumi-core/src/resources/image_resampler.rs
@@ -1,0 +1,324 @@
+//! Streaming separable resampler fed one source row at a time, so a decoder
+//! never materializes the full-size image.
+//!
+//! Replicates `image::imageops::resize` exactly (vertical pass into f32, then
+//! horizontal, same windows, weights, and rounding), so streamed output is
+//! byte-identical to decode-then-resize.
+
+use std::collections::VecDeque;
+
+use crate::{resources::image_buffer::ImageBuffer, style::ImageScalingAlgorithm};
+
+fn sinc(t: f32) -> f32 {
+  let a = t * std::f32::consts::PI;
+  if t == 0.0 { 1.0 } else { a.sin() / a }
+}
+
+fn lanczos3_kernel(x: f32) -> f32 {
+  if x.abs() < 3.0 {
+    sinc(x) * sinc(x / 3.0)
+  } else {
+    0.0
+  }
+}
+
+/// Catmull-Rom spline: `bc_cubic_spline(x, 0.0, 0.5)`.
+fn catmullrom_kernel(x: f32) -> f32 {
+  let a = x.abs();
+  let k = if a < 1.0 {
+    9.0 * a.powi(3) - 15.0 * a.powi(2) + 6.0
+  } else if a < 2.0 {
+    -3.0 * a.powi(3) + 15.0 * a.powi(2) - 24.0 * a + 12.0
+  } else {
+    0.0
+  };
+  k / 6.0
+}
+
+fn box_kernel(_x: f32) -> f32 {
+  1.0
+}
+
+fn filter(algorithm: ImageScalingAlgorithm) -> (fn(f32) -> f32, f32) {
+  match algorithm {
+    ImageScalingAlgorithm::Smooth => (lanczos3_kernel, 3.0),
+    ImageScalingAlgorithm::Pixelated => (box_kernel, 0.0),
+    _ => (catmullrom_kernel, 2.0),
+  }
+}
+
+/// Source window `[left, right)` and normalized kernel weights for one output
+/// index, matching `imageops`' clamping and normalization.
+fn sample_window(
+  out: u32,
+  ratio: f32,
+  sratio: f32,
+  support: f32,
+  source_len: u32,
+  kernel: fn(f32) -> f32,
+  weights: &mut Vec<f32>,
+) -> (u32, u32) {
+  let input = (out as f32 + 0.5) * ratio;
+  let src_support = support * sratio;
+
+  let left = ((input - src_support).floor() as i64).clamp(0, source_len as i64 - 1) as u32;
+  let right =
+    ((input + src_support).ceil() as i64).clamp(left as i64 + 1, source_len as i64) as u32;
+  let center = input - 0.5;
+
+  weights.clear();
+  let mut sum = 0.0;
+  for i in left..right {
+    let weight = kernel((i as f32 - center) / sratio);
+    weights.push(weight);
+    sum += weight;
+  }
+  for weight in weights.iter_mut() {
+    *weight /= sum;
+  }
+
+  (left, right)
+}
+
+struct HorizontalWindow {
+  left: u32,
+  weights: Box<[f32]>,
+}
+
+/// Push premultiplied RGBA source rows in order; target rows are produced as
+/// soon as their vertical window is complete. Peak memory is one vertical
+/// window of source rows plus one intermediate row.
+pub(crate) struct StreamResampler {
+  native_width: u32,
+  native_height: u32,
+  target_width: u32,
+  target_height: u32,
+  kernel: fn(f32) -> f32,
+  support: f32,
+  vertical_ratio: f32,
+  vertical_sratio: f32,
+  horizontal: Box<[HorizontalWindow]>,
+  ring: VecDeque<Box<[u8]>>,
+  spare: Vec<Box<[u8]>>,
+  ring_start: u32,
+  rows_pushed: u32,
+  next_target_row: u32,
+  intermediate: Box<[f32]>,
+  weights: Vec<f32>,
+  output: Vec<u8>,
+}
+
+impl StreamResampler {
+  pub(crate) fn new(
+    (native_width, native_height): (u32, u32),
+    (target_width, target_height): (u32, u32),
+    algorithm: ImageScalingAlgorithm,
+  ) -> Self {
+    let (kernel, support) = filter(algorithm);
+
+    let horizontal_ratio = native_width as f32 / target_width as f32;
+    let horizontal_sratio = horizontal_ratio.max(1.0);
+    let mut weights = Vec::new();
+    let horizontal = (0..target_width)
+      .map(|out_x| {
+        let (left, _) = sample_window(
+          out_x,
+          horizontal_ratio,
+          horizontal_sratio,
+          support,
+          native_width,
+          kernel,
+          &mut weights,
+        );
+        HorizontalWindow {
+          left,
+          weights: weights.as_slice().into(),
+        }
+      })
+      .collect();
+
+    let vertical_ratio = native_height as f32 / target_height as f32;
+
+    Self {
+      native_width,
+      native_height,
+      target_width,
+      target_height,
+      kernel,
+      support,
+      vertical_ratio,
+      vertical_sratio: vertical_ratio.max(1.0),
+      horizontal,
+      ring: VecDeque::new(),
+      spare: Vec::new(),
+      ring_start: 0,
+      rows_pushed: 0,
+      next_target_row: 0,
+      intermediate: vec![0.0; native_width as usize * 4].into(),
+      weights,
+      output: vec![0; target_width as usize * target_height as usize * 4],
+    }
+  }
+
+  fn vertical_window(&mut self, out_y: u32) -> (u32, u32) {
+    let mut weights = std::mem::take(&mut self.weights);
+    let window = sample_window(
+      out_y,
+      self.vertical_ratio,
+      self.vertical_sratio,
+      self.support,
+      self.native_height,
+      self.kernel,
+      &mut weights,
+    );
+    self.weights = weights;
+    window
+  }
+
+  pub(crate) fn push_row(&mut self, row: &[u8]) {
+    let mut stored = self
+      .spare
+      .pop()
+      .unwrap_or_else(|| vec![0; self.native_width as usize * 4].into());
+    stored.copy_from_slice(row);
+    self.ring.push_back(stored);
+    self.rows_pushed += 1;
+
+    while self.next_target_row < self.target_height {
+      let (left, right) = self.vertical_window(self.next_target_row);
+      if right > self.rows_pushed {
+        break;
+      }
+
+      self.emit(left);
+      self.next_target_row += 1;
+
+      if self.next_target_row < self.target_height {
+        let (next_left, _) = self.vertical_window(self.next_target_row);
+        while self.ring_start < next_left {
+          let Some(row) = self.ring.pop_front() else {
+            break;
+          };
+          self.spare.push(row);
+          self.ring_start += 1;
+        }
+      }
+    }
+  }
+
+  /// Vertical pass for the current target row into `intermediate`, then the
+  /// horizontal pass into `output`. Accumulation order and rounding match
+  /// `imageops` (`FloatNearest(clamp(t))`).
+  fn emit(&mut self, left: u32) {
+    self.intermediate.fill(0.0);
+    for (offset, weight) in self.weights.iter().enumerate() {
+      let row = &self.ring[(left - self.ring_start) as usize + offset];
+      for (accumulator, value) in self.intermediate.iter_mut().zip(row.iter()) {
+        *accumulator += *value as f32 * weight;
+      }
+    }
+
+    let out_row = self.next_target_row as usize * self.target_width as usize * 4;
+    for (out_x, window) in self.horizontal.iter().enumerate() {
+      let mut t = [0.0_f32; 4];
+      for (offset, weight) in window.weights.iter().enumerate() {
+        let src = (window.left as usize + offset) * 4;
+        for (accumulator, value) in t.iter_mut().zip(&self.intermediate[src..src + 4]) {
+          *accumulator += value * weight;
+        }
+      }
+      let dst = out_row + out_x * 4;
+      for (out, value) in self.output[dst..dst + 4].iter_mut().zip(t) {
+        *out = value.clamp(0.0, 255.0).round() as u8;
+      }
+    }
+  }
+
+  /// The resampled image, or `None` if the stream ended before every target
+  /// row's window was filled.
+  pub(crate) fn finish(self) -> Option<ImageBuffer> {
+    if self.next_target_row != self.target_height {
+      return None;
+    }
+    ImageBuffer::from_premultiplied_rgba(self.output, self.target_width, self.target_height)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use image::{RgbaImage, imageops};
+
+  use super::*;
+
+  fn gradient(width: u32, height: u32) -> Vec<u8> {
+    let mut data = Vec::with_capacity(width as usize * height as usize * 4);
+    for y in 0..height {
+      for x in 0..width {
+        data.extend_from_slice(&[
+          (x * 7 % 256) as u8,
+          (y * 11 % 256) as u8,
+          ((x + y) * 3 % 256) as u8,
+          255,
+        ]);
+      }
+    }
+    data
+  }
+
+  fn reference(
+    data: &[u8],
+    (width, height): (u32, u32),
+    (target_width, target_height): (u32, u32),
+    algorithm: ImageScalingAlgorithm,
+  ) -> Vec<u8> {
+    let image = RgbaImage::from_raw(width, height, data.to_vec()).unwrap();
+    let filter = match algorithm {
+      ImageScalingAlgorithm::Smooth => imageops::FilterType::Lanczos3,
+      ImageScalingAlgorithm::Pixelated => imageops::FilterType::Nearest,
+      _ => imageops::FilterType::CatmullRom,
+    };
+    imageops::resize(&image, target_width, target_height, filter).into_raw()
+  }
+
+  #[test]
+  fn streamed_output_matches_imageops_resize() {
+    let (width, height) = (64, 48);
+    let data = gradient(width, height);
+
+    for algorithm in [
+      ImageScalingAlgorithm::Auto,
+      ImageScalingAlgorithm::Smooth,
+      ImageScalingAlgorithm::Pixelated,
+    ] {
+      for (target_width, target_height) in [(17, 13), (32, 24), (63, 47), (1, 1)] {
+        let mut resampler =
+          StreamResampler::new((width, height), (target_width, target_height), algorithm);
+        for row in data.chunks_exact(width as usize * 4) {
+          resampler.push_row(row);
+        }
+        let streamed = resampler.finish().unwrap();
+
+        let expected = reference(
+          &data,
+          (width, height),
+          (target_width, target_height),
+          algorithm,
+        );
+        assert_eq!(streamed.data(), expected.as_slice(), "{algorithm:?}");
+      }
+    }
+  }
+
+  #[test]
+  fn truncated_stream_returns_none() {
+    let (width, height) = (16, 16);
+    let data = gradient(width, height);
+
+    let mut resampler = StreamResampler::new((width, height), (8, 8), ImageScalingAlgorithm::Auto);
+    for row in data.chunks_exact(width as usize * 4).take(4) {
+      resampler.push_row(row);
+    }
+
+    assert!(resampler.finish().is_none());
+  }
+}

--- a/takumi-core/src/resources/mod.rs
+++ b/takumi-core/src/resources/mod.rs
@@ -5,3 +5,4 @@ pub mod image;
 /// Backend-agnostic decoded-image buffer
 pub mod image_buffer;
 mod image_decoder;
+mod image_resampler;


### PR DESCRIPTION
## Why

Decode-at-draw-size (#961) shrinks what the cache retains, but the decode itself still materializes the full-size RGBA buffer before resizing. That transient peak, multiplied by concurrency, is what keeps glibc RSS high under unique-image traffic (#889).

## What

- A streaming separable resampler (`image_resampler.rs`) consumes premultiplied rows one at a time; peak memory is one vertical filter window of source rows plus one intermediate row (~tens of KB for a 1080px source) instead of the full decoded image.
- It replicates `image::imageops::resize` exactly — same windows, weights, accumulation order, and rounding — verified byte-identical against `imageops` across filters and sizes, so no golden changes.
- Non-interlaced PNGs route through it via the `png` crate's row reader (RGBA and grayscale-alpha layouts); interlaced or unusual layouts fall back to the existing full decode + resize.
- End-to-end tests assert the streamed path matches the full-decode path byte-for-byte on RGBA, grayscale-alpha, and a real asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming PNG downscaling to decode and resample row-by-row, reducing peak memory use.
  * Supports compatible non-interlaced RGBA and grayscale+alpha PNGs.
  * Produces byte-identical results to the existing decode-then-resize pipeline (when streaming is used).
* **Bug Fixes**
  * Automatically falls back to full decode when streaming downscaling isn’t eligible.
* **Documentation**
  * Documented the streaming PNG decode behavior.
* **Tests**
  * Added byte-equality tests covering multiple scaling algorithms and real PNG assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->