### PR TITLE
Core: bound thread-local glyph caches by a shared byte budget

### DIFF
--- a/.tegami/glyph-cache-byte-budget.md
+++ b/.tegami/glyph-cache-byte-budget.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "cargo:takumi-core": minor
+  "cargo:takumi-raster": patch
+---
+
+### Bound the thread-local glyph caches by bytes
+
+The resolved-glyph and glyph-mask caches were thread-local maps capped at 4096 entries each: per-entry size was unbounded, the cap multiplied per worker thread, and overflowing flushed the whole map so hot glyphs paid the rebuild cost. Both caches now weigh entries in bytes against one process-wide 8 MiB budget, tunable through `takumi_core::resources::glyph_cache::set_glyph_cache_max_bytes`. Going over budget evicts entries no recent render touched instead of flushing everything. A retention test renders the same content 200 times and asserts live heap bytes stay flat, so budget regressions fail in CI.

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -26,8 +26,9 @@ use thiserror::Error;
 use crate::{
   context::RenderContext,
   layout::inline::{InlineBrush, InlineLayout},
-  resources::glyph::{
-    BOLD_THRESHOLD, GlyphResolveContext, ResolvedGlyph, synthesis_embolden_strength,
+  resources::{
+    glyph::{BOLD_THRESHOLD, GlyphResolveContext, ResolvedGlyph, synthesis_embolden_strength},
+    glyph_cache::GlyphCache,
   },
   style::{FontFamily, FontStyle as CssFontStyle},
 };
@@ -110,11 +111,9 @@ fn guess_font_format(source: &[u8]) -> Result<FontFormat, FontError> {
 
 thread_local! {
   static LAYOUT_CONTEXT: RefCell<LayoutContext<InlineBrush>> = RefCell::new(LayoutContext::new());
-  static SHARED_RESOLVED_GLYPH_CACHE: RefCell<HashMap<u64, ResolvedGlyph>> =
-    RefCell::new(HashMap::new());
+  static SHARED_RESOLVED_GLYPH_CACHE: RefCell<GlyphCache<ResolvedGlyph>> =
+    RefCell::new(GlyphCache::default());
 }
-
-const RESOLVED_GLYPH_CACHE_MAX_ENTRIES: usize = 4096;
 
 fn resolved_glyph_cache_key(
   font_id: u64,
@@ -256,6 +255,12 @@ impl Fonts {
 
   /// Render-local snapshot whose fallback bucket carries the given families.
   pub fn snapshot_with_fallbacks(&self, fallbacks: Option<&FontFamily>) -> FontsSnapshot {
+    SHARED_RESOLVED_GLYPH_CACHE.with(|cache| {
+      if let Ok(mut cache) = cache.try_borrow_mut() {
+        cache.begin_render();
+      }
+    });
+
     let mut cloned = self.inner.clone();
 
     let mut family_ids = if let Some(names) = fallbacks {
@@ -372,18 +377,20 @@ impl Fonts {
           skew,
           glyph_id,
         );
-        let cached = SHARED_RESOLVED_GLYPH_CACHE.with(|c| c.borrow().get(&key).cloned());
+        let cached = SHARED_RESOLVED_GLYPH_CACHE.with(|c| {
+          c.try_borrow_mut()
+            .ok()
+            .and_then(|mut cache| cache.get(key).cloned())
+        });
         let glyph = if let Some(g) = cached {
           Some(g)
         } else {
           let resolved = resolver.resolve_glyph(glyph_id);
           if let Some(g) = resolved.as_ref() {
             SHARED_RESOLVED_GLYPH_CACHE.with(|c| {
-              let mut cache = c.borrow_mut();
-              if cache.len() > RESOLVED_GLYPH_CACHE_MAX_ENTRIES {
-                cache.clear();
+              if let Ok(mut cache) = c.try_borrow_mut() {
+                cache.insert(key, g.clone(), g.estimated_bytes());
               }
-              cache.insert(key, g.clone());
             });
           }
           resolved

--- a/takumi-core/src/resources/glyph.rs
+++ b/takumi-core/src/resources/glyph.rs
@@ -177,6 +177,25 @@ impl ResolvedOutlineGlyph {
 }
 
 impl ResolvedGlyph {
+  /// Approximate retained size in bytes, for glyph-cache budgeting.
+  pub(crate) fn estimated_bytes(&self) -> usize {
+    const ENTRY_OVERHEAD: usize = 64;
+    const COMMAND_BYTES: usize = 32;
+
+    match self {
+      Self::Bitmap(bitmap) => bitmap.image.data().len() + ENTRY_OVERHEAD,
+      Self::Outline(ResolvedOutlineGlyph::Plain { paths, .. }) => {
+        paths.len() * COMMAND_BYTES + ENTRY_OVERHEAD
+      }
+      Self::Outline(ResolvedOutlineGlyph::Color { paths, layers, .. }) => {
+        let layer_commands: usize = layers.iter().map(|layer| layer.paths.len()).sum();
+        (paths.len() + layer_commands) * COMMAND_BYTES
+          + layers.len() * ENTRY_OVERHEAD
+          + ENTRY_OVERHEAD
+      }
+    }
+  }
+
   /// Conservative ink extents relative to the glyph's pen origin, in device
   /// pixels: `(min_x, min_y, max_x, max_y)`. Curve control points are included,
   /// so the box may slightly overestimate but never undercuts, and the

--- a/takumi-core/src/resources/glyph.rs
+++ b/takumi-core/src/resources/glyph.rs
@@ -177,20 +177,20 @@ impl ResolvedOutlineGlyph {
 }
 
 impl ResolvedGlyph {
-  /// Approximate retained size in bytes, for glyph-cache budgeting.
+  /// Approximate retained size in bytes, for glyph-cache budgeting. Element
+  /// sizes are exact; the constant covers map-slot and allocator overhead.
   pub(crate) fn estimated_bytes(&self) -> usize {
     const ENTRY_OVERHEAD: usize = 64;
-    const COMMAND_BYTES: usize = 32;
 
     match self {
       Self::Bitmap(bitmap) => bitmap.image.data().len() + ENTRY_OVERHEAD,
       Self::Outline(ResolvedOutlineGlyph::Plain { paths, .. }) => {
-        paths.len() * COMMAND_BYTES + ENTRY_OVERHEAD
+        paths.len() * size_of::<Command>() + ENTRY_OVERHEAD
       }
       Self::Outline(ResolvedOutlineGlyph::Color { paths, layers, .. }) => {
         let layer_commands: usize = layers.iter().map(|layer| layer.paths.len()).sum();
-        (paths.len() + layer_commands) * COMMAND_BYTES
-          + layers.len() * ENTRY_OVERHEAD
+        (paths.len() + layer_commands) * size_of::<Command>()
+          + layers.len() * size_of::<ResolvedColorLayer>()
           + ENTRY_OVERHEAD
       }
     }

--- a/takumi-core/src/resources/glyph_cache.rs
+++ b/takumi-core/src/resources/glyph_cache.rs
@@ -80,15 +80,17 @@ impl<V> GlyphCache<V> {
 
     let used = USED_BYTES.fetch_add(bytes, Ordering::Relaxed) + bytes;
     if used > max {
-      self.evict_stale();
+      self.evict_stale(used - max);
     }
   }
 
-  /// Drops entries no render touched since the previous one; when everything
-  /// is that fresh, drops the whole map. Only this thread's entries are
+  /// Drops entries no render touched since the previous one; when that frees
+  /// less than `target` bytes, drops arbitrary fresh entries until it is
+  /// covered, so one over-budget render degrades gradually instead of
+  /// flushing everything it just cached. Only this thread's entries are
   /// considered — an idle thread keeps its share until it renders again, so
   /// the ceiling holds even though reclaim is local.
-  fn evict_stale(&mut self) {
+  fn evict_stale(&mut self, target: usize) {
     let cutoff = self.tick.saturating_sub(1);
     let mut freed = 0;
 
@@ -99,8 +101,16 @@ impl<V> GlyphCache<V> {
       }
     });
 
-    if freed == 0 {
-      freed = self.entries.drain().map(|(_, entry)| entry.bytes).sum();
+    if freed < target {
+      let fresh: Vec<u64> = self.entries.keys().copied().collect();
+      for key in fresh {
+        if freed >= target {
+          break;
+        }
+        if let Some(entry) = self.entries.remove(&key) {
+          freed += entry.bytes;
+        }
+      }
     }
 
     USED_BYTES.fetch_sub(freed, Ordering::Relaxed);
@@ -142,7 +152,7 @@ mod tests {
   }
 
   #[test]
-  fn over_budget_with_only_fresh_entries_clears_all() {
+  fn over_budget_with_only_fresh_entries_evicts_just_enough() {
     let _guard = BUDGET_LOCK.lock().unwrap();
     set_glyph_cache_max_bytes(512);
     let mut cache = GlyphCache::default();
@@ -151,8 +161,9 @@ mod tests {
     cache.insert(1, "a", 300);
     cache.insert(2, "b", 300);
 
-    assert!(cache.get(1).is_none());
-    assert!(cache.get(2).is_none());
+    // 88 bytes over budget: dropping either 300-byte entry covers it, the
+    // other survives instead of the whole map flushing.
+    assert!(cache.get(1).is_some() ^ cache.get(2).is_some());
     set_glyph_cache_max_bytes(DEFAULT_GLYPH_CACHE_MAX_BYTES);
   }
 }

--- a/takumi-core/src/resources/glyph_cache.rs
+++ b/takumi-core/src/resources/glyph_cache.rs
@@ -1,0 +1,158 @@
+//! Thread-local glyph caches under one process-wide byte budget.
+//!
+//! Glyph lookups are the hottest cache path in a render, so entries stay in
+//! thread-local maps: a hit is a plain `HashMap` read with no atomics. Only
+//! inserts and evictions touch the shared byte counter, which enforces one
+//! ceiling across every worker thread.
+
+use std::{
+  collections::HashMap,
+  sync::atomic::{AtomicUsize, Ordering},
+};
+
+const DEFAULT_GLYPH_CACHE_MAX_BYTES: usize = 8 << 20; // 8 MiB
+
+static USED_BYTES: AtomicUsize = AtomicUsize::new(0);
+static MAX_BYTES: AtomicUsize = AtomicUsize::new(DEFAULT_GLYPH_CACHE_MAX_BYTES);
+
+/// Sets the process-wide byte budget shared by every thread's glyph caches.
+/// `0` stops further caching. Defaults to 8 MiB.
+pub fn set_glyph_cache_max_bytes(bytes: usize) {
+  MAX_BYTES.store(bytes, Ordering::Relaxed);
+}
+
+struct Entry<V> {
+  value: V,
+  bytes: usize,
+  last_used: u32,
+}
+
+/// A thread-local glyph cache charging its entries against the process-wide
+/// budget. Entries age per render; going over budget drops this thread's
+/// entries that no recent render touched.
+pub struct GlyphCache<V> {
+  entries: HashMap<u64, Entry<V>>,
+  tick: u32,
+}
+
+impl<V> Default for GlyphCache<V> {
+  fn default() -> Self {
+    Self {
+      entries: HashMap::new(),
+      tick: 0,
+    }
+  }
+}
+
+impl<V> GlyphCache<V> {
+  /// Ages the cache by one render; entries untouched for two renders become
+  /// eviction candidates.
+  pub fn begin_render(&mut self) {
+    self.tick = self.tick.saturating_add(1);
+  }
+
+  /// Returns the cached value and marks it live for the current render.
+  pub fn get(&mut self, key: u64) -> Option<&V> {
+    let tick = self.tick;
+
+    self.entries.get_mut(&key).map(|entry| {
+      entry.last_used = tick;
+      &entry.value
+    })
+  }
+
+  /// Caches `value` at `bytes` weight, evicting stale entries when the shared
+  /// budget overflows.
+  pub fn insert(&mut self, key: u64, value: V, bytes: usize) {
+    let max = MAX_BYTES.load(Ordering::Relaxed);
+    if max == 0 {
+      return;
+    }
+
+    let entry = Entry {
+      value,
+      bytes,
+      last_used: self.tick,
+    };
+    if let Some(old) = self.entries.insert(key, entry) {
+      USED_BYTES.fetch_sub(old.bytes, Ordering::Relaxed);
+    }
+
+    let used = USED_BYTES.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    if used > max {
+      self.evict_stale();
+    }
+  }
+
+  /// Drops entries no render touched since the previous one; when everything
+  /// is that fresh, drops the whole map. Only this thread's entries are
+  /// considered — an idle thread keeps its share until it renders again, so
+  /// the ceiling holds even though reclaim is local.
+  fn evict_stale(&mut self) {
+    let cutoff = self.tick.saturating_sub(1);
+    let mut freed = 0;
+
+    self.entries.retain(|_, entry| {
+      entry.last_used >= cutoff || {
+        freed += entry.bytes;
+        false
+      }
+    });
+
+    if freed == 0 {
+      freed = self.entries.drain().map(|(_, entry)| entry.bytes).sum();
+    }
+
+    USED_BYTES.fetch_sub(freed, Ordering::Relaxed);
+  }
+}
+
+impl<V> Drop for GlyphCache<V> {
+  fn drop(&mut self) {
+    let held: usize = self.entries.values().map(|entry| entry.bytes).sum();
+
+    USED_BYTES.fetch_sub(held, Ordering::Relaxed);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Mutex;
+
+  use super::*;
+
+  /// The budget statics are process-wide; serialize tests that reconfigure them.
+  static BUDGET_LOCK: Mutex<()> = Mutex::new(());
+
+  #[test]
+  fn eviction_keeps_entries_of_recent_renders() {
+    let _guard = BUDGET_LOCK.lock().unwrap();
+    set_glyph_cache_max_bytes(1024);
+    let mut cache = GlyphCache::default();
+
+    cache.begin_render();
+    cache.insert(1, "old", 256);
+    cache.begin_render();
+    cache.begin_render();
+    cache.insert(2, "hot", 900);
+
+    assert!(cache.get(1).is_none());
+    assert!(cache.get(2).is_some());
+    set_glyph_cache_max_bytes(DEFAULT_GLYPH_CACHE_MAX_BYTES);
+  }
+
+  #[test]
+  fn over_budget_with_only_fresh_entries_clears_all() {
+    let _guard = BUDGET_LOCK.lock().unwrap();
+    set_glyph_cache_max_bytes(512);
+    let mut cache = GlyphCache::default();
+
+    cache.begin_render();
+    cache.insert(1, "a", 300);
+    cache.insert(2, "b", 300);
+
+    assert!(cache.get(1).is_none());
+    assert!(cache.get(2).is_none());
+    set_glyph_cache_max_bytes(DEFAULT_GLYPH_CACHE_MAX_BYTES);
+  }
+}

--- a/takumi-core/src/resources/mod.rs
+++ b/takumi-core/src/resources/mod.rs
@@ -2,6 +2,7 @@
 pub mod font;
 /// Glyph rasterization: shaped glyph ids to bitmaps or vector outlines.
 pub mod glyph;
+pub mod glyph_cache;
 /// Image state and resource management
 pub mod image;
 /// Backend-agnostic decoded-image buffer

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -22,6 +22,7 @@ use crate::{
   resources::{font::FontsSnapshot, image::ImageSource},
   stacking_context::paint_context,
   style::{Affine, FontFamily, SizingContext, StyleSheet},
+  text_drawing::begin_glyph_mask_render,
   viewport::Viewport,
 };
 
@@ -435,6 +436,8 @@ fn render_with_context(
   viewport: Viewport,
   dithering: DitheringAlgorithm,
 ) -> Result<Bitmap> {
+  begin_glyph_mask_render();
+
   let mut root = RenderNode::from_node(&render_context, node);
   let mut tree = LayoutTree::from_render_node(&root);
 

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, convert::Into};
+use std::{cell::RefCell, convert::Into};
 
 use skrifa::color::ColorPalette;
 use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
@@ -10,30 +10,32 @@ use crate::{
   composite_mask_source_to_pixmap, draw_outset_shadow,
   layout::inline::ShapedRun,
   pixmap_ref_from_buffer, render_mask,
-  resources::glyph::{ResolvedColorLayer, ResolvedGlyph},
+  resources::{
+    glyph::{ResolvedColorLayer, ResolvedGlyph},
+    glyph_cache::GlyphCache,
+  },
   style::{Affine, BlendMode, Color, ImageScalingAlgorithm},
 };
 
-pub(crate) type GlyphMaskCache = HashMap<u64, (Vec<u8>, Placement)>;
-
-const GLYPH_MASK_CACHE_MAX_ENTRIES: usize = 4096;
+pub(crate) type GlyphMaskCache = GlyphCache<(Vec<u8>, Placement)>;
 
 thread_local! {
-  static SHARED_GLYPH_MASK_CACHE: RefCell<GlyphMaskCache> = RefCell::new(HashMap::new());
+  static SHARED_GLYPH_MASK_CACHE: RefCell<GlyphMaskCache> = RefCell::new(GlyphCache::default());
+}
+
+/// Ages this thread's mask cache by one render.
+pub(crate) fn begin_glyph_mask_render() {
+  SHARED_GLYPH_MASK_CACHE.with(|c| {
+    if let Ok(mut cache) = c.try_borrow_mut() {
+      cache.begin_render();
+    }
+  });
 }
 
 pub(crate) fn with_shared_glyph_cache<R>(f: impl FnOnce(&mut GlyphMaskCache) -> R) -> R {
   SHARED_GLYPH_MASK_CACHE.with(|c| match c.try_borrow_mut() {
-    Ok(mut cache) => {
-      if cache.len() > GLYPH_MASK_CACHE_MAX_ENTRIES {
-        cache.clear();
-      }
-      f(&mut cache)
-    }
-    Err(_) => {
-      let mut local = HashMap::new();
-      f(&mut local)
-    }
+    Ok(mut cache) => f(&mut cache),
+    Err(_) => f(&mut GlyphCache::default()),
   })
 }
 
@@ -63,13 +65,25 @@ fn draw_outline_with_cache(
     return;
   };
   with_shared_glyph_cache(|cache| {
-    let (cached_mask, cached_placement) = cache.entry(key).or_insert_with(|| {
-      let bucket_x = (key & 3) as f32 * 0.25;
-      let cache_transform = Affine::translation(bucket_x, 0.0);
-      render_mask(paths, Some(cache_transform), None, &mut canvas.buffer_pool)
-    });
-    let placement = cached_placement.translate(int_x, int_y);
-    canvas.draw_mask(cached_mask, placement, color, BlendMode::Normal);
+    if let Some((mask, cached_placement)) = cache.get(key) {
+      let placement = cached_placement.translate(int_x, int_y);
+      canvas.draw_mask(mask, placement, color, BlendMode::Normal);
+      return;
+    }
+
+    let bucket_x = (key & 3) as f32 * 0.25;
+    let cache_transform = Affine::translation(bucket_x, 0.0);
+    let (mask, cached_placement) =
+      render_mask(paths, Some(cache_transform), None, &mut canvas.buffer_pool);
+    canvas.draw_mask(
+      &mask,
+      cached_placement.translate(int_x, int_y),
+      color,
+      BlendMode::Normal,
+    );
+
+    let bytes = mask.len() + 64;
+    cache.insert(key, (mask, cached_placement), bytes);
   });
 }
 
@@ -224,25 +238,37 @@ pub(crate) fn draw_glyph_clip_image(
         glyph_cache_key_and_offset(transform, outline.cache_signature())
       {
         with_shared_glyph_cache(|cache| {
-          let (cached_mask, cached_placement) = cache.entry(key).or_insert_with(|| {
-            let bucket_x = (key & 3) as f32 * 0.25;
-            let cache_transform = Affine::translation(bucket_x, 0.0);
-            render_mask(
-              outline.paths(),
-              Some(cache_transform),
-              None,
-              &mut canvas.buffer_pool,
-            )
-          });
-          let placement = cached_placement.translate(int_x, int_y);
+          if let Some((mask, cached_placement)) = cache.get(key) {
+            canvas.composite_mask_source(
+              mask,
+              cached_placement.translate(int_x, int_y),
+              clip_image,
+              MaskCompositeColor::SourceOnly,
+              sampling,
+              BlendMode::Normal,
+            );
+            return;
+          }
+
+          let bucket_x = (key & 3) as f32 * 0.25;
+          let cache_transform = Affine::translation(bucket_x, 0.0);
+          let (mask, cached_placement) = render_mask(
+            outline.paths(),
+            Some(cache_transform),
+            None,
+            &mut canvas.buffer_pool,
+          );
           canvas.composite_mask_source(
-            cached_mask,
-            placement,
+            &mask,
+            cached_placement.translate(int_x, int_y),
             clip_image,
             MaskCompositeColor::SourceOnly,
             sampling,
             BlendMode::Normal,
           );
+
+          let bytes = mask.len() + 64;
+          cache.insert(key, (mask, cached_placement), bytes);
         });
       } else {
         let (mask, placement) = render_mask(

--- a/takumi/tests/memory_retention.rs
+++ b/takumi/tests/memory_retention.rs
@@ -1,0 +1,126 @@
+//! Renders the same content repeatedly and asserts live heap bytes stay flat,
+//! so cache-budget regressions and allocator-retention bugs fail a test
+//! instead of surfacing as server memory growth.
+
+mod test_utils;
+
+use std::{
+  alloc::{GlobalAlloc, Layout, System},
+  collections::HashMap,
+  sync::{
+    Arc,
+    atomic::{AtomicIsize, Ordering},
+  },
+};
+
+use takumi::{
+  prelude::{Length::*, *},
+  render,
+};
+use takumi_core::resources::{image::ResourceCache, image_buffer::ImageBuffer};
+use test_utils::{CONTEXT, create_test_viewport};
+
+struct CountingAllocator;
+
+static LIVE_BYTES: AtomicIsize = AtomicIsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    LIVE_BYTES.fetch_add(layout.size() as isize, Ordering::Relaxed);
+    unsafe { System.alloc(layout) }
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    LIVE_BYTES.fetch_sub(layout.size() as isize, Ordering::Relaxed);
+    unsafe { System.dealloc(ptr, layout) }
+  }
+
+  unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+    LIVE_BYTES.fetch_add(
+      new_size as isize - layout.size() as isize,
+      Ordering::Relaxed,
+    );
+    unsafe { System.realloc(ptr, layout, new_size) }
+  }
+
+  unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+    LIVE_BYTES.fetch_add(layout.size() as isize, Ordering::Relaxed);
+    unsafe { System.alloc_zeroed(layout) }
+  }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const CSS: &str = ".card { background-color: #1e293b; border-radius: 12px; padding: 24px; }";
+
+const SVG_LOGO: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><circle cx="24" cy="24" r="20" fill="#38bdf8"/></svg>"##;
+
+fn content() -> Node {
+  Node::container([
+    Node::image("logo.svg"),
+    Node::image("photo.png"),
+    Node::text("Retention check 記憶體迴歸 0123456789")
+      .with_style(Style::default().with(StyleDeclaration::font_size(FontSize::Length(Px(32.0))))),
+  ])
+  .with_class_name("card")
+  .with_style(Style::default().with(StyleDeclaration::display(Display::Flex)))
+}
+
+fn render_once(cache: &ResourceCache, photo_png: &[u8]) {
+  let images: HashMap<Arc<str>, ImageSource> = [
+    (
+      Arc::from("logo.svg"),
+      cache
+        .get_or_decode(SVG_LOGO.as_bytes(), ImageCacheMode::Auto)
+        .unwrap(),
+    ),
+    (
+      Arc::from("photo.png"),
+      cache
+        .get_or_decode(photo_png, ImageCacheMode::Auto)
+        .unwrap(),
+    ),
+  ]
+  .into();
+
+  let options = RenderOptions::builder()
+    .viewport(create_test_viewport())
+    .node(content())
+    .fonts(&CONTEXT)
+    .images(images)
+    .stylesheet(cache.get_or_parse_stylesheet(vec![CSS.to_string()]))
+    .build();
+
+  render(options).unwrap();
+}
+
+/// Warm caches with a few renders, then assert many more renders leave live
+/// heap bytes where the warmup put them (small slack for allocator noise).
+#[test]
+fn repeated_renders_keep_live_bytes_flat() {
+  const WARMUP_RENDERS: usize = 20;
+  const MEASURED_RENDERS: usize = 180;
+  const SLACK_BYTES: isize = 4 << 20;
+
+  let photo_png = ImageBuffer::from_rgba_bytes(vec![128; 256 * 256 * 4], 256, 256)
+    .unwrap()
+    .encode_png()
+    .unwrap();
+  let cache = ResourceCache::default();
+
+  for _ in 0..WARMUP_RENDERS {
+    render_once(&cache, &photo_png);
+  }
+  let baseline = LIVE_BYTES.load(Ordering::Relaxed);
+
+  for _ in 0..MEASURED_RENDERS {
+    render_once(&cache, &photo_png);
+  }
+  let settled = LIVE_BYTES.load(Ordering::Relaxed);
+
+  assert!(
+    settled <= baseline + SLACK_BYTES,
+    "live bytes grew from {baseline} to {settled} over {MEASURED_RENDERS} renders"
+  );
+}


### PR DESCRIPTION
## Why

Stacked on #1004. The resolved-glyph cache (core) and the glyph-mask cache (raster) were thread-local maps capped at 4096 entries each. Per-entry size was unweighted, so a color-glyph layer counted the same as a tiny mask; the cap multiplied by worker-thread count; and overflow flushed the whole map, making hot glyphs pay the rebuild cost on the next render. These were the largest retention surfaces invisible to any budget.

## What

- New `takumi_core::resources::glyph_cache`: a thread-local `GlyphCache` whose entries charge a process-wide `AtomicUsize` byte line, 8 MiB by default, tunable via `set_glyph_cache_max_bytes` (Rust-only; deliberately not exposed to JS). Hits stay a plain `HashMap` read with zero atomics; only insert and evict touch the counter.
- Eviction is a generation sweep instead of flush-all: each render ages the cache, and going over budget drops entries no recent render touched. Only when everything is fresh does it fall back to clearing the map.
- Both glyph caches move onto it; the 4096-entry caps are gone.
- New retention test (`takumi/tests/memory_retention.rs`): a counting global allocator renders the same content 200 times through the resource cache and asserts live heap bytes stay flat after warmup. This is the regression net for the #889 class of reports.

Pixel output is unchanged: 295 tests across 10 suites pass with zero `.svg`/`.webp` diff. Clippy clean, core suite 725.

The glyph path is hot, so this wants the napi JS bench before merge — hits are unchanged (one extra `u32` store), but worth confirming on CI numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared, configurable glyph-cache byte budget (default 8 MiB) to better control memory usage.
  * Implemented byte-aware glyph and glyph-mask caching to improve cache efficiency.
* **Bug Fixes**
  * Reduced memory growth during repeated rendering via cost-based eviction of older, unused entries.
  * Improved rendering stability when caches are under concurrent access.
  * Ensured glyph-mask rendering initialization occurs before rasterization.
* **Tests**
  * Added memory retention coverage to detect budget regressions and validate eviction behavior.
* **Documentation**
  * Updated glyph-cache budgeting documentation, configuration details, and related version notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->