### PR TITLE
Bindings: trim takumi-bindings-common to shared lowering only

### DIFF
--- a/takumi-bindings-common/src/lib.rs
+++ b/takumi-bindings-common/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! Both bindings lower raw JS input into a takumi render request the same way —
 //! the embedded fallback fonts, a font resource from optional fields, the
-//! stylesheet, the WebP encoding policy. That lowering lives here so neither
-//! binding re-derives it. Each binding keeps only its platform-specific glue
-//! (JS type coercion, error mapping, threading).
+//! stylesheet. That lowering lives here so neither binding re-derives it. Each
+//! binding keeps only its platform-specific glue (JS type coercion, error
+//! mapping, threading).
 
 use takumi_core::{
   Fonts,
@@ -71,12 +71,4 @@ pub fn stylesheet(stylesheets: Option<Vec<String>>, keyframes: Vec<KeyframesRule
   let mut stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
   stylesheet.extend_keyframes(keyframes);
   stylesheet
-}
-
-/// WebP is lossless when explicitly requested, or when no `quality` is given.
-///
-/// The wasm binding does not use this: its `image-webp` backend has no lossy
-/// encoder, so it always encodes lossless regardless of `quality`.
-pub fn webp_lossless(quality: Option<u8>, lossless: Option<bool>) -> bool {
-  lossless.unwrap_or(quality.is_none())
 }

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -21,10 +21,10 @@ use serde::{
   Deserialize, Deserializer,
   de::{DeserializeOwned, Error as DeError},
 };
-use takumi_bindings_common::{build_font_resource, stylesheet};
+use takumi_bindings_common::build_font_resource;
 use takumi_core::{
   resources::font::FontResource,
-  style::{FontStyle, FromCssStr, KeyframesRule, StyleSheet},
+  style::{FontStyle, FromCssStr},
 };
 
 /// A font family produced by `registerFont`, with the faces it contains.
@@ -191,11 +191,4 @@ pub(crate) fn deserialize_with_tracing<T: DeserializeOwned>(value: Object) -> Re
 
 pub(crate) fn map_error<E: Display>(err: E) -> napi::Error {
   napi::Error::from_reason(err.to_string())
-}
-
-pub(crate) fn parse_stylesheet(
-  stylesheets: Option<Vec<String>>,
-  keyframes: Vec<KeyframesRule>,
-) -> Result<StyleSheet> {
-  Ok(stylesheet(stylesheets, keyframes))
 }

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -9,12 +9,13 @@ use takumi_core::{
 use takumi_raster::measure;
 
 use crate::{
-  buffer_from_object, map_error, parse_stylesheet,
+  buffer_from_object, map_error,
   renderer::{
     ImageCacheMode, MeasuredNode, RenderOptions, RendererState, decode_images,
     deserialize_keyframes,
   },
 };
+use takumi_bindings_common::stylesheet;
 
 pub struct MeasureTask {
   pub(crate) node: Option<Node>,
@@ -44,10 +45,10 @@ impl MeasureTask {
           .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
       ),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
-      stylesheet: parse_stylesheet(
+      stylesheet: stylesheet(
         options.stylesheets,
         deserialize_keyframes(options.keyframes)?,
-      )?,
+      ),
       images: options
         .images
         .unwrap_or_default()

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -12,12 +12,13 @@ use takumi_raster::{
 };
 
 use crate::{
-  buffer_from_object, deserialize_with_tracing, map_error, parse_stylesheet,
+  buffer_from_object, deserialize_with_tracing, map_error,
   renderer::{
     AnimationOutputFormat, ImageCacheMode, ImageSource, RenderAnimationOptions, RendererState,
     decode_images, deserialize_keyframes, webp_lossless,
   },
 };
+use takumi_bindings_common::stylesheet;
 
 pub struct RenderAnimationTask {
   pub(crate) scenes: Option<Vec<(Node, u32)>>,
@@ -125,7 +126,7 @@ impl Task for RenderAnimationTask {
       };
       let fonts = self.state.fonts.load();
       let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
-      let stylesheet = parse_stylesheet(take(&mut self.stylesheets), take(&mut self.keyframes))?;
+      let stylesheet = stylesheet(take(&mut self.stylesheets), take(&mut self.keyframes));
       let scene_options = scenes
         .into_iter()
         .map(|(node, duration_ms)| {

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -9,12 +9,13 @@ use takumi_core::{
 use takumi_raster::{DitheringAlgorithm, render, write_image};
 
 use crate::{
-  buffer_from_object, map_error, parse_stylesheet,
+  buffer_from_object, map_error,
   renderer::{
     ImageCacheMode, OutputFormat, RenderOptions, RendererState, decode_images,
     deserialize_keyframes,
   },
 };
+use takumi_bindings_common::stylesheet;
 
 pub struct RenderTask {
   pub(crate) draw_debug_border: bool,
@@ -54,10 +55,10 @@ impl RenderTask {
       dithering: options.dithering.map(Into::into).unwrap_or_default(),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
       draw_debug_border: options.draw_debug_border.unwrap_or_default(),
-      stylesheet: parse_stylesheet(
+      stylesheet: stylesheet(
         options.stylesheets,
         deserialize_keyframes(options.keyframes)?,
-      )?,
+      ),
       images: options
         .images
         .unwrap_or_default()

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -346,11 +346,6 @@ pub struct ImageSource<'ctx> {
   pub cache: Option<ImageCacheMode>,
 }
 
-/// Builds the default font set holding the embedded last-resort fonts.
-fn default_fonts() -> Result<Fonts> {
-  takumi_bindings_common::default_fonts().map_err(map_error)
-}
-
 #[napi]
 impl Renderer {
   /// Creates a new Renderer instance.
@@ -360,7 +355,7 @@ impl Renderer {
 
     Ok(Self {
       state: Arc::new(RendererState {
-        fonts: ArcSwap::from_pointee(default_fonts()?),
+        fonts: ArcSwap::from_pointee(takumi_bindings_common::default_fonts().map_err(map_error)?),
         font_write: Mutex::new(()),
         image_cache: ImageCache::default(),
       }),

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -311,7 +311,7 @@ impl OutputFormat {
 
 /// WebP is lossless when explicitly requested or when no `quality` is given.
 pub(crate) fn webp_lossless(quality: Option<u8>, lossless: Option<bool>) -> bool {
-  takumi_bindings_common::webp_lossless(quality, lossless)
+  lossless.unwrap_or(quality.is_none())
 }
 
 /// Cache policy for a decoded image. Defaults to `"auto"`.

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -8,11 +8,12 @@ use takumi_core::{
 };
 
 use crate::{
-  buffer_from_object, map_error, parse_stylesheet,
+  buffer_from_object, map_error,
   renderer::{
     ImageCacheMode, RendererState, SvgRenderOptions, decode_images, deserialize_keyframes,
   },
 };
+use takumi_bindings_common::stylesheet;
 
 pub struct SvgRenderTask {
   pub(crate) node: Option<Node>,
@@ -37,10 +38,10 @@ impl SvgRenderTask {
       state,
       viewport: Viewport::new((options.width, options.height)),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
-      stylesheet: parse_stylesheet(
+      stylesheet: stylesheet(
         options.stylesheets,
         deserialize_keyframes(options.keyframes)?,
-      )?,
+      ),
       images: options
         .images
         .unwrap_or_default()

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -15,7 +15,7 @@ use takumi_core::{
     font::{FontResource, RegisteredFamily},
     image::{ImageCache, ImageSource as LoadedImageSource},
   },
-  style::{FontFamily, KeyframesRule, Lang, StyleSheet},
+  style::{FontFamily, Lang},
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
 };
 use takumi_raster::{
@@ -80,14 +80,6 @@ impl Renderer {
 
 #[wasm_bindgen]
 impl Renderer {
-  fn parse_stylesheet(
-    &self,
-    stylesheets: Option<Vec<String>>,
-    keyframes: Vec<KeyframesRule>,
-  ) -> Result<StyleSheet, JsValue> {
-    Ok(stylesheet(stylesheets, keyframes))
-  }
-
   fn images_map(
     &self,
     images: Option<&[ImageSource]>,
@@ -153,8 +145,7 @@ impl Renderer {
     images: HashMap<Arc<str>, LoadedImageSource>,
   ) -> Result<Vec<u8>, JsValue> {
     let dithering = options.dithering.unwrap_or_default();
-    let stylesheet =
-      self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
+    let stylesheet = stylesheet(options.stylesheets, options.keyframes.unwrap_or_default());
 
     let lang = options
       .lang
@@ -214,8 +205,7 @@ impl Renderer {
       .unwrap_or_default();
 
     let images = self.images_map(options.images.as_deref())?;
-    let stylesheet =
-      self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
+    let stylesheet = stylesheet(options.stylesheets, options.keyframes.unwrap_or_default());
     let state = self.read_state()?;
 
     let lang = options
@@ -259,8 +249,7 @@ impl Renderer {
       .transpose()?;
 
     let images = self.images_map(options.images.as_deref())?;
-    let stylesheet =
-      self.parse_stylesheet(options.stylesheets, options.keyframes.unwrap_or_default())?;
+    let stylesheet = stylesheet(options.stylesheets, options.keyframes.unwrap_or_default());
 
     let state = self.read_state()?;
     let render_options = takumi_raster::RenderOptions::builder()
@@ -355,7 +344,7 @@ impl Renderer {
     let viewport = Viewport::new((width, height))
       .with_device_pixel_ratio(device_pixel_ratio.unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO));
     let draw_debug_border = draw_debug_border.unwrap_or_default();
-    let stylesheet = self.parse_stylesheet(stylesheets, keyframes.unwrap_or_default())?;
+    let stylesheet = stylesheet(stylesheets, keyframes.unwrap_or_default());
     let state = self.read_state()?;
     let scene_options = scenes
       .into_iter()


### PR DESCRIPTION
## Why

Follow-up to #1001 — two cleanup commits raced the squash-merge and didn't land:

- `webp_lossless` sat in `takumi-bindings-common` but only napi ever called it (wasm always encodes lossless), so it was a shared helper with a single consumer.
- After the lowering moved to common, napi's `parse_stylesheet`/`default_fonts` and wasm's `parse_stylesheet` were left as one-line forwarders that only wrapped the shared fn in `Ok(...)`/`map_err`.

## What

- Move `webp_lossless` back into napi (its only user); common now holds only what both bindings share — `default_fonts`, `build_font_resource`, `stylesheet`.
- Inline the forwarders: the napi tasks and wasm renderer call `takumi_bindings_common::stylesheet`/`default_fonts` directly, dropping the spurious `Result` wrapping.

No behavior change. Both bindings `cargo check` (native + `wasm32-unknown-unknown`) and clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized stylesheet and animation processing across raster, SVG, measurement, and animation rendering.
  - Improved consistency of stylesheet and keyframe handling across supported runtime environments.
  - Preserved existing font loading, error reporting, and WebP lossless rendering behavior.
  - Removed an obsolete public WebP helper that was no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->