### PR TITLE
Core: memoize GIF frames at draw size

### DIFF
--- a/.tegami/gif-frames-at-draw-size.md
+++ b/.tegami/gif-frames-at-draw-size.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "cargo:takumi-core": minor
+  "cargo:takumi-raster": patch
+---
+
+### Memoize GIF frames at draw size
+
+Frames past the first decode scaled to the box the GIF is drawn into, so an animation's memoized timeline holds draw-sized frames instead of canvas-sized ones. Adds `GifSource::frame_at_time_covering`.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -143,19 +143,18 @@ impl GifSource {
 
   /// The first caller decides the memoized frame size; renders of the same GIF
   /// use one draw box in practice.
-  fn rest(&self, target: Option<(u32, u32, ImageScalingAlgorithm)>) -> &RestFrames {
+  fn rest(&self, target: (u32, u32, ImageScalingAlgorithm)) -> &RestFrames {
     self.inner.rest.get_or_init(|| {
       let mut frames = Vec::new();
       let mut total_duration_ms = self.inner.first.duration_ms as u64;
-      let _ = decode_gif_frames(&self.inner.bytes, 1, None, target, |frame| {
+      let _ = decode_gif_frames(&self.inner.bytes, 1, None, Some(target), |frame| {
         total_duration_ms += frame.duration_ms as u64;
         frames.push(frame);
       });
       RestFrames {
         target: frames
           .first()
-          .map(|frame: &DecodedGifFrame| (frame.buffer.width(), frame.buffer.height()))
-          .filter(|&size| size != (self.inner.width, self.inner.height)),
+          .map(|frame: &DecodedGifFrame| (frame.buffer.width(), frame.buffer.height())),
         frames: frames.into(),
         total_duration_ms,
       }
@@ -186,19 +185,21 @@ impl GifSource {
   }
 
   /// Shared frame shown at the given playback time, looping over total duration.
-  pub fn frame_at_time(&self, time_ms: u64) -> Arc<ImageBuffer> {
+  #[cfg(test)]
+  fn frame_at_time(&self, time_ms: u64) -> Arc<ImageBuffer> {
     self.frame_at_time_covering(
       time_ms,
       self.inner.width,
       self.inner.height,
-      Default::default(),
+      ImageScalingAlgorithm::Auto,
     )
   }
 
-  /// [`frame_at_time`](Self::frame_at_time), but frames past the first are
-  /// decoded scaled to cover a `width` x `height` draw box (never upscaled), so
-  /// the memoized timeline holds draw-sized frames instead of canvas-sized
-  /// ones. A request larger than the memoized size decodes that frame fresh.
+  /// Shared frame shown at the given playback time, looping over total
+  /// duration. Frames past the first decode scaled to cover a `width` x
+  /// `height` draw box (never upscaled), so the memoized timeline holds
+  /// draw-sized frames; a request larger than the memoized size decodes that
+  /// frame fresh.
   pub fn frame_at_time_covering(
     &self,
     time_ms: u64,
@@ -212,38 +213,28 @@ impl GifSource {
     }
 
     let requested = cover_target((self.inner.width, self.inner.height), (width, height));
-    let rest = self.rest(
-      Some((requested.0, requested.1, algorithm))
-        .filter(|&(w, h, _)| (w, h) != (self.inner.width, self.inner.height)),
-    );
+    let rest = self.rest((requested.0, requested.1, algorithm));
     let Some(index) = self.rest_index_at(rest, time_ms) else {
       return first.buffer.clone();
     };
 
     let memoized = rest.target.unwrap_or((self.inner.width, self.inner.height));
     if requested.0 > memoized.0 || requested.1 > memoized.1 {
-      if let Some(frame) = self.decode_single(index + 1, requested, algorithm) {
+      let mut frame = None;
+      let target = (requested.0, requested.1, algorithm);
+      let _ = decode_gif_frames(
+        &self.inner.bytes,
+        index + 1,
+        Some(1),
+        Some(target),
+        |decoded| frame = Some(decoded.buffer),
+      );
+      if let Some(frame) = frame {
         return frame;
       }
     }
 
     rest.frames[index].buffer.clone()
-  }
-
-  /// Decodes one frame fresh at the requested size, bypassing the memo.
-  fn decode_single(
-    &self,
-    frame_index: usize,
-    (width, height): (u32, u32),
-    algorithm: ImageScalingAlgorithm,
-  ) -> Option<Arc<ImageBuffer>> {
-    let mut frame = None;
-    let target = Some((width, height, algorithm)).filter(|&(w, h, _)| (w, h) != self.dimensions());
-    decode_gif_frames(&self.inner.bytes, frame_index, Some(1), target, |decoded| {
-      frame = Some(decoded.buffer)
-    })
-    .ok()?;
-    frame
   }
 
   fn decoded_bytes(&self) -> usize {
@@ -1307,13 +1298,21 @@ mod tests {
 
   #[test]
   fn gif_scaled_frame_matches_resized_native() {
-    use crate::resources::image_decoder::resize_buffer;
+    use crate::resources::image_resampler::resample_premultiplied;
 
-    let native = gif_source(&[(0, 10), (1, 10)]).frame_at_time(15);
+    let source = gif_source(&[(0, 10), (1, 10)]);
+    let (width, height) = source.dimensions();
+    let native = source.frame_at_time_covering(15, width, height, ImageScalingAlgorithm::Auto);
     let scaled =
       gif_source(&[(0, 10), (1, 10)]).frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
 
-    let expected = resize_buffer(&native, 2, 2, ImageScalingAlgorithm::Auto).unwrap();
+    let expected = resample_premultiplied(
+      native.data(),
+      (native.width(), native.height()),
+      (2, 2),
+      ImageScalingAlgorithm::Auto,
+    )
+    .unwrap();
     assert_eq!(scaled.data(), expected.data());
   }
 

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -110,6 +110,8 @@ struct RestFrames {
   frames: Box<[DecodedGifFrame]>,
   /// Duration of the whole animation, first frame included.
   total_duration_ms: u64,
+  /// Size the frames were decoded at; `None` means canvas size.
+  target: Option<(u32, u32)>,
 }
 
 impl GifSource {
@@ -117,7 +119,7 @@ impl GifSource {
     let (width, height) = gif_dimensions(bytes).map_err(ImageError::decode)?;
 
     let mut first = None;
-    decode_gif_frames(bytes, 0, Some(1), |frame| first = Some(frame))
+    decode_gif_frames(bytes, 0, Some(1), None, |frame| first = Some(frame))
       .map_err(ImageError::decode)?;
     let Some(first) = first else {
       return Err(ImageError::InvalidGif);
@@ -139,47 +141,109 @@ impl GifSource {
     (self.inner.width, self.inner.height)
   }
 
-  fn rest(&self) -> &RestFrames {
+  /// The first caller decides the memoized frame size; renders of the same GIF
+  /// use one draw box in practice.
+  fn rest(&self, target: Option<(u32, u32, ImageScalingAlgorithm)>) -> &RestFrames {
     self.inner.rest.get_or_init(|| {
       let mut frames = Vec::new();
       let mut total_duration_ms = self.inner.first.duration_ms as u64;
-      let _ = decode_gif_frames(&self.inner.bytes, 1, None, |frame| {
+      let _ = decode_gif_frames(&self.inner.bytes, 1, None, target, |frame| {
         total_duration_ms += frame.duration_ms as u64;
         frames.push(frame);
       });
       RestFrames {
+        target: frames
+          .first()
+          .map(|frame: &DecodedGifFrame| (frame.buffer.width(), frame.buffer.height()))
+          .filter(|&size| size != (self.inner.width, self.inner.height)),
         frames: frames.into(),
         total_duration_ms,
       }
     })
   }
 
+  /// Index into `rest.frames` for the given playback time, or `None` when the
+  /// time falls on the first frame.
+  fn rest_index_at(&self, rest: &RestFrames, time_ms: u64) -> Option<usize> {
+    if rest.total_duration_ms == 0 {
+      return None;
+    }
+
+    let mut elapsed_ms = self.inner.first.duration_ms as u64;
+    let target_time = time_ms % rest.total_duration_ms;
+    if target_time < elapsed_ms {
+      return None;
+    }
+
+    for (index, frame) in rest.frames.iter().enumerate() {
+      elapsed_ms += frame.duration_ms as u64;
+      if target_time < elapsed_ms {
+        return Some(index);
+      }
+    }
+
+    None
+  }
+
   /// Shared frame shown at the given playback time, looping over total duration.
   pub fn frame_at_time(&self, time_ms: u64) -> Arc<ImageBuffer> {
+    self.frame_at_time_covering(
+      time_ms,
+      self.inner.width,
+      self.inner.height,
+      Default::default(),
+    )
+  }
+
+  /// [`frame_at_time`](Self::frame_at_time), but frames past the first are
+  /// decoded scaled to cover a `width` x `height` draw box (never upscaled), so
+  /// the memoized timeline holds draw-sized frames instead of canvas-sized
+  /// ones. A request larger than the memoized size decodes that frame fresh.
+  pub fn frame_at_time_covering(
+    &self,
+    time_ms: u64,
+    width: u32,
+    height: u32,
+    algorithm: ImageScalingAlgorithm,
+  ) -> Arc<ImageBuffer> {
     let first = &self.inner.first;
     if time_ms < first.duration_ms as u64 {
       return first.buffer.clone();
     }
 
-    let rest = self.rest();
-    if rest.total_duration_ms == 0 {
+    let requested = cover_target((self.inner.width, self.inner.height), (width, height));
+    let rest = self.rest(
+      Some((requested.0, requested.1, algorithm))
+        .filter(|&(w, h, _)| (w, h) != (self.inner.width, self.inner.height)),
+    );
+    let Some(index) = self.rest_index_at(rest, time_ms) else {
       return first.buffer.clone();
-    }
+    };
 
-    let mut elapsed_ms = first.duration_ms as u64;
-    let target_time = time_ms % rest.total_duration_ms;
-    if target_time < elapsed_ms {
-      return first.buffer.clone();
-    }
-
-    for frame in &rest.frames {
-      elapsed_ms += frame.duration_ms as u64;
-      if target_time < elapsed_ms {
-        return frame.buffer.clone();
+    let memoized = rest.target.unwrap_or((self.inner.width, self.inner.height));
+    if requested.0 > memoized.0 || requested.1 > memoized.1 {
+      if let Some(frame) = self.decode_single(index + 1, requested, algorithm) {
+        return frame;
       }
     }
 
-    first.buffer.clone()
+    rest.frames[index].buffer.clone()
+  }
+
+  /// Decodes one frame fresh at the requested size, bypassing the memo.
+  fn decode_single(
+    &self,
+    frame_index: usize,
+    (width, height): (u32, u32),
+    algorithm: ImageScalingAlgorithm,
+  ) -> Option<Arc<ImageBuffer>> {
+    let mut frame = None;
+    let target = Some((width, height, algorithm)).filter(|&(w, h, _)| (w, h) != self.dimensions());
+    decode_gif_frames(&self.inner.bytes, frame_index, Some(1), target, |decoded| {
+      frame = Some(decoded.buffer)
+    })
+    .ok()?;
+    frame
   }
 
   fn decoded_bytes(&self) -> usize {
@@ -240,11 +304,7 @@ impl EncodedBitmap {
     height: u32,
     algorithm: ImageScalingAlgorithm,
   ) -> Result<(Arc<ImageBuffer>, (f32, f32)), ImageError> {
-    let scale = (width as f32 / self.width as f32)
-      .max(height as f32 / self.height as f32)
-      .min(1.0);
-    let target_width = ((self.width as f32 * scale).round() as u32).clamp(1, self.width);
-    let target_height = ((self.height as f32 * scale).round() as u32).clamp(1, self.height);
+    let (target_width, target_height) = cover_target((self.width, self.height), (width, height));
 
     let buffer = self.decode_scaled(target_width, target_height, algorithm)?;
     let scale = (
@@ -483,13 +543,20 @@ impl ImageSource {
         algorithm: image_rendering,
         source_scale: (1.0, 1.0),
       }),
-      ImageSource::Gif(gif) => Ok(RenderedImage::Sampled {
-        source: gif.frame_at_time(time_ms),
-        width,
-        height,
-        algorithm: image_rendering,
-        source_scale: (1.0, 1.0),
-      }),
+      ImageSource::Gif(gif) => {
+        let source = gif.frame_at_time_covering(time_ms, width, height, image_rendering);
+        let (native_width, native_height) = gif.dimensions();
+        Ok(RenderedImage::Sampled {
+          source_scale: (
+            source.width() as f32 / native_width as f32,
+            source.height() as f32 / native_height as f32,
+          ),
+          source,
+          width,
+          height,
+          algorithm: image_rendering,
+        })
+      }
       ImageSource::Encoded(encoded) => {
         let (source, source_scale) = encoded.decode_at(width, height, image_rendering)?;
         Ok(RenderedImage::Sampled {
@@ -568,6 +635,17 @@ impl ImageSource {
       }
     }
   }
+}
+
+/// Cover-fit target for a draw box: uniform scale, never upscaled.
+fn cover_target((native_w, native_h): (u32, u32), (box_w, box_h): (u32, u32)) -> (u32, u32) {
+  let scale = (box_w as f32 / native_w as f32)
+    .max(box_h as f32 / native_h as f32)
+    .min(1.0);
+  (
+    ((native_w as f32 * scale).round() as u32).clamp(1, native_w),
+    ((native_h as f32 * scale).round() as u32).clamp(1, native_h),
+  )
 }
 
 /// Check if the string looks like an SVG image.
@@ -1198,6 +1276,45 @@ mod tests {
 
     drop(cloned.frame_at_time(25));
     assert_eq!(gif.decoded_frame_count(), 3);
+  }
+
+  #[test]
+  fn gif_frames_memoize_at_draw_size() {
+    let gif = gif_source(&[(0, 10), (1, 10), (2, 10)]);
+
+    let scaled = gif.frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
+    assert_eq!((scaled.width(), scaled.height()), (2, 2));
+
+    let again = gif.frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
+    assert!(Arc::ptr_eq(&scaled, &again));
+
+    let smaller = gif.frame_at_time_covering(15, 1, 1, ImageScalingAlgorithm::Auto);
+    assert!(Arc::ptr_eq(&scaled, &smaller));
+
+    let larger = gif.frame_at_time_covering(15, 4, 4, ImageScalingAlgorithm::Auto);
+    assert_eq!((larger.width(), larger.height()), (4, 4));
+    assert!(!Arc::ptr_eq(&scaled, &larger));
+  }
+
+  #[test]
+  fn gif_first_frame_stays_native() {
+    let gif = gif_source(&[(0, 10), (1, 10)]);
+
+    let first = gif.frame_at_time_covering(0, 2, 2, ImageScalingAlgorithm::Auto);
+    assert_eq!((first.width(), first.height()), (4, 4));
+    assert_eq!(gif.decoded_frame_count(), 1);
+  }
+
+  #[test]
+  fn gif_scaled_frame_matches_resized_native() {
+    use crate::resources::image_decoder::resize_buffer;
+
+    let native = gif_source(&[(0, 10), (1, 10)]).frame_at_time(15);
+    let scaled =
+      gif_source(&[(0, 10), (1, 10)]).frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
+
+    let expected = resize_buffer(&native, 2, 2, ImageScalingAlgorithm::Auto).unwrap();
+    assert_eq!(scaled.data(), expected.data());
   }
 
   #[test]

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -143,22 +143,6 @@ pub(crate) fn bitmap_dimensions(bytes: &[u8]) -> Option<ImageResult<(u32, u32)>>
   Some(dimensions)
 }
 
-/// Downscales a decoded (premultiplied) buffer; linear filtering of
-/// premultiplied RGBA is alpha-correct.
-pub(crate) fn resize_buffer(
-  buffer: &ImageBuffer,
-  width: u32,
-  height: u32,
-  algorithm: ImageScalingAlgorithm,
-) -> Option<ImageBuffer> {
-  resample_premultiplied(
-    buffer.data(),
-    (buffer.width(), buffer.height()),
-    (width, height),
-    algorithm,
-  )
-}
-
 /// Decodes bitmap bytes scaled to cover `width` x `height`, never upscaling.
 /// Non-interlaced PNGs stream row-by-row through the resampler without a
 /// full-size buffer; everything else decodes fully and resizes.
@@ -177,7 +161,13 @@ pub(crate) fn decode_bitmap_scaled(
     return Ok(decoded);
   }
 
-  resize_buffer(&decoded, width, height, algorithm).ok_or_else(invalid_buffer_error)
+  resample_premultiplied(
+    decoded.data(),
+    (decoded.width(), decoded.height()),
+    (width, height),
+    algorithm,
+  )
+  .ok_or_else(invalid_buffer_error)
 }
 
 fn png_decode_error(error: png::DecodingError) -> ImageError {
@@ -602,7 +592,13 @@ mod tests {
     ] {
       let streamed = decode_bitmap_scaled(bytes, width, height, algorithm).unwrap();
       let full = decode_image(bytes).unwrap();
-      let resized = resize_buffer(&full, width, height, algorithm).unwrap();
+      let resized = resample_premultiplied(
+        full.data(),
+        (full.width(), full.height()),
+        (width, height),
+        algorithm,
+      )
+      .unwrap();
       assert_eq!(streamed.data(), resized.data(), "{algorithm:?}");
     }
   }

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -20,7 +20,7 @@ use crate::{
   geometry::Rect,
   resources::{
     image_buffer::{ImageBuffer, premultiply_rgba_in_place},
-    image_resampler::StreamResampler,
+    image_resampler::{StreamResampler, resample_premultiplied},
   },
   style::ImageScalingAlgorithm,
 };
@@ -151,15 +151,12 @@ pub(crate) fn resize_buffer(
   height: u32,
   algorithm: ImageScalingAlgorithm,
 ) -> Option<ImageBuffer> {
-  let mut resampler = StreamResampler::new(
+  resample_premultiplied(
+    buffer.data(),
     (buffer.width(), buffer.height()),
     (width, height),
     algorithm,
-  );
-  for row in buffer.data().chunks_exact(buffer.width() as usize * 4) {
-    resampler.push_row(row);
-  }
-  resampler.finish()
+  )
 }
 
 /// Decodes bitmap bytes scaled to cover `width` x `height`, never upscaling.
@@ -320,6 +317,9 @@ fn clear_rect(canvas: &mut [u8], canvas_size: (u32, u32), rect: Rect<u32>) {
 /// truncates the timeline (reported as ended); only a stream with no decodable
 /// first frame errors.
 ///
+/// With `target` set (and smaller than the canvas), pushed frames are resampled
+/// to that size; compositing always happens at canvas size.
+///
 /// Compositing matches the `image` crate (and browsers): frames blend over a
 /// transparent canvas, `Keep` persists the composited result, `Background`
 /// clears the frame rect, `Previous` restores the pre-frame canvas.
@@ -327,10 +327,12 @@ pub(crate) fn decode_gif_frames(
   bytes: &[u8],
   skip: usize,
   limit: Option<usize>,
+  target: Option<(u32, u32, ImageScalingAlgorithm)>,
   mut push: impl FnMut(DecodedGifFrame),
 ) -> ImageResult<bool> {
   let mut decoder = gif_decoder(bytes)?;
   let (width, height) = (decoder.width() as u32, decoder.height() as u32);
+  let target = target.filter(|&(w, h, _)| w < width || h < height);
 
   // GIF alpha is 0 or 255, so the canvas is valid premultiplied RGBA as-is:
   // blits copy opaque pixels (premultiply is identity) and cleared pixels are
@@ -378,35 +380,56 @@ pub(crate) fn decode_gif_frames(
     }
 
     // The emitted frame is the canvas after compositing, before disposal.
+    // With a target, the composited canvas resamples down instead of cloning.
     let keep = current >= skip;
     let last_needed = keep && limit.is_some_and(|limit| pushed + 1 >= limit);
-    let composited = if last_needed {
-      // The canvas is never read again: emit it without cloning.
-      blit_frame(&mut canvas, (width, height), rect, &scratch);
-      Some(take(&mut canvas))
-    } else {
-      match dispose {
-        DisposalMethod::Any | DisposalMethod::Keep => {
-          blit_frame(&mut canvas, (width, height), rect, &scratch);
-          keep.then(|| canvas.clone())
+    let buffer = match dispose {
+      DisposalMethod::Any | DisposalMethod::Keep => {
+        blit_frame(&mut canvas, (width, height), rect, &scratch);
+        if !keep {
+          None
+        } else if let Some((w, h, algorithm)) = target {
+          Some(resample_premultiplied(
+            &canvas,
+            (width, height),
+            (w, h),
+            algorithm,
+          ))
+        } else if last_needed {
+          // The canvas is never read again: emit it without cloning.
+          Some(ImageBuffer::from_premultiplied_rgba(
+            take(&mut canvas),
+            width,
+            height,
+          ))
+        } else {
+          Some(ImageBuffer::from_premultiplied_rgba(
+            canvas.clone(),
+            width,
+            height,
+          ))
         }
-        DisposalMethod::Background | DisposalMethod::Previous => {
-          let composited = keep.then(|| {
-            let mut out = canvas.clone();
-            blit_frame(&mut out, (width, height), rect, &scratch);
-            out
-          });
-          if matches!(dispose, DisposalMethod::Background) {
-            clear_rect(&mut canvas, (width, height), rect);
+      }
+      DisposalMethod::Background | DisposalMethod::Previous => {
+        let buffer = keep.then(|| {
+          let mut out = canvas.clone();
+          blit_frame(&mut out, (width, height), rect, &scratch);
+          match target {
+            Some((w, h, algorithm)) => {
+              resample_premultiplied(&out, (width, height), (w, h), algorithm)
+            }
+            None => ImageBuffer::from_premultiplied_rgba(out, width, height),
           }
-          composited
+        });
+        if matches!(dispose, DisposalMethod::Background) {
+          clear_rect(&mut canvas, (width, height), rect);
         }
+        buffer
       }
     };
 
-    if let Some(composited) = composited {
-      let buffer = ImageBuffer::from_premultiplied_rgba(composited, width, height)
-        .ok_or_else(invalid_buffer_error)?;
+    if let Some(buffer) = buffer {
+      let buffer = buffer.ok_or_else(invalid_buffer_error)?;
       push(DecodedGifFrame {
         buffer: Arc::new(buffer),
         duration_ms,
@@ -670,7 +693,7 @@ mod tests {
 
   fn our_frames(bytes: &[u8], skip: usize) -> Vec<(Vec<u8>, u32)> {
     let mut frames = Vec::new();
-    let ended = decode_gif_frames(bytes, skip, None, |frame| {
+    let ended = decode_gif_frames(bytes, skip, None, None, |frame| {
       frames.push((frame.buffer.data().to_vec(), frame.duration_ms));
     })
     .unwrap();
@@ -894,7 +917,7 @@ mod tests {
     );
 
     let mut frames = Vec::new();
-    let ended = decode_gif_frames(&bytes, 0, Some(1), |frame| frames.push(frame)).unwrap();
+    let ended = decode_gif_frames(&bytes, 0, Some(1), None, |frame| frames.push(frame)).unwrap();
     assert!(!ended);
     assert_eq!(frames.len(), 1);
   }

--- a/takumi-core/src/resources/image_resampler.rs
+++ b/takumi-core/src/resources/image_resampler.rs
@@ -244,6 +244,20 @@ impl StreamResampler {
   }
 }
 
+/// Resamples a whole premultiplied RGBA buffer in one call.
+pub(crate) fn resample_premultiplied(
+  data: &[u8],
+  source: (u32, u32),
+  target: (u32, u32),
+  algorithm: ImageScalingAlgorithm,
+) -> Option<ImageBuffer> {
+  let mut resampler = StreamResampler::new(source, target, algorithm);
+  for row in data.chunks_exact(source.0 as usize * 4) {
+    resampler.push_row(row);
+  }
+  resampler.finish()
+}
+
 #[cfg(test)]
 mod tests {
   use image::{RgbaImage, imageops};

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -538,7 +538,12 @@ pub(crate) fn render_tile(
             algo: context.style.image_rendering,
           }),
           ImageSource::Gif(gif) => Some(BackgroundTile::SampledBitmap {
-            source: gif.frame_at_time(context.time_ms),
+            source: gif.frame_at_time_covering(
+              context.time_ms,
+              tile_w,
+              tile_h,
+              context.style.image_rendering,
+            ),
             width: tile_w,
             height: tile_h,
             algo: context.style.image_rendering,

--- a/takumi-svg/src/image.rs
+++ b/takumi-svg/src/image.rs
@@ -11,7 +11,7 @@ use takumi_core::{
   context::RenderContext,
   layout::node::{ImageData, ImageSourceInput, resolve_image},
   resources::image::ImageSource,
-  style::{Length, ObjectFit, PositionComponent},
+  style::{ImageScalingAlgorithm, Length, ObjectFit, PositionComponent},
 };
 
 use crate::{Frame, SvgDocument, box_model::rect_path_data};
@@ -101,10 +101,13 @@ fn loaded_data_url(source: &ImageSource) -> Option<String> {
   match source {
     ImageSource::Bitmap(buffer) => buffer.encode_png().map(|png| encode("image/png", &png)),
     ImageSource::Encoded(encoded) => Some(encode(sniff_mime(encoded.bytes()), encoded.bytes())),
-    ImageSource::Gif(gif) => gif
-      .frame_at_time(0)
-      .encode_png()
-      .map(|png| encode("image/png", &png)),
+    ImageSource::Gif(gif) => {
+      let (width, height) = gif.dimensions();
+      gif
+        .frame_at_time_covering(0, width, height, ImageScalingAlgorithm::Auto)
+        .encode_png()
+        .map(|png| encode("image/png", &png))
+    }
     ImageSource::Svg(svg) => Some(encode("image/svg+xml", svg.source().as_bytes())),
     _ => None,
   }


### PR DESCRIPTION
## Why

`GifSource` memoizes every frame past the first at full canvas size, so an animation render keeps the whole timeline resident at source resolution: a 500px 100-frame GIF drawn into a 200px box holds ~100 MB. The memo itself has to stay — GIF frames are delta patches (frame N needs 0..N composited) and #963 renders frames in parallel, so random access over the decoded timeline is required — but it doesn't have to be canvas-sized.

## What

- `decode_gif_frames` takes an optional target: compositing still happens on the native canvas, but kept frames stream through the resampler and are stored at the cover-fit draw size (never upscaled).
- `GifSource::frame_at_time_covering(time, width, height, algorithm)` decodes the timeline at the draw box; the first caller fixes the memoized size, smaller requests reuse it (the sampler scales at draw), and a larger request decodes that single frame fresh without touching the memo.
- The first frame stays native (decoded before any draw size is known), so static renders are unchanged; `frame_at_time` keeps native semantics for the SVG backend's data-URI embed.
- The raster image and background paths pass their box through; `RenderedImage::Sampled`'s `source_scale` comes from the returned buffer's dimensions, so object-fit math is unchanged.
- `cover_target` is shared with `EncodedBitmap`'s decode-at-size path. Tests cover memo dimensions and reuse, the fresh larger-request path, the native first frame, and pixel equality of scaled frames against resize-after-decode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GIF frame sampling now supports cover-fit rendering that matches the intended draw/tile dimensions and image-scaling settings.
  * GIF embedding in SVG for PNG data URLs now selects the most appropriate frame for the target size.

* **Bug Fixes**
  * Improved memoization for GIF frames across repeated renders at the same draw size, with safe re-decoding when dimensions increase.
  * Fixed scaled GIF output consistency and preserved native resolution for initial covering requests.
  * Kept GIF disposal and transparency behavior consistent during scaling and compositing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->