### PR TITLE
Helpers: support generic on googleFonts families

### DIFF
--- a/.tegami/google-fonts-generic.md
+++ b/.tegami/google-fonts-generic.md
@@ -5,4 +5,4 @@ packages:
 
 ### Support generic on googleFonts families
 
-A family's `generic` (e.g. `"monospace"`) propagates to every loaded coverage subset, so generic stacks like `font-mono` resolve to it. Families Google Fonts categorizes as Monospace claim it automatically.
+A family's `generic` (e.g. `"monospace"`) propagates to every loaded coverage subset, so generic stacks like `font-mono` resolve to it.

--- a/.tegami/google-fonts-generic.md
+++ b/.tegami/google-fonts-generic.md
@@ -5,4 +5,4 @@ packages:
 
 ### Support generic on googleFonts families
 
-A family's `generic` (e.g. `"monospace"`) propagates to every loaded coverage subset, so generic stacks like `font-mono` resolve to it.
+A family's `generic` (e.g. `"monospace"`) propagates to every loaded coverage subset, so generic stacks like `font-mono` resolve to it. Families Google Fonts categorizes as Monospace claim it automatically.

--- a/.tegami/google-fonts-generic.md
+++ b/.tegami/google-fonts-generic.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "npm:@takumi-rs/helpers": minor
+---
+
+### Support generic on googleFonts families
+
+A family's `generic` (e.g. `"monospace"`) propagates to every loaded coverage subset, so generic stacks like `font-mono` resolve to it.

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -114,12 +114,13 @@ await googleFonts([
 
 Each family accepts:
 
-| Field    | Accepts                                     | Effect                                                                     |
-| -------- | ------------------------------------------- | -------------------------------------------------------------------------- |
-| `name`   | a family name                               | The family to load. Known families autocomplete their weights and axes.    |
-| `weight` | a weight, an array, or a range `"100..900"` | A range loads the variable font; CSS `font-weight` drives it.              |
-| `style`  | `"normal"`, `"italic"`, or both             | Which styles to fetch.                                                     |
-| `axes`   | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live. |
+| Field     | Accepts                                     | Effect                                                                     |
+| --------- | ------------------------------------------- | -------------------------------------------------------------------------- |
+| `name`    | a family name                               | The family to load. Known families autocomplete their weights and axes.    |
+| `weight`  | a weight, an array, or a range `"100..900"` | A range loads the variable font; CSS `font-weight` drives it.              |
+| `style`   | `"normal"`, `"italic"`, or both             | Which styles to fetch.                                                     |
+| `axes`    | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live. |
+| `generic` | a CSS generic family keyword                | Every loaded subset claims it, so e.g. `font-mono` resolves to the family. |
 
 Pass an object instead of a list for request-level options:
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -114,13 +114,13 @@ await googleFonts([
 
 Each family accepts:
 
-| Field     | Accepts                                     | Effect                                                                     |
-| --------- | ------------------------------------------- | -------------------------------------------------------------------------- |
-| `name`    | a family name                               | The family to load. Known families autocomplete their weights and axes.    |
-| `weight`  | a weight, an array, or a range `"100..900"` | A range loads the variable font; CSS `font-weight` drives it.              |
-| `style`   | `"normal"`, `"italic"`, or both             | Which styles to fetch.                                                     |
-| `axes`    | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live. |
-| `generic` | a CSS generic family keyword                | Every loaded subset claims it, so e.g. `font-mono` resolves to the family. |
+| Field     | Accepts                                     | Effect                                                                                                                                               |
+| --------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`    | a family name                               | The family to load. Known families autocomplete their weights and axes.                                                                              |
+| `weight`  | a weight, an array, or a range `"100..900"` | A range loads the variable font; CSS `font-weight` drives it.                                                                                        |
+| `style`   | `"normal"`, `"italic"`, or both             | Which styles to fetch.                                                                                                                               |
+| `axes`    | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live.                                                                           |
+| `generic` | a CSS generic family keyword                | Every loaded subset claims it, so e.g. `font-mono` resolves to the family. Families Google categorizes as Monospace claim `monospace` automatically. |
 
 Pass an object instead of a list for request-level options:
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -114,13 +114,13 @@ await googleFonts([
 
 Each family accepts:
 
-| Field     | Accepts                                     | Effect                                                                                                                                               |
-| --------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`    | a family name                               | The family to load. Known families autocomplete their weights and axes.                                                                              |
-| `weight`  | a weight, an array, or a range `"100..900"` | A range loads the variable font; CSS `font-weight` drives it.                                                                                        |
-| `style`   | `"normal"`, `"italic"`, or both             | Which styles to fetch.                                                                                                                               |
-| `axes`    | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live.                                                                           |
-| `generic` | a CSS generic family keyword                | Every loaded subset claims it, so e.g. `font-mono` resolves to the family. Families Google categorizes as Monospace claim `monospace` automatically. |
+| Field     | Accepts                                     | Effect                                                                     |
+| --------- | ------------------------------------------- | -------------------------------------------------------------------------- |
+| `name`    | a family name                               | The family to load. Known families autocomplete their weights and axes.    |
+| `weight`  | a weight, an array, or a range `"100..900"` | A range loads the variable font; CSS `font-weight` drives it.              |
+| `style`   | `"normal"`, `"italic"`, or both             | Which styles to fetch.                                                     |
+| `axes`    | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live. |
+| `generic` | a CSS generic family keyword                | Every loaded subset claims it, so e.g. `font-mono` resolves to the family. |
 
 Pass an object instead of a list for request-level options:
 

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,4 +1,8 @@
-import type { GoogleFontShapeFamilies, GoogleFontShapes } from "./google-fonts-catalog";
+import {
+  MONOSPACE_FAMILIES,
+  type GoogleFontShapeFamilies,
+  type GoogleFontShapes,
+} from "./google-fonts-catalog";
 import type { Node } from "./types";
 import { defaultMaxFetchBytes, fetchOk, type FetchOptions, readBodyLimited } from "./utils";
 
@@ -438,11 +442,16 @@ export async function googleFonts(
       index,
     ]),
   );
-  const generics = new Map(
-    options.families.flatMap((family) =>
-      typeof family === "string" || !family.generic ? [] : [[family.name, family.generic] as const],
-    ),
-  );
+  // Explicit `generic` wins; families Google Fonts categorizes as monospace claim it themselves.
+  const generics = new Map<string, GenericFontFamily>();
+  for (const family of options.families) {
+    const name = typeof family === "string" ? family : family.name;
+    const explicit = typeof family === "string" ? undefined : family.generic;
+    const generic = explicit ?? (MONOSPACE_FAMILIES.has(name) ? "monospace" : undefined);
+    if (generic) {
+      generics.set(name, generic);
+    }
+  }
 
   return mergeVariableFaces(parseSubsetFaces(css))
     .sort((a, b) => (familyOrder.get(a.family) ?? 0) - (familyOrder.get(b.family) ?? 0))

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -6,6 +6,22 @@ const chromeUserAgent =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
 type FontStyle = "normal" | "italic";
+
+/** CSS generic family keywords a font can claim. */
+export type GenericFontFamily =
+  | "serif"
+  | "sans-serif"
+  | "monospace"
+  | "cursive"
+  | "fantasy"
+  | "system-ui"
+  | "ui-serif"
+  | "ui-sans-serif"
+  | "ui-monospace"
+  | "ui-rounded"
+  | "emoji"
+  | "math"
+  | "fangsong";
 type WeightRange = `${number}..${number}`;
 type AxisValue = number | WeightRange;
 
@@ -22,6 +38,8 @@ type KnownGoogleFontFamily = {
     axes?: [GoogleFontShapes[S]["axis"]] extends [never]
       ? never
       : Partial<Record<GoogleFontShapes[S]["axis"], AxisValue>>;
+    /** CSS generic family the loaded subsets claim, e.g. `"monospace"`. */
+    generic?: GenericFontFamily;
   };
 }[keyof GoogleFontShapes];
 
@@ -41,6 +59,8 @@ export type GoogleFontFamily =
       weight?: number | number[] | WeightRange;
       style?: FontStyle | FontStyle[];
       axes?: Record<string, AxisValue>;
+      /** CSS generic family the loaded subsets claim, e.g. `"monospace"`. */
+      generic?: GenericFontFamily;
     };
 
 export type GoogleFontsOptions = FetchOptions & {
@@ -177,11 +197,17 @@ export type FontSubset = {
   style?: string;
   /** Inclusive codepoint ranges this subset covers; empty covers everything. */
   ranges: [number, number][];
+  /** CSS generic family the subset claims, from the family's `generic` option. */
+  generic?: GenericFontFamily;
   /** Fetches the subset bytes. The renderer skips files it has already loaded. */
   data: () => Promise<ArrayBuffer>;
 };
 
-function toSubset(face: SubsetFace, options: FetchOptions): FontSubset {
+function toSubset(
+  face: SubsetFace,
+  options: FetchOptions,
+  generic?: GenericFontFamily,
+): FontSubset {
   const name = `${face.family} ${face.subset}`;
   const range = face.ranges.map(([lo, hi]) => `${lo}-${hi}`).join(",");
 
@@ -190,10 +216,11 @@ function toSubset(face: SubsetFace, options: FetchOptions): FontSubset {
     subsetOf: face.family,
     // Stable coverage identity, not the woff2 URL Google may rotate, so the renderer dedups
     // across calls yet never merges two subsets that cover different ranges.
-    key: `${name}:${face.weight ?? ""}:${face.style ?? ""}:${range}`,
+    key: `${name}:${face.weight ?? ""}:${face.style ?? ""}:${range}:${generic ?? ""}`,
     weight: face.weight,
     style: face.style,
     ranges: face.ranges,
+    generic,
     data: () =>
       fetchOk(face.url, options).then((r) =>
         readBodyLimited(r, options.maxBytes ?? defaultMaxFetchBytes),
@@ -411,8 +438,13 @@ export async function googleFonts(
       index,
     ]),
   );
+  const generics = new Map(
+    options.families.flatMap((family) =>
+      typeof family === "string" || !family.generic ? [] : [[family.name, family.generic] as const],
+    ),
+  );
 
   return mergeVariableFaces(parseSubsetFaces(css))
     .sort((a, b) => (familyOrder.get(a.family) ?? 0) - (familyOrder.get(b.family) ?? 0))
-    .map((face) => toSubset(face, options));
+    .map((face) => toSubset(face, options, generics.get(face.family)));
 }

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,8 +1,4 @@
-import {
-  MONOSPACE_FAMILIES,
-  type GoogleFontShapeFamilies,
-  type GoogleFontShapes,
-} from "./google-fonts-catalog";
+import type { GoogleFontShapeFamilies, GoogleFontShapes } from "./google-fonts-catalog";
 import type { Node } from "./types";
 import { defaultMaxFetchBytes, fetchOk, type FetchOptions, readBodyLimited } from "./utils";
 
@@ -442,16 +438,11 @@ export async function googleFonts(
       index,
     ]),
   );
-  // Explicit `generic` wins; families Google Fonts categorizes as monospace claim it themselves.
-  const generics = new Map<string, GenericFontFamily>();
-  for (const family of options.families) {
-    const name = typeof family === "string" ? family : family.name;
-    const explicit = typeof family === "string" ? undefined : family.generic;
-    const generic = explicit ?? (MONOSPACE_FAMILIES.has(name) ? "monospace" : undefined);
-    if (generic) {
-      generics.set(name, generic);
-    }
-  }
+  const generics = new Map(
+    options.families.flatMap((family) =>
+      typeof family === "string" || !family.generic ? [] : [[family.name, family.generic] as const],
+    ),
+  );
 
   return mergeVariableFaces(parseSubsetFaces(css))
     .sort((a, b) => (familyOrder.get(a.family) ?? 0) - (familyOrder.get(b.family) ?? 0))

--- a/takumi-helpers/src/renderer.ts
+++ b/takumi-helpers/src/renderer.ts
@@ -1,4 +1,4 @@
-import { fontFromUrl, subsetFonts } from "./fonts";
+import { fontFromUrl, type GenericFontFamily, subsetFonts } from "./fonts";
 import type { Node } from "./types";
 
 /**
@@ -31,20 +31,7 @@ export type FontDetails = {
    * CSS generic family keyword this font resolves for, so stacks ending in e.g.
    * `monospace` reach it without naming the family.
    */
-  generic?:
-    | "serif"
-    | "sans-serif"
-    | "monospace"
-    | "cursive"
-    | "fantasy"
-    | "system-ui"
-    | "ui-serif"
-    | "ui-sans-serif"
-    | "ui-monospace"
-    | "ui-rounded"
-    | "emoji"
-    | "math"
-    | "fangsong";
+  generic?: GenericFontFamily;
 };
 
 /** A registered font, either detailed or raw bytes. */

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -53,6 +53,23 @@ describe("googleFonts", () => {
     }
   `;
 
+  test("families Google categorizes as monospace claim the generic automatically", async () => {
+    const monoCss = interCss.replaceAll("Inter", "JetBrains Mono");
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(url.includes("/css2") ? new Response(monoCss) : new Response(bytes(url))),
+    );
+
+    const fonts = await googleFonts({ families: ["JetBrains Mono"], fetch: fetchMock });
+    expect(fonts.length).toBeGreaterThan(0);
+    expect(fonts.every((f) => f.generic === "monospace")).toBe(true);
+
+    const overridden = await googleFonts({
+      families: [{ name: "JetBrains Mono", generic: "ui-monospace" }],
+      fetch: fetchMock,
+    });
+    expect(overridden.every((f) => f.generic === "ui-monospace")).toBe(true);
+  });
+
   test("propagates the family's generic claim to every subset", async () => {
     const fonts = await googleFonts({
       families: [{ name: "Inter", generic: "sans-serif" }],

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -53,6 +53,20 @@ describe("googleFonts", () => {
     }
   `;
 
+  test("propagates the family's generic claim to every subset", async () => {
+    const fonts = await googleFonts({
+      families: [{ name: "Inter", generic: "sans-serif" }],
+      fetch: mockInter(),
+    });
+
+    expect(fonts.length).toBeGreaterThan(0);
+    expect(fonts.every((f) => f.generic === "sans-serif")).toBe(true);
+    expect(fonts.every((f) => f.key.endsWith(":sans-serif"))).toBe(true);
+
+    const plain = await googleFonts({ families: ["Inter"], fetch: mockInter() });
+    expect(plain.every((f) => f.generic === undefined)).toBe(true);
+  });
+
   test("gives each coverage subset a distinct name so glyphs can't collide", async () => {
     const fonts = await googleFonts({ families: ["Inter"], fetch: mockInter() });
 

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -53,23 +53,6 @@ describe("googleFonts", () => {
     }
   `;
 
-  test("families Google categorizes as monospace claim the generic automatically", async () => {
-    const monoCss = interCss.replaceAll("Inter", "JetBrains Mono");
-    const fetchMock = mock((url: string) =>
-      Promise.resolve(url.includes("/css2") ? new Response(monoCss) : new Response(bytes(url))),
-    );
-
-    const fonts = await googleFonts({ families: ["JetBrains Mono"], fetch: fetchMock });
-    expect(fonts.length).toBeGreaterThan(0);
-    expect(fonts.every((f) => f.generic === "monospace")).toBe(true);
-
-    const overridden = await googleFonts({
-      families: [{ name: "JetBrains Mono", generic: "ui-monospace" }],
-      fetch: fetchMock,
-    });
-    expect(overridden.every((f) => f.generic === "ui-monospace")).toBe(true);
-  });
-
   test("propagates the family's generic claim to every subset", async () => {
     const fonts = await googleFonts({
       families: [{ name: "Inter", generic: "sans-serif" }],

--- a/takumi-helpers/tsdown.config.ts
+++ b/takumi-helpers/tsdown.config.ts
@@ -8,7 +8,6 @@ interface FamilyMetadata {
   family: string;
   fonts: Record<string, unknown>;
   axes?: { tag: string }[];
-  category?: string;
 }
 
 async function generateCatalog() {
@@ -84,11 +83,6 @@ async function generateCatalog() {
   const shapeFamilyLines = [...shapeFamilies.entries()].map(
     ([name, names]) => `  ${name}: ${names.map((f) => JSON.stringify(f)).join(" | ")};`,
   );
-  // Google's own category misses real mono faces (Cascadia Code, Noto Sans Mono, ...); a
-  // word-bounded name check recovers them with no false positives against the current catalog.
-  const monospaceLines = families
-    .filter(({ category, family }) => category === "Monospace" || /\b(mono|code)\b/i.test(family))
-    .map(({ family }) => `  ${JSON.stringify(family)},`);
 
   await writeFile(
     CATALOG_FILE,
@@ -103,11 +97,6 @@ ${shapeLines.join("\n")}
 export interface GoogleFontShapeFamilies {
 ${shapeFamilyLines.join("\n")}
 }
-
-// Families Google Fonts categorizes as Monospace; they claim the generic automatically.
-export const MONOSPACE_FAMILIES: ReadonlySet<string> = new Set([
-${monospaceLines.join("\n")}
-]);
 `,
   );
 }

--- a/takumi-helpers/tsdown.config.ts
+++ b/takumi-helpers/tsdown.config.ts
@@ -8,6 +8,7 @@ interface FamilyMetadata {
   family: string;
   fonts: Record<string, unknown>;
   axes?: { tag: string }[];
+  category?: string;
 }
 
 async function generateCatalog() {
@@ -83,6 +84,11 @@ async function generateCatalog() {
   const shapeFamilyLines = [...shapeFamilies.entries()].map(
     ([name, names]) => `  ${name}: ${names.map((f) => JSON.stringify(f)).join(" | ")};`,
   );
+  // Google's own category misses real mono faces (Cascadia Code, Noto Sans Mono, ...); a
+  // word-bounded name check recovers them with no false positives against the current catalog.
+  const monospaceLines = families
+    .filter(({ category, family }) => category === "Monospace" || /\b(mono|code)\b/i.test(family))
+    .map(({ family }) => `  ${JSON.stringify(family)},`);
 
   await writeFile(
     CATALOG_FILE,
@@ -97,6 +103,11 @@ ${shapeLines.join("\n")}
 export interface GoogleFontShapeFamilies {
 ${shapeFamilyLines.join("\n")}
 }
+
+// Families Google Fonts categorizes as Monospace; they claim the generic automatically.
+export const MONOSPACE_FAMILIES: ReadonlySet<string> = new Set([
+${monospaceLines.join("\n")}
+]);
 `,
   );
 }


### PR DESCRIPTION
## Why

#964 lets a font claim a CSS generic family, but `googleFonts` had no way to pass one through — loading a mono family from Google Fonts still left `font-mono` unresolved.

## What

- `googleFonts` family objects accept `generic`; it propagates to every coverage subset the family produces and joins the subset's dedup key.
- `GenericFontFamily` moves to `fonts.ts` (renderer.ts already imports from it; the reverse import was circular).
- Docs list the field, and the helpers test pins propagation and the unclaimed default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Fonts families can now specify a CSS generic family, such as `serif` or `sans-serif`.
  * The selected generic family is applied consistently across all loaded font subsets, improving font stack resolution.

* **Documentation**
  * Updated typography documentation with details about the new `generic` option.
  * Added a changelog entry describing generic family propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->