### PR TITLE
Core: skip style-match arena allocations when no CSS rules apply

### DIFF
--- a/.tegami/skip-empty-stylesheet-match.md
+++ b/.tegami/skip-empty-stylesheet-match.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Skip the style-match arena allocations when no CSS rules apply
+
+`match_stylesheets_view` now filters the stylesheet rules before it builds the per-node match buckets, and returns early when nothing survives. Renders driven only by inline styles or Tailwind classes (the common case) no longer allocate the per-node bucket vectors or walk the matcher for zero rules. Rendered output is unchanged.

--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -446,17 +446,6 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
   stylesheet: &'a StyleSheet,
   viewport: Viewport,
 ) -> Vec<NodeMatchedDeclarations<'a>> {
-  let arena = StyleArena::new(root);
-  let node_count = arena.nodes.len();
-  let mut per_node = vec![NodeMatchedDeclarations::default(); node_count];
-
-  let mut matched_element: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
-  let mut matched_before: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
-  let mut matched_after: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
-
-  let mut ancestor_bloom_filter = BloomFilter::new();
-  let mut ancestor_stack: Vec<usize> = Vec::new();
-  let mut selector_ancestor_hashes_cache: HashMap<usize, AncestorHashes> = HashMap::new();
   let flattened_rules: Vec<&CssRule> = stylesheet
     .rules
     .iter()
@@ -467,6 +456,24 @@ pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
         .all(|media_queries| media_queries.matches(viewport))
     })
     .collect();
+
+  let arena = StyleArena::new(root);
+  let node_count = arena.nodes.len();
+  let mut per_node = vec![NodeMatchedDeclarations::default(); node_count];
+
+  // No rules survive the media-query filter, so every node keeps the default
+  // declarations. Skip the per-node match buckets and the matching walk.
+  if flattened_rules.is_empty() {
+    return per_node;
+  }
+
+  let mut matched_element: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
+  let mut matched_before: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
+  let mut matched_after: Vec<Vec<MatchedRule<'a>>> = vec![Vec::new(); node_count];
+
+  let mut ancestor_bloom_filter = BloomFilter::new();
+  let mut ancestor_stack: Vec<usize> = Vec::new();
+  let mut selector_ancestor_hashes_cache: HashMap<usize, AncestorHashes> = HashMap::new();
 
   let mut element_caches = SelectorCaches::default();
   let mut pseudo_caches = SelectorCaches::default();


### PR DESCRIPTION
## Why

`match_stylesheets_view` runs on every render. It built a full StyleArena plus four per-node allocation vectors and only then filtered the stylesheet's rules. The common Takumi path (inline styles, Tailwind classes) passes an empty rule set, so every such render paid O(nodes) allocations to match against zero rules, repeated per frame for animation.

## What

- Filter the rules before allocating the per-node match buckets.
- Return the defaulted per-node result immediately when no rules survive, skipping the bucket vectors, ancestor bloom filter, selector caches, and the matching walk.
- Output is unchanged: with zero rules the matching loop never modified the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved rendering efficiency when no stylesheet rules apply by skipping unnecessary matching work.
  * Reduced resource usage for pages styled only with inline styles or utility classes.
* **Documentation**
  * Added documentation describing the optimized no-matching-rules behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->