### PR TITLE
CI: build napi artifacts with unwind panics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,9 +220,12 @@ jobs:
       - name: Build
         working-directory: takumi-napi
         env:
-          CARGO_UNSTABLE_BUILD_STD: std,panic_abort
+          CARGO_UNSTABLE_BUILD_STD: std
           CARGO_UNSTABLE_BUILD_STD_FEATURES: optimize_for_size
-          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zunstable-options -Cpanic=immediate-abort
+          # Unwind panics so napi-rs converts panics into catchable JS errors
+          # instead of aborting the host process.
+          CARGO_PROFILE_RELEASE_PANIC: unwind
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zunstable-options
         run: ${{ matrix.settings.build }} && bun build:js
 
       - name: Upload artifact

--- a/.tegami/napi-unwind-panics.md
+++ b/.tegami/napi-unwind-panics.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "@takumi-rs/core": patch
+---
+
+### Convert native panics into catchable errors instead of aborting the process
+
+The published napi artifacts are now built with unwind panics, so a Rust panic reached through malformed input surfaces as a JS error rather than killing the host process. Wasm keeps abort panics by design.


### PR DESCRIPTION
## Why
The release profile's `panic = "abort"` plus `-Cpanic=immediate-abort` means any panic reachable from malformed HTML, CSS, image, or font bytes aborts the whole Node process — one hostile request kills every in-flight request on a long-lived server. napi-rs wraps native calls in `catch_unwind`, but only unwind panics can be converted into catchable JS errors.

## What
The napi build step drops `-Cpanic=immediate-abort`, builds std without `panic_abort`, and overrides the workspace profile with `CARGO_PROFILE_RELEASE_PANIC: unwind`. The wasm step is untouched: a wasm panic traps and poisons the instance either way, and abort is part of its size budget. The malformed-input suite from #1008 is the regression net.

Binary size will grow some (landing pads, non-size-optimized std); worth comparing artifact sizes on this run before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed input errors in published native bindings now surface as catchable JavaScript errors instead of terminating the host process.

* **Documentation**
  * Documented panic behavior for native and WebAssembly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->