### PR TITLE
Core: route vendored resvg image decoding through the core decoders

### DIFF
--- a/.tegami/resvg-reuse-decoders.md
+++ b/.tegami/resvg-reuse-decoders.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Route vendored resvg image decoding through the core decoders
+
+SVG-embedded raster images now decode through the shared image pipeline, dropping the imagesize and zune-jpeg dependencies and tiny-skia's png-format feature.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,7 +1846,6 @@ dependencies = [
  "gif",
  "image",
  "image-webp",
- "imagesize",
  "kurbo",
  "libwebp-sys",
  "log",
@@ -1875,7 +1874,6 @@ dependencies = [
  "typed-builder",
  "wuff",
  "xxhash-rust",
- "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ data-url = "0.3"
 gif = "0.14"
 html5ever = "0.39"
 image-webp = "0.2"
-imagesize = "0.14"
 js-sys = "0.3"
 kurbo = "0.13"
 libwebp-sys = "0.14"
@@ -45,14 +44,17 @@ strict-num = "0.1"
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
 svgtypes = "0.16"
-zune-jpeg = "0.5"
 thiserror = "2.0"
-tiny-skia = "0.12"
 tiny-skia-path = "0.12"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 typed-builder = "0.23"
 wasm-bindgen = "0.2"
+
+[workspace.dependencies.tiny-skia]
+version = "0.12"
+default-features = false
+features = ["std", "simd"]
 
 [workspace.dependencies.quick_cache]
 version = "0.7"

--- a/takumi-core/Cargo.toml
+++ b/takumi-core/Cargo.toml
@@ -77,10 +77,6 @@ optional = true
 workspace = true
 optional = true
 
-[dependencies.imagesize]
-workspace = true
-optional = true
-
 [dependencies.log]
 workspace = true
 optional = true
@@ -89,15 +85,7 @@ optional = true
 workspace = true
 optional = true
 
-[dependencies.zune-jpeg]
-workspace = true
-optional = true
-
 [dependencies.tiny-skia-path]
-workspace = true
-optional = true
-
-[dependencies.image-webp]
 workspace = true
 optional = true
 
@@ -113,12 +101,9 @@ svg = [
   "dep:simplecss",
   "dep:siphasher",
   "dep:strict-num",
-  "dep:imagesize",
   "dep:log",
   "dep:rgb",
-  "dep:zune-jpeg",
   "dep:tiny-skia-path",
-  "dep:image-webp",
 ]
 woff2 = ["dep:wuff", "wuff/brotli"]
 woff = ["dep:wuff", "wuff/z"]

--- a/takumi-core/src/resources/image_buffer.rs
+++ b/takumi-core/src/resources/image_buffer.rs
@@ -57,6 +57,12 @@ impl ImageBuffer {
     self.height
   }
 
+  /// Consumes the buffer, returning the premultiplied RGBA bytes.
+  #[cfg(feature = "svg")]
+  pub(crate) fn into_premultiplied_rgba(self) -> Vec<u8> {
+    self.data
+  }
+
   /// The premultiplied RGBA bytes, row-major.
   pub fn data(&self) -> &[u8] {
     &self.data

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -80,7 +80,7 @@ pub(crate) fn decode_image(bytes: &[u8]) -> ImageResult<ImageBuffer> {
   }
 }
 
-fn detect_image_format(bytes: &[u8]) -> Option<DetectedImageFormat> {
+pub(crate) fn detect_image_format(bytes: &[u8]) -> Option<DetectedImageFormat> {
   if bytes.starts_with(&PNG_SIGNATURE) {
     return Some(DetectedImageFormat::Png);
   }
@@ -101,7 +101,7 @@ fn detect_image_format(bytes: &[u8]) -> Option<DetectedImageFormat> {
 }
 
 #[derive(Clone, Copy)]
-enum DetectedImageFormat {
+pub(crate) enum DetectedImageFormat {
   Png,
   Jpeg,
   Gif,

--- a/takumi-core/src/resources/mod.rs
+++ b/takumi-core/src/resources/mod.rs
@@ -4,5 +4,5 @@ pub mod font;
 pub mod image;
 /// Backend-agnostic decoded-image buffer
 pub mod image_buffer;
-mod image_decoder;
+pub(crate) mod image_decoder;
 mod image_resampler;

--- a/takumi-core/src/resvg/image.rs
+++ b/takumi-core/src/resvg/image.rs
@@ -49,125 +49,53 @@ fn render_vector(
 }
 
 mod raster_images {
+  use crate::resources::image_buffer::ImageBuffer;
+  use crate::resources::image_decoder::{decode_gif_frames, decode_image};
   use crate::resvg::OptionLog;
   use crate::resvg::usvg::ImageRendering;
-  use std::io::Cursor;
+
+  fn pixmap_from_premultiplied(
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+  ) -> Option<tiny_skia::Pixmap> {
+    let size = tiny_skia::IntSize::from_wh(width, height)?;
+    tiny_skia::Pixmap::from_vec(data, size)
+  }
+
+  fn buffer_to_pixmap(buffer: ImageBuffer) -> Option<tiny_skia::Pixmap> {
+    let (width, height) = (buffer.width(), buffer.height());
+    pixmap_from_premultiplied(buffer.into_premultiplied_rgba(), width, height)
+  }
 
   fn decode_raster(image: &crate::resvg::usvg::ImageKind) -> Option<tiny_skia::Pixmap> {
+    use crate::resvg::usvg::ImageKind;
+
     match image {
-      crate::resvg::usvg::ImageKind::SVG(_) => None,
-      crate::resvg::usvg::ImageKind::JPEG(data) => {
-        decode_jpeg(data).log_none(|| log::warn!("Failed to decode a JPEG image."))
+      ImageKind::SVG(_) => None,
+      ImageKind::JPEG(data) | ImageKind::PNG(data) | ImageKind::WEBP(data) => decode_image(data)
+        .ok()
+        .and_then(buffer_to_pixmap)
+        .log_none(|| log::warn!("Failed to decode an image.")),
+      ImageKind::GIF(data) => {
+        let mut first = None;
+        decode_gif_frames(data, 0, Some(1), None, |frame| first = Some(frame)).ok()?;
+        first
+          .and_then(|frame| {
+            pixmap_from_premultiplied(
+              frame.buffer.data().to_vec(),
+              frame.buffer.width(),
+              frame.buffer.height(),
+            )
+          })
+          .log_none(|| log::warn!("Failed to decode a GIF image."))
       }
-      crate::resvg::usvg::ImageKind::PNG(data) => {
-        decode_png(data).log_none(|| log::warn!("Failed to decode a PNG image."))
-      }
-      crate::resvg::usvg::ImageKind::GIF(data) => {
-        decode_gif(data).log_none(|| log::warn!("Failed to decode a GIF image."))
-      }
-      crate::resvg::usvg::ImageKind::WEBP(data) => {
-        decode_webp(data).log_none(|| log::warn!("Failed to decode a WebP image."))
-      }
-      crate::resvg::usvg::ImageKind::Raw {
+      ImageKind::Raw {
         width,
         height,
         data,
-      } => {
-        let size = tiny_skia::IntSize::from_wh(*width, *height)?;
-        tiny_skia::Pixmap::from_vec(data.as_ref().clone(), size)
-          .log_none(|| log::warn!("Raw image buffer has an invalid size. Skipped."))
-      }
-    }
-  }
-
-  fn decode_png(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    tiny_skia::Pixmap::decode_png(data).ok()
-  }
-
-  fn decode_jpeg(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    use zune_jpeg::zune_core::colorspace::ColorSpace;
-    use zune_jpeg::zune_core::options::DecoderOptions;
-
-    let cursor = Cursor::new(data);
-    let options = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGBA);
-    let mut decoder = zune_jpeg::JpegDecoder::new_with_options(cursor, options);
-    decoder.decode_headers().ok()?;
-    let output_cs = decoder.output_colorspace()?;
-
-    let img_data = {
-      let data = decoder.decode().ok()?;
-      match output_cs {
-        ColorSpace::RGBA => data,
-        _ => return None,
-      }
-    };
-
-    let info = decoder.info()?;
-
-    let size = tiny_skia::IntSize::from_wh(info.width as u32, info.height as u32)?;
-    tiny_skia::Pixmap::from_vec(img_data, size)
-  }
-
-  fn decode_gif(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    let mut decoder = gif::DecodeOptions::new();
-    decoder.set_color_output(gif::ColorOutput::RGBA);
-    let mut decoder = decoder.read_info(data).ok()?;
-    let first_frame = decoder.read_next_frame().ok()??;
-
-    let size =
-      tiny_skia::IntSize::from_wh(u32::from(first_frame.width), u32::from(first_frame.height))?;
-
-    let (w, h) = size.dimensions();
-    let mut pixmap = tiny_skia::Pixmap::new(w, h)?;
-    rgba_to_pixmap(&first_frame.buffer, &mut pixmap);
-    Some(pixmap)
-  }
-
-  fn decode_webp(data: &[u8]) -> Option<tiny_skia::Pixmap> {
-    let mut decoder = image_webp::WebPDecoder::new(std::io::Cursor::new(data)).ok()?;
-    let mut first_frame = vec![0; decoder.output_buffer_size()?];
-    decoder.read_image(&mut first_frame).ok()?;
-
-    let (w, h) = decoder.dimensions();
-    let mut pixmap = tiny_skia::Pixmap::new(w, h)?;
-
-    if decoder.has_alpha() {
-      rgba_to_pixmap(&first_frame, &mut pixmap);
-    } else {
-      rgb_to_pixmap(&first_frame, &mut pixmap);
-    }
-
-    Some(pixmap)
-  }
-
-  fn rgb_to_pixmap(data: &[u8], pixmap: &mut tiny_skia::Pixmap) {
-    use rgb::FromSlice;
-
-    let mut i = 0;
-    let dst = pixmap.data_mut();
-    for p in data.as_rgb() {
-      dst[i + 0] = p.r;
-      dst[i + 1] = p.g;
-      dst[i + 2] = p.b;
-      dst[i + 3] = 255;
-
-      i += tiny_skia::BYTES_PER_PIXEL;
-    }
-  }
-
-  fn rgba_to_pixmap(data: &[u8], pixmap: &mut tiny_skia::Pixmap) {
-    use rgb::FromSlice;
-
-    let mut i = 0;
-    let dst = pixmap.data_mut();
-    for p in data.as_rgba() {
-      let a = p.a as f64 / 255.0;
-      dst[i + 0] = (p.r as f64 * a + 0.5) as u8;
-      dst[i + 1] = (p.g as f64 * a + 0.5) as u8;
-      dst[i + 2] = (p.b as f64 * a + 0.5) as u8;
-      dst[i + 3] = p.a;
-
-      i += tiny_skia::BYTES_PER_PIXEL;
+      } => pixmap_from_premultiplied(data.as_ref().clone(), *width, *height)
+        .log_none(|| log::warn!("Raw image buffer has an invalid size. Skipped.")),
     }
   }
 

--- a/takumi-core/src/resvg/usvg/parser/image.rs
+++ b/takumi-core/src/resvg/usvg/parser/image.rs
@@ -314,12 +314,13 @@ fn get_image_file_format(path: &std::path::Path, data: &[u8]) -> Option<ImageFor
 
 /// Checks that file has a PNG, a GIF, a JPEG or a WebP magic bytes.
 fn get_image_data_format(data: &[u8]) -> Option<ImageFormat> {
-  match imagesize::image_type(data).ok()? {
-    imagesize::ImageType::Gif => Some(ImageFormat::GIF),
-    imagesize::ImageType::Jpeg => Some(ImageFormat::JPEG),
-    imagesize::ImageType::Png => Some(ImageFormat::PNG),
-    imagesize::ImageType::Webp => Some(ImageFormat::WEBP),
-    _ => None,
+  use crate::resources::image_decoder::DetectedImageFormat;
+
+  match crate::resources::image_decoder::detect_image_format(data)? {
+    DetectedImageFormat::Gif => Some(ImageFormat::GIF),
+    DetectedImageFormat::Jpeg => Some(ImageFormat::JPEG),
+    DetectedImageFormat::Png => Some(ImageFormat::PNG),
+    DetectedImageFormat::WebP => Some(ImageFormat::WEBP),
   }
 }
 

--- a/takumi-core/src/resvg/usvg/tree/mod.rs
+++ b/takumi-core/src/resvg/usvg/tree/mod.rs
@@ -1475,12 +1475,15 @@ pub enum ImageKind {
 impl ImageKind {
   pub(crate) fn actual_size(&self) -> Option<Size> {
     match self {
-      ImageKind::JPEG(data)
-      | ImageKind::PNG(data)
-      | ImageKind::GIF(data)
-      | ImageKind::WEBP(data) => imagesize::blob_size(data)
+      ImageKind::JPEG(data) | ImageKind::PNG(data) | ImageKind::WEBP(data) => {
+        crate::resources::image_decoder::bitmap_dimensions(data)
+          .and_then(Result::ok)
+          .and_then(|(width, height)| Size::from_wh(width as f32, height as f32))
+          .log_none(|| log::warn!("Image has an invalid size. Skipped."))
+      }
+      ImageKind::GIF(data) => crate::resources::image_decoder::gif_dimensions(data)
         .ok()
-        .and_then(|size| Size::from_wh(size.width as f32, size.height as f32))
+        .and_then(|(width, height)| Size::from_wh(width as f32, height as f32))
         .log_none(|| log::warn!("Image has an invalid size. Skipped.")),
       ImageKind::Raw { width, height, .. } => Size::from_wh(*width as f32, *height as f32)
         .log_none(|| log::warn!("Image has an invalid size. Skipped.")),


### PR DESCRIPTION
## Why

The vendored resvg carried its own JPEG/PNG/GIF/WebP decode wrappers although takumi-core already decodes all four formats. One pipeline means fewer dependencies and one set of decode semantics.

## What

- `raster_images::decode_raster` now calls the core `decode_image`/`decode_gif_frames` and converts the premultiplied `ImageBuffer` into a pixmap; the zune-jpeg, gif, image-webp and `tiny_skia::Pixmap::decode_png` wrappers are gone.
- `ImageKind::actual_size` and the format sniffing use the core `bitmap_dimensions`/`gif_dimensions`/`detect_image_format` instead of imagesize.
- Dependency diet: `imagesize` and the explicit `zune-jpeg` are dropped from the workspace (zune-jpeg stays transitively as the `image` crate's JPEG decoder, so nothing is decoded differently), `image-webp` leaves the `svg` feature, and `tiny-skia` loses its `png-format` feature since nothing calls its PNG codec anymore.

All 287 tests pass, wasm32 compiles, no golden drift.

Stacked on #981.

https://claude.ai/code/session_01VkYpKpgHYAd971sQRiJZDV