### PR TITLE
Core: fix inherited resvg filter and parser bugs

### DIFF
--- a/.tegami/resvg-reuse-decoders.md
+++ b/.tegami/resvg-reuse-decoders.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Route vendored resvg image decoding through the core decoders
+
+SVG-embedded raster images now decode through the shared image pipeline, dropping the imagesize and zune-jpeg dependencies and tiny-skia's png-format feature.

--- a/.tegami/resvg-upstream-bugfixes.md
+++ b/.tegami/resvg-upstream-bugfixes.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Fix inherited resvg filter and parser bugs
+
+Correct the spotlight Y offset, drop-shadow sRGB double conversion and displacement-map premultiplied reads; guard href cycles, turbulence seed overflow, convolve-matrix size overflow and oversized blur/morphology radii; make `<switch>` skip text branches and paint fallbacks apply for non-paint-server references.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,7 +1846,6 @@ dependencies = [
  "gif",
  "image",
  "image-webp",
- "imagesize",
  "kurbo",
  "libwebp-sys",
  "log",
@@ -1875,7 +1874,6 @@ dependencies = [
  "typed-builder",
  "wuff",
  "xxhash-rust",
- "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ data-url = "0.3"
 gif = "0.14"
 html5ever = "0.39"
 image-webp = "0.2"
-imagesize = "0.14"
 js-sys = "0.3"
 kurbo = "0.13"
 libwebp-sys = "0.14"
@@ -45,14 +44,17 @@ strict-num = "0.1"
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
 svgtypes = "0.16"
-zune-jpeg = "0.5"
 thiserror = "2.0"
-tiny-skia = "0.12"
 tiny-skia-path = "0.12"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 typed-builder = "0.23"
 wasm-bindgen = "0.2"
+
+[workspace.dependencies.tiny-skia]
+version = "0.12"
+default-features = false
+features = ["std", "simd"]
 
 [workspace.dependencies.quick_cache]
 version = "0.7"

--- a/takumi-core/Cargo.toml
+++ b/takumi-core/Cargo.toml
@@ -77,10 +77,6 @@ optional = true
 workspace = true
 optional = true
 
-[dependencies.imagesize]
-workspace = true
-optional = true
-
 [dependencies.log]
 workspace = true
 optional = true
@@ -89,15 +85,7 @@ optional = true
 workspace = true
 optional = true
 
-[dependencies.zune-jpeg]
-workspace = true
-optional = true
-
 [dependencies.tiny-skia-path]
-workspace = true
-optional = true
-
-[dependencies.image-webp]
 workspace = true
 optional = true
 
@@ -113,12 +101,9 @@ svg = [
   "dep:simplecss",
   "dep:siphasher",
   "dep:strict-num",
-  "dep:imagesize",
   "dep:log",
   "dep:rgb",
-  "dep:zune-jpeg",
   "dep:tiny-skia-path",
-  "dep:image-webp",
 ]
 woff2 = ["dep:wuff", "wuff/brotli"]
 woff = ["dep:wuff", "wuff/z"]

--- a/takumi-core/src/resources/image_buffer.rs
+++ b/takumi-core/src/resources/image_buffer.rs
@@ -57,6 +57,12 @@ impl ImageBuffer {
     self.height
   }
 
+  /// Consumes the buffer, returning the premultiplied RGBA bytes.
+  #[cfg(feature = "svg")]
+  pub(crate) fn into_premultiplied_rgba(self) -> Vec<u8> {
+    self.data
+  }
+
   /// The premultiplied RGBA bytes, row-major.
   pub fn data(&self) -> &[u8] {
     &self.data

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -80,7 +80,7 @@ pub(crate) fn decode_image(bytes: &[u8]) -> ImageResult<ImageBuffer> {
   }
 }
 
-fn detect_image_format(bytes: &[u8]) -> Option<DetectedImageFormat> {
+pub(crate) fn detect_image_format(bytes: &[u8]) -> Option<DetectedImageFormat> {
   if bytes.starts_with(&PNG_SIGNATURE) {
     return Some(DetectedImageFormat::Png);
   }
@@ -101,7 +101,7 @@ fn detect_image_format(bytes: &[u8]) -> Option<DetectedImageFormat> {
 }
 
 #[derive(Clone, Copy)]
-enum DetectedImageFormat {
+pub(crate) enum DetectedImageFormat {
   Png,
   Jpeg,
   Gif,

--- a/takumi-core/src/resources/mod.rs
+++ b/takumi-core/src/resources/mod.rs
@@ -4,5 +4,5 @@ pub mod font;
 pub mod image;
 /// Backend-agnostic decoded-image buffer
 pub mod image_buffer;
-mod image_decoder;
+pub(crate) mod image_decoder;
 mod image_resampler;

--- a/takumi-core/src/resvg/filter/box_blur.rs
+++ b/takumi-core/src/resvg/filter/box_blur.rs
@@ -21,8 +21,10 @@ const STEPS: usize = 5;
 ///
 /// This method will allocate a copy of the `src` image as a back buffer.
 pub fn apply(sigma_x: f64, sigma_y: f64, mut src: ImageRefMut) {
-  let boxes_horz = create_box_gauss(sigma_x as f32);
-  let boxes_vert = create_box_gauss(sigma_y as f32);
+  // A sigma past the image size already blurs into a uniform smear; the cap
+  // keeps the derived box radii addressable on 32-bit targets.
+  let boxes_horz = create_box_gauss(sigma_x.min(src.width as f64) as f32);
+  let boxes_vert = create_box_gauss(sigma_y.min(src.height as f64) as f32);
   let mut backbuf = src.data.to_vec();
   let mut backbuf = ImageRefMut::new(src.width, src.height, &mut backbuf);
 

--- a/takumi-core/src/resvg/filter/mod.rs
+++ b/takumi-core/src/resvg/filter/mod.rs
@@ -614,9 +614,10 @@ fn apply_drop_shadow(
     *p = color.premultiply().to_color_u8();
   }
 
-  match cs {
-    crate::resvg::usvg::filter::ColorInterpolation::SRGB => shadow_pixmap.into_srgb(),
-    crate::resvg::usvg::filter::ColorInterpolation::LinearRGB => shadow_pixmap.into_linear_rgb(),
+  // The shadow color is defined in sRGB, so only a linearRGB
+  // interpolation space needs a conversion.
+  if cs == crate::resvg::usvg::filter::ColorInterpolation::LinearRGB {
+    shadow_pixmap.into_linear_rgb();
   }
 
   pixmap.draw_pixmap(
@@ -956,7 +957,8 @@ fn apply_displacement_map(
   input2: Image,
 ) -> Result<Image, Error> {
   let pixmap1 = input1.into_color_space(cs)?.take()?;
-  let pixmap2 = input2.into_color_space(cs)?.take()?;
+  let mut pixmap2 = input2.into_color_space(cs)?.take()?;
+  demultiply_alpha(pixmap2.data_mut().as_rgba_mut());
 
   let mut pixmap = tiny_skia::Pixmap::try_create(region.width(), region.height())?;
 
@@ -1075,13 +1077,13 @@ fn transform_light_source(
       let mut point = tiny_skia::Point::from_xy(light.x, light.y);
       ts.map_point(&mut point);
       light.x = point.x - region.x() as f32;
-      light.y = point.y - region.x() as f32;
+      light.y = point.y - region.y() as f32;
       light.z *= sz;
 
       let mut point = tiny_skia::Point::from_xy(light.points_at_x, light.points_at_y);
       ts.map_point(&mut point);
       light.points_at_x = point.x - region.x() as f32;
-      light.points_at_y = point.y - region.x() as f32;
+      light.points_at_y = point.y - region.y() as f32;
       light.points_at_z *= sz;
     }
   }

--- a/takumi-core/src/resvg/filter/morphology.rs
+++ b/takumi-core/src/resvg/filter/morphology.rs
@@ -14,8 +14,8 @@ use rgb::RGBA8;
 /// This method will allocate a copy of the `src` image as a back buffer.
 pub fn apply(operator: MorphologyOperator, rx: f32, ry: f32, src: ImageRefMut) {
   // No point in making matrix larger than image.
-  let columns = std::cmp::min(rx.ceil() as u32 * 2, src.width);
-  let rows = std::cmp::min(ry.ceil() as u32 * 2, src.height);
+  let columns = std::cmp::min((rx.ceil() as u32).saturating_mul(2), src.width);
+  let rows = std::cmp::min((ry.ceil() as u32).saturating_mul(2), src.height);
   let target_x = (columns as f32 / 2.0).floor() as u32;
   let target_y = (rows as f32 / 2.0).floor() as u32;
 

--- a/takumi-core/src/resvg/filter/turbulence.rs
+++ b/takumi-core/src/resvg/filter/turbulence.rs
@@ -95,7 +95,7 @@ fn init(mut seed: i32) -> (Vec<usize>, Vec<Vec<Vec<f64>>>) {
   let mut gradient = vec![vec![vec![0.0; 2]; B_LEN]; 4];
 
   if seed <= 0 {
-    seed = -seed % (RAND_M - 1) + 1;
+    seed = -(seed % (RAND_M - 1)) + 1;
   }
 
   if seed > RAND_M - 1 {

--- a/takumi-core/src/resvg/image.rs
+++ b/takumi-core/src/resvg/image.rs
@@ -49,125 +49,53 @@ fn render_vector(
 }
 
 mod raster_images {
+  use crate::resources::image_buffer::ImageBuffer;
+  use crate::resources::image_decoder::{decode_gif_frames, decode_image};
   use crate::resvg::OptionLog;
   use crate::resvg::usvg::ImageRendering;
-  use std::io::Cursor;
+
+  fn pixmap_from_premultiplied(
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+  ) -> Option<tiny_skia::Pixmap> {
+    let size = tiny_skia::IntSize::from_wh(width, height)?;
+    tiny_skia::Pixmap::from_vec(data, size)
+  }
+
+  fn buffer_to_pixmap(buffer: ImageBuffer) -> Option<tiny_skia::Pixmap> {
+    let (width, height) = (buffer.width(), buffer.height());
+    pixmap_from_premultiplied(buffer.into_premultiplied_rgba(), width, height)
+  }
 
   fn decode_raster(image: &crate::resvg::usvg::ImageKind) -> Option<tiny_skia::Pixmap> {
+    use crate::resvg::usvg::ImageKind;
+
     match image {
-      crate::resvg::usvg::ImageKind::SVG(_) => None,
-      crate::resvg::usvg::ImageKind::JPEG(data) => {
-        decode_jpeg(data).log_none(|| log::warn!("Failed to decode a JPEG image."))
+      ImageKind::SVG(_) => None,
+      ImageKind::JPEG(data) | ImageKind::PNG(data) | ImageKind::WEBP(data) => decode_image(data)
+        .ok()
+        .and_then(buffer_to_pixmap)
+        .log_none(|| log::warn!("Failed to decode an image.")),
+      ImageKind::GIF(data) => {
+        let mut first = None;
+        decode_gif_frames(data, 0, Some(1), None, |frame| first = Some(frame)).ok()?;
+        first
+          .and_then(|frame| {
+            pixmap_from_premultiplied(
+              frame.buffer.data().to_vec(),
+              frame.buffer.width(),
+              frame.buffer.height(),
+            )
+          })
+          .log_none(|| log::warn!("Failed to decode a GIF image."))
       }
-      crate::resvg::usvg::ImageKind::PNG(data) => {
-        decode_png(data).log_none(|| log::warn!("Failed to decode a PNG image."))
-      }
-      crate::resvg::usvg::ImageKind::GIF(data) => {
-        decode_gif(data).log_none(|| log::warn!("Failed to decode a GIF image."))
-      }
-      crate::resvg::usvg::ImageKind::WEBP(data) => {
-        decode_webp(data).log_none(|| log::warn!("Failed to decode a WebP image."))
-      }
-      crate::resvg::usvg::ImageKind::Raw {
+      ImageKind::Raw {
         width,
         height,
         data,
-      } => {
-        let size = tiny_skia::IntSize::from_wh(*width, *height)?;
-        tiny_skia::Pixmap::from_vec(data.as_ref().clone(), size)
-          .log_none(|| log::warn!("Raw image buffer has an invalid size. Skipped."))
-      }
-    }
-  }
-
-  fn decode_png(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    tiny_skia::Pixmap::decode_png(data).ok()
-  }
-
-  fn decode_jpeg(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    use zune_jpeg::zune_core::colorspace::ColorSpace;
-    use zune_jpeg::zune_core::options::DecoderOptions;
-
-    let cursor = Cursor::new(data);
-    let options = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGBA);
-    let mut decoder = zune_jpeg::JpegDecoder::new_with_options(cursor, options);
-    decoder.decode_headers().ok()?;
-    let output_cs = decoder.output_colorspace()?;
-
-    let img_data = {
-      let data = decoder.decode().ok()?;
-      match output_cs {
-        ColorSpace::RGBA => data,
-        _ => return None,
-      }
-    };
-
-    let info = decoder.info()?;
-
-    let size = tiny_skia::IntSize::from_wh(info.width as u32, info.height as u32)?;
-    tiny_skia::Pixmap::from_vec(img_data, size)
-  }
-
-  fn decode_gif(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    let mut decoder = gif::DecodeOptions::new();
-    decoder.set_color_output(gif::ColorOutput::RGBA);
-    let mut decoder = decoder.read_info(data).ok()?;
-    let first_frame = decoder.read_next_frame().ok()??;
-
-    let size =
-      tiny_skia::IntSize::from_wh(u32::from(first_frame.width), u32::from(first_frame.height))?;
-
-    let (w, h) = size.dimensions();
-    let mut pixmap = tiny_skia::Pixmap::new(w, h)?;
-    rgba_to_pixmap(&first_frame.buffer, &mut pixmap);
-    Some(pixmap)
-  }
-
-  fn decode_webp(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    let mut decoder = image_webp::WebPDecoder::new(std::io::Cursor::new(data)).ok()?;
-    let mut first_frame = vec![0; decoder.output_buffer_size()?];
-    decoder.read_image(&mut first_frame).ok()?;
-
-    let (w, h) = decoder.dimensions();
-    let mut pixmap = tiny_skia::Pixmap::new(w, h)?;
-
-    if decoder.has_alpha() {
-      rgba_to_pixmap(&first_frame, &mut pixmap);
-    } else {
-      rgb_to_pixmap(&first_frame, &mut pixmap);
-    }
-
-    Some(pixmap)
-  }
-
-  fn rgb_to_pixmap(data: &[u8], pixmap: &mut tiny_skia::Pixmap) {
-    use rgb::FromSlice;
-
-    let mut i = 0;
-    let dst = pixmap.data_mut();
-    for p in data.as_rgb() {
-      dst[i + 0] = p.r;
-      dst[i + 1] = p.g;
-      dst[i + 2] = p.b;
-      dst[i + 3] = 255;
-
-      i += tiny_skia::BYTES_PER_PIXEL;
-    }
-  }
-
-  fn rgba_to_pixmap(data: &[u8], pixmap: &mut tiny_skia::Pixmap) {
-    use rgb::FromSlice;
-
-    let mut i = 0;
-    let dst = pixmap.data_mut();
-    for p in data.as_rgba() {
-      let a = p.a as f64 / 255.0;
-      dst[i + 0] = (p.r as f64 * a + 0.5) as u8;
-      dst[i + 1] = (p.g as f64 * a + 0.5) as u8;
-      dst[i + 2] = (p.b as f64 * a + 0.5) as u8;
-      dst[i + 3] = p.a;
-
-      i += tiny_skia::BYTES_PER_PIXEL;
+      } => pixmap_from_premultiplied(data.as_ref().clone(), *width, *height)
+        .log_none(|| log::warn!("Raw image buffer has an invalid size. Skipped.")),
     }
   }
 

--- a/takumi-core/src/resvg/usvg/parser/filter.rs
+++ b/takumi-core/src/resvg/usvg/parser/filter.rs
@@ -674,7 +674,7 @@ fn convert_convolve_matrix(fe: SvgNode, primitives: &[Primitive]) -> Option<Kind
 
   let mut matrix = Vec::new();
   if let Some(list) = fe.attribute::<Vec<f32>>(AId::KernelMatrix) {
-    if list.len() == (order_x * order_y) as usize {
+    if order_x.checked_mul(order_y).map(|len| len as usize) == Some(list.len()) {
       matrix = list;
     }
   }

--- a/takumi-core/src/resvg/usvg/parser/image.rs
+++ b/takumi-core/src/resvg/usvg/parser/image.rs
@@ -314,12 +314,13 @@ fn get_image_file_format(path: &std::path::Path, data: &[u8]) -> Option<ImageFor
 
 /// Checks that file has a PNG, a GIF, a JPEG or a WebP magic bytes.
 fn get_image_data_format(data: &[u8]) -> Option<ImageFormat> {
-  match imagesize::image_type(data).ok()? {
-    imagesize::ImageType::Gif => Some(ImageFormat::GIF),
-    imagesize::ImageType::Jpeg => Some(ImageFormat::JPEG),
-    imagesize::ImageType::Png => Some(ImageFormat::PNG),
-    imagesize::ImageType::Webp => Some(ImageFormat::WEBP),
-    _ => None,
+  use crate::resources::image_decoder::DetectedImageFormat;
+
+  match crate::resources::image_decoder::detect_image_format(data)? {
+    DetectedImageFormat::Gif => Some(ImageFormat::GIF),
+    DetectedImageFormat::Jpeg => Some(ImageFormat::JPEG),
+    DetectedImageFormat::Png => Some(ImageFormat::PNG),
+    DetectedImageFormat::WebP => Some(ImageFormat::WEBP),
   }
 }
 

--- a/takumi-core/src/resvg/usvg/parser/style.rs
+++ b/takumi-core/src/resvg/usvg/parser/style.rs
@@ -224,7 +224,7 @@ fn convert_paint(
           }
         } else {
           log::warn!("'{}' cannot be used to {} a shape.", tag_name, aid);
-          None
+          from_fallback(node, fallback, opacity).map(|p| (p, None))
         }
       } else {
         from_fallback(node, fallback, opacity).map(|p| (p, None))

--- a/takumi-core/src/resvg/usvg/parser/svgtree/mod.rs
+++ b/takumi-core/src/resvg/usvg/parser/svgtree/mod.rs
@@ -487,6 +487,7 @@ impl<'a, 'input: 'a> SvgNode<'a, 'input> {
       doc: self.document(),
       origin: self.id(),
       curr: self.id(),
+      visited: Vec::new(),
       is_first: true,
       is_finished: false,
     }
@@ -612,6 +613,7 @@ pub struct HrefIter<'a, 'input: 'a> {
   doc: &'a Document<'input>,
   origin: NodeId,
   curr: NodeId,
+  visited: Vec<NodeId>,
   is_first: bool,
   is_finished: bool,
 }
@@ -630,7 +632,7 @@ impl<'a, 'input: 'a> Iterator for HrefIter<'a, 'input> {
     }
 
     if let Some(link) = self.doc.get(self.curr).node_attribute(AId::Href) {
-      if link.id() == self.curr || link.id() == self.origin {
+      if link.id() == self.curr || link.id() == self.origin || self.visited.contains(&link.id()) {
         log::warn!(
           "Element '#{}' cannot reference itself via 'xlink:href'.",
           self.doc.get(self.origin).element_id()
@@ -639,6 +641,7 @@ impl<'a, 'input: 'a> Iterator for HrefIter<'a, 'input> {
         return None;
       }
 
+      self.visited.push(self.curr);
       self.curr = link.id();
       Some(self.doc.get(self.curr))
     } else {

--- a/takumi-core/src/resvg/usvg/parser/svgtree/parse.rs
+++ b/takumi-core/src/resvg/usvg/parser/svgtree/parse.rs
@@ -303,10 +303,9 @@ pub(crate) fn parse_svg_element<'input>(
         // 1) Existing is not important, new is not important -> swap
         // 2) Existing is important, new is not important -> don't swap
         // 3) Existing is not important, new is important -> swap
-        // 4) Existing is important, new is important -> don't swap (since the order
-        // is reversed, so existing important attributes take precedence over new
-        // important attributes)
-        let has_precedence = !doc.attrs[existing_idx].important;
+        // 4) Existing is important, new is important -> swap (all declarations
+        // here share the author origin, so the later one wins as usual)
+        let has_precedence = !doc.attrs[existing_idx].important || important;
 
         if has_precedence {
           doc.attrs.swap(existing_idx, last_idx);

--- a/takumi-core/src/resvg/usvg/parser/switch.rs
+++ b/takumi-core/src/resvg/usvg/parser/switch.rs
@@ -18,8 +18,6 @@ static FEATURES: &[&str] = &[
   "http://www.w3.org/TR/SVG11/feature#Style",
   // "http://www.w3.org/TR/SVG11/feature#ViewportAttribute", // `clip` and `overflow`, not yet
   "http://www.w3.org/TR/SVG11/feature#Shape",
-  "http://www.w3.org/TR/SVG11/feature#Text",
-  "http://www.w3.org/TR/SVG11/feature#BasicText",
   "http://www.w3.org/TR/SVG11/feature#PaintAttribute", // no color-interpolation and color-rendering
   "http://www.w3.org/TR/SVG11/feature#BasicPaintAttribute", // no color-interpolation
   "http://www.w3.org/TR/SVG11/feature#OpacityAttribute",
@@ -73,7 +71,7 @@ pub(crate) fn is_condition_passed(node: SvgNode, opt: &Options) -> bool {
   // If all of the given features are supported, then the attribute evaluates to true;
   // otherwise, the current element and its children are skipped and thus will not be rendered.'
   if let Some(features) = node.attribute::<&str>(AId::RequiredFeatures) {
-    for feature in features.split(' ') {
+    for feature in features.split_ascii_whitespace() {
       if !FEATURES.contains(&feature) {
         return false;
       }

--- a/takumi-core/src/resvg/usvg/tree/filter.rs
+++ b/takumi-core/src/resvg/usvg/tree/filter.rs
@@ -457,7 +457,8 @@ impl ConvolveMatrixData {
     rows: u32,
     data: Vec<f32>,
   ) -> Option<Self> {
-    if (columns * rows) as usize != data.len() || target_x >= columns || target_y >= rows {
+    let len = columns.checked_mul(rows)?;
+    if len as usize != data.len() || target_x >= columns || target_y >= rows {
       return None;
     }
 

--- a/takumi-core/src/resvg/usvg/tree/mod.rs
+++ b/takumi-core/src/resvg/usvg/tree/mod.rs
@@ -1475,12 +1475,15 @@ pub enum ImageKind {
 impl ImageKind {
   pub(crate) fn actual_size(&self) -> Option<Size> {
     match self {
-      ImageKind::JPEG(data)
-      | ImageKind::PNG(data)
-      | ImageKind::GIF(data)
-      | ImageKind::WEBP(data) => imagesize::blob_size(data)
+      ImageKind::JPEG(data) | ImageKind::PNG(data) | ImageKind::WEBP(data) => {
+        crate::resources::image_decoder::bitmap_dimensions(data)
+          .and_then(Result::ok)
+          .and_then(|(width, height)| Size::from_wh(width as f32, height as f32))
+          .log_none(|| log::warn!("Image has an invalid size. Skipped."))
+      }
+      ImageKind::GIF(data) => crate::resources::image_decoder::gif_dimensions(data)
         .ok()
-        .and_then(|size| Size::from_wh(size.width as f32, size.height as f32))
+        .and_then(|(width, height)| Size::from_wh(width as f32, height as f32))
         .log_none(|| log::warn!("Image has an invalid size. Skipped.")),
       ImageKind::Raw { width, height, .. } => Size::from_wh(*width as f32, *height as f32)
         .log_none(|| log::warn!("Image has an invalid size. Skipped.")),


### PR DESCRIPTION
## Why

CodeRabbit flagged 18 issues on the vendored resvg code. Each was verified against the code; eleven are real bugs inherited from upstream 0.47, the rest are deliberate upstream choices or writer-only concerns (verdicts below).

## What

Fixed:
- Spotlight lights subtracted `region.x()` from Y coordinates (copy-paste bug).
- `feDropShadow` ran `into_srgb()` on an already-sRGB shadow, double-applying the transfer curve.
- `feDisplacementMap` read premultiplied channels; the map is now demultiplied first, as its own contract states.
- `HrefIter` only guarded direct self-references, so an `A → B → C → B` href cycle hung the parser; it now tracks visited nodes.
- feTurbulence seed normalization negated before the modulo, overflowing on `i32::MIN`.
- `feConvolveMatrix` `order_x * order_y` could overflow in both the parser and `ConvolveMatrixData::new`; both use checked multiplication.
- Oversized blur sigmas and morphology radii overflowed radius arithmetic (32-bit targets / debug builds); both are capped at the image dimensions.
- `<switch>` still advertised the Text/BasicText features although text elements are dropped, so text branches beat renderable fallbacks; also `requiredFeatures` now splits on all whitespace.
- `fill="url(#not-a-paint-server) red"` returned no paint instead of the spec-mandated fallback.
- A later `!important` declaration now overrides an earlier one, matching the cascade within one origin.

Skipped, with reasons:
- clipPath/mask cycles: already neutralized at parse time by `fix_recursive_links`.
- `update_paint_servers` Arc clone-on-write and `push_pattern_transform` descendant transforms: upstream-known TODOs on the niche context-paint path, not regressions.
- `all_ids` collecting only resource tags: generated IDs can only collide with other referenced resources; element IDs are unused for rendering.
- SVGZ error/format cosmetics: gzip input already fails cleanly; removing the mentions changes nothing observable.
- `get_clip_rect` zero-size viewport: needs a new tri-state API for an edge case with no observed misrender.
- Morphology zero-radius rewrite to 1.0: deliberate upstream Chrome/Safari-parity choice, documented in the code.

All 287 tests pass with zero golden drift.

Stacked on #978.

https://claude.ai/code/session_01VkYpKpgHYAd971sQRiJZDV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG filter rendering for blur, shadows, displacement maps, lighting, turbulence, and morphology effects.
  * Prevented crashes and incorrect behavior caused by oversized filter values or arithmetic overflow.
  * Fixed SVG paint fallbacks when referenced resources are invalid.
  * Prevented circular linked-resource traversal.
  * Improved SVG attribute precedence and whitespace handling in feature conditions.
  * Corrected rendering behavior for spotlight positioning and filter color handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->