### PR TITLE
Core: serialize text-fit none without target and limit

### DIFF
--- a/.tegami/text-fit-none-serialization.md
+++ b/.tegami/text-fit-none-serialization.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Serialize `text-fit: none` without its target and limit
+
+The computed value of `text-fit` kept the target and limit keywords after `none`, so `none per-line 50%` round-tripped verbatim. Chromium drops both, since neither scales anything when the value is `none`. The serializer now stops after `none`.

--- a/takumi-core/src/style/properties/text_fit.rs
+++ b/takumi-core/src/style/properties/text_fit.rs
@@ -107,6 +107,13 @@ declare_enum_from_css_impl!(
 impl ToCss for TextFit {
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
     self.mode.to_css(dest)?;
+
+    // Matching Chromium's ValueForTextFit: `none` drops the target and limit,
+    // since neither applies when nothing is scaled.
+    if self.mode == TextFitMode::None {
+      return Ok(());
+    }
+
     if self.target != TextFitTarget::Consistent {
       dest.write_char(' ')?;
       self.target.to_css(dest)?;
@@ -167,6 +174,12 @@ mod tests {
       let reparsed = TextFit::from_css_str(&parsed.to_css_string()).unwrap();
       assert_eq!(parsed, reparsed, "failed for {css}");
     }
+  }
+
+  #[test]
+  fn test_text_fit_none_drops_target_and_limit() {
+    let parsed = TextFit::from_css_str("none per-line 50%").unwrap();
+    assert_eq!(parsed.to_css_string(), "none");
   }
 
   #[test]


### PR DESCRIPTION
## Why
Chrome shipped `text-fit` as stable in M152 (the `CssTextFit` runtime flag is now `status: stable`). Comparing our implementation against the shipped one surfaced one gap in computed-value serialization.

Chromium's `ComputedStyleUtils::ValueForTextFit` returns `none` alone and drops any target or limit that follows it, because neither scales anything when the value is `none`. We kept them, so `none per-line 50%` round-tripped verbatim.

The grammar, keywords, and the three optional-token forms already match Chromium's `ConsumeTextFit`; this was the only divergence.

## What
Stop serializing after `none` in `TextFit::to_css`. Adds a test for the drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CSS serialization for `text-fit: none` to output only `none`, matching Chromium behavior.
  * Corrected handling of trailing target and limit values during serialization.

* **Documentation**
  * Added documentation describing the updated `text-fit: none` serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->