### PR TITLE
Chore: typecheck published TypeScript packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
 
       - run: bun knip
 
+      - run: bun --filter './takumi-helpers' --filter './takumi-js' --filter './takumi-image-response' typecheck
+
   test-rust:
     name: Rust Test
     runs-on: ubuntu-latest

--- a/takumi-helpers/package.json
+++ b/takumi-helpers/package.json
@@ -92,6 +92,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "typecheck": "tsc --noEmit",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "devDependencies": {

--- a/takumi-image-response/package.json
+++ b/takumi-image-response/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "typecheck": "tsc --noEmit",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {

--- a/takumi-js/package.json
+++ b/takumi-js/package.json
@@ -209,6 +209,7 @@
     "build": "tsdown",
     "test": "bun test",
     "test:bundlers": "bun test tests/bundlers.test.ts",
+    "typecheck": "tsc --noEmit",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {


### PR DESCRIPTION
## Why

Nothing in repo CI typechecks the published TypeScript packages. `bun lint` runs oxlint and oxfmt, neither of which type-checks, and tsdown emits per-file without whole-program checking, so a cross-file type regression in the public API surface could ship uncaught.

## What

- Add a `typecheck` script (`tsc --noEmit`) to `takumi-js`, `@takumi-rs/helpers`, and `@takumi-rs/image-response`.
- Run them in the `lint-and-format` CI job. All three are type-clean today.
- `takumi-napi` and `takumi-wasm` import generated bindings that must be built first, so they are left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated TypeScript type checking for the helpers, JavaScript, and image response packages.
  * Type checks now run as part of the continuous integration validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->