### PR TITLE
Core: apply filter references without building a render tree

### DIFF
--- a/.tegami/resvg-direct-filter.md
+++ b/.tegami/resvg-direct-filter.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Apply filter references without building a render tree
+
+Parse `<filter>` markup straight into resolved filters and run them on the layer pixels, skipping the synthetic document render.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -8,7 +8,10 @@ use std::str::{FromStr, from_utf8};
 use std::sync::{Arc, OnceLock, Weak};
 
 #[cfg(feature = "svg")]
-use crate::resvg::usvg::{Options, Transform, Tree};
+use crate::resvg::{
+  apply_filters_to_layer,
+  usvg::{Options, Transform, Tree, filters_from_markup},
+};
 use quick_cache::{
   Weighter,
   sync::{Cache, GuardResult},
@@ -691,7 +694,7 @@ pub fn apply_svg_filter(
   markup: &str,
   filter_id: &str,
 ) -> Result<(), ImageError> {
-  let filters = crate::resvg::usvg::filters_from_markup(
+  let filters = filters_from_markup(
     markup,
     filter_id,
     width as f32,
@@ -706,8 +709,7 @@ pub fn apply_svg_filter(
     return Ok(());
   };
 
-  crate::resvg::apply_filters_to_layer(&filters, layer, width, height)
-    .ok_or(ImageError::InvalidPixmapSize)
+  apply_filters_to_layer(&filters, layer, width, height).ok_or(ImageError::InvalidPixmapSize)
 }
 
 /// Encodes bytes as a base64 `data:` URI.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -8,7 +8,7 @@ use std::str::{FromStr, from_utf8};
 use std::sync::{Arc, OnceLock, Weak};
 
 #[cfg(feature = "svg")]
-use crate::resvg::usvg::{ImageHrefResolver, ImageKind, Options, Transform, Tree};
+use crate::resvg::usvg::{Options, Transform, Tree};
 use quick_cache::{
   Weighter,
   sync::{Cache, GuardResult},
@@ -678,16 +678,11 @@ pub(crate) fn decode_data_uri(src: &str) -> Result<DecodedDataUri, DataUriError>
   Ok(DecodedDataUri { mime, bytes })
 }
 
-/// The synthetic href our resolver hands the layer pixels out for.
-#[cfg(feature = "svg")]
-const LAYER_HREF: &str = "takumi:layer";
-
 /// Applies SVG `<filter>` markup (carrying `id="{filter_id}"`) to a
-/// premultiplied-RGBA layer in place through the resvg pipeline.
+/// premultiplied-RGBA layer in place through the resvg filter pipeline.
 ///
-/// The layer is wrapped in a minimal document referencing it by a synthetic
-/// href that a custom resolver answers with the premultiplied pixels as
-/// [`ImageKind::Raw`] — no encode roundtrip, no base64, no data-URI parsing.
+/// The markup is resolved against the layer bounds and applied straight to
+/// the layer pixels; no render tree is built and nothing is re-encoded.
 #[cfg(feature = "svg")]
 pub fn apply_svg_filter(
   layer: &mut [u8],
@@ -696,30 +691,23 @@ pub fn apply_svg_filter(
   markup: &str,
   filter_id: &str,
 ) -> Result<(), ImageError> {
-  let pixels = Arc::new(layer.to_vec());
+  let filters = crate::resvg::usvg::filters_from_markup(
+    markup,
+    filter_id,
+    width as f32,
+    height as f32,
+    &Options::default(),
+  )
+  .map_err(ImageError::svg_parse)?;
 
-  let document = format!(
-    r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">{markup}<image width="{width}" height="{height}" href="{LAYER_HREF}" filter="url(#{filter_id})"/></svg>"#
-  );
-  let options = Options {
-    image_href_resolver: ImageHrefResolver {
-      resolve_data: ImageHrefResolver::default_data_resolver(),
-      resolve_string: Box::new(move |href: &str, _: &Options| {
-        (href == LAYER_HREF).then(|| ImageKind::Raw {
-          width,
-          height,
-          data: pixels.clone(),
-        })
-      }),
-    },
-    ..Options::default()
+  let Some(filters) = filters else {
+    // An invalid filter reference hides the element.
+    layer.fill(0);
+    return Ok(());
   };
-  let tree = Tree::from_str(&document, &options).map_err(ImageError::svg_parse)?;
 
-  let mut pixmap = Pixmap::new(width, height).ok_or(ImageError::InvalidPixmapSize)?;
-  crate::resvg::render(&tree, Transform::identity(), &mut pixmap.as_mut());
-  layer.copy_from_slice(pixmap.data());
-  Ok(())
+  crate::resvg::apply_filters_to_layer(&filters, layer, width, height)
+    .ok_or(ImageError::InvalidPixmapSize)
 }
 
 /// Encodes bytes as a base64 `data:` URI.

--- a/takumi-core/src/resvg/image.rs
+++ b/takumi-core/src/resvg/image.rs
@@ -90,12 +90,6 @@ mod raster_images {
           })
           .log_none(|| log::warn!("Failed to decode a GIF image."))
       }
-      ImageKind::Raw {
-        width,
-        height,
-        data,
-      } => pixmap_from_premultiplied(data.as_ref().clone(), *width, *height)
-        .log_none(|| log::warn!("Raw image buffer has an invalid size. Skipped.")),
     }
   }
 

--- a/takumi-core/src/resvg/mod.rs
+++ b/takumi-core/src/resvg/mod.rs
@@ -17,6 +17,10 @@ Vendored from resvg 0.47.0 (Apache-2.0 OR MIT), stripped of the `text`,
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::wrong_self_convention)]
 
+use std::sync::Arc;
+
+use usvg::filter::Filter;
+
 pub mod usvg;
 
 mod clip;
@@ -93,7 +97,7 @@ pub fn render_node(
 ///
 /// Returns `None` when a pixmap cannot be allocated.
 pub(crate) fn apply_filters_to_layer(
-  filters: &[std::sync::Arc<usvg::filter::Filter>],
+  filters: &[Arc<Filter>],
   layer: &mut [u8],
   width: u32,
   height: u32,

--- a/takumi-core/src/resvg/mod.rs
+++ b/takumi-core/src/resvg/mod.rs
@@ -85,6 +85,54 @@ pub fn render_node(
   Some(())
 }
 
+/// Applies parsed filters to a premultiplied RGBA layer in place.
+///
+/// Mirrors the `render_group` filter path: each filter runs on a pixmap sized
+/// to its region (the contract the filter primitives assert), with the layer
+/// placed at the region offset and the region window copied back afterwards.
+///
+/// Returns `None` when a pixmap cannot be allocated.
+pub(crate) fn apply_filters_to_layer(
+  filters: &[std::sync::Arc<usvg::filter::Filter>],
+  layer: &mut [u8],
+  width: u32,
+  height: u32,
+) -> Option<()> {
+  for f in filters {
+    let region = f.rect();
+    let ts = tiny_skia::Transform::from_translate(-region.x(), -region.y());
+    let region_int = region.transform(ts)?.to_int_rect();
+    let mut sub = tiny_skia::Pixmap::new(region_int.width(), region_int.height())?;
+
+    let dx = (-region.x()).round() as i32;
+    let dy = (-region.y()).round() as i32;
+    let layer_ref = tiny_skia::PixmapRef::from_bytes(layer, width, height)?;
+    sub.draw_pixmap(
+      dx,
+      dy,
+      layer_ref,
+      &tiny_skia::PixmapPaint::default(),
+      tiny_skia::Transform::identity(),
+      None,
+    );
+
+    filter::apply(f, ts, &mut sub);
+
+    let mut out = tiny_skia::Pixmap::new(width, height)?;
+    out.draw_pixmap(
+      -dx,
+      -dy,
+      sub.as_ref(),
+      &tiny_skia::PixmapPaint::default(),
+      tiny_skia::Transform::identity(),
+      None,
+    );
+    layer.copy_from_slice(out.data());
+  }
+
+  Some(())
+}
+
 pub(crate) trait OptionLog {
   fn log_none<F: FnOnce()>(self, f: F) -> Self;
 }

--- a/takumi-core/src/resvg/usvg/parser/mod.rs
+++ b/takumi-core/src/resvg/usvg/parser/mod.rs
@@ -16,6 +16,12 @@ mod switch;
 mod units;
 mod use_node;
 
+use std::sync::Arc;
+
+use crate::resvg::usvg::NonZeroRect;
+use crate::resvg::usvg::filter::Filter;
+use svgtree::AId;
+
 pub use image::ImageHrefResolver;
 pub use options::Options;
 
@@ -161,7 +167,7 @@ pub(crate) fn filters_from_markup(
   width: f32,
   height: f32,
   opt: &Options,
-) -> Result<Option<Vec<std::sync::Arc<crate::resvg::usvg::filter::Filter>>>, Error> {
+) -> Result<Option<Vec<Arc<Filter>>>, Error> {
   let document = format!(
     r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">{markup}<rect width="{width}" height="{height}" filter="url(#{filter_id})"/></svg>"#
   );
@@ -173,8 +179,7 @@ pub(crate) fn filters_from_markup(
     roxmltree::Document::parse_with_options(&document, xml_opt).map_err(Error::ParsingFailed)?;
   let doc = svgtree::Document::parse_tree(&xml, None)?;
 
-  let bbox = crate::resvg::usvg::NonZeroRect::from_xywh(0.0, 0.0, width, height)
-    .ok_or(Error::InvalidSize)?;
+  let bbox = NonZeroRect::from_xywh(0.0, 0.0, width, height).ok_or(Error::InvalidSize)?;
   let state = converter::State {
     parent_clip_path: None,
     parent_markers: Vec::new(),
@@ -187,7 +192,7 @@ pub(crate) fn filters_from_markup(
   let mut cache = converter::Cache::new();
   let node = doc
     .descendants()
-    .find(|n| n.has_attribute(svgtree::AId::Filter))
+    .find(|n| n.has_attribute(AId::Filter))
     .ok_or(Error::InvalidSize)?;
 
   Ok(filter::convert(node, &state, Some(bbox), &mut cache).ok())

--- a/takumi-core/src/resvg/usvg/parser/mod.rs
+++ b/takumi-core/src/resvg/usvg/parser/mod.rs
@@ -149,6 +149,50 @@ impl crate::resvg::usvg::Tree {
   }
 }
 
+/// Parses standalone `<filter>` markup (carrying `id="{filter_id}"`) and
+/// resolves it against a `width` x `height` element box, skipping the render
+/// tree entirely.
+///
+/// Returns `Ok(None)` when the filter reference is invalid, which per the
+/// converter's behaviour hides the filtered element.
+pub(crate) fn filters_from_markup(
+  markup: &str,
+  filter_id: &str,
+  width: f32,
+  height: f32,
+  opt: &Options,
+) -> Result<Option<Vec<std::sync::Arc<crate::resvg::usvg::filter::Filter>>>, Error> {
+  let document = format!(
+    r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">{markup}<rect width="{width}" height="{height}" filter="url(#{filter_id})"/></svg>"#
+  );
+  let xml_opt = roxmltree::ParsingOptions {
+    allow_dtd: true,
+    ..Default::default()
+  };
+  let xml =
+    roxmltree::Document::parse_with_options(&document, xml_opt).map_err(Error::ParsingFailed)?;
+  let doc = svgtree::Document::parse_tree(&xml, None)?;
+
+  let bbox = crate::resvg::usvg::NonZeroRect::from_xywh(0.0, 0.0, width, height)
+    .ok_or(Error::InvalidSize)?;
+  let state = converter::State {
+    parent_clip_path: None,
+    parent_markers: Vec::new(),
+    context_element: None,
+    fe_image_link: false,
+    view_box: bbox,
+    use_size: (None, None),
+    opt,
+  };
+  let mut cache = converter::Cache::new();
+  let node = doc
+    .descendants()
+    .find(|n| n.has_attribute(svgtree::AId::Filter))
+    .ok_or(Error::InvalidSize)?;
+
+  Ok(filter::convert(node, &state, Some(bbox), &mut cache).ok())
+}
+
 #[inline]
 pub(crate) fn f32_bound(min: f32, val: f32, max: f32) -> f32 {
   debug_assert!(min.is_finite());

--- a/takumi-core/src/resvg/usvg/tree/mod.rs
+++ b/takumi-core/src/resvg/usvg/tree/mod.rs
@@ -1456,18 +1456,6 @@ pub enum ImageKind {
   GIF(Arc<Vec<u8>>),
   /// A reference to raw WebP data. Should be decoded by the caller.
   WEBP(Arc<Vec<u8>>),
-  /// A premultiplied RGBA8 pixel buffer. Can be rendered as is.
-  ///
-  /// Not part of upstream resvg; lets callers hand a rasterized layer to the
-  /// filter pipeline without an encode roundtrip.
-  Raw {
-    /// Buffer width in pixels.
-    width: u32,
-    /// Buffer height in pixels.
-    height: u32,
-    /// Premultiplied RGBA8 pixels, `width * height * 4` bytes.
-    data: Arc<Vec<u8>>,
-  },
   /// A preprocessed SVG tree. Can be rendered as is.
   SVG(Tree),
 }
@@ -1485,8 +1473,6 @@ impl ImageKind {
         .ok()
         .and_then(|(width, height)| Size::from_wh(width as f32, height as f32))
         .log_none(|| log::warn!("Image has an invalid size. Skipped.")),
-      ImageKind::Raw { width, height, .. } => Size::from_wh(*width as f32, *height as f32)
-        .log_none(|| log::warn!("Image has an invalid size. Skipped.")),
       ImageKind::SVG(svg) => Some(svg.size),
     }
   }
@@ -1499,7 +1485,6 @@ impl std::fmt::Debug for ImageKind {
       ImageKind::PNG(_) => f.write_str("ImageKind::PNG(..)"),
       ImageKind::GIF(_) => f.write_str("ImageKind::GIF(..)"),
       ImageKind::WEBP(_) => f.write_str("ImageKind::WEBP(..)"),
-      ImageKind::Raw { .. } => f.write_str("ImageKind::Raw(..)"),
       ImageKind::SVG(_) => f.write_str("ImageKind::SVG(..)"),
     }
   }


### PR DESCRIPTION
## Why

`apply_svg_filter` wrapped the filter markup in a synthetic document, built a full usvg `Tree` (svgtree parse, converter traversal, bounding boxes) and rendered it through `resvg::render` (image blit, group isolation, composite) on every filter application — per layer, per frame for animations. The only parts that matter are resolving the `<filter>` element and running the primitives.

## What

- New internal usvg entry point `filters_from_markup`: svgtree-parses the markup fragment and resolves it against the layer box via `filter::convert`, skipping the converter and tree construction. An invalid filter reference reports as `None`, matching the converter's element-hiding behavior.
- New `resvg::apply_filters_to_layer`: runs each filter on a pixmap sized to its region — the contract the filter primitives assert (the earlier direct-call attempt crashed in `lighting.rs` precisely because the region outgrows the canvas) — then copies the canvas window back.
- `apply_svg_filter` now parses the fragment and applies filters directly; per application this drops the tree build, the render walk and two full-canvas blits.
- `ImageKind::Raw` is gone: it existed only to hand the layer to the resolver, which the direct path no longer needs.

All 287 tests pass, wasm32 compiles. `showcase_chrome_text.webp` stays within compare tolerance locally; the CI artifact decides whether the golden moves.

Follow-up candidate: cache parsed filters per (markup, size) — parsing is now a small fragment but still runs per application.

Stacked on #978.

https://claude.ai/code/session_01VkYpKpgHYAd971sQRiJZDV