### PR TITLE
Docs: name the generic font loader example

### DIFF
--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -64,6 +64,7 @@ export function GET() {
   return new ImageResponse(<div tw="font-mono">let x = 1;</div>, {
     fonts: [
       {
+        name: "Geist Mono",
         generic: "monospace",
         data: () => fetch("https://example.com/GeistMono.woff2").then((res) => res.arrayBuffer()),
       },


### PR DESCRIPTION
## Why

The Deploy docs job fails on master: twoslash flags the `generic` font example from #964 — a loader-form `FontLoader` requires `name`.

## What

The example names the family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the typography and fonts example to explicitly name the built-in “Geist Mono” font.
  * Clarified usage when configuring the generic `monospace` font family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->