### PR TITLE
Helpers: enforce allowUrl on every redirect hop

### DIFF
--- a/.tegami/allowurl-redirect-hops.md
+++ b/.tegami/allowurl-redirect-hops.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "@takumi-rs/helpers": patch
+---
+
+### Enforce allowUrl on every redirect hop
+
+`fetchOk` with an `allowUrl` policy now follows redirects manually (capped at 5 hops) and re-checks the resolved target of each hop, so an allowed URL can no longer redirect to a blocked address. Callers without a policy keep default redirect handling.

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -51,7 +51,7 @@ const image = await render(element, {
 });
 ```
 
-`allowUrl` only filters the URL string. Redirects and DNS are not inspected; keep a custom `fetch` for a stricter SSRF policy.
+`render()` and `ImageResponse` fetch these URLs from your server, so set an `allowUrl` allowlist whenever user input can influence the markup. The policy is checked on every redirect hop (capped at 5), so an allowed URL can't 3xx its way to an internal address. DNS is not inspected; keep a custom `fetch` for a stricter policy such as resolved-address filtering.
 
 ## Pre-fetched Images
 

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -59,6 +59,7 @@ async function followRedirectsWithPolicy(
       return response;
     }
 
+    await response.body?.cancel().catch(() => {});
     current = new URL(location, current).toString();
     if (!allowUrl(current)) {
       throw new Error(`URL blocked by allowUrl policy: ${current}`);

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 import type { Node } from "./types";
 
 const defaultFetchTimeout = 5000;
+const maxRedirectHops = 5;
 export const defaultMaxFetchBytes = 32 * 1024 * 1024;
 const cssUrlPattern = /url\(\s*(['"]?)(.*?)\1\s*\)/g;
 
@@ -33,11 +34,37 @@ export async function fetchOk(url: string, options: FetchOptions & { init?: Requ
     (s): s is AbortSignal => s !== undefined,
   );
   const signal = signals.length ? AbortSignal.any(signals) : undefined;
-  const response = await fetchImpl(url, { ...options.init, signal });
+  const init = { ...options.init, signal };
+  const response = options.allowUrl
+    ? await followRedirectsWithPolicy(url, options.allowUrl, fetchImpl, init)
+    : await fetchImpl(url, init);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} ${response.statusText} fetching ${url}`);
   }
   return response;
+}
+
+/** Follows redirects manually so `allowUrl` is enforced on every hop, not just the first URL. */
+async function followRedirectsWithPolicy(
+  url: string,
+  allowUrl: (url: string) => boolean,
+  fetchImpl: FetchLike,
+  init: RequestInit,
+): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop < maxRedirectHops; hop++) {
+    const response = await fetchImpl(current, { ...init, redirect: "manual" });
+    const location = response.headers.get("location");
+    if (response.status < 300 || response.status >= 400 || !location) {
+      return response;
+    }
+
+    current = new URL(location, current).toString();
+    if (!allowUrl(current)) {
+      throw new Error(`URL blocked by allowUrl policy: ${current}`);
+    }
+  }
+  throw new Error(`Too many redirects fetching ${url}`);
 }
 
 /** Reads a response body, rejecting once it exceeds `maxBytes` (by content-length or streamed size). */

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -70,6 +70,87 @@ describe("allowUrl policy", () => {
     ).rejects.toThrow(/blocked by allowUrl/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  const redirectTo = (location: string) =>
+    new Response(null, { status: 302, headers: { location } });
+
+  const routedFetch = (routes: Record<string, () => Response>) =>
+    mock((url: string) => {
+      const route = routes[url];
+      if (!route) {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      return Promise.resolve(route());
+    });
+
+  test("rejects a redirect to a disallowed url without fetching it", async () => {
+    const fetchMock = routedFetch({
+      "https://allowed.example.com/a.png": () => redirectTo("http://169.254.169.254/meta"),
+    });
+
+    await expect(
+      prepareImages({
+        node: tree("https://allowed.example.com/a.png"),
+        fetch: fetchMock,
+        allowUrl: (url) => url.startsWith("https://allowed.example.com/"),
+      }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("follows an allowed redirect chain and checks every hop", async () => {
+    const payload = new TextEncoder().encode("pixels");
+    const fetchMock = routedFetch({
+      "https://allowed.example.com/a.png": () => redirectTo("/b.png"),
+      "https://allowed.example.com/b.png": () => new Response(streamOf(payload)),
+    });
+    const checked: string[] = [];
+
+    const images = await prepareImages({
+      node: tree("https://allowed.example.com/a.png"),
+      fetch: fetchMock,
+      allowUrl: (url) => {
+        checked.push(url);
+        return url.startsWith("https://allowed.example.com/");
+      },
+    });
+
+    expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
+    expect(checked).toEqual([
+      "https://allowed.example.com/a.png",
+      "https://allowed.example.com/b.png",
+    ]);
+  });
+
+  test("rejects a redirect chain longer than the hop cap", async () => {
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(redirectTo(`${url.split("?")[0]}?hop=${Math.random()}`)),
+    );
+
+    await expect(
+      prepareImages({
+        node: tree("https://allowed.example.com/loop.png"),
+        fetch: fetchMock,
+        allowUrl: () => true,
+      }),
+    ).rejects.toThrow(/Too many redirects/);
+  });
+
+  test("without allowUrl a redirecting fetch keeps default handling", async () => {
+    const payload = new TextEncoder().encode("pixels");
+    const fetchMock = mock((_url: string, init?: RequestInit) => {
+      expect(init?.redirect).toBeUndefined();
+      return Promise.resolve(new Response(streamOf(payload)));
+    });
+
+    const images = await prepareImages({
+      node: tree("https://anywhere.example.com/a.png"),
+      fetch: fetchMock,
+    });
+
+    expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("default fetch timeout", () => {


### PR DESCRIPTION
## Why
`allowUrl` was checked once before the fetch, and the fetch followed redirects. An allowed URL answering with a 3xx to an internal address bypassed the policy entirely.

## What
With a policy set, `fetchOk` now fetches with `redirect: "manual"`, resolves each `location` against the hop URL, and re-checks `allowUrl` on every hop (capped at 5). Callers without `allowUrl` keep the single fetch with default redirect handling, byte-for-byte unchanged. Docs updated; tests cover blocked hop, allowed chain, relative location, hop cap, and the no-policy path.

Known limits left as-is: no default policy, and hostname allowlists remain subject to DNS rebinding since `fetch` never exposes the resolved address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced the URL allowlist on every HTTP redirect hop, preventing an allowed URL from 3xx-ing to a blocked destination.
  * Followed redirects manually with a cap of five hops to avoid redirect loops, while preserving the prior default redirect behavior when no allowlist is provided.

* **Documentation**
  * Clarified redirect-hop allowlist behavior, the five-hop limit, DNS considerations, and when custom fetch is required for stricter policies.

* **Tests**
  * Expanded redirect and allowlist coverage, including rejection on disallowed hops and “Too many redirects” errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->