### PR TITLE
Raster: render animation frames in parallel chunks

### DIFF
--- a/.tegami/chunked-animation-render.md
+++ b/.tegami/chunked-animation-render.md
@@ -5,4 +5,4 @@ packages:
 
 ### Render animation frames in parallel chunks
 
-`write_animation` renders one chunk of rayon threads' worth of frames in parallel while streaming into the encoder, keeping at most one chunk of raw frames in memory.
+`write_animation` renders one chunk of rayon threads' worth of frames in parallel between encoder drains, keeping at most one chunk of raw frames in memory.

--- a/.tegami/chunked-animation-render.md
+++ b/.tegami/chunked-animation-render.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+---
+
+### Render animation frames in parallel chunks
+
+`write_animation` renders one chunk of rayon threads' worth of frames in parallel while streaming into the encoder, keeping at most one chunk of raw frames in memory.

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -549,9 +549,9 @@ fn encode_frames<W: Write>(
   }
 }
 
-/// Renders frames one chunk at a time: a chunk of `rayon` threads' worth of
-/// frames renders in parallel while the encoder drains the previous chunk, so
-/// at most one chunk of raw frames is in memory.
+/// Renders frames one chunk at a time: `next()` renders a chunk of `rayon`
+/// threads' worth of frames in parallel once the encoder has consumed the
+/// previous chunk, so at most one chunk of raw frames is in memory.
 #[cfg(feature = "rayon")]
 struct ChunkedFrames<'a, 'g> {
   scenes: &'a [SequentialScene<'g>],
@@ -584,8 +584,7 @@ impl Iterator for ChunkedFrames<'_, '_> {
       let chunk = &self.spans[self.next..(self.next + chunk_len).min(self.spans.len())];
       self.next += chunk.len();
 
-      // `PreparedScene` is not `Send`; each worker prepares its own copy and
-      // reuses it across the frames it takes from the chunk.
+      // `PreparedScene` is not `Send`: each worker prepares and reuses its own copy.
       self.ready = chunk
         .par_iter()
         .map_init(

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -1,5 +1,6 @@
 use std::{
   borrow::{Borrow, Cow},
+  collections::VecDeque,
   io::Write,
 };
 
@@ -18,7 +19,7 @@ use crate::webp::write_webp_lossy;
 use crate::{
   Result,
   error::Error,
-  render::{SequentialScene, frame_spans, prepare_scenes, render_frame},
+  render::{FrameSpan, SequentialScene, frame_spans, prepare_scenes, render_frame},
   webp::{encode_animated_webp, has_any_alpha_pixel, strip_alpha_channel, write_webp_lossless},
 };
 
@@ -510,8 +511,33 @@ pub fn write_animation<W: Write>(
     return Err(Error::EmptyAnimationFrames);
   }
 
-  let prepared = prepare_scenes(scenes);
-  let frames = spans.iter().map(|&span| render_frame(&prepared, span));
+  #[cfg(feature = "rayon")]
+  {
+    encode_frames(
+      ChunkedFrames::new(scenes, &spans),
+      &spans,
+      format,
+      destination,
+    )
+  }
+  #[cfg(not(feature = "rayon"))]
+  {
+    let prepared = prepare_scenes(scenes);
+    encode_frames(
+      spans.iter().map(|&span| render_frame(&prepared, span)),
+      &spans,
+      format,
+      destination,
+    )
+  }
+}
+
+fn encode_frames<W: Write>(
+  frames: impl Iterator<Item = Result<AnimationFrame>>,
+  spans: &[FrameSpan],
+  format: AnimationFormat,
+  destination: &mut W,
+) -> Result<()> {
   match format {
     AnimationFormat::WebP(options) => encode_animated_webp(frames, destination, options),
     AnimationFormat::Gif(options) => encode_animated_gif(frames, destination, options),
@@ -520,6 +546,56 @@ pub fn write_animation<W: Write>(
       let min_duration_ms = spans.iter().map(|span| span.duration_ms).min().unwrap_or(0);
       encode_animated_png(frames, frame_count, min_duration_ms, destination, options)
     }
+  }
+}
+
+/// Renders frames one chunk at a time: a chunk of `rayon` threads' worth of
+/// frames renders in parallel while the encoder drains the previous chunk, so
+/// at most one chunk of raw frames is in memory.
+#[cfg(feature = "rayon")]
+struct ChunkedFrames<'a, 'g> {
+  scenes: &'a [SequentialScene<'g>],
+  spans: &'a [FrameSpan],
+  next: usize,
+  ready: VecDeque<Result<AnimationFrame>>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, 'g> ChunkedFrames<'a, 'g> {
+  fn new(scenes: &'a [SequentialScene<'g>], spans: &'a [FrameSpan]) -> Self {
+    Self {
+      scenes,
+      spans,
+      next: 0,
+      ready: VecDeque::new(),
+    }
+  }
+}
+
+#[cfg(feature = "rayon")]
+impl Iterator for ChunkedFrames<'_, '_> {
+  type Item = Result<AnimationFrame>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    use rayon::prelude::*;
+
+    if self.ready.is_empty() && self.next < self.spans.len() {
+      let chunk_len = rayon::current_num_threads().max(1);
+      let chunk = &self.spans[self.next..(self.next + chunk_len).min(self.spans.len())];
+      self.next += chunk.len();
+
+      // `PreparedScene` is not `Send`; each worker prepares its own copy and
+      // reuses it across the frames it takes from the chunk.
+      self.ready = chunk
+        .par_iter()
+        .map_init(
+          || prepare_scenes(self.scenes),
+          |prepared, &span| render_frame(prepared, span),
+        )
+        .collect();
+    }
+
+    self.ready.pop_front()
   }
 }
 


### PR DESCRIPTION
## Why

`write_animation` streams one frame at a time into the encoder, which bounds memory but renders frames serially — animation timelines are embarrassingly parallel and multi-core sits idle between the per-frame rayon fan-out.

## What

- `write_animation` renders a chunk of `rayon::current_num_threads()` frames in parallel, then drains it into the encoder; at most one chunk of raw frames is in memory (~threads × frame size, vs the whole timeline under the old eager path).
- `PreparedScene` is not `Send`, so each worker prepares its own copy via `map_init` and reuses it across the frames it takes; the core render context stays single-threaded.
- Without the `rayon` feature the serial path is unchanged. The existing parity test pins chunked output byte-identical to render-then-encode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Animation frame exporting can now render frames in parallel (when supported), improving export speed.
  - Frame rendering is processed in bounded chunks to limit peak memory usage during animation encoding.
  - When parallel rendering isn’t available, exports continue to run sequentially.

- **Documentation**
  - Added documentation explaining chunked animation frame rendering and how streaming/buffering works.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->