### PR TITLE
Tests: add malformed binary input coverage at binding boundaries

### DIFF
--- a/takumi-napi/tests/binary-inputs.test.ts
+++ b/takumi-napi/tests/binary-inputs.test.ts
@@ -25,6 +25,60 @@ const imageNode = container({
   ],
 });
 
+const recoveryNode = container({ style: { width: 8, height: 8, backgroundColor: "black" } });
+
+const withImageBytes = (data: Uint8Array) =>
+  container({
+    style: { width: 64, height: 64 },
+    children: [image({ src: data, width: 64, height: 64 })],
+  });
+
+// Undecodable image sources are skipped at paint like a browser's broken
+// image, so renders complete instead of rejecting; these cases pin that no
+// input aborts the process and the renderer stays usable afterwards.
+describe("malformed binary inputs", () => {
+  const renderer = new Renderer();
+
+  const expectRecovery = async () => {
+    const recovered = await renderer.render(recoveryNode, { width: 8, height: 8 });
+    expect(recovered).toBeInstanceOf(Buffer);
+  };
+
+  test("corrupt PNG bytes render without crashing", async () => {
+    const corrupt = new Uint8Array(72);
+    corrupt.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    for (let i = 8; i < corrupt.length; i++) {
+      corrupt[i] = (i * 37) % 256;
+    }
+
+    const result = await renderer.render(withImageBytes(corrupt), { width: 64, height: 64 });
+    expect(result).toBeInstanceOf(Buffer);
+    await expectRecovery();
+  });
+
+  test("truncated font rejects", async () => {
+    await expect(renderer.registerFont(fontArrayBuffer.slice(0, 100))).rejects.toThrow();
+    await expectRecovery();
+  });
+
+  test("malformed inline SVG bytes render without crashing", async () => {
+    const bytes = new TextEncoder().encode("<svg garbage");
+
+    const result = await renderer.render(withImageBytes(bytes), { width: 64, height: 64 });
+    expect(result).toBeInstanceOf(Buffer);
+    await expectRecovery();
+  });
+
+  test("truncated GIF bytes render without crashing", async () => {
+    const truncated = new Uint8Array(16);
+    truncated.set(new TextEncoder().encode("GIF89a"));
+
+    const result = await renderer.render(withImageBytes(truncated), { width: 64, height: 64 });
+    expect(result).toBeInstanceOf(Buffer);
+    await expectRecovery();
+  });
+});
+
 describe("binary inputs", () => {
   test("registerFont accepts Buffer, Uint8Array, and ArrayBuffer", async () => {
     const renderer = new Renderer();

--- a/takumi-wasm/tests/binary-inputs.test.ts
+++ b/takumi-wasm/tests/binary-inputs.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { container, image } from "@takumi-rs/helpers";
+import { Renderer } from "../bundlers/node";
+
+const fontPath = join(
+  import.meta.dir,
+  "../../assets/fonts/manrope/manrope-latin-wght-normal.woff2",
+);
+const font = await readFile(fontPath);
+
+const renderer = new Renderer();
+
+afterAll(() => {
+  renderer.free();
+});
+
+const recoveryNode = container({ style: { width: 8, height: 8, backgroundColor: "black" } });
+
+const withImageBytes = (data: Uint8Array) =>
+  container({
+    style: { width: 64, height: 64 },
+    children: [image({ src: data, width: 64, height: 64 })],
+  });
+
+// Undecodable image sources are skipped at paint like a browser's broken
+// image, so renders complete instead of rejecting; these cases pin that no
+// input traps the wasm instance and the renderer stays usable afterwards.
+describe("malformed binary inputs", () => {
+  const expectRecovery = async () => {
+    const recovered = await renderer.render(recoveryNode, { width: 8, height: 8 });
+    expect(recovered).toBeInstanceOf(Uint8Array);
+  };
+
+  test("corrupt PNG bytes render without crashing", async () => {
+    const corrupt = new Uint8Array(72);
+    corrupt.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    for (let i = 8; i < corrupt.length; i++) {
+      corrupt[i] = (i * 37) % 256;
+    }
+
+    const result = await renderer.render(withImageBytes(corrupt), { width: 64, height: 64 });
+    expect(result).toBeInstanceOf(Uint8Array);
+    await expectRecovery();
+  });
+
+  test("truncated font rejects", async () => {
+    await expect(renderer.registerFont(font.subarray(0, 100))).rejects.toThrow();
+    await expectRecovery();
+  });
+
+  test("malformed inline SVG bytes render without crashing", async () => {
+    const bytes = new TextEncoder().encode("<svg garbage");
+
+    const result = await renderer.render(withImageBytes(bytes), { width: 64, height: 64 });
+    expect(result).toBeInstanceOf(Uint8Array);
+    await expectRecovery();
+  });
+
+  test("truncated GIF bytes render without crashing", async () => {
+    const truncated = new Uint8Array(16);
+    truncated.set(new TextEncoder().encode("GIF89a"));
+
+    const result = await renderer.render(withImageBytes(truncated), { width: 64, height: 64 });
+    expect(result).toBeInstanceOf(Uint8Array);
+    await expectRecovery();
+  });
+});


### PR DESCRIPTION
## Why
Nothing asserted what corrupt caller bytes do at the napi/wasm boundaries. This suite is the regression net for the upcoming panic-strategy change to the napi artifacts.

## What
Adds a malformed-input block to both bindings: corrupt PNG, truncated font, malformed inline SVG bytes, truncated GIF, each followed by a recovery render on the same `Renderer`.

One finding worth a decision: undecodable image sources do not reject — measure and paint both skip them (`takumi-core/src/layout/node/image.rs:54`, `takumi-raster/src/node_paint.rs:321`), like a browser's broken image. The tests pin that behavior (render completes, process survives, renderer stays usable); only the truncated font rejects. If a bad image source should be a hard error instead, that's a separate behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for malformed PNG, SVG, GIF, and font binary inputs.
  * Verified invalid data is handled without crashing the renderer.
  * Confirmed the renderer remains usable for subsequent rendering after invalid input errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->