### PR TITLE
Core: align inline whitespace handling with Blink

### DIFF
--- a/.tegami/br-white-space-pre.md
+++ b/.tegami/br-white-space-pre.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-core": patch
+  "cargo:takumi-html": patch
+  "npm:@takumi-rs/helpers": patch
+---
+
+### Honour per-element white-space when collapsing inline text
+
+Inline whitespace collapsing read the block's white-space value for every span, so a `white-space: pre` child inside a normal-collapsing parent lost its spaces and line breaks. Each span now collapses against its own value. `<br>` also carries a `white-space: pre` preset, so its line break survives.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -1248,7 +1248,7 @@ fn build_inline_layout_tree<'c>(
         let transformed = apply_text_transform(text, context.style.text_transform);
         let collapsed = apply_white_space_collapse(
           &transformed,
-          style.parent.white_space_collapse,
+          context.style.white_space_collapse,
           &mut previous_collapsible_space,
           &mut previous_was_line_break,
         );

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1044,13 +1044,12 @@ impl RenderNode {
       .is_some_and(Node::is_whitespace_only_text)
   }
 
-  // Blink's ComputedStyle::ShouldPreserveBreaks marks pre/pre-line whitespace
-  // as always rendered; only the collapsible modes may be dropped.
+  // Only fully-collapsible whitespace may be dropped. preserve / preserve-spaces
+  // keep their spaces, and preserve-breaks may hold a forced break, so a
+  // whitespace-only node in any of those still renders.
   fn is_collapsible_whitespace_only_text_node(&self) -> bool {
-    matches!(
-      self.context.style.white_space_collapse,
-      WhiteSpaceCollapse::Collapse | WhiteSpaceCollapse::PreserveSpaces
-    ) && self.is_whitespace_only_text_node()
+    self.context.style.white_space_collapse == WhiteSpaceCollapse::Collapse
+      && self.is_whitespace_only_text_node()
   }
 
   /// True if any direct child is an anonymous text item.
@@ -1381,11 +1380,14 @@ impl RenderNode {
             .iter()
             .any(|child| !child.participates_in_inline_formatting_context());
           let has_out_of_flow = children.iter().any(RenderNode::is_out_of_flow);
-          let requires_inline_parent_blockification =
-            finished.context.style.display.is_inline() && has_block;
-          // Out-of-flow boxes cannot live inside the inline layout, so any mix
-          // of inline content and absolute children needs the anonymous block.
-          let needs_anonymous_boxes = has_inline && (has_block || has_out_of_flow);
+          let parent_is_inline = finished.context.style.display.is_inline();
+          let requires_inline_parent_blockification = parent_is_inline && has_block;
+          // A block parent mixing inline content with out-of-flow children wraps
+          // the inline part so the absolute boxes stay as block-level children.
+          // An inline parent keeps its inline formatting context untouched — an
+          // anonymous block there would be dropped by the surrounding line box.
+          let needs_anonymous_boxes =
+            has_inline && (has_block || (!parent_is_inline && has_out_of_flow));
 
           if requires_inline_parent_blockification {
             finished.context.style.display = finished.context.style.display.as_blockified();

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -27,7 +27,7 @@ use crate::{
     BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem,
     ContentValue, Display, Filters, Float, Isolation, Length, LineHeight, PercentageNumber,
     Position, SizingContext, Style as NodeStyle, StyleDeclaration, StyleSheet, TextWrapMode,
-    apply_stylesheet_animations,
+    WhiteSpaceCollapse, apply_stylesheet_animations,
   },
   viewport::Viewport,
 };
@@ -1044,6 +1044,15 @@ impl RenderNode {
       .is_some_and(Node::is_whitespace_only_text)
   }
 
+  // Blink's ComputedStyle::ShouldPreserveBreaks marks pre/pre-line whitespace
+  // as always rendered; only the collapsible modes may be dropped.
+  fn is_collapsible_whitespace_only_text_node(&self) -> bool {
+    matches!(
+      self.context.style.white_space_collapse,
+      WhiteSpaceCollapse::Collapse | WhiteSpaceCollapse::PreserveSpaces
+    ) && self.is_whitespace_only_text_node()
+  }
+
   /// True if any direct child is an anonymous text item.
   pub fn has_anonymous_text_item_child(&self) -> bool {
     self
@@ -1303,16 +1312,6 @@ impl RenderNode {
       };
 
       if let Some(child) = current.pending_children.next() {
-        // CSS Grid L1 §6 / Flexbox L1 §4: whitespace-only anonymous items
-        // are not rendered. Advance the preorder cursor to keep
-        // `matched_declarations` indices aligned with the original tree.
-        if current.context.style.display.should_blockify_children()
-          && child.is_whitespace_only_text()
-        {
-          next_preorder_index(&mut preorder_cursor);
-          continue;
-        }
-
         let child_pending = build_pending_node(
           &current.context,
           child,
@@ -1346,6 +1345,10 @@ impl RenderNode {
 
       let render_node = if let Some(mut children) = children {
         if finished.context.style.display.should_blockify_children() {
+          // CSS Flexbox L1 §4 / Grid L1 §6: collapsible whitespace-only text
+          // between items is not rendered; every remaining child blockifies.
+          let mut children = Vec::from(children);
+          children.retain(|child| !child.is_collapsible_whitespace_only_text_node());
           for child in &mut children {
             child.context.style.display.blockify();
           }
@@ -1353,20 +1356,21 @@ impl RenderNode {
           RenderNode {
             context: finished.context,
             node: Some(finished.node),
-            children: Some(children),
+            children: Some(children.into_boxed_slice()),
             layout_style_override: None,
             anonymous_text_content: None,
             force_inline_layout: false,
           }
         } else {
-          // https://github.com/kane50613/takumi/issues/711
-          // https://github.com/kane50613/takumi/issues/992
-          if children
-            .iter()
-            .any(|child| !child.participates_in_inflow_inline_formatting_context())
-          {
-            children = drop_block_boundary_whitespace(Vec::from(children)).into_boxed_slice();
-          }
+          // Blink's Text::TextLayoutObjectIsNeeded: collapsible
+          // whitespace-only text renders only after an in-flow inline-level
+          // sibling, and leading whitespace only inside an inline parent
+          // (#711, #992).
+          children = drop_collapsible_boundary_whitespace(
+            Vec::from(children),
+            finished.context.style.display.is_inline(),
+          )
+          .into_boxed_slice();
 
           // https://github.com/kane50613/takumi/issues/738: out-of-flow boxes
           // must not be swept into an anonymous block box.
@@ -1376,9 +1380,12 @@ impl RenderNode {
           let has_block = children
             .iter()
             .any(|child| !child.participates_in_inline_formatting_context());
+          let has_out_of_flow = children.iter().any(RenderNode::is_out_of_flow);
           let requires_inline_parent_blockification =
             finished.context.style.display.is_inline() && has_block;
-          let needs_anonymous_boxes = has_inline && has_block;
+          // Out-of-flow boxes cannot live inside the inline layout, so any mix
+          // of inline content and absolute children needs the anonymous block.
+          let needs_anonymous_boxes = has_inline && (has_block || has_out_of_flow);
 
           if requires_inline_parent_blockification {
             finished.context.style.display = finished.context.style.display.as_blockified();
@@ -1898,31 +1905,28 @@ fn flush_inline_group(
   ));
 }
 
-fn drop_block_boundary_whitespace(input: Vec<RenderNode>) -> Vec<RenderNode> {
-  let mut result = Vec::with_capacity(input.len());
-  let mut run: Vec<RenderNode> = Vec::new();
-
-  fn flush(run: &mut Vec<RenderNode>, out: &mut Vec<RenderNode>) {
-    let has_meaningful_inline = run.iter().any(|c| {
-      c.participates_in_inflow_inline_formatting_context() && !c.is_whitespace_only_text_node()
-    });
-    if has_meaningful_inline {
-      out.append(run);
-    } else {
-      out.extend(run.drain(..).filter(|c| !c.is_whitespace_only_text_node()));
-    }
-  }
+// Mirrors Blink's Text::TextLayoutObjectIsNeeded, minus the ends-with-space
+// refinement (inline collapsing already merges adjacent spaces).
+fn drop_collapsible_boundary_whitespace(
+  input: Vec<RenderNode>,
+  parent_is_inline: bool,
+) -> Vec<RenderNode> {
+  let mut out = Vec::with_capacity(input.len());
+  let mut after_in_flow_inline = parent_is_inline;
 
   for child in input {
-    if !child.participates_in_inline_formatting_context() {
-      flush(&mut run, &mut result);
-      result.push(child);
-    } else {
-      run.push(child);
+    if child.is_collapsible_whitespace_only_text_node() && !after_in_flow_inline {
+      continue;
     }
+
+    if !child.is_out_of_flow() && child.context.style.float == Float::None {
+      after_in_flow_inline = child.participates_in_inflow_inline_formatting_context();
+    }
+
+    out.push(child);
   }
-  flush(&mut run, &mut result);
-  result
+
+  out
 }
 
 #[cfg(test)]

--- a/takumi-core/src/text_processing.rs
+++ b/takumi-core/src/text_processing.rs
@@ -57,6 +57,9 @@ pub(crate) fn apply_white_space_collapse<'a>(
 ) -> Cow<'a, str> {
   match collapse {
     WhiteSpaceCollapse::Preserve => {
+      // A following collapsible span drops its leading space when this span
+      // already ends in whitespace, so carry that state across the mode switch.
+      *previous_collapsible_space = input.chars().next_back().is_some_and(char::is_whitespace);
       *previous_was_line_break = false;
       Cow::Borrowed(input)
     }
@@ -414,6 +417,26 @@ mod tests {
     let left = apply_white_space_collapse(
       "A ",
       WhiteSpaceCollapse::Collapse,
+      &mut previous_collapsible_space,
+      &mut previous_was_line_break,
+    );
+    let right = apply_white_space_collapse(
+      " B",
+      WhiteSpaceCollapse::Collapse,
+      &mut previous_collapsible_space,
+      &mut previous_was_line_break,
+    );
+
+    assert_eq!(format!("{left}{right}"), "A B");
+  }
+
+  #[test]
+  fn test_white_space_collapse_after_preserve_span_drops_leading_space() {
+    let mut previous_collapsible_space = false;
+    let mut previous_was_line_break = false;
+    let left = apply_white_space_collapse(
+      "A ",
+      WhiteSpaceCollapse::Preserve,
       &mut previous_collapsible_space,
       &mut previous_was_line_break,
     );

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -101,7 +101,7 @@ function buildStaticNodes(
     nodes.push(
       text({
         text: "\n",
-        preset: presets?.span,
+        preset: presets?.br,
         ...metadata,
       }),
     );

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -395,7 +395,7 @@ async function processReactElement(
       nodes: [
         text({
           text: "\n",
-          preset: options.presets?.span,
+          preset: options.presets?.br,
           ...metadata,
         }),
       ],

--- a/takumi-helpers/src/jsx/style-presets.ts
+++ b/takumi-helpers/src/jsx/style-presets.ts
@@ -257,6 +257,9 @@ export const defaultStylePresets: Partial<Record<keyof JSX.IntrinsicElements, CS
     margin: "1em 0",
     display: "block",
   },
+  br: {
+    whiteSpace: "pre",
+  },
   mark: {
     backgroundColor: "yellow",
     color: "black",

--- a/takumi-helpers/tests/jsx/jsx-processing.test.tsx
+++ b/takumi-helpers/tests/jsx/jsx-processing.test.tsx
@@ -817,7 +817,7 @@ describe("fromJsx", () => {
     expect(node).toEqual({
       type: "text",
       text: "\n",
-      preset: defaultStylePresets.span,
+      preset: defaultStylePresets.br,
       tagName: "br",
       id: "line-break",
       className: "spacer",

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -146,6 +146,7 @@ const DEFAULT_PRESETS: &[(&str, &str)] = &[
   ("sub", "font-size:smaller;vertical-align:sub"),
   ("sup", "font-size:smaller;vertical-align:super"),
   ("div", "display:block"),
+  ("br", "white-space:pre"),
 ];
 
 static DEFAULT_STYLE_PRESETS: LazyLock<HashMap<Box<str>, Style>> = LazyLock::new(|| {

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1795,6 +1795,55 @@ fn test_block_container_drops_whitespace_between_absolute_only_siblings() {
   assert_eq!(with_result, without_result);
 }
 
+#[test]
+fn test_block_container_preserves_pre_whitespace_next_to_absolute_sibling() {
+  let abs = || {
+    Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Block))
+        .with(StyleDeclaration::position(Position::Absolute))
+        .with(StyleDeclaration::width(Px(40.0)))
+        .with(StyleDeclaration::height(Px(40.0))),
+    )
+  };
+  let parent = Node::container([Node::text("\n\n".to_string()), abs()]).with_style(
+    Style::default()
+      .with(StyleDeclaration::display(Display::Block))
+      .with(StyleDeclaration::white_space_collapse(
+        WhiteSpaceCollapse::Preserve,
+      ))
+      .with(StyleDeclaration::width(Px(200.0))),
+  );
+
+  let result = measure(parent, create_measure_viewport());
+
+  assert!(
+    result
+      .children
+      .iter()
+      .any(|child| child.width == 40.0 && child.height == 40.0),
+    "absolute child must stay in the layout"
+  );
+  assert!(
+    result.height > 0.0,
+    "preserved line breaks should keep their line boxes"
+  );
+}
+
+#[test]
+fn test_block_container_drops_whitespace_only_child() {
+  let parent = Node::container([Node::text("\n  ".to_string())]).with_style(
+    Style::default()
+      .with(StyleDeclaration::display(Display::Block))
+      .with(StyleDeclaration::width(Px(200.0))),
+  );
+
+  let result = measure(parent, create_measure_viewport());
+
+  assert!(result.runs.is_empty());
+  assert_close(result.height, 0.0);
+}
+
 // https://github.com/kane50613/takumi/issues/711
 #[test]
 fn test_block_container_preserves_whitespace_between_inline_siblings() {
@@ -1834,5 +1883,38 @@ fn test_block_container_preserves_whitespace_between_inline_siblings() {
     with_result.height > without_result.height
       || with_result.children[0] != without_result.children[0],
     "inline-interior whitespace should change layout (preserved space between siblings)"
+  );
+}
+
+// https://github.com/kane50613/takumi/issues/992
+#[test]
+fn test_block_container_keeps_absolute_child_next_to_text() {
+  let abs = || {
+    Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Block))
+        .with(StyleDeclaration::position(Position::Absolute))
+        .with(StyleDeclaration::width(Px(40.0)))
+        .with(StyleDeclaration::height(Px(40.0))),
+    )
+  };
+  let parent = Node::container([Node::text("hi".to_string()), abs()]).with_style(
+    Style::default()
+      .with(StyleDeclaration::display(Display::Block))
+      .with(StyleDeclaration::width(Px(200.0))),
+  );
+
+  let result = measure(parent, create_measure_viewport());
+
+  assert!(
+    result
+      .children
+      .iter()
+      .any(|child| child.width == 40.0 && child.height == 40.0),
+    "absolute child must stay in the layout"
+  );
+  assert!(
+    result.height > 0.0,
+    "text sibling must still produce a line box"
   );
 }


### PR DESCRIPTION
## Why
Follow-up to #993 (already merged). Two related whitespace bugs remained in the HTML/inline path:

- Inline whitespace collapsing used the block's `white-space` value for every span, so a `white-space: pre` child inside a normal-collapsing parent lost its spaces and line breaks.
- `<br>` emitted a bare `\n` that the parent's collapsing then swallowed, so it produced no line break.

## What
- Collapse each inline span against its own `white-space-collapse` instead of the block's, matching how browsers resolve the property per element.
- Give `<br>` a `white-space: pre` preset (HTML crate + `@takumi-rs/helpers`) so its line break survives collapsing.
- Drop whitespace-only text following Blink's `Text::TextLayoutObjectIsNeeded`: collapsible whitespace only renders after an in-flow inline sibling, `white-space: pre` whitespace is always kept, and flex/grid items drop only collapsible whitespace.

Regression tests added; no render fixture changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace-collapsing so `white-space: pre` descendants keep their spaces and line breaks, even inside normally-collapsing parents.
  * `<br>` now renders consistently as a preserved line break across HTML and JSX.
  * Refined whitespace-only and boundary handling in layout, preventing relevant text and absolutely positioned elements from being dropped or mismeasured.
* **Tests**
  * Added/updated cases covering preserved whitespace after `pre`, whitespace-only containers, and positioned elements adjacent to text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->