### PR TITLE
Core: unify decoded resources behind one budgeted cache

### DIFF
--- a/.tegami/unified-resource-cache.md
+++ b/.tegami/unified-resource-cache.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-core": minor
+  "cargo:takumi-raster": minor
+  "cargo:takumi-svg": minor
+  "cargo:takumi-bindings-common": minor
+  "npm:@takumi-rs/core": minor
+  "npm:@takumi-rs/wasm": minor
+---
+
+### Unify decoded resources behind one budgeted cache
+
+Memory retention was governed by differently-shaped caches: decoded images had a byte budget, but each SVG kept up to 32 rasterized pixmaps outside it, and every render re-parsed its stylesheets from scratch. `ImageCache` is now `ResourceCache`: SVG sources, their rasterized pixmaps, and parsed stylesheets all weigh against the same budget as decoded images. The default budget drops from 64 MiB to 16 MiB and becomes configurable — `new Renderer({ cacheMaxBytes })` in the bindings, `ResourceCache::new(max_bytes)` in Rust, with `0` disabling caching. SVG rasters and parsed stylesheets now also survive across renders, so a server re-rendering the same template stops re-rasterizing and re-parsing per request. Rust callers: `RenderOptions.stylesheet` is now `Arc<StyleSheet>`; pass `sheet.into()`.

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -116,7 +116,13 @@ Takumi caches each decoded image so repeated content is decoded once. Two indepe
 | Byte cache   | Fetched bytes  | URL                 | `images.fetchCache`                |
 | Decode cache | Decoded pixels | Hash of image bytes | per-image `cache` / `images.cache` |
 
-The decode cache lives in the renderer and is bounded: entries weigh in at their decoded size against a 64 MiB budget, and once it fills the cache evicts the least recently used. A high-cardinality workload (a different image every render) won't grow memory; it misses the cache and decodes each time. SVGs skip the cache and re-parse per render.
+The decode cache lives in the renderer and is bounded: entries weigh in at their decoded size against a byte budget (16 MiB by default), and once it fills the cache evicts the least recently used. A high-cardinality workload (a different image every render) won't grow memory; it misses the cache and decodes each time. SVG sources and their rasterized pixmaps share the same budget, as do parsed stylesheets.
+
+Set the budget when constructing the renderer; `0` disables caching:
+
+```ts
+const renderer = new Renderer({ cacheMaxBytes: 64 * 1024 * 1024 });
+```
 
 The per-image `cache` mode takes two values:
 

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -14,6 +14,14 @@ The `Renderer` holds Takumi's caches. Reuse one instance across renders instead 
 
 [`ImageResponse`](/docs/image-response) manages an internal renderer, or pass your own through the `renderer` option. See [Typography & Fonts](/docs/typography-and-fonts) and [Load Images](/docs/load-images).
 
+### Size the Resource Cache
+
+Decoded images, SVG rasters, and parsed stylesheets share one byte budget, 16 MiB by default. The default suits a single-template server; raise it when many large images stay hot across renders:
+
+```ts
+const renderer = new Renderer({ cacheMaxBytes: 64 * 1024 * 1024 });
+```
+
 ### Preload Frequently Used Images
 
 Loading images from URLs or bytes during the rendering pass is a bottleneck. Register [Load Images](/docs/load-images) to avoid re-decoding.

--- a/takumi-bindings-common/src/lib.rs
+++ b/takumi-bindings-common/src/lib.rs
@@ -6,9 +6,14 @@
 //! binding keeps only its platform-specific glue (JS type coercion, error
 //! mapping, threading).
 
+use std::sync::Arc;
+
 use takumi_core::{
   Fonts,
-  resources::font::{FontError, FontOverride, FontResource},
+  resources::{
+    font::{FontError, FontOverride, FontResource},
+    image::ResourceCache,
+  },
   style::{FontStyle, KeyframesRule, StyleSheet},
 };
 
@@ -67,8 +72,20 @@ pub fn build_font_resource<'a>(
 }
 
 /// The stylesheet for a render: the loose-parsed sheet list with its keyframes.
-pub fn stylesheet(stylesheets: Option<Vec<String>>, keyframes: Vec<KeyframesRule>) -> StyleSheet {
-  let mut stylesheet = StyleSheet::parse_owned_list_loosy(stylesheets.unwrap_or_default());
-  stylesheet.extend_keyframes(keyframes);
-  stylesheet
+/// Parsed sheets are cached by source text in `cache`; per-render keyframes are
+/// grafted onto a copy so the cached parse stays pristine.
+pub fn stylesheet(
+  cache: &ResourceCache,
+  stylesheets: Option<Vec<String>>,
+  keyframes: Vec<KeyframesRule>,
+) -> Arc<StyleSheet> {
+  let sheet = cache.get_or_parse_stylesheet(stylesheets.unwrap_or_default());
+
+  if keyframes.is_empty() {
+    return sheet;
+  }
+
+  let mut extended = (*sheet).clone();
+  extended.extend_keyframes(keyframes);
+  Arc::new(extended)
 }

--- a/takumi-core/src/context.rs
+++ b/takumi-core/src/context.rs
@@ -34,7 +34,7 @@ pub struct RenderContext {
   pub(crate) images: Rc<HashMap<Arc<str>, ImageSource>>,
   /// The stylesheets to apply before layout/rendering.
   #[builder(default)]
-  pub(crate) stylesheet: Rc<StyleSheet>,
+  pub(crate) stylesheet: Arc<StyleSheet>,
 }
 
 impl RenderContext {

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -2373,7 +2373,7 @@ mod tests {
 
   #[test]
   fn lang_pseudo_class_matches_the_nearest_ancestor_or_self_lang_attribute() {
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     use crate::{
       context::RenderContext,
@@ -2398,7 +2398,7 @@ mod tests {
           .viewport(Viewport::default())
           .build(),
       )
-      .stylesheet(Rc::new(stylesheet))
+      .stylesheet(Arc::new(stylesheet))
       .build();
 
     let tree = RenderNode::from_node(

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -33,7 +33,7 @@ use crate::{
       gif_dimensions, gif_frame_durations, is_gif,
     },
   },
-  style::{ImageScalingAlgorithm, IntrinsicSizing, SizingContext},
+  style::{ImageScalingAlgorithm, IntrinsicSizing, SizingContext, StyleSheet},
 };
 
 /// Represents the state of an image resource.
@@ -65,7 +65,8 @@ pub struct SvgSource {
   /// Intrinsic dimensions (non-percentage `width`/`height`) and `viewBox`
   /// aspect ratio, for CSS `background-size`/`mask-size` resolution.
   intrinsic: SvgIntrinsic,
-  raster_cache: SvgRasterCache,
+  hash: u64,
+  cache: Weak<SharedResourceCache>,
 }
 
 #[cfg(feature = "svg")]
@@ -247,7 +248,7 @@ impl From<SvgSource> for ImageSource {
 
 /// An encoded bitmap (PNG/JPEG/WebP) that decodes lazily at draw time, scaled
 /// down to the box it is drawn into. Decoded results are stored in the owning
-/// [`ImageCache`] keyed by content and target size, so a source drawn at a
+/// [`ResourceCache`] keyed by content and target size, so a source drawn at a
 /// stable size decodes once while the retained bytes track the draw size, not
 /// the source size.
 #[derive(Debug)]
@@ -256,7 +257,7 @@ pub struct EncodedBitmap {
   width: u32,
   height: u32,
   hash: u64,
-  cache: Weak<SharedImageCache>,
+  cache: Weak<SharedResourceCache>,
 }
 
 impl EncodedBitmap {
@@ -300,11 +301,11 @@ impl EncodedBitmap {
       return self.decode_uncached(width, height, algorithm);
     };
 
-    let key = ImageCacheKey::sized(self.hash, width, height, algorithm);
+    let key = ResourceCacheKey::sized(self.hash, width, height, algorithm);
 
     match cache.get_value_or_guard(&key, None) {
       GuardResult::Value(CacheEntry::Sized(buffer)) => Ok(buffer),
-      GuardResult::Value(CacheEntry::Source(_)) => self.decode_uncached(width, height, algorithm),
+      GuardResult::Value(_) => self.decode_uncached(width, height, algorithm),
       GuardResult::Guard(guard) => {
         let buffer = self.decode_uncached(width, height, algorithm)?;
         let _ = guard.insert(CacheEntry::Sized(buffer.clone()));
@@ -355,43 +356,10 @@ impl From<ImageBuffer> for ImageSource {
 }
 
 #[cfg(feature = "svg")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct SvgRasterCacheKey {
-  width: u32,
-  height: u32,
-  image_rendering: u8,
-}
-
-#[cfg(feature = "svg")]
-impl SvgRasterCacheKey {
-  fn new(width: u32, height: u32, image_rendering: ImageScalingAlgorithm) -> Self {
-    Self {
-      width,
-      height,
-      image_rendering: match image_rendering {
-        ImageScalingAlgorithm::Smooth => 1,
-        ImageScalingAlgorithm::Pixelated => 2,
-        _ => 0,
-      },
-    }
-  }
-}
-
-/// An SVG is rasterized at only a handful of distinct sizes; this caps that.
-#[cfg(feature = "svg")]
-const SVG_RASTER_CACHE_CAPACITY: usize = 32;
-
-/// Per-`SvgSource` cache of rasterized bitmaps keyed by target size. Count-bounded and lock-free
-/// (the same `quick_cache` as `ImageCache`); byte-budget it if a huge SVG cached at many sizes ever
-/// bloats memory.
-#[cfg(feature = "svg")]
-type SvgRasterCache = Cache<SvgRasterCacheKey, Arc<ImageBuffer>>;
-
-#[cfg(feature = "svg")]
-impl FromStr for SvgSource {
-  type Err = ImageError;
-
-  fn from_str(src: &str) -> Result<Self, Self::Err> {
+impl SvgSource {
+  /// Parses SVG markup; rasterized pixmaps go into `cache` while it is alive,
+  /// keyed by content hash and target size. A dead handle rasterizes per call.
+  fn parse(src: &str, hash: u64, cache: Weak<SharedResourceCache>) -> Result<Self, ImageError> {
     // One parse, shared with usvg via `from_xmltree` (what `from_str` does
     // internally). No text stripping: usvg drops `<text>`/`<tspan>` with its
     // `text` feature off.
@@ -408,37 +376,75 @@ impl FromStr for SvgSource {
       source: Box::from(src),
       tree,
       intrinsic,
-      raster_cache: SvgRasterCache::new(SVG_RASTER_CACHE_CAPACITY),
+      hash,
+      cache,
     })
+  }
+
+  fn rasterize(&self, width: u32, height: u32) -> Result<Arc<ImageBuffer>, ImageError> {
+    let mut pixmap = Pixmap::new(width, height).ok_or(ImageError::InvalidPixmapSize)?;
+
+    let original_size = self.tree.size();
+    let sx = width as f32 / original_size.width();
+    let sy = height as f32 / original_size.height();
+
+    crate::resvg::render(
+      &self.tree,
+      Transform::from_scale(sx, sy),
+      &mut pixmap.as_mut(),
+    );
+
+    ImageBuffer::from_premultiplied_rgba(pixmap.data().to_vec(), width, height)
+      .map(Arc::new)
+      .ok_or(ImageError::InvalidPixmapSize)
+  }
+
+  fn rasterize_cached(
+    &self,
+    width: u32,
+    height: u32,
+    image_rendering: ImageScalingAlgorithm,
+  ) -> Result<Arc<ImageBuffer>, ImageError> {
+    let Some(cache) = self.cache.upgrade() else {
+      return self.rasterize(width, height);
+    };
+
+    let key = ResourceCacheKey::sized(self.hash, width, height, image_rendering);
+
+    match cache.get_value_or_guard(&key, None) {
+      GuardResult::Value(CacheEntry::Sized(buffer)) => Ok(buffer),
+      GuardResult::Value(_) => self.rasterize(width, height),
+      GuardResult::Guard(guard) => {
+        let buffer = self.rasterize(width, height)?;
+        let _ = guard.insert(CacheEntry::Sized(buffer.clone()));
+        Ok(buffer)
+      }
+      // `None` timeout never times out.
+      GuardResult::Timeout => self.rasterize(width, height),
+    }
+  }
+}
+
+#[cfg(feature = "svg")]
+impl FromStr for SvgSource {
+  type Err = ImageError;
+
+  fn from_str(src: &str) -> Result<Self, Self::Err> {
+    Self::parse(src, xxh3_64(src.as_bytes()), Weak::new())
   }
 }
 
 impl ImageSource {
-  /// Approximate decoded size in bytes, used for cache budgeting.
+  /// Approximate retained size in bytes, used for cache budgeting.
   pub(crate) fn estimated_bytes(&self) -> usize {
     match self {
       Self::Bitmap(buffer) => buffer.data().len(),
       Self::Gif(gif) => gif.decoded_bytes(),
       Self::Encoded(encoded) => encoded.bytes.len(),
+      // Markup plus a parsed-tree estimate; rasterized pixmaps are weighted
+      // separately as their own sized entries.
       #[cfg(feature = "svg")]
-      Self::Svg(svg) => svg.source.len(),
-    }
-  }
-
-  /// Whether this decoded source is safe to retain in the byte-budgeted cache.
-  ///
-  /// SVGs and GIFs are excluded: their lazily-populated state (rasterized
-  /// pixmaps, memoized frames) grows after insertion and isn't counted by
-  /// [`estimated_bytes`](Self::estimated_bytes), so caching them across renders
-  /// would let memory exceed the configured budget. Encoded bitmaps stay
-  /// cacheable: their decoded-at-size buffers live in the same budgeted cache
-  /// as their own weighted entries.
-  pub(crate) fn is_cacheable(&self) -> bool {
-    match self {
-      Self::Bitmap(_) | Self::Encoded(_) => true,
-      Self::Gif(_) => false,
-      #[cfg(feature = "svg")]
-      Self::Svg(_) => false,
+      Self::Svg(svg) => svg.source.len() * 3,
     }
   }
 
@@ -466,19 +472,22 @@ impl ImageSource {
   }
 
   /// [`from_bytes`](Self::from_bytes), but bitmaps stay encoded and decode at
-  /// draw size. Sized decodes go into `cache` while it is alive; a dead handle
-  /// (inline node bytes, data URIs) decodes per render.
+  /// draw size, and SVG rasters go into `cache`. Sized entries go into `cache`
+  /// while it is alive; a dead handle (inline node bytes, data URIs) decodes
+  /// per render.
   pub(crate) fn from_bytes_lazy(
     bytes: &[u8],
     hash: u64,
-    cache: Weak<SharedImageCache>,
+    cache: Weak<SharedResourceCache>,
   ) -> ImageResult {
     #[cfg(feature = "svg")]
     {
       if let Ok(text) = from_utf8(bytes)
         && is_svg_like(text)
       {
-        return Ok(ImageSource::Svg(Arc::new(text.parse()?)));
+        return Ok(ImageSource::Svg(Arc::new(SvgSource::parse(
+          text, hash, cache,
+        )?)));
       }
     }
 
@@ -543,28 +552,11 @@ impl ImageSource {
         })
       }
       #[cfg(feature = "svg")]
-      ImageSource::Svg(svg) => {
-        let cache_key = SvgRasterCacheKey::new(width, height, image_rendering);
-        if let Some(pixmap) = svg.raster_cache.get(&cache_key) {
-          return Ok(RenderedImage::Rasterized(pixmap));
-        }
-
-        let tree = &svg.tree;
-        let mut pixmap = Pixmap::new(width, height).ok_or(ImageError::InvalidPixmapSize)?;
-
-        let original_size = tree.size();
-        let sx = width as f32 / original_size.width();
-        let sy = height as f32 / original_size.height();
-
-        crate::resvg::render(tree, Transform::from_scale(sx, sy), &mut pixmap.as_mut());
-
-        let buffer = ImageBuffer::from_premultiplied_rgba(pixmap.data().to_vec(), width, height)
-          .ok_or(ImageError::InvalidPixmapSize)?;
-        let buffer = Arc::new(buffer);
-        svg.raster_cache.insert(cache_key, buffer.clone());
-
-        Ok(RenderedImage::Rasterized(buffer))
-      }
+      ImageSource::Svg(svg) => Ok(RenderedImage::Rasterized(svg.rasterize_cached(
+        width,
+        height,
+        image_rendering,
+      )?)),
     }
   }
 
@@ -820,10 +812,12 @@ impl ImageError {
   }
 }
 
-/// Decoded-image budget before entries start getting evicted.
-const DEFAULT_MAX_BYTES: u64 = 64 << 20; // 64 MiB
+/// Resource budget before entries start getting evicted. Deliberately
+/// conservative: a single-template server's working set fits comfortably, and
+/// heavier workloads raise it through [`ResourceCache::new`].
+const DEFAULT_MAX_BYTES: u64 = 16 << 20; // 16 MiB
 
-/// Cache policy for a decoded image, applied per [`ImageCache::get_or_decode`] call.
+/// Cache policy for a decoded image, applied per [`ResourceCache::get_or_decode`] call.
 #[derive(Clone, Copy, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -836,22 +830,29 @@ pub enum ImageCacheMode {
 }
 
 /// Cache key: the content hash alone addresses a source entry; a target size
-/// and filter address a decoded-at-size entry.
+/// and filter address a decoded-at-size entry; a stylesheet hash addresses a
+/// parsed sheet. `kind` keeps the hash domains apart.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct ImageCacheKey {
+pub(crate) struct ResourceCacheKey {
   hash: u64,
   width: u32,
   height: u32,
   algorithm: u8,
+  kind: u8,
 }
 
-impl ImageCacheKey {
+const KIND_SOURCE: u8 = 0;
+const KIND_SIZED: u8 = 1;
+const KIND_STYLESHEET: u8 = 2;
+
+impl ResourceCacheKey {
   fn source(hash: u64) -> Self {
     Self {
       hash,
       width: 0,
       height: 0,
       algorithm: 0,
+      kind: KIND_SOURCE,
     }
   }
 
@@ -865,6 +866,17 @@ impl ImageCacheKey {
         ImageScalingAlgorithm::Pixelated => 2,
         _ => 0,
       },
+      kind: KIND_SIZED,
+    }
+  }
+
+  fn stylesheet(hash: u64) -> Self {
+    Self {
+      hash,
+      width: 0,
+      height: 0,
+      algorithm: 0,
+      kind: KIND_STYLESHEET,
     }
   }
 }
@@ -873,36 +885,42 @@ impl ImageCacheKey {
 pub(crate) enum CacheEntry {
   Source(ImageSource),
   Sized(Arc<ImageBuffer>),
+  Stylesheet { sheet: Arc<StyleSheet>, weight: u32 },
 }
 
 #[derive(Clone)]
-pub(crate) struct ImageWeighter;
+pub(crate) struct ResourceWeighter;
 
-impl Weighter<ImageCacheKey, CacheEntry> for ImageWeighter {
-  fn weight(&self, _key: &ImageCacheKey, entry: &CacheEntry) -> u64 {
+impl Weighter<ResourceCacheKey, CacheEntry> for ResourceWeighter {
+  fn weight(&self, _key: &ResourceCacheKey, entry: &CacheEntry) -> u64 {
     let bytes = match entry {
       CacheEntry::Source(source) => source.estimated_bytes(),
       CacheEntry::Sized(buffer) => buffer.data().len(),
+      CacheEntry::Stylesheet { weight, .. } => *weight as usize,
     };
     (bytes as u64).max(1)
   }
 }
 
-pub(crate) type SharedImageCache = Cache<ImageCacheKey, CacheEntry, ImageWeighter>;
+pub(crate) type SharedResourceCache = Cache<ResourceCacheKey, CacheEntry, ResourceWeighter>;
 
-/// Content-addressed store of decoded images with a byte budget, used by the renderer to avoid re-decoding.
-pub struct ImageCache {
-  cache: Arc<SharedImageCache>,
+/// Content-addressed store of decoded render resources — images, SVG rasters,
+/// parsed stylesheets — sharing one byte budget, used by the renderer to avoid
+/// re-decoding and re-parsing.
+pub struct ResourceCache {
+  cache: Arc<SharedResourceCache>,
 }
 
-impl Default for ImageCache {
+impl Default for ResourceCache {
   fn default() -> Self {
-    Self::with_capacity(DEFAULT_MAX_BYTES)
+    Self::new(DEFAULT_MAX_BYTES)
   }
 }
 
-impl ImageCache {
-  fn with_capacity(max_bytes: u64) -> Self {
+impl ResourceCache {
+  /// Creates a cache holding at most `max_bytes` across every entry kind.
+  /// `0` disables retention: lookups miss and nothing is kept.
+  pub fn new(max_bytes: u64) -> Self {
     // ~64 KiB average decoded image ⇒ a reasonable item-count hint for the budget.
     let estimated_items = (max_bytes / (64 << 10)).max(1) as usize;
 
@@ -910,7 +928,7 @@ impl ImageCache {
       cache: Arc::new(Cache::with_weighter(
         estimated_items,
         max_bytes,
-        ImageWeighter,
+        ResourceWeighter,
       )),
     }
   }
@@ -922,7 +940,7 @@ impl ImageCache {
   /// decodes while the others wait, so each unique image is decoded once.
   pub fn get_or_decode(&self, bytes: &[u8], mode: ImageCacheMode) -> ImageResult {
     let hash = xxh3_64(bytes);
-    let key = ImageCacheKey::source(hash);
+    let key = ResourceCacheKey::source(hash);
 
     if matches!(mode, ImageCacheMode::None) {
       return match self.cache.get(&key) {
@@ -933,26 +951,60 @@ impl ImageCache {
 
     match self.cache.get_value_or_guard(&key, None) {
       GuardResult::Value(CacheEntry::Source(source)) => Ok(source),
-      GuardResult::Value(CacheEntry::Sized(_)) => ImageSource::from_bytes(bytes),
+      GuardResult::Value(_) => ImageSource::from_bytes(bytes),
       GuardResult::Guard(guard) => {
         let source = ImageSource::from_bytes_lazy(bytes, hash, Arc::downgrade(&self.cache))?;
-        if source.is_cacheable() {
-          let _ = guard.insert(CacheEntry::Source(source.clone()));
-        }
+        let _ = guard.insert(CacheEntry::Source(source.clone()));
         Ok(source)
       }
       // `None` timeout never times out.
       GuardResult::Timeout => ImageSource::from_bytes(bytes),
     }
   }
+
+  /// Returns the parsed sheet for `sources`, parsing on a miss. Keyed by the
+  /// source text, so a server re-sending the same CSS parses it once.
+  pub fn get_or_parse_stylesheet(&self, sources: Vec<String>) -> Arc<StyleSheet> {
+    use xxhash_rust::xxh3::Xxh3;
+
+    let mut hasher = Xxh3::new();
+    for source in &sources {
+      hasher.update(source.as_bytes());
+      hasher.update(&(source.len() as u64).to_le_bytes());
+    }
+    let key = ResourceCacheKey::stylesheet(hasher.digest());
+
+    // Parsed rules retain roughly this much beyond the source text.
+    let weight = sources
+      .iter()
+      .map(|source| source.len())
+      .sum::<usize>()
+      .saturating_mul(3)
+      .min(u32::MAX as usize) as u32;
+
+    match self.cache.get_value_or_guard(&key, None) {
+      GuardResult::Value(CacheEntry::Stylesheet { sheet, .. }) => sheet,
+      GuardResult::Value(_) => Arc::new(StyleSheet::parse_owned_list_loosy(sources)),
+      GuardResult::Guard(guard) => {
+        let sheet = Arc::new(StyleSheet::parse_owned_list_loosy(sources));
+        let _ = guard.insert(CacheEntry::Stylesheet {
+          sheet: sheet.clone(),
+          weight,
+        });
+        sheet
+      }
+      // `None` timeout never times out.
+      GuardResult::Timeout => Arc::new(StyleSheet::parse_owned_list_loosy(sources)),
+    }
+  }
 }
 
 #[cfg(test)]
-mod image_cache_tests {
+mod resource_cache_tests {
   use quick_cache::sync::Cache;
 
   use super::{
-    CacheEntry, ImageCache, ImageCacheKey, ImageCacheMode, ImageWeighter, RenderedImage,
+    CacheEntry, ImageCacheMode, RenderedImage, ResourceCache, ResourceCacheKey, ResourceWeighter,
   };
   use crate::{
     resources::{image::ImageSource, image_buffer::ImageBuffer},
@@ -966,7 +1018,7 @@ mod image_cache_tests {
 
   #[test]
   fn decodes_and_reuses_on_hit() {
-    let cache = ImageCache::default();
+    let cache = ResourceCache::default();
     let bytes = png_bytes();
 
     let first = cache.get_or_decode(&bytes, ImageCacheMode::Auto).unwrap();
@@ -1007,7 +1059,7 @@ mod image_cache_tests {
 
   #[test]
   fn encoded_decodes_at_draw_size_and_reuses() {
-    let cache = ImageCache::default();
+    let cache = ResourceCache::default();
     let bytes = sized_png_bytes(64, 64);
     let source = cache.get_or_decode(&bytes, ImageCacheMode::Auto).unwrap();
 
@@ -1021,7 +1073,7 @@ mod image_cache_tests {
 
   #[test]
   fn encoded_covers_the_larger_axis() {
-    let cache = ImageCache::default();
+    let cache = ResourceCache::default();
     let bytes = sized_png_bytes(64, 64);
     let source = cache.get_or_decode(&bytes, ImageCacheMode::Auto).unwrap();
 
@@ -1033,7 +1085,7 @@ mod image_cache_tests {
 
   #[test]
   fn encoded_never_upscales() {
-    let cache = ImageCache::default();
+    let cache = ResourceCache::default();
     let bytes = sized_png_bytes(8, 8);
     let source = cache.get_or_decode(&bytes, ImageCacheMode::Auto).unwrap();
 
@@ -1045,7 +1097,7 @@ mod image_cache_tests {
 
   #[test]
   fn store_false_does_not_populate_cache() {
-    let cache = ImageCache::default();
+    let cache = ResourceCache::default();
     let bytes = png_bytes();
 
     let a = cache.get_or_decode(&bytes, ImageCacheMode::None).unwrap();
@@ -1059,19 +1111,59 @@ mod image_cache_tests {
 
   #[cfg(feature = "svg")]
   #[test]
-  fn svg_is_not_cached() {
-    let cache = ImageCache::default();
+  fn svg_source_and_raster_are_cached() {
+    let cache = ResourceCache::default();
     let svg = br#"<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>"#;
 
     let a = cache.get_or_decode(svg, ImageCacheMode::Auto).unwrap();
     let b = cache.get_or_decode(svg, ImageCacheMode::Auto).unwrap();
 
-    assert!(matches!(a, ImageSource::Svg(_)));
     match (&a, &b) {
       (ImageSource::Svg(x), ImageSource::Svg(y)) => {
-        assert!(!std::sync::Arc::ptr_eq(x, y))
+        assert!(std::sync::Arc::ptr_eq(x, y))
       }
       _ => panic!("expected svgs"),
+    }
+
+    let (first, second) = (rendered_raster(&a, 4, 4), rendered_raster(&b, 4, 4));
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+  }
+
+  #[cfg(feature = "svg")]
+  fn rendered_raster(source: &ImageSource, width: u32, height: u32) -> std::sync::Arc<ImageBuffer> {
+    match source
+      .render_for_layout(width, height, ImageScalingAlgorithm::Auto, 0)
+      .unwrap()
+    {
+      RenderedImage::Rasterized(buffer) => buffer,
+      _ => panic!("expected rasterized"),
+    }
+  }
+
+  #[test]
+  fn stylesheet_is_parsed_once() {
+    let cache = ResourceCache::default();
+    let sources = vec![".a { color: red; }".to_string()];
+
+    let first = cache.get_or_parse_stylesheet(sources.clone());
+    let second = cache.get_or_parse_stylesheet(sources);
+
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+  }
+
+  #[test]
+  fn zero_budget_disables_retention() {
+    let cache = ResourceCache::new(0);
+    let bytes = png_bytes();
+
+    let a = cache.get_or_decode(&bytes, ImageCacheMode::Auto).unwrap();
+    let b = cache.get_or_decode(&bytes, ImageCacheMode::Auto).unwrap();
+
+    match (&a, &b) {
+      (ImageSource::Encoded(x), ImageSource::Encoded(y)) => {
+        assert!(!std::sync::Arc::ptr_eq(x, y))
+      }
+      _ => panic!("expected encoded bitmaps"),
     }
   }
 
@@ -1084,10 +1176,13 @@ mod image_cache_tests {
   #[test]
   fn eviction_stays_within_byte_budget() {
     let max_bytes = 4096u64;
-    let cache = Cache::with_weighter(8, max_bytes, ImageWeighter);
+    let cache = Cache::with_weighter(8, max_bytes, ResourceWeighter);
 
     for key in 0..64u64 {
-      cache.insert(ImageCacheKey::source(key), CacheEntry::Source(image(1024)));
+      cache.insert(
+        ResourceCacheKey::source(key),
+        CacheEntry::Source(image(1024)),
+      );
     }
 
     assert!(cache.weight() <= max_bytes);
@@ -1233,26 +1328,6 @@ mod tests {
     let rendered = image.render_for_layout(4, 4, ImageScalingAlgorithm::Auto, 0)?;
 
     assert_eq!(premul_at(&rendered, 2, 2), [0, 0, 0, 255]);
-    Ok(())
-  }
-
-  #[cfg(feature = "svg")]
-  #[test]
-  fn svg_reuses_rasterized_pixmap() -> Result<(), ImageError> {
-    let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect x="0" y="0" width="4" height="4" fill="#ff0000"/></svg>"##;
-    let image: ImageSource = SvgSource::from_str(svg)?.into();
-
-    let first = image.render_for_layout(4, 4, ImageScalingAlgorithm::Auto, 0)?;
-    let second = image.render_for_layout(4, 4, ImageScalingAlgorithm::Auto, 0)?;
-
-    let RenderedImage::Rasterized(first) = first else {
-      return Ok(());
-    };
-    let RenderedImage::Rasterized(second) = second else {
-      return Ok(());
-    };
-
-    assert!(Arc::ptr_eq(&first, &second));
     Ok(())
   }
 

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, OnceLock, Weak};
 
 #[cfg(feature = "svg")]
 use crate::resvg::{
-  apply_filters_to_layer,
+  apply_filters_to_layer, render as render_svg_tree,
   usvg::{Options, Transform, Tree, filters_from_markup},
 };
 use quick_cache::{
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use thiserror::Error;
 #[cfg(feature = "svg")]
 use tiny_skia::Pixmap;
-use xxhash_rust::xxh3::xxh3_64;
+use xxhash_rust::xxh3::{Xxh3, xxh3_64};
 
 use crate::{
   resources::{
@@ -388,7 +388,7 @@ impl SvgSource {
     let sx = width as f32 / original_size.width();
     let sy = height as f32 / original_size.height();
 
-    crate::resvg::render(
+    render_svg_tree(
       &self.tree,
       Transform::from_scale(sx, sy),
       &mut pixmap.as_mut(),
@@ -965,8 +965,6 @@ impl ResourceCache {
   /// Returns the parsed sheet for `sources`, parsing on a miss. Keyed by the
   /// source text, so a server re-sending the same CSS parses it once.
   pub fn get_or_parse_stylesheet(&self, sources: Vec<String>) -> Arc<StyleSheet> {
-    use xxhash_rust::xxh3::Xxh3;
-
     let mut hasher = Xxh3::new();
     for source in &sources {
       hasher.update(source.as_bytes());

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -975,7 +975,7 @@ impl ResourceCache {
     // Parsed rules retain roughly this much beyond the source text.
     let weight = sources
       .iter()
-      .map(|source| source.len())
+      .map(String::len)
       .sum::<usize>()
       .saturating_mul(3)
       .min(u32::MAX as usize) as u32;

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -3,6 +3,7 @@ import type {
   RegisteredFamily,
   RenderAnimationOptions as RenderAnimationOptionsInternal,
   RenderOptions as RenderOptionsInternal,
+  RendererOptions,
   SvgRenderOptions as SvgRenderOptionsInternal,
 } from "../index";
 export type * from "../index";
@@ -29,8 +30,13 @@ export type RenderAnimationOptions = BackendAnimationOptions<RenderAnimationOpti
 export type SvgRenderOptions = BackendSvgOptions<SvgRenderOptionsInternal>;
 
 export class Renderer {
-  private inner = new RendererInternal();
-  private fonts = new FontRegistry<RegisteredFamily>((font) => this.inner.registerFont(font));
+  private inner: RendererInternal;
+  private fonts: FontRegistry<RegisteredFamily>;
+
+  constructor(options?: RendererOptions) {
+    this.inner = new RendererInternal(options);
+    this.fonts = new FontRegistry<RegisteredFamily>((font) => this.inner.registerFont(font));
+  }
 
   async render(node: Node, options?: RenderOptions) {
     const { options: opts, signal } = await prepareRenderInput(this.fonts, options ?? {}, node);

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -22,7 +22,7 @@ pub struct MeasureTask {
   pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
-  pub(crate) stylesheet: StyleSheet,
+  pub(crate) stylesheet: Arc<StyleSheet>,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
@@ -35,6 +35,12 @@ impl MeasureTask {
     options: RenderOptions,
     state: Arc<RendererState>,
   ) -> Result<Self> {
+    let stylesheet = stylesheet(
+      &state.resource_cache,
+      options.stylesheets,
+      deserialize_keyframes(options.keyframes)?,
+    );
+
     Ok(MeasureTask {
       node: Some(node),
       state,
@@ -45,10 +51,7 @@ impl MeasureTask {
           .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
       ),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
-      stylesheet: stylesheet(
-        options.stylesheets,
-        deserialize_keyframes(options.keyframes)?,
-      ),
+      stylesheet,
       images: options
         .images
         .unwrap_or_default()
@@ -85,7 +88,7 @@ impl Task for MeasureTask {
 
     let fonts = self.state.fonts.load();
 
-    let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
+    let initialized_images = decode_images(&self.state.resource_cache, take(&mut self.images))?;
 
     let options = takumi_raster::RenderOptions::builder()
       .viewport(self.viewport)

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -125,8 +125,12 @@ impl Task for RenderAnimationTask {
         unreachable!()
       };
       let fonts = self.state.fonts.load();
-      let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
-      let stylesheet = stylesheet(take(&mut self.stylesheets), take(&mut self.keyframes));
+      let initialized_images = decode_images(&self.state.resource_cache, take(&mut self.images))?;
+      let stylesheet = stylesheet(
+        &self.state.resource_cache,
+        take(&mut self.stylesheets),
+        take(&mut self.keyframes),
+      );
       let scene_options = scenes
         .into_iter()
         .map(|(node, duration_ms)| {

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -27,7 +27,7 @@ pub struct RenderTask {
   pub(crate) lossless: Option<bool>,
   pub(crate) dithering: DitheringAlgorithm,
   pub(crate) time_ms: u64,
-  pub(crate) stylesheet: StyleSheet,
+  pub(crate) stylesheet: Arc<StyleSheet>,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
@@ -40,6 +40,12 @@ impl RenderTask {
     options: RenderOptions,
     state: Arc<RendererState>,
   ) -> Result<Self> {
+    let stylesheet = stylesheet(
+      &state.resource_cache,
+      options.stylesheets,
+      deserialize_keyframes(options.keyframes)?,
+    );
+
     Ok(RenderTask {
       node: Some(node),
       state,
@@ -55,10 +61,7 @@ impl RenderTask {
       dithering: options.dithering.map(Into::into).unwrap_or_default(),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
       draw_debug_border: options.draw_debug_border.unwrap_or_default(),
-      stylesheet: stylesheet(
-        options.stylesheets,
-        deserialize_keyframes(options.keyframes)?,
-      ),
+      stylesheet,
       images: options
         .images
         .unwrap_or_default()
@@ -95,7 +98,7 @@ impl Task for RenderTask {
 
     let fonts = self.state.fonts.load();
 
-    let initialized_images = decode_images(&self.state.image_cache, take(&mut self.images))?;
+    let initialized_images = decode_images(&self.state.resource_cache, take(&mut self.images))?;
 
     let image = render(
       takumi_raster::RenderOptions::builder()

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -10,7 +10,7 @@ use takumi_core::{
   Fonts,
   layout::node::Node,
   resources::image::{
-    ImageCache, ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource,
+    ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource, ResourceCache,
   },
   style::KeyframesRule as CoreKeyframesRule,
 };
@@ -90,19 +90,19 @@ pub(crate) struct RendererState {
   /// a fresh `Arc<Fonts>` via `store`. Renders in flight keep their old snapshot alive.
   pub(crate) fonts: ArcSwap<Fonts>,
   pub(crate) font_write: Mutex<()>,
-  pub(crate) image_cache: ImageCache,
+  pub(crate) resource_cache: ResourceCache,
 }
 
-/// Decodes the per-call image buffers into a `src`-keyed map. The image cache is
+/// Decodes the per-call image buffers into a `src`-keyed map. The resource cache is
 /// `quick_cache::sync` (internally locked, single-flight), so it needs no outer lock.
 pub(crate) fn decode_images(
-  image_cache: &ImageCache,
+  resource_cache: &ResourceCache,
   images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
 ) -> Result<HashMap<Arc<str>, LoadedImageSource>> {
   let mut map = HashMap::new();
 
   for (src, (buffer, mode)) in images {
-    let decoded = image_cache
+    let decoded = resource_cache
       .get_or_decode(&buffer, mode.into())
       .map_err(map_error)?;
 
@@ -346,18 +346,31 @@ pub struct ImageSource<'ctx> {
   pub cache: Option<ImageCacheMode>,
 }
 
+/// Options for constructing a [`Renderer`].
+#[napi(object)]
+#[derive(Default)]
+pub struct RendererOptions {
+  /// Byte budget shared by every cached resource — decoded images, SVG
+  /// rasters, parsed stylesheets. `0` disables caching.
+  /// @default 16 MiB
+  pub cache_max_bytes: Option<f64>,
+}
+
 #[napi]
 impl Renderer {
   /// Creates a new Renderer instance.
   #[napi(constructor)]
-  pub fn new(env: Env) -> Result<Self> {
+  pub fn new(env: Env, options: Option<RendererOptions>) -> Result<Self> {
     crate::pool::register_cleanup(&env);
 
     Ok(Self {
       state: Arc::new(RendererState {
         fonts: ArcSwap::from_pointee(takumi_bindings_common::default_fonts().map_err(map_error)?),
         font_write: Mutex::new(()),
-        image_cache: ImageCache::default(),
+        resource_cache: match options.and_then(|options| options.cache_max_bytes) {
+          Some(bytes) => ResourceCache::new(bytes.max(0.0) as u64),
+          None => ResourceCache::default(),
+        },
       }),
     })
   }

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -20,7 +20,7 @@ pub struct SvgRenderTask {
   pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
-  pub(crate) stylesheet: StyleSheet,
+  pub(crate) stylesheet: Arc<StyleSheet>,
   pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
@@ -33,15 +33,18 @@ impl SvgRenderTask {
     options: SvgRenderOptions,
     state: Arc<RendererState>,
   ) -> Result<Self> {
+    let stylesheet = stylesheet(
+      &state.resource_cache,
+      options.stylesheets,
+      deserialize_keyframes(options.keyframes)?,
+    );
+
     Ok(SvgRenderTask {
       node: Some(node),
       state,
       viewport: Viewport::new((options.width, options.height)),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
-      stylesheet: stylesheet(
-        options.stylesheets,
-        deserialize_keyframes(options.keyframes)?,
-      ),
+      stylesheet,
       images: options
         .images
         .unwrap_or_default()
@@ -76,7 +79,7 @@ impl Task for SvgRenderTask {
 
     let fonts = self.state.fonts.load();
 
-    let images = decode_images(&self.state.image_cache, take(&mut self.images))?;
+    let images = decode_images(&self.state.resource_cache, take(&mut self.images))?;
 
     takumi_svg::render(
       takumi_svg::SvgOptions::builder()

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -167,7 +167,7 @@ pub fn measure<'g>(options: RenderOptions<'g>) -> Result<MeasuredNode> {
     .fonts(fonts.snapshot_with_fallbacks(font_families.as_ref()))
     .sizing(SizingContext::builder().viewport(viewport).build())
     .images(Rc::new(images))
-    .stylesheet(stylesheet.into())
+    .stylesheet(stylesheet)
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
     .style(Box::new(ComputedStyle {
@@ -413,7 +413,7 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
     .fonts(fonts.snapshot_with_fallbacks(font_families.as_ref()))
     .sizing(SizingContext::builder().viewport(viewport).build())
     .images(Rc::new(images))
-    .stylesheet(stylesheet.into())
+    .stylesheet(stylesheet)
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
     .style(Box::new(ComputedStyle {

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -42,7 +42,7 @@ pub struct RenderOptions<'g> {
   pub(crate) images: HashMap<Arc<str>, ImageSource>,
   /// CSS stylesheets to apply before layout/rendering.
   #[builder(default)]
-  pub(crate) stylesheet: StyleSheet,
+  pub(crate) stylesheet: Arc<StyleSheet>,
   /// Global animation time in milliseconds.
   #[builder(default = 0)]
   pub(crate) time_ms: u64,
@@ -76,7 +76,7 @@ impl<'g> RenderOptions<'g> {
   }
 
   /// Returns the CSS stylesheet applied before layout.
-  pub fn stylesheet(&self) -> &StyleSheet {
+  pub fn stylesheet(&self) -> &Arc<StyleSheet> {
     &self.stylesheet
   }
 
@@ -489,7 +489,7 @@ pub(crate) struct PreparedScene<'a, 'g> {
   scene: &'a SequentialScene<'g>,
   fonts: FontsSnapshot,
   images: Rc<HashMap<Arc<str>, ImageSource>>,
-  stylesheet: Rc<StyleSheet>,
+  stylesheet: Arc<StyleSheet>,
 }
 
 impl<'a, 'g> PreparedScene<'a, 'g> {
@@ -501,7 +501,7 @@ impl<'a, 'g> PreparedScene<'a, 'g> {
         .fonts
         .snapshot_with_fallbacks(options.font_families.as_ref()),
       images: Rc::new(options.images.clone()),
-      stylesheet: Rc::new(options.stylesheet.clone()),
+      stylesheet: options.stylesheet.clone(),
       scene,
     }
   }
@@ -693,6 +693,7 @@ mod tests {
     style::{
       AnimationFillMode, AnimationTime, AnimationTimingFunction, Color, ColorInput, Display,
       KeyframeRule, KeyframesRule, Length, Length::Px, Position, Style, StyleDeclaration,
+      StyleSheet,
     },
     viewport::Viewport,
   };
@@ -905,7 +906,7 @@ mod tests {
       .viewport(Viewport::new((200, 100)))
       .node(node)
       .stylesheet(
-        vec![KeyframesRule {
+        StyleSheet::from(vec![KeyframesRule {
           name: "grow".to_string(),
           keyframes: vec![
             KeyframeRule::builder()
@@ -926,7 +927,7 @@ mod tests {
               .build(),
           ],
           media_queries: Vec::new(),
-        }]
+        }])
         .into(),
       )
       .time_ms(500)

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -75,7 +75,7 @@ pub fn render(options: SvgOptions<'_>) -> Result<String> {
     )
     .sizing(SizingContext::builder().viewport(viewport).build())
     .images(Rc::new(options.images))
-    .stylesheet(options.stylesheet.into())
+    .stylesheet(options.stylesheet)
     .time_ms(options.time_ms)
     .style({
       Box::new(ComputedStyle {

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -49,7 +49,7 @@ pub struct SvgOptions<'g> {
   pub(crate) images: HashMap<Arc<str>, ImageSource>,
   /// CSS stylesheets to apply before layout.
   #[builder(default)]
-  pub(crate) stylesheet: StyleSheet,
+  pub(crate) stylesheet: Arc<StyleSheet>,
   /// Global animation time in milliseconds.
   #[builder(default = 0)]
   pub(crate) time_ms: u64,

--- a/takumi-wasm/src/dts-header.d.ts
+++ b/takumi-wasm/src/dts-header.d.ts
@@ -34,6 +34,15 @@ export type DitheringAlgorithm = "none" | "ordered-bayer" | "floyd-steinberg";
 /** Cache policy for a decoded image. Defaults to `"auto"`. */
 export type ImageCacheMode = "auto" | "none";
 
+export type RendererOptions = {
+  /**
+   * Byte budget shared by every cached resource — decoded images, SVG
+   * rasters, parsed stylesheets. `0` disables caching.
+   * @default 16 MiB
+   */
+  cacheMaxBytes?: number;
+};
+
 export type RenderOptions = {
   /**
    * The width of the image. If not provided, the width will be automatically calculated based on the content.

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -20,6 +20,10 @@ extern "C" {
   #[derive(Debug)]
   pub type NodeType;
 
+  /// JavaScript object representing renderer construction options.
+  #[wasm_bindgen(typescript_type = "RendererOptions")]
+  pub type RendererOptionsType;
+
   /// JavaScript object representing render options.
   #[wasm_bindgen(typescript_type = "RenderOptions")]
   pub type RenderOptionsType;
@@ -51,6 +55,15 @@ extern "C" {
   /// JavaScript object representing an animation scene source.
   #[wasm_bindgen(typescript_type = "AnimationScene")]
   pub type AnimationSceneType;
+}
+
+/// Options for constructing a `Renderer`.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RendererOptions {
+  /// Byte budget shared by every cached resource — decoded images, SVG
+  /// rasters, parsed stylesheets. `0` disables caching. Defaults to 16 MiB.
+  pub cache_max_bytes: Option<u64>,
 }
 
 /// Options for rendering an image.

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -13,7 +13,7 @@ use takumi_core::{
   layout::node::Node,
   resources::{
     font::{FontResource, RegisteredFamily},
-    image::{ImageCache, ImageSource as LoadedImageSource},
+    image::{ImageSource as LoadedImageSource, ResourceCache},
   },
   style::{FontFamily, Lang},
   viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
@@ -34,7 +34,7 @@ use crate::{helper::map_error, model::*};
 #[wasm_bindgen]
 pub struct Renderer {
   state: RwLock<Fonts>,
-  image_cache: ImageCache,
+  resource_cache: ResourceCache,
 }
 
 fn load_font_internal(
@@ -89,7 +89,7 @@ impl Renderer {
     for source in images.unwrap_or_default() {
       let mode = source.cache.unwrap_or_default();
       let image = self
-        .image_cache
+        .resource_cache
         .get_or_decode(&source.data, mode)
         .map_err(map_error)?;
 
@@ -101,10 +101,18 @@ impl Renderer {
 
   /// Creates a new Renderer instance.
   #[wasm_bindgen(constructor)]
-  pub fn new() -> Result<Renderer, js_sys::Error> {
+  pub fn new(options: Option<RendererOptionsType>) -> Result<Renderer, js_sys::Error> {
+    let options: RendererOptions = options
+      .map(|options| from_value(options.into()).map_err(map_error))
+      .transpose()?
+      .unwrap_or_default();
+
     Ok(Renderer {
       state: RwLock::new(default_fonts().map_err(map_error)?),
-      image_cache: ImageCache::default(),
+      resource_cache: match options.cache_max_bytes {
+        Some(bytes) => ResourceCache::new(bytes),
+        None => ResourceCache::default(),
+      },
     })
   }
 
@@ -145,7 +153,11 @@ impl Renderer {
     images: HashMap<Arc<str>, LoadedImageSource>,
   ) -> Result<Vec<u8>, JsValue> {
     let dithering = options.dithering.unwrap_or_default();
-    let stylesheet = stylesheet(options.stylesheets, options.keyframes.unwrap_or_default());
+    let stylesheet = stylesheet(
+      &self.resource_cache,
+      options.stylesheets,
+      options.keyframes.unwrap_or_default(),
+    );
 
     let lang = options
       .lang
@@ -205,7 +217,11 @@ impl Renderer {
       .unwrap_or_default();
 
     let images = self.images_map(options.images.as_deref())?;
-    let stylesheet = stylesheet(options.stylesheets, options.keyframes.unwrap_or_default());
+    let stylesheet = stylesheet(
+      &self.resource_cache,
+      options.stylesheets,
+      options.keyframes.unwrap_or_default(),
+    );
     let state = self.read_state()?;
 
     let lang = options
@@ -249,7 +265,11 @@ impl Renderer {
       .transpose()?;
 
     let images = self.images_map(options.images.as_deref())?;
-    let stylesheet = stylesheet(options.stylesheets, options.keyframes.unwrap_or_default());
+    let stylesheet = stylesheet(
+      &self.resource_cache,
+      options.stylesheets,
+      options.keyframes.unwrap_or_default(),
+    );
 
     let state = self.read_state()?;
     let render_options = takumi_raster::RenderOptions::builder()
@@ -344,7 +364,11 @@ impl Renderer {
     let viewport = Viewport::new((width, height))
       .with_device_pixel_ratio(device_pixel_ratio.unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO));
     let draw_debug_border = draw_debug_border.unwrap_or_default();
-    let stylesheet = stylesheet(stylesheets, keyframes.unwrap_or_default());
+    let stylesheet = stylesheet(
+      &self.resource_cache,
+      stylesheets,
+      keyframes.unwrap_or_default(),
+    );
     let state = self.read_state()?;
     let scene_options = scenes
       .into_iter()

--- a/takumi/tests/fixtures/animation.rs
+++ b/takumi/tests/fixtures/animation.rs
@@ -127,7 +127,7 @@ fn keyframe_interpolation_options() -> RenderOptions<'static> {
     .viewport(Viewport::new((800, 400)))
     .node(keyframe_interpolation_node())
     .fonts(&CONTEXT)
-    .stylesheet(stylesheet)
+    .stylesheet(stylesheet.into())
     .build()
 }
 

--- a/takumi/tests/fixtures/pseudo.rs
+++ b/takumi/tests/fixtures/pseudo.rs
@@ -103,7 +103,11 @@ fn test_pseudo_text_attr() {
     .viewport(create_test_viewport())
     .node(root)
     .fonts(&CONTEXT)
-    .stylesheet(StyleSheet::parse(&format!("{SHARED_CSS}{pseudo_css}")).unwrap())
+    .stylesheet(
+      StyleSheet::parse(&format!("{SHARED_CSS}{pseudo_css}"))
+        .unwrap()
+        .into(),
+    )
     .build();
 
   run_fixture_test_with_options(options, "pseudo_text_attr");
@@ -160,7 +164,11 @@ fn test_pseudo_display_image() {
     .node(root)
     .fonts(&CONTEXT)
     .images(TEST_IMAGES.clone())
-    .stylesheet(StyleSheet::parse(&format!("{SHARED_CSS}{pseudo_css}")).unwrap())
+    .stylesheet(
+      StyleSheet::parse(&format!("{SHARED_CSS}{pseudo_css}"))
+        .unwrap()
+        .into(),
+    )
     .build();
 
   run_fixture_test_with_options(options, "pseudo_display_image");

--- a/takumi/tests/fixtures/stylesheets.rs
+++ b/takumi/tests/fixtures/stylesheets.rs
@@ -72,7 +72,8 @@ fn test_stylesheets() {
           }
         "#,
       )
-      .unwrap(),
+      .unwrap()
+      .into(),
     )
     .build();
 
@@ -118,7 +119,7 @@ fn test_stylesheets_background_multiple_gradients() {
           }
         "#,
       )
-      .unwrap()).build()
+      .unwrap().into()).build()
   };
 
   run_fixture_test_with_options(build_options(), "stylesheets_background_multiple_gradients");

--- a/takumi/tests/fixtures/visual_showcase.rs
+++ b/takumi/tests/fixtures/visual_showcase.rs
@@ -30,7 +30,7 @@ fn run_showcase(node: Node, css: &str, fixture_name: &str) {
     .node(node)
     .fonts(&CONTEXT)
     .images(TEST_IMAGES.clone())
-    .stylesheet(StyleSheet::parse(&stylesheet).unwrap())
+    .stylesheet(StyleSheet::parse(&stylesheet).unwrap().into())
     .build();
 
   run_fixture_test_with_options(options, fixture_name);

--- a/takumi/tests/pseudo_element_tests.rs
+++ b/takumi/tests/pseudo_element_tests.rs
@@ -18,7 +18,7 @@ fn measure_with_css(node: Node, css: &str) -> MeasuredNode {
     RenderOptions::builder()
       .viewport(viewport())
       .node(node)
-      .stylesheet(stylesheet)
+      .stylesheet(stylesheet.into())
       .fonts(&CONTEXT)
       .build(),
   )

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -11,7 +11,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use takumi::{
   prelude::*, render, write_animated_gif, write_animated_png, write_animated_webp, write_image,
 };
-use takumi_core::resources::image::ImageCache;
+use takumi_core::resources::image::ResourceCache;
 use takumi_svg::{SvgOptions, render as svg_render};
 
 fn repo_base_path(path: &str) -> PathBuf {
@@ -112,10 +112,10 @@ pub fn create_test_viewport() -> Viewport {
 pub static CONTEXT: LazyLock<Fonts> = LazyLock::new(create_test_context);
 
 /// Test images, provided to renders as pre-fetched resources. Loaded through
-/// an [`ImageCache`] so fixtures exercise the same decode-at-draw-size path as
+/// an [`ResourceCache`] so fixtures exercise the same decode-at-draw-size path as
 /// the renderer bindings.
 pub static TEST_IMAGES: LazyLock<HashMap<Arc<str>, ImageSource>> = LazyLock::new(|| {
-  let cache = ImageCache::default();
+  let cache = ResourceCache::default();
   let images = IMAGES
     .iter()
     .map(|path| {
@@ -136,7 +136,7 @@ pub static TEST_IMAGES: LazyLock<HashMap<Arc<str>, ImageSource>> = LazyLock::new
 
 /// Keeps the decode cache alive so lazily decoded sources keep their sized
 /// entries across renders.
-static CACHE: OnceLock<ImageCache> = OnceLock::new();
+static CACHE: OnceLock<ResourceCache> = OnceLock::new();
 
 #[allow(dead_code)]
 pub fn run_fixture_test(node: Node, fixture_name: &str) {


### PR DESCRIPTION
## Why

Memory retention was spread across differently-shaped caches. Decoded images had a 64 MiB budget, hard-coded and untunable. Each SVG source kept up to 32 rasterized pixmaps in its own count-bounded cache, invisible to that budget, and excluded from the shared cache entirely (the `is_cacheable` hack) precisely because that hidden state would grow after insertion. Stylesheets were re-parsed on every render, so a server re-sending the same CSS paid the full selector-parse cost per request.

## What

- `ImageCache` becomes `ResourceCache`: one `quick_cache` instance with a kind-tagged key holding image sources, decoded-at-size bitmaps, SVG rasters, and parsed stylesheets under a single byte budget.
- SVG raster pixmaps move into the store, keyed by content hash and target size. `SvgRasterCache` and `is_cacheable` are gone; SVG sources and rasters now survive across renders and count against the budget.
- Stylesheet parses are cached by source-text hash. Per-render keyframes graft onto a copy so the cached parse stays pristine. `RenderOptions.stylesheet` is `Arc<StyleSheet>` end to end.
- The budget is configurable: `new Renderer({ cacheMaxBytes })` in napi and wasm, `ResourceCache::new(max_bytes)` in Rust, `0` disables caching. The default drops from 64 MiB to 16 MiB, sized for a single-template server; heavier workloads raise it through the new knob.
- Docs updated (load-images, performance).

Verified: 723 core tests, 294 golden fixtures with zero `.svg`/`.webp` diff (pixel output unchanged), clippy clean across touched crates, wasm32 target checks.

A stacked PR follows: byte budget for the thread-local glyph caches plus a memory-retention regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified shared cache for decoded images, SVG raster outputs, and parsed stylesheets with budgeted LRU eviction.
  * JavaScript and WebAssembly renderers now accept `RendererOptions` (`cacheMaxBytes` / `cache_max_bytes`) to configure the shared cache budget (default 16 MiB; `0` disables caching).
  * Reuses cached SVG raster and parsed stylesheet results across renders when caching is enabled.
* **Documentation**
  * Updated caching/performance docs and examples to reflect the shared budget, eviction behavior, and renderer configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->