### PR TITLE
Bindings: share font and stylesheet lowering across napi and wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "takumi-bindings-common"
+version = "0.0.0"
+dependencies = [
+ "takumi-core",
+]
+
+[[package]]
 name = "takumi-core"
 version = "0.6.3"
 dependencies = [
@@ -1887,6 +1894,7 @@ dependencies = [
  "napi-derive",
  "rayon",
  "serde",
+ "takumi-bindings-common",
  "takumi-core",
  "takumi-raster",
  "takumi-svg",
@@ -1933,6 +1941,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
+ "takumi-bindings-common",
  "takumi-core",
  "takumi-raster",
  "takumi-svg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "takumi-raster",
   "takumi-svg",
   "takumi-html",
+  "takumi-bindings-common",
   "takumi-napi",
   "takumi-wasm",
   "example/rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,9 @@ codegen-units = 1
 [profile.release.package."takumi-wasm"]
 strip = "debuginfo"
 
+[profile.release.package."takumi-bindings-common"]
+opt-level = "z"
+
 [profile.bench]
 debug = true
 strip = "debuginfo"

--- a/takumi-bindings-common/Cargo.toml
+++ b/takumi-bindings-common/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "takumi-bindings-common"
+publish = false
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies.takumi-core]
+path = "../takumi-core"
+default-features = false
+features = ["woff2", "woff", "svg"]
+
+[lints]
+workspace = true

--- a/takumi-bindings-common/src/lib.rs
+++ b/takumi-bindings-common/src/lib.rs
@@ -1,0 +1,82 @@
+//! Platform-agnostic glue shared by the napi and wasm bindings.
+//!
+//! Both bindings lower raw JS input into a takumi render request the same way —
+//! the embedded fallback fonts, a font resource from optional fields, the
+//! stylesheet, the WebP encoding policy. That lowering lives here so neither
+//! binding re-derives it. Each binding keeps only its platform-specific glue
+//! (JS type coercion, error mapping, threading).
+
+use takumi_core::{
+  Fonts,
+  resources::font::{FontError, FontOverride, FontResource},
+  style::{FontStyle, KeyframesRule, StyleSheet},
+};
+
+/// Last-resort only: no generic family claim, so `sans-serif` and friends
+/// resolve to caller-registered fonts via the fallback bucket instead of this
+/// face.
+const EMBEDDED_FONTS: &[(&[u8], &str)] = &[(
+  include_bytes!("../../assets/fonts/geist/geist-latin-wght-300-800.woff2"),
+  "Geist",
+)];
+
+/// The default font set holding the embedded last-resort fonts.
+pub fn default_fonts() -> Result<Fonts, FontError> {
+  let mut fonts = Fonts::default();
+
+  for (bytes, name) in EMBEDDED_FONTS {
+    let resource = FontResource::new(*bytes)
+      .override_info(FontOverride {
+        family_name: Some((*name).into()),
+        ..Default::default()
+      })
+      .last_resort();
+
+    drop(fonts.register(resource)?);
+  }
+
+  Ok(fonts)
+}
+
+/// Builds a font resource from normalized optional fields. Each binding pulls
+/// these out of its own input type before calling in.
+pub fn build_font_resource<'a>(
+  bytes: &'a [u8],
+  name: Option<String>,
+  weight: Option<f32>,
+  style: Option<FontStyle>,
+  subset_of: Option<String>,
+  generic: Option<String>,
+) -> Result<FontResource<'a>, FontError> {
+  let resource = FontResource::new(bytes).override_info(FontOverride {
+    family_name: name.map(Into::into),
+    weight,
+    style,
+    ..Default::default()
+  });
+
+  let resource = match subset_of {
+    Some(logical) => resource.subset_of(logical),
+    None => resource,
+  };
+
+  match generic {
+    Some(generic) => Ok(resource.generic_family(generic.parse()?)),
+    None => Ok(resource),
+  }
+}
+
+/// The stylesheet for a render: the loose-parsed sheet list with its keyframes.
+pub fn stylesheet(stylesheets: Option<Vec<String>>, keyframes: Vec<KeyframesRule>) -> StyleSheet {
+  let mut stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
+  stylesheet.extend_keyframes(keyframes);
+  stylesheet
+}
+
+/// WebP is lossless when explicitly requested, or when no `quality` is given.
+///
+/// The wasm binding does not use this: its `image-webp` backend has no lossy
+/// encoder, so it always encodes lossless regardless of `quality`.
+pub fn webp_lossless(quality: Option<u8>, lossless: Option<bool>) -> bool {
+  lossless.unwrap_or(quality.is_none())
+}

--- a/takumi-napi/Cargo.toml
+++ b/takumi-napi/Cargo.toml
@@ -13,7 +13,9 @@ rayon.workspace = true
 napi.workspace = true
 napi-derive.workspace = true
 arc-swap.workspace = true
-takumi-bindings-common = { path = "../takumi-bindings-common" }
+
+[dependencies.takumi-bindings-common]
+path = "../takumi-bindings-common"
 
 [dependencies.takumi-core]
 path = "../takumi-core"

--- a/takumi-napi/Cargo.toml
+++ b/takumi-napi/Cargo.toml
@@ -13,6 +13,7 @@ rayon.workspace = true
 napi.workspace = true
 napi-derive.workspace = true
 arc-swap.workspace = true
+takumi-bindings-common = { path = "../takumi-bindings-common" }
 
 [dependencies.takumi-core]
 path = "../takumi-core"

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -21,8 +21,9 @@ use serde::{
   Deserialize, Deserializer,
   de::{DeserializeOwned, Error as DeError},
 };
+use takumi_bindings_common::{build_font_resource, stylesheet};
 use takumi_core::{
-  resources::font::{FontOverride, FontResource},
+  resources::font::FontResource,
   style::{FontStyle, FromCssStr, KeyframesRule, StyleSheet},
 };
 
@@ -122,30 +123,17 @@ pub(crate) fn resolve_font_resource<'a>(
   font: &'a FontInput,
   buffer: &'a [u8],
 ) -> Result<FontResource<'a>> {
-  let resource = FontResource::new(buffer).override_info(FontOverride {
-    family_name: font.name.clone().map(Into::into),
-    style: font.style.map(|style| style.0),
-    weight: font.weight.map(|weight| weight as f32),
-    ..Default::default()
-  });
-
-  let resource = match &font.subset_of {
-    Some(logical) => resource.subset_of(logical.clone()),
-    None => resource,
-  };
-
-  let resource = match &font.generic {
-    Some(generic) => resource.generic_family(
-      generic
-        .parse()
-        .map_err(|e| Error::from_reason(format!("Failed to load font: {e}")))?,
-    ),
-    None => resource,
-  };
-
-  resource
-    .into_resolved()
-    .map_err(|e| Error::from_reason(format!("Failed to load font: {e}")))
+  build_font_resource(
+    buffer,
+    font.name.clone(),
+    font.weight.map(|weight| weight as f32),
+    font.style.map(|style| style.0),
+    font.subset_of.clone(),
+    font.generic.clone(),
+  )
+  .map_err(map_error)?
+  .into_resolved()
+  .map_err(map_error)
 }
 
 pub(crate) enum BufferOrSlice<'env> {
@@ -209,7 +197,5 @@ pub(crate) fn parse_stylesheet(
   stylesheets: Option<Vec<String>>,
   keyframes: Vec<KeyframesRule>,
 ) -> Result<StyleSheet> {
-  let mut stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
-  stylesheet.extend_keyframes(keyframes);
-  Ok(stylesheet)
+  Ok(stylesheet(stylesheets, keyframes))
 }

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -9,9 +9,8 @@ use napi_derive::napi;
 use takumi_core::{
   Fonts,
   layout::node::Node,
-  resources::{
-    font::{FontOverride, FontResource},
-    image::{ImageCache, ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource},
+  resources::image::{
+    ImageCache, ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource,
   },
   style::KeyframesRule as CoreKeyframesRule,
 };
@@ -312,7 +311,7 @@ impl OutputFormat {
 
 /// WebP is lossless when explicitly requested or when no `quality` is given.
 pub(crate) fn webp_lossless(quality: Option<u8>, lossless: Option<bool>) -> bool {
-  lossless.unwrap_or(quality.is_none())
+  takumi_bindings_common::webp_lossless(quality, lossless)
 }
 
 /// Cache policy for a decoded image. Defaults to `"auto"`.
@@ -347,29 +346,9 @@ pub struct ImageSource<'ctx> {
   pub cache: Option<ImageCacheMode>,
 }
 
-// Last-resort only: no generic family claim, so `sans-serif` and friends resolve
-// to caller-registered fonts via the fallback bucket instead of this face.
-const EMBEDDED_FONTS: &[(&[u8], &str)] = &[(
-  include_bytes!("../../assets/fonts/geist/geist-latin-wght-300-800.woff2"),
-  "Geist",
-)];
-
 /// Builds the default font set holding the embedded last-resort fonts.
 fn default_fonts() -> Result<Fonts> {
-  let mut fonts = Fonts::default();
-
-  for (font, name) in EMBEDDED_FONTS {
-    let resource = FontResource::new(*font)
-      .override_info(FontOverride {
-        family_name: Some((*name).to_string().into()),
-        ..Default::default()
-      })
-      .last_resort();
-
-    drop(fonts.register(resource).map_err(map_error)?);
-  }
-
-  Ok(fonts)
+  takumi_bindings_common::default_fonts().map_err(map_error)
 }
 
 #[napi]

--- a/takumi-wasm/Cargo.toml
+++ b/takumi-wasm/Cargo.toml
@@ -8,12 +8,14 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-takumi-bindings-common = { path = "../takumi-bindings-common" }
 serde-wasm-bindgen.workspace = true
 wasm-bindgen.workspace = true
 base64.workspace = true
 serde_bytes.workspace = true
 js-sys.workspace = true
+
+[dependencies.takumi-bindings-common]
+path = "../takumi-bindings-common"
 
 [dependencies.serde]
 workspace = true

--- a/takumi-wasm/Cargo.toml
+++ b/takumi-wasm/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
+takumi-bindings-common = { path = "../takumi-bindings-common" }
 serde-wasm-bindgen.workspace = true
 wasm-bindgen.workspace = true
 base64.workspace = true

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -7,11 +7,12 @@ use std::{
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use serde_wasm_bindgen::{from_value, to_value};
+use takumi_bindings_common::{build_font_resource, default_fonts, stylesheet};
 use takumi_core::{
   Fonts,
   layout::node::Node,
   resources::{
-    font::{FontOverride, FontResource, RegisteredFamily},
+    font::{FontResource, RegisteredFamily},
     image::{ImageCache, ImageSource as LoadedImageSource},
   },
   style::{FontFamily, KeyframesRule, Lang, StyleSheet},
@@ -25,13 +26,6 @@ use wasm_bindgen::prelude::*;
 
 use crate::{helper::map_error, model::*};
 
-// Last-resort only: no generic family claim, so `sans-serif` and friends resolve
-// to caller-registered fonts via the fallback bucket instead of this face.
-const EMBEDDED_FONTS: &[(&[u8], &str)] = &[(
-  include_bytes!("../../assets/fonts/geist/geist-latin-wght-300-800.woff2"),
-  "Geist",
-)];
-
 /// The main renderer for Takumi image rendering engine.
 ///
 /// State lives behind a lock and every method takes `&self`, mirroring the
@@ -43,24 +37,6 @@ pub struct Renderer {
   image_cache: ImageCache,
 }
 
-/// Builds the default font set holding the embedded last-resort fonts.
-fn default_fonts() -> Result<Fonts, js_sys::Error> {
-  let mut fonts = Fonts::default();
-
-  for (font, family_name) in EMBEDDED_FONTS {
-    let resource = FontResource::new(*font)
-      .override_info(FontOverride {
-        family_name: Some((*family_name).into()),
-        ..Default::default()
-      })
-      .last_resort();
-
-    drop(fonts.register(resource).map_err(map_error)?);
-  }
-
-  Ok(fonts)
-}
-
 fn load_font_internal(
   fonts: &mut Fonts,
   font: Font,
@@ -70,22 +46,16 @@ fn load_font_internal(
       .register(FontResource::new(buffer.into_vec()))
       .map_err(map_error),
     Font::Object(details) => {
-      let resource = FontResource::new(details.data.into_vec()).override_info(FontOverride {
-        family_name: details.name.map(Into::into),
-        style: details.style.map(Into::into),
-        weight: details.weight.map(|weight| weight as f32),
-        ..Default::default()
-      });
-
-      let resource = match &details.subset_of {
-        Some(logical) => resource.subset_of(logical.clone()),
-        None => resource,
-      };
-
-      let resource = match &details.generic {
-        Some(generic) => resource.generic_family(generic.parse().map_err(map_error)?),
-        None => resource,
-      };
+      let data = details.data.into_vec();
+      let resource = build_font_resource(
+        &data,
+        details.name,
+        details.weight.map(|weight| weight as f32),
+        details.style.map(Into::into),
+        details.subset_of,
+        details.generic,
+      )
+      .map_err(map_error)?;
 
       fonts.register(resource).map_err(map_error)
     }
@@ -115,10 +85,7 @@ impl Renderer {
     stylesheets: Option<Vec<String>>,
     keyframes: Vec<KeyframesRule>,
   ) -> Result<StyleSheet, JsValue> {
-    let stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
-    let mut stylesheet = stylesheet;
-    stylesheet.extend_keyframes(keyframes);
-    Ok(stylesheet)
+    Ok(stylesheet(stylesheets, keyframes))
   }
 
   fn images_map(
@@ -144,7 +111,7 @@ impl Renderer {
   #[wasm_bindgen(constructor)]
   pub fn new() -> Result<Renderer, js_sys::Error> {
     Ok(Renderer {
-      state: RwLock::new(default_fonts()?),
+      state: RwLock::new(default_fonts().map_err(map_error)?),
       image_cache: ImageCache::default(),
     })
   }


### PR DESCRIPTION
## Why

The napi and wasm bindings each build one `takumi_raster::RenderOptions` — that seam is already shared. But the lowering in front of it was copy-pasted between them: the embedded fallback fonts (byte-for-byte, comment and all), the `FontResource` builder chain from optional fields, the stylesheet-plus-keyframes parse. Two independent copies that had to be kept in step by hand.

## What

A new internal `takumi-bindings-common` crate (`publish = false`) holds the platform-agnostic lowering: `default_fonts`, `build_font_resource`, `stylesheet`, and `webp_lossless`. Both bindings call in and keep only their platform-specific glue — napi's JS coercion and threading, wasm's borrow guard and `serde_wasm_bindgen`.

The WebP policy stays deliberately split, and the shared helper documents it: napi uses `webp_lossless` (lossy when a quality is given); wasm always encodes lossless because its `image-webp` backend has no lossy encoder. No behavior change to either binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when registering fonts, including subset, weight, style, and generic-family information.
  * Standardized stylesheet and keyframe handling across native and WebAssembly integrations.
  * Aligned WebP lossless behavior when quality and lossless options are combined.
  * Improved fallback font availability and consistency across supported runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->