### PR TITLE
Core: blend animated WebP frames by default on the native binding

### DIFF
--- a/.tegami/napi-animated-webp-blend.md
+++ b/.tegami/napi-animated-webp-blend.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+  "@takumi-rs/core": patch
+---
+
+### Blend animated WebP frames by default on the native binding
+
+`AnimatedWebpOptions::builder()` left `blend` and `dispose` unset, so they fell back to `false` while the type's `Default` and the wasm backend use `blend: true`. Native animated WebP now alpha-blends frames over prior content like wasm does, so animations with partially transparent later frames render the same on both backends. The builder defaults are pinned to the `Default` values.

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -166,8 +166,10 @@ impl AnimationFrame {
 #[non_exhaustive]
 pub struct AnimatedWebpOptions {
   /// Whether frames should be alpha-blended with previous content.
+  #[builder(default = true)]
   pub blend: bool,
   /// Whether frame disposal clears to background before the next frame.
+  #[builder(default = false)]
   pub dispose: bool,
   /// Number of times to loop; `None` means infinite loop.
   pub loop_count: Option<u16>,
@@ -1114,5 +1116,14 @@ mod tests {
       WebPDemuxReleaseIterator(&mut iter);
       WebPDemuxDelete(demux);
     }
+  }
+
+  #[test]
+  fn animated_webp_builder_blend_matches_default() {
+    let built = AnimatedWebpOptions::builder().build();
+
+    assert!(built.blend);
+    assert_eq!(built.blend, AnimatedWebpOptions::default().blend);
+    assert_eq!(built.dispose, AnimatedWebpOptions::default().dispose);
   }
 }


### PR DESCRIPTION
## Why

`AnimatedWebpOptions` uses `#[builder(field_defaults(default))]`, so `builder()` left `blend` and `dispose` at the bool default of `false`. But the type's own `Default` impl and the wasm backend both use `blend: true`. The napi animated-WebP encoder builds its options through the builder, so native output did not blend frames while wasm did. Animations whose later frames rely on alpha-compositing over prior content rendered differently, and wrongly, on Node.

## What

- Pin the builder defaults for `blend` (true) and `dispose` (false) to the `Default` values, so the builder and `Default` can no longer diverge.
- Add a unit test asserting `AnimatedWebpOptions::builder().build().blend` is true and matches `Default`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animated WebP rendering for partially transparent frames by blending them correctly with prior content.
  * Aligned native rendering behavior with the WebAssembly backend.

* **Documentation**
  * Documented the updated animated WebP frame blending and disposal defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->