### PR TITLE
Core: decode animated GIF frames on demand

### DIFF
--- a/.tegami/gif-decode-on-demand.md
+++ b/.tegami/gif-decode-on-demand.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Decode animated GIF frames on demand instead of holding the whole timeline
+
+Once a render scrubbed past the first frame, an animated GIF decoded and kept every remaining frame, so the encoded bytes, the first frame, and all later frames stayed resident at once — and none of it counted against the image cache budget. Frames past the first now decode at draw size when they are sampled and drop right after, so a GIF holds only its encoded bytes and first frame. Output is unchanged.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -236,13 +236,6 @@ impl GifSource {
   fn decoded_bytes(&self) -> usize {
     self.inner.first.buffer.data().len() + self.inner.bytes.len()
   }
-
-  /// Decoded frames held resident. Always 1 — only the first frame is retained;
-  /// the rest are decoded on demand and dropped.
-  #[cfg(test)]
-  fn decoded_frame_count(&self) -> usize {
-    1
-  }
 }
 
 #[cfg(feature = "svg")]
@@ -1344,16 +1337,6 @@ mod tests {
   }
 
   #[test]
-  fn gif_static_render_decodes_only_first_frame() {
-    let gif = gif_source(&[(0, 10), (1, 10), (2, 10)]);
-    assert_eq!(gif.decoded_frame_count(), 1);
-
-    let frame = gif.frame_at_time(0);
-    assert_eq!(gif.decoded_frame_count(), 1);
-    assert_eq!(frame.pixel(2, 2), GIF_COLORS[0]);
-  }
-
-  #[test]
   fn gif_source_frame_selection_matches_expected_indices() {
     let durations = [10, 20, 30];
     let gif = gif_source(&[(0, 10), (1, 20), (2, 30)]);
@@ -1363,7 +1346,6 @@ mod tests {
       let expected_color = GIF_COLORS[expected_frame_index(&durations, time_ms)];
       assert_eq!(gif.frame_at_time(time_ms).pixel(2, 2), expected_color);
     }
-    assert_eq!(gif.decoded_frame_count(), 1);
   }
 
   #[test]
@@ -1376,16 +1358,7 @@ mod tests {
   }
 
   #[test]
-  fn gif_clone_shares_source_without_retaining_frames() {
-    let gif = gif_source(&[(0, 10), (1, 10), (2, 10)]);
-    let cloned = gif.clone();
-
-    drop(cloned.frame_at_time(25));
-    assert_eq!(gif.decoded_frame_count(), 1);
-  }
-
-  #[test]
-  fn gif_later_frame_decodes_at_draw_size_without_retention() {
+  fn gif_later_frame_decodes_at_draw_size() {
     let gif = gif_source(&[(0, 10), (1, 10), (2, 10)]);
 
     let scaled = gif.frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
@@ -1396,8 +1369,6 @@ mod tests {
 
     let larger = gif.frame_at_time_covering(15, 4, 4, ImageScalingAlgorithm::Auto);
     assert_eq!((larger.width(), larger.height()), (4, 4));
-
-    assert_eq!(gif.decoded_frame_count(), 1);
   }
 
   #[test]
@@ -1406,7 +1377,6 @@ mod tests {
 
     let first = gif.frame_at_time_covering(0, 2, 2, ImageScalingAlgorithm::Auto);
     assert_eq!((first.width(), first.height()), (4, 4));
-    assert_eq!(gif.decoded_frame_count(), 1);
   }
 
   #[test]
@@ -1430,9 +1400,8 @@ mod tests {
   }
 
   #[test]
-  fn gif_dimensions_come_from_header_without_full_decode() {
+  fn gif_dimensions_come_from_header() {
     let gif = gif_source(&[(0, 10), (1, 10)]);
     assert_eq!(gif.dimensions(), (4, 4));
-    assert_eq!(gif.decoded_frame_count(), 1);
   }
 }

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -30,7 +30,7 @@ use crate::{
     image_buffer::ImageBuffer,
     image_decoder::{
       DecodedGifFrame, bitmap_dimensions, decode_bitmap_scaled, decode_gif_frames, decode_image,
-      gif_dimensions, is_gif,
+      gif_dimensions, gif_frame_durations, is_gif,
     },
   },
   style::{ImageScalingAlgorithm, IntrinsicSizing, SizingContext},
@@ -92,8 +92,11 @@ struct SvgIntrinsic {
   ratio: Option<f32>,
 }
 
-/// A lazily decoded animated GIF: only the first frame is decoded up front,
-/// the rest of the stream the first time a render samples past it.
+/// A lazily decoded animated GIF. Only the first frame and the (pixel-free)
+/// per-frame timing are retained; every later frame is decoded on demand at the
+/// size it is drawn and dropped afterwards, so the whole timeline never sits in
+/// memory at once. No cache holds decoded frames — retention stays a single
+/// frame, and the byte budget can account for it exactly.
 #[derive(Debug, Clone)]
 pub struct GifSource {
   inner: Arc<GifInner>,
@@ -105,17 +108,16 @@ struct GifInner {
   width: u32,
   height: u32,
   first: DecodedGifFrame,
-  rest: OnceLock<RestFrames>,
+  timing: OnceLock<GifTiming>,
 }
 
-/// Every frame after the first, decoded in one pass.
+/// Per-frame timing for the whole animation, decoded once without pixels.
 #[derive(Debug)]
-struct RestFrames {
-  frames: Box<[DecodedGifFrame]>,
-  /// Duration of the whole animation, first frame included.
-  total_duration_ms: u64,
-  /// Size the frames were decoded at; `None` means canvas size.
-  target: Option<(u32, u32)>,
+struct GifTiming {
+  /// Millisecond delay of each frame in stream order, first frame included.
+  durations: Box<[u32]>,
+  /// Duration of the whole loop.
+  total_ms: u64,
 }
 
 impl GifSource {
@@ -135,7 +137,7 @@ impl GifSource {
         width,
         height,
         first,
-        rest: OnceLock::new(),
+        timing: OnceLock::new(),
       }),
     })
   }
@@ -145,51 +147,43 @@ impl GifSource {
     (self.inner.width, self.inner.height)
   }
 
-  /// The first caller decides the memoized frame size and filter; renders of
-  /// the same GIF use one draw box in practice, and a single slot is what keeps
-  /// the timeline's memory bounded.
-  fn rest(&self, target: (u32, u32, ImageScalingAlgorithm)) -> &RestFrames {
-    self.inner.rest.get_or_init(|| {
-      let mut frames = Vec::new();
-      let mut total_duration_ms = self.inner.first.duration_ms as u64;
-      let _ = decode_gif_frames(&self.inner.bytes, 1, None, Some(target), |frame| {
-        total_duration_ms += frame.duration_ms as u64;
-        frames.push(frame);
-      });
-      RestFrames {
-        target: frames
-          .first()
-          .map(|frame: &DecodedGifFrame| (frame.buffer.width(), frame.buffer.height())),
-        frames: frames.into(),
-        total_duration_ms,
+  /// Per-frame timing, decoded once (pixel-free) and memoized. Falls back to a
+  /// single-frame loop if the stream can't be re-read.
+  fn timing(&self) -> &GifTiming {
+    self.inner.timing.get_or_init(|| {
+      let durations = gif_frame_durations(&self.inner.bytes)
+        .ok()
+        .filter(|durations| !durations.is_empty())
+        .unwrap_or_else(|| Box::from([self.inner.first.duration_ms]));
+      let total_ms = durations.iter().map(|&duration| duration as u64).sum();
+
+      GifTiming {
+        durations,
+        total_ms,
       }
     })
   }
 
-  /// Index into `rest.frames` for the given playback time, or `None` when the
-  /// time falls on the first frame.
-  fn rest_index_at(&self, rest: &RestFrames, time_ms: u64) -> Option<usize> {
-    if rest.total_duration_ms == 0 {
-      return None;
+  /// Stream index of the frame shown at the given playback time, looping over
+  /// the total duration.
+  fn frame_index_at(&self, timing: &GifTiming, time_ms: u64) -> usize {
+    if timing.total_ms == 0 || timing.durations.len() <= 1 {
+      return 0;
     }
 
-    let mut elapsed_ms = self.inner.first.duration_ms as u64;
-    let target_time = time_ms % rest.total_duration_ms;
-    if target_time < elapsed_ms {
-      return None;
-    }
-
-    for (index, frame) in rest.frames.iter().enumerate() {
-      elapsed_ms += frame.duration_ms as u64;
+    let target_time = time_ms % timing.total_ms;
+    let mut elapsed_ms = 0_u64;
+    for (index, &duration) in timing.durations.iter().enumerate() {
+      elapsed_ms += duration as u64;
       if target_time < elapsed_ms {
-        return Some(index);
+        return index;
       }
     }
 
-    None
+    timing.durations.len() - 1
   }
 
-  /// Shared frame shown at the given playback time, looping over total duration.
+  /// Frame shown at the given playback time, looping over total duration.
   #[cfg(test)]
   fn frame_at_time(&self, time_ms: u64) -> Arc<ImageBuffer> {
     self.frame_at_time_covering(
@@ -200,11 +194,10 @@ impl GifSource {
     )
   }
 
-  /// Shared frame shown at the given playback time, looping over total
-  /// duration. Frames past the first decode scaled to cover a `width` x
-  /// `height` draw box (never upscaled), so the memoized timeline holds
-  /// draw-sized frames; a request larger than the memoized size decodes that
-  /// frame fresh.
+  /// Frame shown at the given playback time, looping over total duration,
+  /// decoded to cover a `width` x `height` draw box (never upscaled). The first
+  /// frame is served from the retained copy; any later frame is decoded fresh
+  /// and not retained.
   pub fn frame_at_time_covering(
     &self,
     time_ms: u64,
@@ -212,50 +205,43 @@ impl GifSource {
     height: u32,
     algorithm: ImageScalingAlgorithm,
   ) -> Arc<ImageBuffer> {
-    let first = &self.inner.first;
-    if time_ms < first.duration_ms as u64 {
-      return first.buffer.clone();
+    let timing = self.timing();
+    let index = self.frame_index_at(timing, time_ms);
+    if index == 0 {
+      return self.inner.first.buffer.clone();
     }
 
-    let requested = cover_target((self.inner.width, self.inner.height), (width, height));
-    let rest = self.rest((requested.0, requested.1, algorithm));
-    let Some(index) = self.rest_index_at(rest, time_ms) else {
-      return first.buffer.clone();
-    };
+    // ponytail: decode-to-index each call — GIF disposal is stateful, so
+    // reaching frame N replays frames 0..N. O(N) per sample, O(1) retained;
+    // fine for a static render (one sample per GIF). A GIF re-encoded to an
+    // animation samples every frame → O(N²); if that path gets hot, cache a
+    // thread-local resumable decode cursor (canvas + position) keyed by GIF id.
+    let (target_width, target_height) =
+      cover_target((self.inner.width, self.inner.height), (width, height));
+    let mut frame = None;
+    let _ = decode_gif_frames(
+      &self.inner.bytes,
+      index,
+      Some(1),
+      Some((target_width, target_height, algorithm)),
+      |decoded| frame = Some(decoded.buffer),
+    );
 
-    let memoized = rest.target.unwrap_or((self.inner.width, self.inner.height));
-    if requested.0 > memoized.0 || requested.1 > memoized.1 {
-      let mut frame = None;
-      let target = (requested.0, requested.1, algorithm);
-      let _ = decode_gif_frames(
-        &self.inner.bytes,
-        index + 1,
-        Some(1),
-        Some(target),
-        |decoded| frame = Some(decoded.buffer),
-      );
-      if let Some(frame) = frame {
-        return frame;
-      }
-    }
-
-    rest.frames[index].buffer.clone()
+    frame.unwrap_or_else(|| self.inner.first.buffer.clone())
   }
 
+  /// Bytes retained for cache budgeting: the encoded stream plus the single
+  /// decoded first frame. Later frames are decoded on demand and dropped, so
+  /// they never count.
   fn decoded_bytes(&self) -> usize {
-    let rest = self.inner.rest.get().map_or(0, |rest| {
-      rest
-        .frames
-        .iter()
-        .map(|frame| frame.buffer.data().len())
-        .sum()
-    });
-    self.inner.first.buffer.data().len() + rest + self.inner.bytes.len()
+    self.inner.first.buffer.data().len() + self.inner.bytes.len()
   }
 
+  /// Decoded frames held resident. Always 1 — only the first frame is retained;
+  /// the rest are decoded on demand and dropped.
   #[cfg(test)]
   fn decoded_frame_count(&self) -> usize {
-    1 + self.inner.rest.get().map_or(0, |rest| rest.frames.len())
+    1
   }
 }
 
@@ -1377,7 +1363,7 @@ mod tests {
       let expected_color = GIF_COLORS[expected_frame_index(&durations, time_ms)];
       assert_eq!(gif.frame_at_time(time_ms).pixel(2, 2), expected_color);
     }
-    assert_eq!(gif.decoded_frame_count(), 3);
+    assert_eq!(gif.decoded_frame_count(), 1);
   }
 
   #[test]
@@ -1390,30 +1376,28 @@ mod tests {
   }
 
   #[test]
-  fn gif_source_clone_shares_decoded_state() {
+  fn gif_clone_shares_source_without_retaining_frames() {
     let gif = gif_source(&[(0, 10), (1, 10), (2, 10)]);
     let cloned = gif.clone();
 
     drop(cloned.frame_at_time(25));
-    assert_eq!(gif.decoded_frame_count(), 3);
+    assert_eq!(gif.decoded_frame_count(), 1);
   }
 
   #[test]
-  fn gif_frames_memoize_at_draw_size() {
+  fn gif_later_frame_decodes_at_draw_size_without_retention() {
     let gif = gif_source(&[(0, 10), (1, 10), (2, 10)]);
 
     let scaled = gif.frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
     assert_eq!((scaled.width(), scaled.height()), (2, 2));
 
-    let again = gif.frame_at_time_covering(15, 2, 2, ImageScalingAlgorithm::Auto);
-    assert!(Arc::ptr_eq(&scaled, &again));
-
     let smaller = gif.frame_at_time_covering(15, 1, 1, ImageScalingAlgorithm::Auto);
-    assert!(Arc::ptr_eq(&scaled, &smaller));
+    assert_eq!((smaller.width(), smaller.height()), (1, 1));
 
     let larger = gif.frame_at_time_covering(15, 4, 4, ImageScalingAlgorithm::Auto);
     assert_eq!((larger.width(), larger.height()), (4, 4));
-    assert!(!Arc::ptr_eq(&scaled, &larger));
+
+    assert_eq!(gif.decoded_frame_count(), 1);
   }
 
   #[test]

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -277,10 +277,20 @@ pub(crate) fn gif_frame_durations(bytes: &[u8]) -> ImageResult<Box<[u32]>> {
     .read_info(Cursor::new(bytes))
     .map_err(gif_decode_error)?;
 
+  // Stop at the same cumulative pixel budget as `decode_gif_frames`, so the
+  // timing covers exactly the frames that are actually decodable.
+  let frame_pixels = decoder.width() as u64 * decoder.height() as u64;
+  let mut total_pixels = 0_u64;
   let mut durations = Vec::new();
   loop {
     match decoder.read_next_frame() {
-      Ok(Some(frame)) => durations.push((frame.delay as u32 * 10).max(1)),
+      Ok(Some(frame)) => {
+        total_pixels += frame_pixels;
+        if total_pixels > MAX_GIF_TOTAL_PIXELS {
+          break;
+        }
+        durations.push((frame.delay as u32 * 10).max(1));
+      }
       Ok(None) => break,
       Err(error) if durations.is_empty() => return Err(gif_decode_error(error)),
       Err(_) => break,

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -267,6 +267,29 @@ pub(crate) fn gif_dimensions(bytes: &[u8]) -> ImageResult<(u32, u32)> {
   Ok((decoder.width() as u32, decoder.height() as u32))
 }
 
+/// Per-frame delays in milliseconds, in stream order (first frame included),
+/// without decoding any pixels. Uses the same `delay * 10` (min 1ms) rule as
+/// [`decode_gif_frames`], so the durations line up with decoded frames.
+pub(crate) fn gif_frame_durations(bytes: &[u8]) -> ImageResult<Box<[u32]>> {
+  let mut options = DecodeOptions::new();
+  options.skip_frame_decoding(true);
+  let mut decoder = options
+    .read_info(Cursor::new(bytes))
+    .map_err(gif_decode_error)?;
+
+  let mut durations = Vec::new();
+  loop {
+    match decoder.read_next_frame() {
+      Ok(Some(frame)) => durations.push((frame.delay as u32 * 10).max(1)),
+      Ok(None) => break,
+      Err(error) if durations.is_empty() => return Err(gif_decode_error(error)),
+      Err(_) => break,
+    }
+  }
+
+  Ok(durations.into())
+}
+
 /// Rows and columns of the rect that fall inside the canvas, plus the rect's
 /// unclamped pixel stride.
 fn clamped_span(rect: Rect<u32>, canvas_width: u32, canvas_height: u32) -> (u32, usize, usize) {


### PR DESCRIPTION
## Why

An animated GIF used to decode and retain every frame the first time a render sampled past frame one. The encoded bytes, the decoded first frame, and all later frames then sat in memory together — three copies of the same pixels — and, because that state grows after the source is cached, GIFs were excluded from the byte-budgeted image cache entirely. A page holding several animated GIFs had no eviction backstop for any of them.

## What

`GifSource` now keeps only its encoded bytes, the first frame, and pixel-free per-frame timing (a `skip_frame_decoding` pass memoized in a `OnceLock`). Any frame past the first is decoded at draw size when it is sampled and dropped immediately — no frame cache, so retention is a single frame and nothing needs a lock. Rendered output is identical; the fixture goldens are unchanged.

GIF disposal is stateful, so reaching frame N replays frames 0..N — O(N) per sample. That is fine for a static render, which samples one frame per GIF; a GIF re-encoded to an animation samples every frame and pays O(N²). The upgrade path (a thread-local resumable decode cursor) is noted at the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage for animated GIFs by retaining only the first decoded frame.
  * Later frames are decoded on demand at the needed display size and released immediately after rendering.
  * Frame timing is computed efficiently without pre-decoding all pixel data.
* **Bug Fixes**
  * Animated GIFs render unchanged while using less retained decoded content.
* **Documentation**
  * Documented the updated on-demand GIF decoding behavior.
* **Tests**
  * Updated GIF-related tests to reflect the new decode-and-retain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->