### PR TITLE
Core: skip empty declaration blocks and share one bloom filter in style matching

### DIFF
--- a/.tegami/matcher-cheap-wins.md
+++ b/.tegami/matcher-cheap-wins.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Cut wasted work in style matching
+
+`record_matches` no longer pushes entries for empty declaration blocks, and the per-node ancestor bloom filters (one multi-kilobyte copy per node) are replaced by a single counting filter walked along the DFS ancestor chain. Rendered output is unchanged.

--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -186,6 +186,22 @@ fn add_node_unique_hashes_to_filter<N: MatchableNode>(node: &N, filter: &mut Blo
   added
 }
 
+fn remove_node_unique_hashes_from_filter<N: MatchableNode>(node: &N, filter: &mut BloomFilter) {
+  if let Some(tag) = node.tag_name() {
+    filter.remove_hash(hash_ascii_case_insensitive(tag));
+  }
+
+  if let Some(id) = node.id() {
+    filter.remove_hash(hash_ascii_case_insensitive(id));
+  }
+
+  if let Some(classes) = node.class_name() {
+    for class_name in classes.split_whitespace() {
+      filter.remove_hash(hash_ascii_case_insensitive(class_name));
+    }
+  }
+}
+
 impl<'a, N: MatchableNode> Element for ArenaElement<'a, N> {
   type Impl = SelectorImpl;
 
@@ -438,7 +454,8 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
   let mut matched_before: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
   let mut matched_after: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
 
-  let mut ancestor_bloom_filters = vec![BloomFilter::new(); node_count];
+  let mut ancestor_bloom_filter = BloomFilter::new();
+  let mut ancestor_stack: Vec<usize> = Vec::new();
   let mut selector_ancestor_hashes_cache: HashMap<usize, AncestorHashes> = HashMap::new();
   let flattened_rules: Vec<&CssRule> = stylesheet
     .rules
@@ -451,18 +468,21 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
     })
     .collect();
 
-  for i in 0..node_count {
-    let Some(parent) = arena.nodes[i].parent else {
-      continue;
-    };
-    ancestor_bloom_filters[i] = ancestor_bloom_filters[parent].clone();
-    add_node_unique_hashes_to_filter(arena.nodes[parent].node, &mut ancestor_bloom_filters[i]);
-  }
-
   let mut element_caches = SelectorCaches::default();
   let mut pseudo_caches = SelectorCaches::default();
 
+  // Arena order is DFS preorder, so one counting filter walked along the
+  // ancestor chain replaces a per-node filter copy: pop-and-remove until the
+  // stack top is this node's parent, match against strict-ancestor hashes
+  // only, then push self before descending.
   for i in 0..node_count {
+    while ancestor_stack.last().copied() != arena.nodes[i].parent {
+      let Some(left) = ancestor_stack.pop() else {
+        break;
+      };
+      remove_node_unique_hashes_from_filter(arena.nodes[left].node, &mut ancestor_bloom_filter);
+    }
+
     let element = ArenaElement {
       tree: &arena,
       index: i,
@@ -471,7 +491,7 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
 
     let mut element_ctx = MatchingContext::new(
       MatchingMode::Normal,
-      Some(&ancestor_bloom_filters[i]),
+      Some(&ancestor_bloom_filter),
       &mut element_caches,
       QuirksMode::NoQuirks,
       NeedsSelectorFlags::No,
@@ -479,7 +499,7 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
     );
     let mut pseudo_ctx = MatchingContext::new(
       MatchingMode::ForStatelessPseudoElement,
-      Some(&ancestor_bloom_filters[i]),
+      Some(&ancestor_bloom_filter),
       &mut pseudo_caches,
       QuirksMode::NoQuirks,
       NeedsSelectorFlags::No,
@@ -547,6 +567,9 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
         &mut matched_after[i],
       );
     }
+
+    ancestor_stack.push(i);
+    add_node_unique_hashes_to_filter(arena.nodes[i].node, &mut ancestor_bloom_filter);
   }
 
   for (i, matched) in per_node.iter_mut().enumerate() {
@@ -577,22 +600,26 @@ fn record_matches<'a>(
   let Some(specificity) = best_specificity else {
     return;
   };
-  let normal_layer_order = rule.layer_order.map_or(layer_count, |order| order);
-  bucket.push(MatchedRule {
-    important: false,
-    layer_order: normal_layer_order,
-    specificity,
-    source_order,
-    declarations: &rule.normal_declarations,
-  });
-  let important_layer_order = rule.layer_order.map_or(0, |order| layer_count - order);
-  bucket.push(MatchedRule {
-    important: true,
-    layer_order: important_layer_order,
-    specificity,
-    source_order,
-    declarations: &rule.important_declarations,
-  });
+  if !rule.normal_declarations.is_empty() {
+    let normal_layer_order = rule.layer_order.map_or(layer_count, |order| order);
+    bucket.push(MatchedRule {
+      important: false,
+      layer_order: normal_layer_order,
+      specificity,
+      source_order,
+      declarations: &rule.normal_declarations,
+    });
+  }
+  if !rule.important_declarations.is_empty() {
+    let important_layer_order = rule.layer_order.map_or(0, |order| layer_count - order);
+    bucket.push(MatchedRule {
+      important: true,
+      layer_order: important_layer_order,
+      specificity,
+      source_order,
+      declarations: &rule.important_declarations,
+    });
+  }
 }
 
 fn finalize_bucket<'a>(

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -53,10 +53,12 @@ fn empty_rule_blocks_do_not_disturb_the_cascade() {
 fn descendant_selector_matches_after_sibling_subtrees() {
   let plain = Node::container([block("probe")]);
   let outer = Node::container([block("probe")]).with_class_name("outer");
-  let root = Node::container([plain, outer]);
+  let trailing = Node::container([block("probe")]);
+  let root = Node::container([plain, outer, trailing]);
   let result = measure_with_css(root, r#".outer .probe { width: 150px; }"#);
 
   let default_width = result.children[0].children[0].width;
   assert_ne!(default_width, 150.0);
   assert_eq!(result.children[1].children[0].width, 150.0);
+  assert_eq!(result.children[2].children[0].width, default_width);
 }

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -1,0 +1,62 @@
+mod test_utils;
+
+use takumi::{measure, prelude::*};
+use test_utils::CONTEXT;
+
+fn measure_with_css(node: Node, css: &str) -> MeasuredNode {
+  let stylesheet = StyleSheet::parse_loosy(css);
+  measure(
+    RenderOptions::builder()
+      .viewport(Viewport::new((1200, 630)))
+      .node(node)
+      .stylesheet(stylesheet.into())
+      .fonts(&CONTEXT)
+      .build(),
+  )
+  .unwrap()
+}
+
+fn block(class: &str) -> Node {
+  Node::container([])
+    .with_class_name(class)
+    .with_style(Style::default().with(StyleDeclaration::display(Display::Block)))
+}
+
+#[test]
+fn important_wins_over_higher_specificity_normal() {
+  let root = Node::container([block("box")]);
+  let result = measure_with_css(
+    root,
+    r#"
+      .box { width: 100px !important; }
+      div.box { width: 200px; }
+    "#,
+  );
+  assert_eq!(result.children[0].width, 100.0);
+}
+
+#[test]
+fn empty_rule_blocks_do_not_disturb_the_cascade() {
+  let root = Node::container([block("box")]);
+  let result = measure_with_css(
+    root,
+    r#"
+      .box {}
+      .box { width: 120px; }
+      div.box {}
+    "#,
+  );
+  assert_eq!(result.children[0].width, 120.0);
+}
+
+#[test]
+fn descendant_selector_matches_after_sibling_subtrees() {
+  let plain = Node::container([block("probe")]);
+  let outer = Node::container([block("probe")]).with_class_name("outer");
+  let root = Node::container([plain, outer]);
+  let result = measure_with_css(root, r#".outer .probe { width: 150px; }"#);
+
+  let default_width = result.children[0].children[0].width;
+  assert_ne!(default_width, 150.0);
+  assert_eq!(result.children[1].children[0].width, 150.0);
+}


### PR DESCRIPTION
## Why
Two constant-factor wastes in the matcher. Every matched rule pushed a normal and an `!important` entry even when the declaration block was empty, inflating every per-node sort for a rare feature. And each node allocated its own multi-kilobyte counting bloom filter deep-copied from its parent — O(nodes) allocations where one filter walked along the tree suffices.

## What
`record_matches` guards each push on the block being non-empty. The per-node filter vec is replaced by a single counting filter maintained over the DFS preorder the arena already stores: pop-and-remove until the stack top is the node's parent, match against strict-ancestor hashes, push self before descending — same ancestor-only invariant as before.

Output is unchanged: full fixture suite passes with zero `.svg`/`.webp` diffs. New `cascade_tests.rs` pins important-over-specificity, empty-block skipping, and descendant matching across sibling subtrees (the fixture corpus had no `!important` coverage at all). Perf claims should ride the napi JS bench in CI, not local numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved style matching efficiency by streamlining ancestor hash filtering to reduce memory use during rendering.

* **Bug Fixes**
  * Fixed CSS cascade behavior so `!important` rules correctly override non-`!important` rules by precedence.
  * Ensured empty rule blocks don’t impact later cascade results.
  * Corrected descendant selector matching across sibling subtree boundaries.

* **Tests**
  * Added new cascade tests covering `!important` precedence, empty declarations, and descendant selector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->