### PR TITLE
Core: keep whitespace collapse state across empty inline spans

### DIFF
--- a/.tegami/empty-span-collapse-state.md
+++ b/.tegami/empty-span-collapse-state.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Keep whitespace collapse state across empty inline spans
+
+An empty span with `white-space: pre` reset the cross-span collapse state, so a boundary space next to it could double up or vanish. Empty spans now leave the state untouched, matching Blink's opaque-to-collapsing empty text items.

--- a/takumi-core/src/text_processing.rs
+++ b/takumi-core/src/text_processing.rs
@@ -55,6 +55,11 @@ pub(crate) fn apply_white_space_collapse<'a>(
   previous_collapsible_space: &mut bool,
   previous_was_line_break: &mut bool,
 ) -> Cow<'a, str> {
+  // An empty span contributes no characters, so boundary state carries through.
+  if input.is_empty() {
+    return Cow::Borrowed(input);
+  }
+
   match collapse {
     WhiteSpaceCollapse::Preserve => {
       // A following collapsible span drops its leading space when this span
@@ -448,6 +453,32 @@ mod tests {
     );
 
     assert_eq!(format!("{left}{right}"), "A B");
+  }
+
+  #[test]
+  fn test_white_space_empty_span_keeps_boundary_state() {
+    let mut previous_collapsible_space = false;
+    let mut previous_was_line_break = false;
+    let left = apply_white_space_collapse(
+      "A ",
+      WhiteSpaceCollapse::Collapse,
+      &mut previous_collapsible_space,
+      &mut previous_was_line_break,
+    );
+    let middle = apply_white_space_collapse(
+      "",
+      WhiteSpaceCollapse::Preserve,
+      &mut previous_collapsible_space,
+      &mut previous_was_line_break,
+    );
+    let right = apply_white_space_collapse(
+      " B",
+      WhiteSpaceCollapse::Collapse,
+      &mut previous_collapsible_space,
+      &mut previous_was_line_break,
+    );
+
+    assert_eq!(format!("{left}{middle}{right}"), "A B");
   }
 
   #[test]


### PR DESCRIPTION
## Why
An empty inline span with `white-space: pre` clobbered the cross-span collapse state: `apply_white_space_collapse` set `previous_collapsible_space` from the span's last character, which for an empty span meant forcing it to `false`. A boundary space next to the empty span could then double up or vanish. Blink treats empty text items as opaque to collapsing (`AppendEmptyTextItem` sets `kOpaqueToCollapsing`), so state should carry through unchanged.

## What
- Early return in `apply_white_space_collapse` for empty input, leaving both state flags untouched across all collapse modes.
- Regression test: empty `Preserve` span between two `Collapse` spans keeps the single boundary space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace handling across empty inline spans.
  * Prevented spaces from being duplicated or unexpectedly removed around empty spans.
  * Updated behavior to preserve consistent text spacing across span boundaries.

* **Documentation**
  * Added documentation describing the updated whitespace-collapse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->