### PR TITLE
Docs: tighten prose into lists and tables, drop em dashes

### DIFF
--- a/docs/content/docs/comparison-to-satori.mdx
+++ b/docs/content/docs/comparison-to-satori.mdx
@@ -4,7 +4,7 @@ description: How Takumi differs from satori and next/og, and how to migrate a te
 icon: Scale
 ---
 
-[satori](https://github.com/vercel/satori) pioneered OG images without a headless browser and powers `next/og`. It turns JSX into an SVG string, so a bitmap takes a pipeline: yoga computes layout in WebAssembly, satori emits SVG, then `resvg` or `sharp` rasterizes it. Takumi is one Rust engine that does the whole job: JSX in, encoded image out.
+[satori](https://github.com/vercel/satori) pioneered OG images without a headless browser and powers `next/og`. It turns JSX into an SVG string, so a bitmap takes a pipeline: yoga computes layout in WebAssembly, satori emits SVG, and `resvg` or `sharp` rasterizes it. Takumi is one Rust engine that does the whole job: JSX in, encoded image out.
 
 ```mermaid
 flowchart LR
@@ -139,7 +139,7 @@ satori renders one static frame. Takumi threads a time axis through the pipeline
 
 ## Performance and memory
 
-satori runs layout and text shaping in JavaScript on the calling thread, then hands the SVG string to a separate rasterizer. Takumi's native binding moves the whole pipeline off the event loop:
+satori runs layout and text shaping in JavaScript on the calling thread. It hands the SVG string to a separate rasterizer. Takumi's native binding moves the whole pipeline off the event loop:
 
 - **Renders run on worker threads.** `render` executes as an async task, so the event loop stays free, and concurrent renders read the font store without locking.
 - **Animation frames render in parallel** across a thread pool and stream into the encoder, so memory stays flat as frame count grows.
@@ -158,7 +158,7 @@ Measured from a clean `npm install` (macOS arm64) and gzip of the published arti
 | `@vercel/og`               | 35 MB (16 MB is optional `sharp`) | ~0.7 MB (`index.edge.js` + `resvg.wasm`) |
 | `takumi-js`                | 8.6 MB                            | 1.5 MB (`takumi_wasm_bg.wasm`)           |
 
-The WebAssembly binary is the weak spot: 3.7 MB raw, 1.5 MB gzipped, about twice the `@vercel/og` edge stack. Cold starts download and compile more, and it takes a bigger bite out of platform script-size limits. On Node the picture flips: one native binary replaces satori, yoga, opentype.js, and resvg.
+The WebAssembly binary is the weak spot: **3.7 MB raw, 1.5 MB gzipped**, about twice the `@vercel/og` edge stack. Cold starts download and compile more, and it takes a bigger bite out of platform script-size limits. On Node the picture flips: one native binary replaces satori, yoga, opentype.js, and resvg.
 
 ## Used in production
 

--- a/docs/content/docs/image-response.mdx
+++ b/docs/content/docs/image-response.mdx
@@ -91,7 +91,7 @@ try {
 }
 ```
 
-`onError` is a notification hook for side effects like logging. Its return value is ignored and the response stream still errors, so it cannot substitute a fallback image — use `ready` for that.
+`onError` is a notification hook for side effects like logging. Its return value is ignored and the response stream still errors, so it cannot substitute a fallback image; use `ready` for that.
 
 ```tsx
 new ImageResponse(<OgImage />, {

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -18,7 +18,7 @@ Generate OG images and social cards without a headless browser:
 npm i takumi-js
 ```
 
-`takumi-js` bundles both bindings: the native renderer (`@takumi-rs/core`) and the WebAssembly one (`@takumi-rs/wasm`). It picks the right one at runtime — native on Node.js, WebAssembly on Cloudflare Workers, Vercel Edge, Deno, and the browser. No extra install.
+`takumi-js` bundles both bindings: the native renderer (`@takumi-rs/core`) and the WebAssembly one (`@takumi-rs/wasm`). It picks the right one at runtime: native on Node.js, WebAssembly on Cloudflare Workers, Vercel Edge, Deno, and the browser. No extra install.
 
 ## Render an image
 

--- a/docs/content/docs/keyframe-animation.mdx
+++ b/docs/content/docs/keyframe-animation.mdx
@@ -61,7 +61,11 @@ const output = await render(<div tw="animate-[move_1s_ease-in-out_infinite_alter
 
 Use stylesheet `@keyframes` when you want the animation to travel with the JSX tree and then render it with either `renderAnimation()` or `render()` + `stylesheets`.
 
-`renderAnimation()` takes the scenes directly: each scene's JSX (or HTML string, or node tree) is transformed and its `<style>` is extracted automatically, and images are fetched once across every scene.
+`renderAnimation()` takes the scenes directly and handles the rest:
+
+- Transforms each scene's JSX (or HTML string, or node tree)
+- Extracts its `<style>` automatically
+- Fetches images once across every scene
 
 ```tsx twoslash title="render.tsx"
 // @noErrors

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -8,7 +8,7 @@ icon: Image
 
 Takumi fetches external images in `src` attributes and CSS `background-image` / `mask-image`.
 
-To reuse fetched bytes across renders, pass a `fetchCache` — a `Map<string, Promise<ArrayBuffer>>`, or anything with `Map`-like `get`/`set`/`delete`. It stores the in-flight promise, so concurrent renders needing the same URL share one fetch:
+To reuse fetched bytes across renders, pass a `fetchCache`: a `Map<string, Promise<ArrayBuffer>>`, or anything with `Map`-like `get`/`set`/`delete`. It stores the in-flight promise, so concurrent renders needing the same URL share one fetch:
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -30,12 +30,12 @@ A plain `Map` never evicts. If your URLs are high-cardinality (a different image
 
 Every remote fetch (images, fonts, Google Fonts CSS) is bounded. The group form of `images` takes the same options:
 
-| Option     | Default            | Use                                                            |
-| :--------- | :----------------- | :------------------------------------------------------------- |
-| `timeout`  | `5000` (ms)        | Abort a hanging host. `0` or negative disables it.             |
-| `maxBytes` | 32 MiB             | Reject a body past this size, by `content-length` or streamed. |
-| `allowUrl` | allow all          | Return `false` to block a URL, e.g. an SSRF allowlist.         |
-| `fetch`    | `globalThis.fetch` | Custom fetch implementation.                                   |
+| Option     | Default            | Use                                                                                  |
+| :--------- | :----------------- | :----------------------------------------------------------------------------------- |
+| `timeout`  | `5000` (ms)        | Abort a hanging host. `0` or negative disables it.                                   |
+| `maxBytes` | 32 MiB             | Reject a body past this size, by `content-length` or streamed.                       |
+| `allowUrl` | allow all          | Return `false` to block a URL, e.g. an SSRF (server-side request forgery) allowlist. |
+| `fetch`    | `globalThis.fetch` | Custom fetch implementation.                                                         |
 
 ```tsx twoslash
 import { render } from "takumi-js";

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -50,7 +50,7 @@ For other package managers, refer to their docs for hoist config instructions.
 
 #### Install the native package for your deploy target
 
-Package managers only install the native package matching the machine that runs the install. Installing on one platform and deploying to another — for example installing on macOS and deploying to a Linux server — leaves the target's native package missing.
+Package managers only install the native package matching the machine that runs the install. Installing on one platform and deploying to another (for example installing on macOS and deploying to a Linux server) leaves the target's native package missing.
 
 Install the package for the deploy target explicitly:
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -55,7 +55,7 @@ export function GET() {
 
 The takumi-js functions `render`, `renderAnimation`, and `renderSvg` take the same `fonts` option.
 
-`generic` claims a CSS generic family keyword for the font, so stacks ending in `monospace`, `serif`, and friends reach it without naming the family — the way Tailwind's `font-mono` resolves:
+`generic` claims a CSS generic family keyword for the font, so stacks ending in `monospace`, `serif`, and friends reach it without naming the family, the way Tailwind's `font-mono` resolves:
 
 ```tsx twoslash
 import { ImageResponse } from "takumi-js/response";
@@ -146,7 +146,7 @@ To trim before the render, call `subsetFonts({ fonts, source })`, where `source`
 
 ### Preloading with `registerFont`
 
-`registerFont` is the escape hatch for preloading. Register a font on a renderer up front, outside the request path. Then reuse that renderer. It takes the same entries as `fonts` and returns the families it made.
+`registerFont` is the escape hatch for preloading. Register a font on a renderer up front, outside the request path, and reuse that renderer. It takes the same entries as `fonts` and returns the families it made.
 
 ```tsx
 import { Renderer } from "@takumi-rs/core";
@@ -292,7 +292,7 @@ Takumi supports `balance` and `pretty` wrapping, adapted from [satori](https://g
 <div style={{ textWrap: "balance" }}>Super Long Text</div>
 ```
 
-`word-break` and `overflow-wrap` decide where a long token splits. `break-all`, `keep-all`, and `anywhere` cover CJK and long URLs.
+`word-break` and `overflow-wrap` decide where a long token splits. `break-all`, `keep-all`, and `anywhere` cover CJK (Chinese/Japanese/Korean) and long URLs.
 
 ### Truncation
 

--- a/docs/content/docs/upgrade/v2.mdx
+++ b/docs/content/docs/upgrade/v2.mdx
@@ -13,7 +13,7 @@ Most v2 breakages surface as type or compile errors, so a coding agent can do th
 npm install takumi-js @takumi-rs/core @takumi-rs/wasm
 ```
 
-Then paste the prompt below. Apply only the lines for packages you import, then run the type checker (`cargo check` for Rust) and fix the rest.
+Paste the prompt below. Apply only the lines for packages you import, run the type checker (`cargo check` for Rust), and fix the rest.
 
 ```text
 Upgrade this project from Takumi v1 to v2. Apply `old -> new` for the packages it imports.
@@ -67,7 +67,7 @@ const image = render(node, options); // [!code --]
 const image = await render(node, options); // [!code ++]
 ```
 
-`measure` is a `Renderer` method, not a top-level export. `encodeFrames` is removed — use `renderAnimation` (or `render` per frame for raw output).
+`measure` is a `Renderer` method, not a top-level export. `encodeFrames` is removed; use `renderAnimation` (or `render` per frame for raw output).
 
 ### The `Renderer` constructor takes no arguments
 
@@ -210,7 +210,7 @@ The sections below cover the subtler cases.
 
 In v1, an SVG supplied as an image (`Node::image`, `background-image: url(...)`, or `mask-image`) had its `currentColor` rewritten to the host element's `color` before rendering. v2 removes this.
 
-An SVG referenced as an image is an isolated document, so it does not inherit `color` from the host, the same rule browsers, [satori](https://github.com/vercel/satori), and `@vercel/og` follow. Its `currentColor` now resolves to the SVG's own default (black) instead of the surrounding text color. This also makes the raster and vector (SVG) backends agree, and lets the raster backend reuse its cached parse instead of reparsing the SVG on every render.
+An SVG referenced as an image is an isolated document. It does not inherit `color` from the host, the same rule browsers, [satori](https://github.com/vercel/satori), and `@vercel/og` follow. Its `currentColor` now resolves to the SVG's own default (black) instead of the surrounding text color. This also makes the raster and vector (SVG) backends agree, and lets the raster backend reuse its cached parse instead of reparsing the SVG on every render.
 
 `currentColor` for Takumi's own properties (text `color`, `border-color`, `box-shadow`, `outline`, `text-decoration-color`) is unchanged. Only the contents of SVG images are affected.
 
@@ -316,7 +316,12 @@ write_image(&image, ImageOutputFormat::WebP, 80)?; // [!code --]
 write_image(&image, &mut output, OutputFormat::WebP { quality: Quality::new(80) })?; // [!code ++]
 ```
 
-In the napi binding, `format` is a string (`"png"` | `"jpeg"` | `"webp"` | ...) with separate optional `quality` and `lossless` fields. `quality` applies to JPEG and lossy WebP; `lossless` applies to WebP. On the wasm binding WebP is always lossless, so there is no `lossless` field and `quality` applies to JPEG only.
+In the napi binding, `format` is a string (`"png"` | `"jpeg"` | `"webp"` | ...) with separate optional `quality` and `lossless` fields. Field support differs by binding:
+
+| Binding | `quality`           | `lossless`                       |
+| ------- | ------------------- | -------------------------------- |
+| napi    | JPEG and lossy WebP | WebP                             |
+| wasm    | JPEG only           | absent (WebP is always lossless) |
 
 ```ts
 renderer.render(node, { format: "jpeg", quality: 80 });
@@ -348,7 +353,7 @@ image.render_for_layout(width, height, image_rendering, time_ms)?; // [!code ++]
 
 ### `Length` and `ColorInput` drop their default-flavor type parameter
 
-`Length` and `ColorInput` were generic over a `const` bool so one enum could default two ways (`auto` vs `0`, `currentColor` vs `transparent`). That parameter is gone: both are plain enums. The `LengthDefaultsToZero` and `ColorDefaultsToTransparent` aliases are removed — use `Length` and `ColorInput`. Rendering is unchanged: the zero/transparent initial values are now declared per field.
+`Length` and `ColorInput` were generic over a `const` bool so one enum could default two ways (`auto` vs `0`, `currentColor` vs `transparent`). That parameter is gone: both are plain enums. The `LengthDefaultsToZero` and `ColorDefaultsToTransparent` aliases are removed; use `Length` and `ColorInput`. Rendering is unchanged: the zero/transparent initial values are now declared per field.
 
 ```rust
 let inset: LengthDefaultsToZero = Length::Px(0.0); // [!code --]
@@ -357,7 +362,7 @@ let inset: Length = Length::Px(0.0); // [!code ++]
 
 ### `BackgroundPosition` is renamed to `PositionValue`
 
-The CSS `<position>` value backs `background-position`, `object-position`, `transform-origin`, `mask-position`, and gradient centers, so `BackgroundPosition` was renamed to `PositionValue`, and `BackgroundPositions` to `PositionValues`. The `ObjectPosition` and `TransformOrigin` aliases are removed — they were aliases of `BackgroundPosition`, so their `Default` was top-left, not the `50% 50%` those properties actually default to. Use `PositionValue`, and `PositionValue::center()` for the `center center` initial value.
+The CSS `<position>` value backs `background-position`, `object-position`, `transform-origin`, `mask-position`, and gradient centers, so `BackgroundPosition` was renamed to `PositionValue`, and `BackgroundPositions` to `PositionValues`. The `ObjectPosition` and `TransformOrigin` aliases are removed; they were aliases of `BackgroundPosition`, so their `Default` was top-left, not the `50% 50%` those properties actually default to. Use `PositionValue`, and `PositionValue::center()` for the `center center` initial value.
 
 ```rust
 let origin: TransformOrigin = TransformOrigin::default(); // [!code --]
@@ -366,7 +371,13 @@ let origin: PositionValue = PositionValue::center(); // [!code ++]
 
 ### Core enums are `#[non_exhaustive]`
 
-Several public enums gained `#[non_exhaustive]`: `NodeKind`, `ImageSource`, `ImageSourceInput`, `ImageCacheMode`, `Length`, and `ColorInput`, plus `PropertyId`, `StyleDeclaration`, and the spec-tracking CSS value enums (`BlendMode`, `Filter`, `BasicShape`, `ContentValue`, `TextTransform`, `WhiteSpaceCollapse`, `OffsetPath`, `ImageScalingAlgorithm`, `Position`) in `takumi-core`. You can no longer build these variants with a struct literal from outside the crate, and a `match` on them needs a wildcard arm.
+Several public enums in `takumi-core` gained `#[non_exhaustive]`:
+
+- **Core**: `NodeKind`, `ImageSource`, `ImageSourceInput`, `ImageCacheMode`, `Length`, `ColorInput`
+- **Style**: `PropertyId`, `StyleDeclaration`
+- **Spec-tracking CSS values**: `BlendMode`, `Filter`, `BasicShape`, `ContentValue`, `TextTransform`, `WhiteSpaceCollapse`, `OffsetPath`, `ImageScalingAlgorithm`, `Position`
+
+You can no longer build these variants with a struct literal from outside the crate, and a `match` on them needs a wildcard arm.
 
 ```rust
 match node.kind {
@@ -378,7 +389,12 @@ match node.kind {
 
 ### CSS value lists are type aliases
 
-The multi-value CSS lists are plain aliases instead of newtypes. `Filters` and `GridTemplateComponents` are `Vec<_>`; `BackgroundImages`, `BackgroundSizes`, `BackgroundRepeats`, and `PositionValues` are `Box<[_]>`. Drop the newtype wrapper when you build one. To parse a value from a string, use the `FromCssStr` trait, which returns an owned `ParseError` and keeps `cssparser` out of the public API.
+The multi-value CSS lists are plain aliases instead of newtypes. Drop the newtype wrapper when you build one.
+
+| Underlying type | Aliases                                                                      |
+| --------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Vec<_>`        | `Filters`, `GridTemplateComponents`                                          |
+| `Box<[_]>`      | `BackgroundImages`, `BackgroundSizes`, `BackgroundRepeats`, `PositionValues` | To parse a value from a string, use the `FromCssStr` trait, which returns an owned `ParseError` and keeps `cssparser` out of the public API. |
 
 ```rust
 let filters = Filters(vec![Filter::Blur(Length::Px(4.0))]); // [!code --]
@@ -388,8 +404,12 @@ let sizes = BackgroundSizes::from_css_str("cover")?;
 
 ### `max-width` / `max-height` and `gap` representation
 
-`max-width` and `max-height` are now represented as a `MaxSize` enum instead of using `Length`'s `auto` to mean unbounded. Its initial value is `MaxSize::None`.
-`column-gap`, `row-gap`, and the `gap` shorthand are represented as a `Gap` enum, whose initial value is `Gap::Normal` (which computes to `0`).
+Two properties moved off `Length` onto dedicated enums:
+
+| Property                       | Enum      | Initial                         |
+| ------------------------------ | --------- | ------------------------------- |
+| `max-width`, `max-height`      | `MaxSize` | `MaxSize::None` (unbounded)     |
+| `column-gap`, `row-gap`, `gap` | `Gap`     | `Gap::Normal` (computes to `0`) |
 
 ```rust
 let max_width = Length::Auto; // [!code --]

--- a/docs/content/docs/visual-effects.mdx
+++ b/docs/content/docs/visual-effects.mdx
@@ -41,8 +41,11 @@ dithers away gradient banding. The title crosses the whole hue wheel with two st
 
 ## Neon CRT
 
-Neon is stacked `text-shadow`s widening in the brand color; chromatic aberration is two hard
-shadows in opposite directions; scanlines and vignette are gradient overlays:
+Three layered effects:
+
+- **Neon**: stacked `text-shadow`s widening in the brand color
+- **Chromatic aberration**: two hard shadows in opposite directions
+- **Scanlines and vignette**: gradient overlays
 
 ```css
 .neon {
@@ -125,9 +128,11 @@ The starburst behind is one `repeating-conic-gradient`:
 
 ## Halftone
 
-A dot screen in three declarations: multiply a tiled radial gradient with a tone ramp, then crush
-it with `contrast()`. A `lighten` overlay re-inks the black dots (set `isolation: isolate` on the
-parent):
+A dot screen in three declarations:
+
+- Multiply a tiled radial gradient with a tone ramp
+- Crush it with `contrast()`
+- Re-ink the black dots with a `lighten` overlay (set `isolation: isolate` on the parent)
 
 ```css
 .dots {
@@ -256,7 +261,7 @@ Threshold effects need `color-interpolation-filters="sRGB"` on the `<filter>`; t
 ```
 
 Tiling a Bayer matrix with `feImage` + `feTile` and adding it as noise before the quantize turns
-the same graph into ordered dithering; a two-color table over a 1-bit luma threshold gives duotone.
+the same graph into ordered dithering. A two-color table over a 1-bit luma threshold gives duotone.
 The full graphs live in
 [`style_filter_reference.rs`](https://github.com/kane50613/takumi/blob/master/takumi/tests/fixtures/style_filter_reference.rs).
 


### PR DESCRIPTION
## Why

Some docs pages packed multiple facts into comma- and semicolon-chained sentences, which is slower to skim, and leaned on em dashes that read as slop.

## What

Applied the fuma writing style across the prose-heavy pages:

- Dense enumerations and conditions turned into lists and tables (`upgrade/v2` non-exhaustive enums, quality/lossless-by-binding, `MaxSize`/`Gap`, CSS-list aliases; `visual-effects` effect breakdowns; `keyframe-animation` scene handling).
- Broke `then`-sequenced sentences into plain statements.
- Bolded the key size numbers in the satori comparison.
- Spelled out `SSRF` and `CJK` on first use.
- Replaced every prose em dash with a colon, semicolon, comma, or parentheses.

Docs-only, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified installation and runtime renderer selection across Node.js, edge platforms, Deno, and browsers.
  - Improved guidance for image caching, fetch limits, fonts, text wrapping, animations, visual effects, and troubleshooting.
  - Expanded the v2 upgrade guide with clearer migration steps, API changes, rendering behavior, and Rust compatibility notes.
  - Refined comparisons and error-handling explanations for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->