### PR TITLE
Core: return an error for viewports too large to allocate

### DIFF
--- a/.tegami/oversized-viewport-error.md
+++ b/.tegami/oversized-viewport-error.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+  "@takumi-rs/core": patch
+  "@takumi-rs/wasm": patch
+---
+
+### Return an error for viewports too large to allocate
+
+A viewport whose pixel buffer overflowed the backing allocation used to fall back to a 1x1 canvas, so the render produced a valid-looking but wrong tiny image with no error. The root canvas is now built through a fallible path that surfaces the allocation failure as an `InvalidViewport` error instead. Internal offscreen canvases keep their bounded sizes and are unaffected.

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -117,21 +117,31 @@ pub(crate) struct CanvasSubcanvas {
 }
 
 impl Canvas {
-  /// Creates a new canvas handle from a draw command sender.
-  pub(crate) fn new(size: Size<u32>) -> Self {
-    let Some(image) = Pixmap::new(size.width, size.height) else {
-      return Self::new(Size {
-        width: 1,
-        height: 1,
-      });
-    };
-    Self {
+  /// Creates a canvas backed by a `size`-sized pixmap, or `None` when the pixmap
+  /// cannot be allocated (zero size, or dimensions large enough to overflow the
+  /// pixel-buffer length).
+  pub(crate) fn try_new(size: Size<u32>) -> Option<Self> {
+    let image = Pixmap::new(size.width, size.height)?;
+    Some(Self {
       image,
       origin: Point { x: 0, y: 0 },
       offscreen_pool: Vec::new(),
       constraint_mask_stack: Vec::new(),
       buffer_pool: BufferPool::default(),
-    }
+    })
+  }
+
+  /// Test-only infallible constructor, falling back to 1x1 when `size` cannot be
+  /// allocated. Production code uses [`Canvas::try_new`] and surfaces the error.
+  #[cfg(test)]
+  pub(crate) fn new(size: Size<u32>) -> Self {
+    Self::try_new(size).unwrap_or_else(|| {
+      Self::try_new(Size {
+        width: 1,
+        height: 1,
+      })
+      .expect("1x1 pixmap always allocates")
+    })
   }
 
   fn acquire_offscreen(&mut self, size: Size<u32>) -> Result<Pixmap> {

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -462,7 +462,7 @@ fn render_with_context(
     return Err(Error::InvalidViewport);
   }
 
-  let mut canvas = Canvas::new(root_size);
+  let mut canvas = Canvas::try_new(root_size).ok_or(Error::InvalidViewport)?;
 
   render_node(
     &mut root,
@@ -751,6 +751,36 @@ mod tests {
     let frames = frames_result.unwrap_or_default();
 
     assert!(frames.is_empty());
+  }
+
+  #[test]
+  fn oversized_viewport_errors_instead_of_silent_1x1() {
+    let fonts = Fonts::default();
+    // A width whose row byte length (width * 4) overflows u32, so the backing
+    // pixmap cannot allocate.
+    let options = RenderOptions::builder()
+      .fonts(&fonts)
+      .viewport(Viewport::new((2_000_000_000, 1)))
+      .node(Node::container([]))
+      .build();
+
+    assert!(matches!(
+      render(options),
+      Err(crate::Error::InvalidViewport)
+    ));
+  }
+
+  #[test]
+  fn ordinary_viewport_still_renders() {
+    let fonts = Fonts::default();
+    let options = RenderOptions::builder()
+      .fonts(&fonts)
+      .viewport(Viewport::new((100, 100)))
+      .node(Node::container([]))
+      .build();
+
+    let bitmap = render(options).unwrap();
+    assert_eq!((bitmap.width(), bitmap.height()), (100, 100));
   }
 
   #[test]


### PR DESCRIPTION
## Why

`Canvas::new` fell back to a 1x1 canvas whenever the backing `Pixmap` could not be allocated (for example a viewport width large enough that the row byte length overflows `u32`), so an oversized render returned a valid-looking 1x1 image with no error. napi and wasm pass width/height straight through, so a caller could receive silently corrupt output.

## What

- Add `Canvas::try_new`, a fallible constructor that returns `None` when the pixmap cannot be allocated.
- The root render canvas uses it and returns `Error::InvalidViewport` on failure instead of degrading to 1x1.
- The infallible `Canvas::new` (with the 1x1 fallback) is now test-only; production offscreen canvases already use bounded sizes.
- Regression test: a 2,000,000,000-wide viewport returns `InvalidViewport`, and an ordinary viewport still renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized viewports now return an `InvalidViewport` error instead of silently falling back to a 1×1 canvas.
  * Normal viewport rendering continues to produce correctly sized output.

* **Documentation**
  * Added documentation describing oversized viewport behavior and allocation limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->