### PR TITLE
Core: share one path-builder helper between layout and raster

### DIFF
--- a/.tegami/dedup-path-helpers.md
+++ b/.tegami/dedup-path-helpers.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Share one path-builder helper between layout and raster
+
+`takumi-core` and `takumi-raster` each kept a private single-impl trait wrapping `Vec<PathCommand>` pushes (`BorderPath`, `PathBuilder`), plus two more one-method traits that existed only for method-call syntax. The push sugar now lives once as `takumi_core::geometry::PathBuilder`; the raster-only ellipse helper becomes a free `push_ellipse`, SVG path strings parse through `parse_svg_path_segments` directly, and border rasterization is a free `paint_border` instead of a trait method. Rendered output is unchanged.

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -352,6 +352,41 @@ pub enum PathCommand {
   Close,
 }
 
+/// Push-style sugar over a [`PathCommand`] list, shared by the geometry and
+/// rasterization path builders.
+pub trait PathBuilder {
+  /// Starts a new subpath at the given point.
+  fn move_to(&mut self, point: (f32, f32));
+  /// Draws a line to the given point.
+  fn line_to(&mut self, point: (f32, f32));
+  /// Draws a cubic Bezier curve through the two control points to the end point.
+  fn curve_to(&mut self, p1: (f32, f32), p2: (f32, f32), p3: (f32, f32));
+  /// Closes the current subpath.
+  fn close(&mut self);
+}
+
+impl PathBuilder for Vec<PathCommand> {
+  fn move_to(&mut self, point: (f32, f32)) {
+    self.push(PathCommand::MoveTo(Point::new(point.0, point.1)));
+  }
+
+  fn line_to(&mut self, point: (f32, f32)) {
+    self.push(PathCommand::LineTo(Point::new(point.0, point.1)));
+  }
+
+  fn curve_to(&mut self, p1: (f32, f32), p2: (f32, f32), p3: (f32, f32)) {
+    self.push(PathCommand::CubicTo(
+      Point::new(p1.0, p1.1),
+      Point::new(p2.0, p2.1),
+      Point::new(p3.0, p3.1),
+    ));
+  }
+
+  fn close(&mut self) {
+    self.push(PathCommand::Close);
+  }
+}
+
 /// Transforms a rect's four corners and returns the axis-aligned `(min_x, min_y,
 /// max_x, max_y)` extents, or `None` if any corner is non-finite.
 pub fn transformed_rect_extents(

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -2,7 +2,7 @@ use std::f32::consts::{PI, SQRT_2};
 
 use crate::{
   context::RenderContext,
-  geometry::{PathCommand as Command, Point, Rect, Size},
+  geometry::{PathBuilder, PathCommand as Command, Point, Rect, Size},
   style::{BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},
 };
 
@@ -17,35 +17,6 @@ pub enum BorderSide {
   Bottom,
   /// Left side.
   Left,
-}
-
-pub(crate) trait BorderPath {
-  fn move_to(&mut self, point: (f32, f32));
-  fn line_to(&mut self, point: (f32, f32));
-  fn curve_to(&mut self, p1: (f32, f32), p2: (f32, f32), p3: (f32, f32));
-  fn close(&mut self);
-}
-
-impl BorderPath for Vec<Command> {
-  fn move_to(&mut self, point: (f32, f32)) {
-    self.push(Command::MoveTo(Point::new(point.0, point.1)));
-  }
-
-  fn line_to(&mut self, point: (f32, f32)) {
-    self.push(Command::LineTo(Point::new(point.0, point.1)));
-  }
-
-  fn curve_to(&mut self, p1: (f32, f32), p2: (f32, f32), p3: (f32, f32)) {
-    self.push(Command::CubicTo(
-      Point::new(p1.0, p1.1),
-      Point::new(p2.0, p2.1),
-      Point::new(p3.0, p3.1),
-    ));
-  }
-
-  fn close(&mut self) {
-    self.push(Command::Close);
-  }
 }
 
 /// Represents the properties of a border, including corner radii and drawing metadata.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -9,8 +9,8 @@ use skrifa::{FontRef, MetadataProvider};
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{AvailableSpace, ComputedLayout, PathCommand, Point, Rect, Size},
-  layout::{border::BorderPath, node::Node, tree::RenderNode},
+  geometry::{AvailableSpace, ComputedLayout, PathBuilder, PathCommand, Point, Rect, Size},
+  layout::{node::Node, tree::RenderNode},
   resources::{
     font::FontError,
     glyph::{ResolvedColorLayer, ResolvedGlyph, ResolvedOutlineGlyph},

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -9,10 +9,10 @@ use tiny_skia::{
 };
 
 use crate::{
-  BorderProperties, Command, Fill, PathBuilder, PathData, Placement, RenderContext, Result, Style,
+  BorderProperties, Command, Fill, PathBuilder, Placement, RenderContext, Result, Style,
   build_path,
   canvas::BufferPool,
-  create_mask, fast_div_255, scale_commands,
+  create_mask, fast_div_255, parse_svg_path_segments, push_ellipse, scale_commands,
   style::{
     Affine, Axis, BasicShape, BorderStyle, Color, ComputedStyle, FillRule, ImageScalingAlgorithm,
     Overflow, ShapeRadius, Sides, SizingContext, SpacePair,
@@ -654,7 +654,8 @@ pub(crate) fn render_clip_shape_mask(
         height: shape.position.0.y.to_px(&context.sizing, size.height),
       };
 
-      paths.add_ellipse(
+      push_ellipse(
+        &mut paths,
         (distance.width, distance.height),
         resolve_radius(shape.radius_x, distance, &context.sizing, size.width),
         resolve_radius(shape.radius_y, distance, &context.sizing, size.height),
@@ -680,7 +681,10 @@ pub(crate) fn render_clip_shape_mask(
     BasicShape::Path(shape) => {
       // path() coords are CSS px; scale to device space like the to_px shapes.
       let scale = context.sizing.to_device(1.0);
-      paths.extend(scale_commands(shape.path.as_ref().commands(), scale));
+      paths.extend(scale_commands(
+        parse_svg_path_segments(shape.path.as_ref()).unwrap_or_default(),
+        scale,
+      ));
     }
     _ => {}
   }

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -13,85 +13,73 @@ use crate::{
 };
 
 /// Canvas-backed rasterization of [`BorderProperties`].
-pub(crate) trait BorderPainting {
-  fn draw(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-  );
-}
+pub(crate) fn paint_border(
+  properties: BorderProperties,
+  canvas: &mut Canvas,
+  border_box: Size<f32>,
+  transform: Affine,
+  clip_image: Option<PaintSource<'_>>,
+) {
+  if let Some(clip_image) = &clip_image {
+    assert_eq!(
+      (clip_image.width(), clip_image.height()),
+      (border_box.width as u32, border_box.height as u32),
+    );
+  }
 
-impl BorderPainting for BorderProperties {
-  fn draw(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-  ) {
-    if let Some(clip_image) = &clip_image {
-      assert_eq!(
-        (clip_image.width(), clip_image.height()),
-        (border_box.width as u32, border_box.height as u32),
-      );
+  if !properties.has_visible_sides() {
+    return;
+  }
+
+  if properties.draw_uniform_fast_path(canvas, border_box, transform, clip_image) {
+    return;
+  }
+
+  let inverse = if clip_image.is_some() {
+    transform.invert()
+  } else {
+    None
+  };
+  let mut paint = SidePaintContext {
+    canvas,
+    transform,
+    clip_image,
+    inverse,
+  };
+
+  let mut border = properties;
+  border.width = properties.visible_side_widths();
+
+  for (side, style, width, color) in [
+    (
+      BorderSide::Top,
+      border.style.top,
+      border.width.top,
+      border.color.top,
+    ),
+    (
+      BorderSide::Right,
+      border.style.right,
+      border.width.right,
+      border.color.right,
+    ),
+    (
+      BorderSide::Bottom,
+      border.style.bottom,
+      border.width.bottom,
+      border.color.bottom,
+    ),
+    (
+      BorderSide::Left,
+      border.style.left,
+      border.width.left,
+      border.color.left,
+    ),
+  ] {
+    if !BorderProperties::is_side_visible(style, width) {
+      continue;
     }
-
-    if !self.has_visible_sides() {
-      return;
-    }
-
-    if self.draw_uniform_fast_path(canvas, border_box, transform, clip_image) {
-      return;
-    }
-
-    let inverse = if clip_image.is_some() {
-      transform.invert()
-    } else {
-      None
-    };
-    let mut paint = SidePaintContext {
-      canvas,
-      transform,
-      clip_image,
-      inverse,
-    };
-
-    let mut border = self;
-    border.width = self.visible_side_widths();
-
-    for (side, style, width, color) in [
-      (
-        BorderSide::Top,
-        border.style.top,
-        border.width.top,
-        border.color.top,
-      ),
-      (
-        BorderSide::Right,
-        border.style.right,
-        border.width.right,
-        border.color.right,
-      ),
-      (
-        BorderSide::Bottom,
-        border.style.bottom,
-        border.width.bottom,
-        border.color.bottom,
-      ),
-      (
-        BorderSide::Left,
-        border.style.left,
-        border.width.left,
-        border.color.left,
-      ),
-    ] {
-      if !BorderProperties::is_side_visible(style, width) {
-        continue;
-      }
-      border.draw_visible_side(&mut paint, side, border_box, style, color);
-    }
+    border.draw_visible_side(&mut paint, side, border_box, style, color);
   }
 }
 
@@ -653,7 +641,7 @@ mod tests {
     style::{Affine, BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},
   };
 
-  use super::{BorderPainting, Cap, compute_side_stroke};
+  use super::{Cap, compute_side_stroke, paint_border};
   use crate::Canvas;
 
   fn test_border(style: BorderStyle, width: f32) -> BorderProperties {
@@ -688,7 +676,8 @@ mod tests {
       height: 48,
     });
 
-    test_border(BorderStyle::Solid, 4.0).draw(
+    paint_border(
+      test_border(BorderStyle::Solid, 4.0),
       &mut canvas,
       Size {
         width: 48.0,
@@ -711,7 +700,8 @@ mod tests {
       height: 24,
     });
 
-    test_border(BorderStyle::Hidden, 4.0).draw(
+    paint_border(
+      test_border(BorderStyle::Hidden, 4.0),
       &mut canvas,
       Size {
         width: 24.0,
@@ -734,7 +724,8 @@ mod tests {
       height: 48,
     });
 
-    test_border(BorderStyle::Dashed, 4.0).draw(
+    paint_border(
+      test_border(BorderStyle::Dashed, 4.0),
       &mut canvas,
       Size {
         width: 48.0,
@@ -768,7 +759,8 @@ mod tests {
       height: 48,
     });
 
-    test_border(BorderStyle::Dotted, 4.0).draw(
+    paint_border(
+      test_border(BorderStyle::Dotted, 4.0),
       &mut canvas,
       Size {
         width: 48.0,
@@ -813,7 +805,8 @@ mod tests {
     let mut border = test_border(BorderStyle::Dashed, 0.0);
     border.width.top = 4.0;
 
-    border.draw(
+    paint_border(
+      border,
       &mut canvas,
       Size {
         width: 48.0,
@@ -862,7 +855,8 @@ mod tests {
     let mut border = test_border(BorderStyle::Dotted, 0.0);
     border.width.left = 4.0;
 
-    border.draw(
+    paint_border(
+      border,
       &mut canvas,
       Size {
         width: 48.0,
@@ -911,7 +905,8 @@ mod tests {
     let mut border = test_border(BorderStyle::Solid, 4.0);
     border.style.top = BorderStyle::Hidden;
 
-    border.draw(
+    paint_border(
+      border,
       &mut canvas,
       Size {
         width: 48.0,
@@ -946,7 +941,8 @@ mod tests {
     let mut border = test_border(BorderStyle::Double, 6.0);
     border.style.top = BorderStyle::Hidden;
 
-    border.draw(
+    paint_border(
+      border,
       &mut canvas,
       Size {
         width: 48.0,
@@ -985,7 +981,8 @@ mod tests {
     border.width.right = 8.0;
     border.width.left = 24.0;
 
-    border.draw(
+    paint_border(
+      border,
       &mut canvas,
       Size {
         width: 64.0,
@@ -1018,7 +1015,8 @@ mod tests {
     });
     let border = test_border(BorderStyle::Solid, 40.0);
 
-    border.draw(
+    paint_border(
+      border,
       &mut canvas,
       Size {
         width: 20.0,

--- a/takumi-raster/src/debug_drawing.rs
+++ b/takumi-raster/src/debug_drawing.rs
@@ -1,31 +1,32 @@
 use takumi_core::geometry::ComputedLayout as Layout;
 
 use crate::{
-  BorderPainting, BorderProperties, Canvas,
+  BorderProperties, Canvas, paint_border,
   style::{Affine, BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair},
 };
 
 /// Draws debug borders around the node's layout areas.
 pub(crate) fn draw_debug_border(canvas: &mut Canvas, layout: Layout, transform: Affine) {
   // border-box
-  BorderProperties {
+  let border_box = BorderProperties {
     width: Sides([1.0; 4]).into(),
     color: Sides([Color([255, 0, 0, 255]); 4]).into(), // red
     radius: Sides([SpacePair::from_single(0.0); 4]),
     image_rendering: ImageScalingAlgorithm::Auto,
     style: Sides([BorderStyle::Solid; 4]).into(),
-  }
-  .draw(canvas, layout.size, transform, None);
+  };
+  paint_border(border_box, canvas, layout.size, transform, None);
 
   // content-box
-  BorderProperties {
+  let content_box = BorderProperties {
     width: Sides([1.0; 4]).into(),
     color: Sides([Color([0, 255, 0, 255]); 4]).into(), // green
     radius: Sides([SpacePair::from_single(0.0); 4]),
     image_rendering: ImageScalingAlgorithm::Auto,
     style: Sides([BorderStyle::Solid; 4]).into(),
-  }
-  .draw(
+  };
+  paint_border(
+    content_box,
     canvas,
     layout.content_box_size(),
     transform

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -10,10 +10,10 @@ use takumi_core::{
 };
 
 use super::{
-  BackgroundTile, BorderPainting, BorderProperties, Canvas, Fill, PaintSource, RenderContext,
-  SizedFontStyle, SizedShadow, TileLayer, collect_background_layers, draw_image,
-  draw_inset_shadow_to_canvas, draw_outset_shadow, inline_drawing::draw_inline_layout,
-  rasterize_layers, release_rasterized_background_tile,
+  BackgroundTile, BorderProperties, Canvas, Fill, PaintSource, RenderContext, SizedFontStyle,
+  SizedShadow, TileLayer, collect_background_layers, draw_image, draw_inset_shadow_to_canvas,
+  draw_outset_shadow, inline_drawing::draw_inline_layout, paint_border, rasterize_layers,
+  release_rasterized_background_tile,
 };
 use crate::{
   Result,
@@ -240,7 +240,8 @@ pub(crate) fn draw_border(
     None
   };
 
-  BorderProperties::from_context(context, layout.size, layout.border).draw(
+  paint_border(
+    BorderProperties::from_context(context, layout.size, layout.border),
     canvas,
     layout.size,
     context.transform,
@@ -261,7 +262,7 @@ pub(crate) fn draw_outline(
   let outline = outline_geometry(context, layout.size);
   let transform = Affine::translation(-outline.grow, -outline.grow) * context.transform;
 
-  outline.border.draw(canvas, outline.size, transform, None);
+  paint_border(outline.border, canvas, outline.size, transform, None);
 
   Ok(())
 }

--- a/takumi-raster/src/path.rs
+++ b/takumi-raster/src/path.rs
@@ -221,51 +221,28 @@ fn from_tiny(segment: TinyPathSegment) -> Command {
   }
 }
 
-pub(crate) trait PathBuilder {
-  fn move_to(&mut self, point: (f32, f32));
-  fn line_to(&mut self, point: (f32, f32));
-  fn close(&mut self);
-  fn add_ellipse(&mut self, center: (f32, f32), radius_x: f32, radius_y: f32);
-}
+pub(crate) use takumi_core::geometry::PathBuilder;
 
-impl PathBuilder for Vec<Command> {
-  fn move_to(&mut self, point: (f32, f32)) {
-    self.push(Command::MoveTo(Point::new(point.0, point.1)));
-  }
+/// Appends an axis-aligned ellipse outline to `commands`.
+pub(crate) fn push_ellipse(
+  commands: &mut Vec<Command>,
+  center: (f32, f32),
+  radius_x: f32,
+  radius_y: f32,
+) {
+  let Some(rect) = TinyRect::from_ltrb(
+    center.0 - radius_x,
+    center.1 - radius_y,
+    center.0 + radius_x,
+    center.1 + radius_y,
+  ) else {
+    return;
+  };
 
-  fn line_to(&mut self, point: (f32, f32)) {
-    self.push(Command::LineTo(Point::new(point.0, point.1)));
-  }
-
-  fn close(&mut self) {
-    self.push(Command::Close);
-  }
-
-  fn add_ellipse(&mut self, center: (f32, f32), radius_x: f32, radius_y: f32) {
-    let Some(rect) = TinyRect::from_ltrb(
-      center.0 - radius_x,
-      center.1 - radius_y,
-      center.0 + radius_x,
-      center.1 + radius_y,
-    ) else {
-      return;
-    };
-
-    let mut builder = TinyPathBuilder::new();
-    builder.push_oval(rect);
-    if let Some(path) = builder.finish() {
-      self.extend(path.segments().map(from_tiny));
-    }
-  }
-}
-
-pub(crate) trait PathData {
-  fn commands(&self) -> Vec<Command>;
-}
-
-impl PathData for str {
-  fn commands(&self) -> Vec<Command> {
-    parse_svg_path_segments(self).unwrap_or_default()
+  let mut builder = TinyPathBuilder::new();
+  builder.push_oval(rect);
+  if let Some(path) = builder.finish() {
+    commands.extend(path.segments().map(from_tiny));
   }
 }
 
@@ -303,7 +280,7 @@ pub(crate) fn build_path(commands: &[Command]) -> Option<TinyPath> {
   builder.finish()
 }
 
-fn parse_svg_path_segments(input: &str) -> Option<Vec<Command>> {
+pub(crate) fn parse_svg_path_segments(input: &str) -> Option<Vec<Command>> {
   let mut commands = Vec::new();
 
   for segment in SimplifyingPathParser::from(input) {


### PR DESCRIPTION
## Why

Ponytail sweep findings: two crates each maintained a near-identical private trait wrapping `Vec<PathCommand>` pushes (`BorderPath` in core, `PathBuilder` in raster), and two more single-impl traits existed only to buy method-call syntax (`PathData for str`, `BorderPainting for BorderProperties`).

## What

- The push sugar lives once as `takumi_core::geometry::PathBuilder` (move/line/curve/close), used by core border geometry, inline decoration, and raster masks. Raster re-exports it, so internal call sites read the same.
- `add_ellipse` becomes a free `push_ellipse`; the one `PathData` call site calls `parse_svg_path_segments` directly.
- `BorderPainting` becomes a free `paint_border(properties, canvas, …)`; `debug_drawing`, `node_paint`, and the border tests call it directly. The private six-method `BorderRasterization` extension trait stays: it is the idiomatic way to hang raster helpers off a core type, and flattening it buys nothing.
- Skipped the two weak findings from the sweep: `FromHtml` is shipped public API (deleting is breaking for sugar-only gain) and `MatchableNode` documents a deliberate seam isolating `matching` from the selectors crate.
- Workspace clippy (including wasm32) is clean.

Verified: core 722 tests, umbrella 294 golden fixtures, zero `.svg`/`.webp` diff — rendered output unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved rendered output while consolidating path construction and border rendering.
  * Improved SVG path handling for clipped shapes and masks.
  * Maintained consistent ellipse, border, outline, and debug-border rendering.

* **Documentation**
  * Added documentation describing the path and border rendering updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->