### PR TITLE
Core: drop whitespace between absolute-only block siblings

### DIFF
--- a/.tegami/abs-only-whitespace-siblings.md
+++ b/.tegami/abs-only-whitespace-siblings.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Drop whitespace between absolute-only block siblings
+
+When every element child of a block container was absolutely positioned, the whitespace text nodes from pretty-printed HTML formed an inline formatting context that swallowed the out-of-flow boxes, so none of them rendered. The whitespace drop now also runs when the only in-flow content is whitespace, keeping the absolute children in the layout.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1360,9 +1360,10 @@ impl RenderNode {
           }
         } else {
           // https://github.com/kane50613/takumi/issues/711
+          // https://github.com/kane50613/takumi/issues/992
           if children
             .iter()
-            .any(|child| !child.participates_in_inline_formatting_context())
+            .any(|child| !child.participates_in_inflow_inline_formatting_context())
           {
             children = drop_block_boundary_whitespace(Vec::from(children)).into_boxed_slice();
           }

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1786,6 +1786,12 @@ fn test_block_container_drops_whitespace_between_absolute_only_siblings() {
   let with_result = measure(with_whitespace, create_measure_viewport());
   let without_result = measure(without_whitespace, create_measure_viewport());
 
+  assert_eq!(with_result.children.len(), 2);
+  assert!(with_result.runs.is_empty());
+  for child in &with_result.children {
+    assert_close(child.width, 40.0);
+    assert_close(child.height, 40.0);
+  }
   assert_eq!(with_result, without_result);
 }
 

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1751,6 +1751,44 @@ fn test_block_container_drops_whitespace_between_absolute_and_in_flow_sibling() 
   assert_eq!(with_result, without_result);
 }
 
+// https://github.com/kane50613/takumi/issues/992
+#[test]
+fn test_block_container_drops_whitespace_between_absolute_only_siblings() {
+  let absolute_child = || {
+    Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Block))
+        .with(StyleDeclaration::position(Position::Absolute))
+        .with(StyleDeclaration::width(Px(40.0)))
+        .with(StyleDeclaration::height(Px(40.0))),
+    )
+  };
+  let block_style = || {
+    Style::default()
+      .with(StyleDeclaration::display(Display::Block))
+      .with(StyleDeclaration::position(Position::Relative))
+      .with(StyleDeclaration::width(Px(200.0)))
+      .with(StyleDeclaration::height(Px(200.0)))
+  };
+
+  let with_whitespace = Node::container([
+    Node::text("\n  ".to_string()),
+    absolute_child(),
+    Node::text("\n  ".to_string()),
+    absolute_child(),
+    Node::text("\n".to_string()),
+  ])
+  .with_style(block_style());
+
+  let without_whitespace =
+    Node::container([absolute_child(), absolute_child()]).with_style(block_style());
+
+  let with_result = measure(with_whitespace, create_measure_viewport());
+  let without_result = measure(without_whitespace, create_measure_viewport());
+
+  assert_eq!(with_result, without_result);
+}
+
 // https://github.com/kane50613/takumi/issues/711
 #[test]
 fn test_block_container_preserves_whitespace_between_inline_siblings() {


### PR DESCRIPTION
## Why
Fixes #992. In a block container whose element children are all absolutely positioned, the whitespace text nodes from pretty-printed HTML markup made every absolute child disappear. Digging further, the whitespace was only a trigger: any block container mixing inline content with absolute children swallowed the absolute boxes into its inline layout, so `<div>hi<div style="position:absolute">…</div></div>` lost the absolute child even without whitespace.

## What
Aligns whitespace text node handling with Blink's `Text::TextLayoutObjectIsNeeded` (third_party/blink/renderer/core/dom/text.cc): collapsible whitespace-only text renders only after an in-flow inline-level sibling, leading whitespace survives only in an inline parent, and `white-space: pre` whitespace is always kept. This replaces the run-based `drop_block_boundary_whitespace` from #711 and also covers float-only siblings and whitespace-only sole children (`<div>\n</div>` now measures 0 height, as in browsers).

For the remaining mixes of inline content and out-of-flow boxes, the anonymous-block grouping now also kicks in when absolute children are present, wrapping the inline content so the absolute boxes stay as regular layout children.

Adds regression tests for the issue's repro, the text-plus-absolute case, preserved whitespace next to an absolute sibling, and the whitespace-only sole child. No render fixture changed.