### PR TITLE
Chore: drop dead code, single-impl traits, and duplicated binding lowering

### DIFF
--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -22,7 +22,6 @@ use crate::{
   context::RenderContext,
   geometry::{AvailableSpace, Size},
   layout::{inline::InlineContentKind, node::image::image_url},
-  matching::MatchableNode,
   resources::{
     image::{ImageError, ImageResult, ImageSource},
     image_buffer::ImageBuffer,
@@ -706,28 +705,29 @@ pub(crate) struct NodeStyleLayers {
   pub(crate) lang: Option<Lang>,
 }
 
-impl MatchableNode for Node {
-  fn tag_name(&self) -> Option<&str> {
+/// Selector-matching queries read by [`crate::matching`].
+impl Node {
+  pub(crate) fn tag_name(&self) -> Option<&str> {
     self.metadata.tag_name.as_deref()
   }
 
-  fn id(&self) -> Option<&str> {
+  pub(crate) fn id(&self) -> Option<&str> {
     self.metadata.id.as_deref()
   }
 
-  fn class_name(&self) -> Option<&str> {
+  pub(crate) fn class_name(&self) -> Option<&str> {
     self.metadata.class_name.as_deref()
   }
 
-  fn attr(&self, name: &str) -> Option<&str> {
+  pub(crate) fn attr(&self, name: &str) -> Option<&str> {
     self.attribute(name)
   }
 
-  fn is_replaced(&self) -> bool {
+  pub(crate) fn is_replaced(&self) -> bool {
     self.is_replaced_element()
   }
 
-  fn children(&self) -> Option<&[Self]> {
+  pub(crate) fn children(&self) -> Option<&[Self]> {
     self.children_ref()
   }
 }

--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -1,8 +1,8 @@
-//! Selector matching over an abstract node tree.
+//! Selector matching over the [`Node`] tree.
 //!
 //! All interaction with the `selectors` crate lives here so it stays out of
-//! takumi's public API. Callers implement [`MatchableNode`] for their node type
-//! and receive back the declaration blocks that apply to each node.
+//! takumi's public API. Callers pass a node tree and receive back the
+//! declaration blocks that apply to each node.
 
 use std::{collections::HashMap, fmt};
 
@@ -16,6 +16,7 @@ use selectors::{
 use smallvec::SmallVec;
 
 use crate::{
+  layout::node::Node,
   style::{
     StyleDeclarationBlock,
     selector::{CssRule, Ident, PseudoClass, PseudoElement, SelectorImpl, StyleSheet},
@@ -23,51 +24,23 @@ use crate::{
   viewport::Viewport,
 };
 
-/// A node the cascade can match selectors against.
-///
-/// Implemented by the caller's node type; the matcher only reads the queries
-/// below, so the caller does not depend on the `selectors` crate.
-pub(crate) trait MatchableNode {
-  /// The element's tag name, if any.
-  fn tag_name(&self) -> Option<&str>;
-  /// The element's `id`, if any.
-  fn id(&self) -> Option<&str>;
-  /// The element's whitespace-separated class list, if any.
-  fn class_name(&self) -> Option<&str>;
-  /// The value of an attribute by name.
-  fn attr(&self, name: &str) -> Option<&str>;
-  /// Whether this is a replaced element (`<img>`-like), which suppresses
-  /// `::before`/`::after`.
-  fn is_replaced(&self) -> bool;
-  /// The element's children in source order.
-  fn children(&self) -> Option<&[Self]>
-  where
-    Self: Sized;
+struct StyleArena<'a> {
+  nodes: Vec<StyleNode<'a>>,
 }
-
-struct StyleArena<'a, N> {
-  nodes: Vec<StyleNode<'a, N>>,
-}
-struct StyleNode<'a, N> {
-  node: &'a N,
+struct StyleNode<'a> {
+  node: &'a Node,
   parent: Option<usize>,
   prev_sibling: Option<usize>,
   next_sibling: Option<usize>,
   first_child: Option<usize>,
 }
-struct ArenaElement<'a, N> {
-  tree: &'a StyleArena<'a, N>,
+#[derive(Clone, Copy)]
+struct ArenaElement<'a> {
+  tree: &'a StyleArena<'a>,
   index: usize,
 }
 
-impl<N> Clone for ArenaElement<'_, N> {
-  fn clone(&self) -> Self {
-    *self
-  }
-}
-impl<N> Copy for ArenaElement<'_, N> {}
-
-impl<N> fmt::Debug for ArenaElement<'_, N> {
+impl fmt::Debug for ArenaElement<'_> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("ArenaElement")
       .field("index", &self.index)
@@ -75,17 +48,22 @@ impl<N> fmt::Debug for ArenaElement<'_, N> {
   }
 }
 
-impl<'a, N: MatchableNode> StyleArena<'a, N> {
-  fn new(root: &'a N) -> Self {
+impl<'a> StyleArena<'a> {
+  fn new(root: &'a Node) -> Self {
     let mut arena = StyleArena { nodes: Vec::new() };
     arena.add_node(root, None, None);
     arena
   }
 
-  fn add_node(&mut self, node: &'a N, parent: Option<usize>, prev_sibling: Option<usize>) -> usize {
-    struct ChildFrame<'a, N> {
+  fn add_node(
+    &mut self,
+    node: &'a Node,
+    parent: Option<usize>,
+    prev_sibling: Option<usize>,
+  ) -> usize {
+    struct ChildFrame<'a> {
       parent_index: usize,
-      children: &'a [N],
+      children: &'a [Node],
       next_child: usize,
       current_prev: Option<usize>,
     }
@@ -133,7 +111,7 @@ impl<'a, N: MatchableNode> StyleArena<'a, N> {
 
   fn push_node(
     &mut self,
-    node: &'a N,
+    node: &'a Node,
     parent: Option<usize>,
     prev_sibling: Option<usize>,
   ) -> usize {
@@ -163,7 +141,7 @@ fn hash_ascii_case_insensitive(value: &str) -> u32 {
   hash
 }
 
-fn add_node_unique_hashes_to_filter<N: MatchableNode>(node: &N, filter: &mut BloomFilter) -> bool {
+fn add_node_unique_hashes_to_filter(node: &Node, filter: &mut BloomFilter) -> bool {
   let mut added = false;
 
   if let Some(tag) = node.tag_name() {
@@ -186,7 +164,7 @@ fn add_node_unique_hashes_to_filter<N: MatchableNode>(node: &N, filter: &mut Blo
   added
 }
 
-fn remove_node_unique_hashes_from_filter<N: MatchableNode>(node: &N, filter: &mut BloomFilter) {
+fn remove_node_unique_hashes_from_filter(node: &Node, filter: &mut BloomFilter) {
   if let Some(tag) = node.tag_name() {
     filter.remove_hash(hash_ascii_case_insensitive(tag));
   }
@@ -202,7 +180,7 @@ fn remove_node_unique_hashes_from_filter<N: MatchableNode>(node: &N, filter: &mu
   }
 }
 
-impl<'a, N: MatchableNode> Element for ArenaElement<'a, N> {
+impl Element for ArenaElement<'_> {
   type Impl = SelectorImpl;
 
   fn opaque(&self) -> OpaqueElement {
@@ -441,8 +419,8 @@ enum SelectorTarget {
 
 /// Matches every rule in `stylesheet` against the tree rooted at `root`,
 /// returning the declaration blocks that apply to each node in tree order.
-pub(crate) fn match_stylesheets_view<'a, N: MatchableNode>(
-  root: &N,
+pub(crate) fn match_stylesheets_view<'a>(
+  root: &Node,
   stylesheet: &'a StyleSheet,
   viewport: Viewport,
 ) -> Vec<NodeMatchedDeclarations<'a>> {

--- a/takumi-helpers/src/emoji.ts
+++ b/takumi-helpers/src/emoji.ts
@@ -11,20 +11,8 @@ const KEYCAP_EMOJI_REGEX = /^[#*0-9]\uFE0F?\u20E3$/u;
 
 function getIconCode(char: string) {
   const c = char.indexOf(U200D) < 0 ? char.replace(UFE0Fg, "") : char;
-  let r = "";
-  for (let i = 0, p = 0; i < c.length; i++) {
-    const cc = c.charCodeAt(i);
-    if (p) {
-      const code = (65536 + ((p - 55296) << 10) + (cc - 56320)).toString(16);
-      r += (r ? "-" : "") + code;
-      p = 0;
-    } else if (55296 <= cc && cc <= 56319) {
-      p = cc;
-    } else {
-      r += (r ? "-" : "") + cc.toString(16);
-    }
-  }
-  return r;
+
+  return [...c].map((ch) => ch.codePointAt(0)?.toString(16)).join("-");
 }
 
 const apis = {
@@ -46,25 +34,10 @@ function getEmojiUrl(icon: string, type: EmojiType) {
   return typeof api === "function" ? api(code) : `${api}${code.toUpperCase()}.svg`;
 }
 
-let segmenter: Intl.Segmenter | null | undefined;
+const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
 
-function getSegmenter(): Intl.Segmenter | null {
-  if (segmenter === undefined) {
-    if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
-      segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
-    } else {
-      segmenter = null;
-    }
-  }
-  return segmenter;
-}
-
-function getSegments(text: string): { segment: string }[] {
-  const s = getSegmenter();
-  if (s) {
-    return Array.from(s.segment(text));
-  }
-  return Array.from(text).map((s) => ({ segment: s }));
+function getSegments(text: string) {
+  return Array.from(segmenter.segment(text));
 }
 
 function isEmojiSegment(segment: string): boolean {

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -202,17 +202,13 @@ function collectChildrenWithContext(
   return collectChildren(element, { ...options, contexts });
 }
 
-function isRenderProp(value: unknown): value is (value: unknown) => ReactNode {
-  return typeof value === "function";
-}
-
 function renderConsumer(
   element: ReactElementLike,
   context: unknown,
   options: ResolvedFromJsxOptions,
 ): Promise<FromJsxTraversalResult> {
   const children = getElementChildren(element);
-  if (!isRenderProp(children)) return collectChildren(element, options);
+  if (!isFunctionComponent(children)) return collectChildren(element, options);
 
   return fromJsxInternal(children(readContext(options, context)), options);
 }

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -12,7 +12,7 @@ mod render_task;
 pub(crate) mod renderer;
 mod svg_render_task;
 
-use std::{fmt::Display, ops::Deref};
+use std::fmt::Display;
 
 use napi::{De, Env, Error, bindgen_prelude::*};
 use napi_derive::napi;
@@ -149,14 +149,6 @@ impl AsRef<[u8]> for BufferOrSlice<'_> {
       BufferOrSlice::Buffer(buffer) => buffer,
       BufferOrSlice::Uint8Array(buffer) => buffer,
     }
-  }
-}
-
-impl Deref for BufferOrSlice<'_> {
-  type Target = [u8];
-
-  fn deref(&self) -> &Self::Target {
-    self.as_ref()
   }
 }
 

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -4,15 +4,15 @@ use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
-  viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
+  viewport::Viewport,
 };
 use takumi_raster::measure;
 
 use crate::{
-  buffer_from_object, map_error,
+  map_error,
   renderer::{
-    ImageCacheMode, MeasuredNode, RenderOptions, RendererState, decode_images,
-    deserialize_keyframes,
+    ImageCacheMode, MeasuredNode, RenderOptions, RendererState, collect_images, decode_images,
+    deserialize_keyframes, device_pixel_ratio, parse_lang,
   },
 };
 use takumi_bindings_common::stylesheet;
@@ -44,35 +44,13 @@ impl MeasureTask {
     Ok(MeasureTask {
       node: Some(node),
       state,
-      viewport: Viewport::new((options.width, options.height)).with_device_pixel_ratio(
-        options
-          .device_pixel_ratio
-          .map(|ratio| ratio as f32)
-          .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
-      ),
+      viewport: Viewport::new((options.width, options.height))
+        .with_device_pixel_ratio(device_pixel_ratio(options.device_pixel_ratio)),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
       stylesheet,
-      images: options
-        .images
-        .unwrap_or_default()
-        .into_iter()
-        .map(|image| {
-          Ok((
-            Arc::from(image.src),
-            (
-              buffer_from_object(env, image.data)?,
-              image.cache.unwrap_or_default(),
-            ),
-          ))
-        })
-        .collect::<Result<_>>()?,
+      images: collect_images(env, options.images)?,
       font_families: options.font_families.map(FontFamily::from_names),
-      lang: options
-        .lang
-        .as_deref()
-        .map(Lang::parse)
-        .transpose()
-        .map_err(map_error)?,
+      lang: parse_lang(options.lang)?,
     })
   }
 }

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -4,7 +4,7 @@ use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, KeyframesRule, Lang},
-  viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
+  viewport::Viewport,
 };
 use takumi_raster::{
   AnimatedGifOptions, AnimatedPngOptions, AnimatedWebpOptions, AnimationFormat, RenderOptions,
@@ -12,10 +12,10 @@ use takumi_raster::{
 };
 
 use crate::{
-  buffer_from_object, deserialize_with_tracing, map_error,
+  deserialize_with_tracing,
   renderer::{
-    AnimationOutputFormat, ImageCacheMode, ImageSource, RenderAnimationOptions, RendererState,
-    decode_images, deserialize_keyframes, webp_lossless,
+    AnimationOutputFormat, ImageCacheMode, RenderAnimationOptions, RendererState, collect_images,
+    decode_images, deserialize_keyframes, device_pixel_ratio, parse_lang, webp_lossless,
   },
 };
 use takumi_bindings_common::stylesheet;
@@ -54,7 +54,7 @@ impl RenderAnimationTask {
       images,
       stylesheets,
       keyframes,
-      device_pixel_ratio,
+      device_pixel_ratio: dpr,
       font_families,
       lang,
     } = options;
@@ -80,36 +80,16 @@ impl RenderAnimationTask {
     Ok(Self {
       scenes: Some(scenes),
       state,
-      viewport: Viewport::new((width, height)).with_device_pixel_ratio(
-        device_pixel_ratio
-          .map(|ratio| ratio as f32)
-          .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
-      ),
+      viewport: Viewport::new((width, height)).with_device_pixel_ratio(device_pixel_ratio(dpr)),
       format: format.unwrap_or(AnimationOutputFormat::WebP),
       quality,
       lossless,
       draw_debug_border: draw_debug_border.unwrap_or_default(),
       stylesheets,
       keyframes: deserialize_keyframes(keyframes)?,
-      images: images
-        .unwrap_or_default()
-        .into_iter()
-        .map(|image: ImageSource<'_>| {
-          Ok((
-            Arc::from(image.src),
-            (
-              buffer_from_object(env, image.data)?,
-              image.cache.unwrap_or_default(),
-            ),
-          ))
-        })
-        .collect::<Result<_>>()?,
+      images: collect_images(env, images)?,
       font_families: font_families.map(FontFamily::from_names),
-      lang: lang
-        .as_deref()
-        .map(Lang::parse)
-        .transpose()
-        .map_err(map_error)?,
+      lang: parse_lang(lang)?,
       fps,
     })
   }

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -4,15 +4,15 @@ use napi::bindgen_prelude::*;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
-  viewport::{DEFAULT_DEVICE_PIXEL_RATIO, Viewport},
+  viewport::Viewport,
 };
 use takumi_raster::{DitheringAlgorithm, render, write_image};
 
 use crate::{
-  buffer_from_object, map_error,
+  map_error,
   renderer::{
-    ImageCacheMode, OutputFormat, RenderOptions, RendererState, decode_images,
-    deserialize_keyframes,
+    ImageCacheMode, OutputFormat, RenderOptions, RendererState, collect_images, decode_images,
+    deserialize_keyframes, device_pixel_ratio, parse_lang,
   },
 };
 use takumi_bindings_common::stylesheet;
@@ -49,12 +49,8 @@ impl RenderTask {
     Ok(RenderTask {
       node: Some(node),
       state,
-      viewport: Viewport::new((options.width, options.height)).with_device_pixel_ratio(
-        options
-          .device_pixel_ratio
-          .map(|ratio| ratio as f32)
-          .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
-      ),
+      viewport: Viewport::new((options.width, options.height))
+        .with_device_pixel_ratio(device_pixel_ratio(options.device_pixel_ratio)),
       format: options.format.unwrap_or(OutputFormat::Png),
       quality: options.quality,
       lossless: options.lossless,
@@ -62,27 +58,9 @@ impl RenderTask {
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
       draw_debug_border: options.draw_debug_border.unwrap_or_default(),
       stylesheet,
-      images: options
-        .images
-        .unwrap_or_default()
-        .into_iter()
-        .map(|image| {
-          Ok((
-            Arc::from(image.src),
-            (
-              buffer_from_object(env, image.data)?,
-              image.cache.unwrap_or_default(),
-            ),
-          ))
-        })
-        .collect::<Result<_>>()?,
+      images: collect_images(env, options.images)?,
       font_families: options.font_families.map(FontFamily::from_names),
-      lang: options
-        .lang
-        .as_deref()
-        .map(Lang::parse)
-        .transpose()
-        .map_err(map_error)?,
+      lang: parse_lang(options.lang)?,
     })
   }
 }

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -12,16 +12,17 @@ use takumi_core::{
   resources::image::{
     ImageCacheMode as CoreImageCacheMode, ImageSource as LoadedImageSource, ResourceCache,
   },
-  style::KeyframesRule as CoreKeyframesRule,
+  style::{KeyframesRule as CoreKeyframesRule, Lang},
+  viewport::DEFAULT_DEVICE_PIXEL_RATIO,
 };
 use takumi_raster::{
   DitheringAlgorithm as CoreDitheringAlgorithm, OutputFormat as RasterOutputFormat, Quality,
 };
 
 use crate::{
-  De, deserialize_with_tracing, load_font_task::LoadFontTask, map_error, measure_task::MeasureTask,
-  parse_font_input, render_animation_task::RenderAnimationTask, render_task::RenderTask,
-  svg_render_task::SvgRenderTask,
+  De, buffer_from_object, deserialize_with_tracing, load_font_task::LoadFontTask, map_error,
+  measure_task::MeasureTask, parse_font_input, render_animation_task::RenderAnimationTask,
+  render_task::RenderTask, svg_render_task::SvgRenderTask,
 };
 
 /// Represents a single run of text in a measured node.
@@ -110,6 +111,39 @@ pub(crate) fn decode_images(
   }
 
   Ok(map)
+}
+
+pub(crate) fn collect_images(
+  env: Env,
+  images: Option<Vec<ImageSource>>,
+) -> Result<HashMap<Arc<str>, (Buffer, ImageCacheMode)>> {
+  images
+    .unwrap_or_default()
+    .into_iter()
+    .map(|image| {
+      Ok((
+        Arc::from(image.src),
+        (
+          buffer_from_object(env, image.data)?,
+          image.cache.unwrap_or_default(),
+        ),
+      ))
+    })
+    .collect()
+}
+
+pub(crate) fn parse_lang(lang: Option<String>) -> Result<Option<Lang>> {
+  lang
+    .as_deref()
+    .map(Lang::parse)
+    .transpose()
+    .map_err(map_error)
+}
+
+pub(crate) fn device_pixel_ratio(ratio: Option<f64>) -> f32 {
+  ratio
+    .map(|ratio| ratio as f32)
+    .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO)
 }
 
 pub(crate) fn deserialize_keyframes(keyframes: Option<Object>) -> Result<Vec<CoreKeyframesRule>> {

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -8,9 +8,10 @@ use takumi_core::{
 };
 
 use crate::{
-  buffer_from_object, map_error,
+  map_error,
   renderer::{
-    ImageCacheMode, RendererState, SvgRenderOptions, decode_images, deserialize_keyframes,
+    ImageCacheMode, RendererState, SvgRenderOptions, collect_images, decode_images,
+    deserialize_keyframes, parse_lang,
   },
 };
 use takumi_bindings_common::stylesheet;
@@ -45,25 +46,9 @@ impl SvgRenderTask {
       viewport: Viewport::new((options.width, options.height)),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
       stylesheet,
-      images: options
-        .images
-        .unwrap_or_default()
-        .into_iter()
-        .map(|image| {
-          Ok((
-            Arc::from(image.src),
-            (
-              buffer_from_object(env, image.data)?,
-              image.cache.unwrap_or_default(),
-            ),
-          ))
-        })
-        .collect::<Result<_>>()?,
+      images: collect_images(env, options.images)?,
       font_families: options.font_families.map(FontFamily::from_names),
-      lang: options
-        .lang
-        .map(|lang| Lang::parse(&lang).map_err(map_error))
-        .transpose()?,
+      lang: parse_lang(options.lang)?,
     })
   }
 }

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -31,7 +31,7 @@ pub(crate) fn paint_border(
     return;
   }
 
-  if properties.draw_uniform_fast_path(canvas, border_box, transform, clip_image) {
+  if draw_uniform_fast_path(properties, canvas, border_box, transform, clip_image) {
     return;
   }
 
@@ -79,261 +79,27 @@ pub(crate) fn paint_border(
     if !BorderProperties::is_side_visible(style, width) {
       continue;
     }
-    border.draw_visible_side(&mut paint, side, border_box, style, color);
+    draw_visible_side(border, &mut paint, side, border_box, style, color);
   }
 }
 
-trait BorderRasterization {
-  fn draw_uniform_fast_path(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-  ) -> bool;
+fn draw_uniform_fast_path(
+  border: BorderProperties,
+  canvas: &mut Canvas,
+  border_box: Size<f32>,
+  transform: Affine,
+  clip_image: Option<PaintSource<'_>>,
+) -> bool {
+  let Some(color) = border.has_uniform_visible_color() else {
+    return false;
+  };
 
-  fn draw_visible_side(
-    self,
-    paint: &mut SidePaintContext<'_, '_>,
-    side: BorderSide,
-    border_box: Size<f32>,
-    style: BorderStyle,
-    color: Color,
-  );
-
-  fn draw_uniform_double(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-    color: Color,
-  );
-
-  fn draw_uniform_pattern(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-    color: Color,
-    style: BorderStyle,
-  );
-
-  fn draw_side_band(
-    self,
-    paint: &mut SidePaintContext<'_, '_>,
-    side: BorderSide,
-    border_box: Size<f32>,
-    inset: Rect<f32>,
-    width: Rect<f32>,
-    color: Color,
-  );
-
-  fn draw_side_pattern_border(
-    self,
-    paint: &mut SidePaintContext<'_, '_>,
-    side: BorderSide,
-    border_box: Size<f32>,
-    color: Color,
-    style: BorderStyle,
-  );
-}
-
-impl BorderRasterization for BorderProperties {
-  fn draw_uniform_fast_path(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-  ) -> bool {
-    let Some(color) = self.has_uniform_visible_color() else {
-      return false;
-    };
-
-    if self.visible_sides_match(BorderStyle::Solid) {
-      let mut border = self;
-      border.width = self.visible_side_widths();
-      let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
-      border.append_border_ring_commands(&mut paths, border_box);
-      let (mask, placement) = render_mask(&paths, Some(transform), Some(Fill::EvenOdd.into()));
-
-      paint_mask(
-        canvas,
-        &mask,
-        placement,
-        color,
-        clip_image,
-        transform,
-        self.image_rendering,
-      );
-      return true;
-    }
-
-    if self.visible_sides_match(BorderStyle::Double) {
-      let mut border = self;
-      border.width = self.visible_side_widths();
-      border.draw_uniform_double(canvas, border_box, transform, clip_image, color);
-      return true;
-    }
-
-    if self.is_uniform_all_sides_style(BorderStyle::Dashed) {
-      self.draw_uniform_pattern(
-        canvas,
-        border_box,
-        transform,
-        clip_image,
-        color,
-        BorderStyle::Dashed,
-      );
-      return true;
-    }
-
-    if self.is_uniform_all_sides_style(BorderStyle::Dotted) {
-      self.draw_uniform_pattern(
-        canvas,
-        border_box,
-        transform,
-        clip_image,
-        color,
-        BorderStyle::Dotted,
-      );
-      return true;
-    }
-
-    false
-  }
-
-  fn draw_visible_side(
-    self,
-    paint: &mut SidePaintContext<'_, '_>,
-    side: BorderSide,
-    border_box: Size<f32>,
-    style: BorderStyle,
-    color: Color,
-  ) {
-    match style {
-      BorderStyle::Dashed | BorderStyle::Dotted => {
-        self.draw_side_pattern_border(paint, side, border_box, color, style);
-      }
-      BorderStyle::Double => {
-        let stripe_width = self.width.map(|value| value / 3.0);
-        self.draw_side_band(paint, side, border_box, Rect::ZERO, stripe_width, color);
-
-        let inset = self.width.map(|value| value * (2.0 / 3.0));
-        self.draw_side_band(paint, side, border_box, inset, stripe_width, color);
-      }
-      BorderStyle::Inset | BorderStyle::Outset => {
-        self.draw_side_band(
-          paint,
-          side,
-          border_box,
-          Rect::ZERO,
-          self.width,
-          shade_3d_border_color(color, side, style),
-        );
-      }
-      BorderStyle::Groove | BorderStyle::Ridge => {
-        let outer_width = self.width.map(|value| value / 2.0);
-        let inner_inset = outer_width;
-        let inner_width = subtract_rect(self.width, outer_width);
-        let (outer_style, inner_style) = match style {
-          BorderStyle::Groove => (BorderStyle::Inset, BorderStyle::Outset),
-          BorderStyle::Ridge => (BorderStyle::Outset, BorderStyle::Inset),
-          _ => unreachable!("non groove/ridge style in groove/ridge branch"),
-        };
-
-        self.draw_side_band(
-          paint,
-          side,
-          border_box,
-          Rect::ZERO,
-          outer_width,
-          shade_3d_border_color(color, side, outer_style),
-        );
-        self.draw_side_band(
-          paint,
-          side,
-          border_box,
-          inner_inset,
-          inner_width,
-          shade_3d_border_color(color, side, inner_style),
-        );
-      }
-      BorderStyle::Solid => {
-        self.draw_side_band(paint, side, border_box, Rect::ZERO, self.width, color);
-      }
-      _ => {}
-    }
-  }
-
-  fn draw_uniform_double(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-    color: Color,
-  ) {
-    let stripe_width = self.width.map(|value| value / 3.0);
-    let mut outer = self;
-    outer.width = stripe_width;
-
-    let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 4);
-    outer.append_border_ring_commands(&mut paths, border_box);
-
-    let inset = self.width.map(|value| value * (2.0 / 3.0));
-    let mut inner = self;
-    inner.width = stripe_width;
-    inner.expand_by(inset.map(|value| -value));
-    inner.append_border_ring_commands_at(
-      &mut paths,
-      inset_size(border_box, inset),
-      rect_offset(inset),
-    );
-
+  if border.visible_sides_match(BorderStyle::Solid) {
+    let mut solid = border;
+    solid.width = border.visible_side_widths();
+    let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
+    solid.append_border_ring_commands(&mut paths, border_box);
     let (mask, placement) = render_mask(&paths, Some(transform), Some(Fill::EvenOdd.into()));
-    paint_mask(
-      canvas,
-      &mask,
-      placement,
-      color,
-      clip_image,
-      transform,
-      self.image_rendering,
-    );
-  }
-
-  fn draw_uniform_pattern(
-    self,
-    canvas: &mut Canvas,
-    border_box: Size<f32>,
-    transform: Affine,
-    clip_image: Option<PaintSource<'_>>,
-    color: Color,
-    style: BorderStyle,
-  ) {
-    let width = self.width.top;
-    if width <= 0.0 {
-      return;
-    }
-
-    let half_width = self.width.map(|v| v / 2.0);
-    let mut center_rect = self;
-    center_rect.expand_by(half_width.map(|v| -v));
-
-    let center_size = inset_size(border_box, half_width);
-    let center_offset = rect_offset(half_width);
-
-    let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT);
-    center_rect.append_mask_commands(&mut paths, center_size, center_offset);
-
-    let perimeter = center_rect.approximate_rounded_rect_perimeter(center_size);
-
-    let stroke = compute_side_stroke(width, style, perimeter, true);
-
-    let (mask, placement) = render_mask(&paths, Some(transform), Some(Style::Stroke(stroke)));
 
     paint_mask(
       canvas,
@@ -342,38 +108,266 @@ impl BorderRasterization for BorderProperties {
       color,
       clip_image,
       transform,
-      self.image_rendering,
+      border.image_rendering,
     );
+    return true;
   }
 
-  fn draw_side_band(
-    self,
-    paint: &mut SidePaintContext<'_, '_>,
-    side: BorderSide,
-    border_box: Size<f32>,
-    inset: Rect<f32>,
-    width: Rect<f32>,
-    color: Color,
-  ) {
-    if border_box.width <= 0.0 || border_box.height <= 0.0 {
-      return;
+  if border.visible_sides_match(BorderStyle::Double) {
+    let mut double = border;
+    double.width = border.visible_side_widths();
+    draw_uniform_double(double, canvas, border_box, transform, clip_image, color);
+    return true;
+  }
+
+  if border.is_uniform_all_sides_style(BorderStyle::Dashed) {
+    draw_uniform_pattern(
+      border,
+      canvas,
+      border_box,
+      transform,
+      clip_image,
+      color,
+      BorderStyle::Dashed,
+    );
+    return true;
+  }
+
+  if border.is_uniform_all_sides_style(BorderStyle::Dotted) {
+    draw_uniform_pattern(
+      border,
+      canvas,
+      border_box,
+      transform,
+      clip_image,
+      color,
+      BorderStyle::Dotted,
+    );
+    return true;
+  }
+
+  false
+}
+
+fn draw_visible_side(
+  border: BorderProperties,
+  paint: &mut SidePaintContext<'_, '_>,
+  side: BorderSide,
+  border_box: Size<f32>,
+  style: BorderStyle,
+  color: Color,
+) {
+  match style {
+    BorderStyle::Dashed | BorderStyle::Dotted => {
+      draw_side_pattern_border(border, paint, side, border_box, color, style);
     }
+    BorderStyle::Double => {
+      let stripe_width = border.width.map(|value| value / 3.0);
+      draw_side_band(
+        border,
+        paint,
+        side,
+        border_box,
+        Rect::ZERO,
+        stripe_width,
+        color,
+      );
 
-    let mut border = self;
-    border.width = width;
-
-    let band_box = inset_size(border_box, inset);
-    if band_box.width <= 0.0 || band_box.height <= 0.0 {
-      return;
+      let inset = border.width.map(|value| value * (2.0 / 3.0));
+      draw_side_band(border, paint, side, border_box, inset, stripe_width, color);
     }
-    let offset = rect_offset(inset);
-    border.expand_by(inset.map(|value| -value));
+    BorderStyle::Inset | BorderStyle::Outset => {
+      draw_side_band(
+        border,
+        paint,
+        side,
+        border_box,
+        Rect::ZERO,
+        border.width,
+        shade_3d_border_color(color, side, style),
+      );
+    }
+    BorderStyle::Groove | BorderStyle::Ridge => {
+      let outer_width = border.width.map(|value| value / 2.0);
+      let inner_inset = outer_width;
+      let inner_width = subtract_rect(border.width, outer_width);
+      let (outer_style, inner_style) = match style {
+        BorderStyle::Groove => (BorderStyle::Inset, BorderStyle::Outset),
+        BorderStyle::Ridge => (BorderStyle::Outset, BorderStyle::Inset),
+        _ => unreachable!("non groove/ridge style in groove/ridge branch"),
+      };
 
-    if border.is_zero() {
-      let mut paths = Vec::with_capacity(5);
-      border.append_side_polygon_commands_at(side, &mut paths, band_box, offset);
-      let (mask, placement) =
-        render_mask(&paths, Some(paint.transform), Some(Fill::NonZero.into()));
+      draw_side_band(
+        border,
+        paint,
+        side,
+        border_box,
+        Rect::ZERO,
+        outer_width,
+        shade_3d_border_color(color, side, outer_style),
+      );
+      draw_side_band(
+        border,
+        paint,
+        side,
+        border_box,
+        inner_inset,
+        inner_width,
+        shade_3d_border_color(color, side, inner_style),
+      );
+    }
+    BorderStyle::Solid => {
+      draw_side_band(
+        border,
+        paint,
+        side,
+        border_box,
+        Rect::ZERO,
+        border.width,
+        color,
+      );
+    }
+    _ => {}
+  }
+}
+
+fn draw_uniform_double(
+  border: BorderProperties,
+  canvas: &mut Canvas,
+  border_box: Size<f32>,
+  transform: Affine,
+  clip_image: Option<PaintSource<'_>>,
+  color: Color,
+) {
+  let stripe_width = border.width.map(|value| value / 3.0);
+  let mut outer = border;
+  outer.width = stripe_width;
+
+  let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 4);
+  outer.append_border_ring_commands(&mut paths, border_box);
+
+  let inset = border.width.map(|value| value * (2.0 / 3.0));
+  let mut inner = border;
+  inner.width = stripe_width;
+  inner.expand_by(inset.map(|value| -value));
+  inner.append_border_ring_commands_at(
+    &mut paths,
+    inset_size(border_box, inset),
+    rect_offset(inset),
+  );
+
+  let (mask, placement) = render_mask(&paths, Some(transform), Some(Fill::EvenOdd.into()));
+  paint_mask(
+    canvas,
+    &mask,
+    placement,
+    color,
+    clip_image,
+    transform,
+    border.image_rendering,
+  );
+}
+
+fn draw_uniform_pattern(
+  border: BorderProperties,
+  canvas: &mut Canvas,
+  border_box: Size<f32>,
+  transform: Affine,
+  clip_image: Option<PaintSource<'_>>,
+  color: Color,
+  style: BorderStyle,
+) {
+  let width = border.width.top;
+  if width <= 0.0 {
+    return;
+  }
+
+  let half_width = border.width.map(|v| v / 2.0);
+  let mut center_rect = border;
+  center_rect.expand_by(half_width.map(|v| -v));
+
+  let center_size = inset_size(border_box, half_width);
+  let center_offset = rect_offset(half_width);
+
+  let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT);
+  center_rect.append_mask_commands(&mut paths, center_size, center_offset);
+
+  let perimeter = center_rect.approximate_rounded_rect_perimeter(center_size);
+
+  let stroke = compute_side_stroke(width, style, perimeter, true);
+
+  let (mask, placement) = render_mask(&paths, Some(transform), Some(Style::Stroke(stroke)));
+
+  paint_mask(
+    canvas,
+    &mask,
+    placement,
+    color,
+    clip_image,
+    transform,
+    border.image_rendering,
+  );
+}
+
+fn draw_side_band(
+  border: BorderProperties,
+  paint: &mut SidePaintContext<'_, '_>,
+  side: BorderSide,
+  border_box: Size<f32>,
+  inset: Rect<f32>,
+  width: Rect<f32>,
+  color: Color,
+) {
+  if border_box.width <= 0.0 || border_box.height <= 0.0 {
+    return;
+  }
+
+  let mut band = border;
+  band.width = width;
+
+  let band_box = inset_size(border_box, inset);
+  if band_box.width <= 0.0 || band_box.height <= 0.0 {
+    return;
+  }
+  let offset = rect_offset(inset);
+  band.expand_by(inset.map(|value| -value));
+
+  if band.is_zero() {
+    let mut paths = Vec::with_capacity(5);
+    band.append_side_polygon_commands_at(side, &mut paths, band_box, offset);
+    let (mask, placement) = render_mask(&paths, Some(paint.transform), Some(Fill::NonZero.into()));
+    paint_mask_with_inverse(
+      paint.canvas,
+      &mask,
+      placement,
+      color,
+      paint.clip_image,
+      paint.inverse,
+      border.image_rendering,
+    );
+    return;
+  }
+
+  let mut ring_paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
+  band.append_border_ring_commands_at(&mut ring_paths, band_box, offset);
+  let (ring_mask, ring_placement) = render_mask(
+    &ring_paths,
+    Some(paint.transform),
+    Some(Fill::EvenOdd.into()),
+  );
+
+  if !ring_mask.is_empty() {
+    let mut clip_paths = Vec::with_capacity(5);
+    band.append_side_clip_polygon_commands_at(side, &mut clip_paths, band_box, offset);
+    let (clip_mask, clip_placement) = render_mask(
+      &clip_paths,
+      Some(paint.transform),
+      Some(Fill::NonZero.into()),
+    );
+
+    if let Some((mask, placement)) =
+      intersect_alpha_masks(&ring_mask, ring_placement, &clip_mask, clip_placement)
+    {
       paint_mask_with_inverse(
         paint.canvas,
         &mask,
@@ -381,103 +375,70 @@ impl BorderRasterization for BorderProperties {
         color,
         paint.clip_image,
         paint.inverse,
-        self.image_rendering,
+        border.image_rendering,
       );
-      return;
     }
+  }
+}
 
-    let mut ring_paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
-    border.append_border_ring_commands_at(&mut ring_paths, band_box, offset);
+fn draw_side_pattern_border(
+  border: BorderProperties,
+  paint: &mut SidePaintContext<'_, '_>,
+  side: BorderSide,
+  border_box: Size<f32>,
+  color: Color,
+  style: BorderStyle,
+) {
+  let line = SidePatternLine::from_border(border.width, border_box, side);
+  if line.width <= 0.0 || line.end <= line.start {
+    return;
+  }
+
+  let mut path = Vec::with_capacity(2);
+  if line.is_horizontal {
+    path.move_to((line.start, line.fixed));
+    path.line_to((line.end, line.fixed));
+  } else {
+    path.move_to((line.fixed, line.start));
+    path.line_to((line.fixed, line.end));
+  }
+
+  let stroke = compute_side_stroke(line.width, style, line.end - line.start, false);
+  let (pattern_mask, pattern_placement) =
+    render_mask(&path, Some(paint.transform), Some(Style::Stroke(stroke)));
+
+  if !pattern_mask.is_empty() {
+    let mut ring_path = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
+    border.append_border_ring_commands(&mut ring_path, border_box);
     let (ring_mask, ring_placement) = render_mask(
-      &ring_paths,
+      &ring_path,
       Some(paint.transform),
       Some(Fill::EvenOdd.into()),
     );
 
-    if !ring_mask.is_empty() {
-      let mut clip_paths = Vec::with_capacity(5);
-      border.append_side_clip_polygon_commands_at(side, &mut clip_paths, band_box, offset);
-      let (clip_mask, clip_placement) = render_mask(
-        &clip_paths,
-        Some(paint.transform),
-        Some(Fill::NonZero.into()),
+    let mut clip_path = Vec::with_capacity(5);
+    border.append_side_clip_polygon_commands_at(side, &mut clip_path, border_box, Point::ZERO);
+    let (clip_mask, clip_placement) = render_mask(
+      &clip_path,
+      Some(paint.transform),
+      Some(Fill::NonZero.into()),
+    );
+
+    if !ring_mask.is_empty()
+      && let Some((mask, placement)) =
+        intersect_alpha_masks(&pattern_mask, pattern_placement, &clip_mask, clip_placement)
+      && let Some((mask, placement)) =
+        intersect_alpha_masks(&mask, placement, &ring_mask, ring_placement)
+    {
+      paint_mask_with_inverse(
+        paint.canvas,
+        &mask,
+        placement,
+        color,
+        paint.clip_image,
+        paint.inverse,
+        border.image_rendering,
       );
-
-      if let Some((mask, placement)) =
-        intersect_alpha_masks(&ring_mask, ring_placement, &clip_mask, clip_placement)
-      {
-        paint_mask_with_inverse(
-          paint.canvas,
-          &mask,
-          placement,
-          color,
-          paint.clip_image,
-          paint.inverse,
-          self.image_rendering,
-        );
-      }
-    }
-  }
-
-  fn draw_side_pattern_border(
-    self,
-    paint: &mut SidePaintContext<'_, '_>,
-    side: BorderSide,
-    border_box: Size<f32>,
-    color: Color,
-    style: BorderStyle,
-  ) {
-    let line = SidePatternLine::from_border(self.width, border_box, side);
-    if line.width <= 0.0 || line.end <= line.start {
-      return;
-    }
-
-    let mut path = Vec::with_capacity(2);
-    if line.is_horizontal {
-      path.move_to((line.start, line.fixed));
-      path.line_to((line.end, line.fixed));
-    } else {
-      path.move_to((line.fixed, line.start));
-      path.line_to((line.fixed, line.end));
-    }
-
-    let stroke = compute_side_stroke(line.width, style, line.end - line.start, false);
-    let (pattern_mask, pattern_placement) =
-      render_mask(&path, Some(paint.transform), Some(Style::Stroke(stroke)));
-
-    if !pattern_mask.is_empty() {
-      let mut ring_path = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
-      self.append_border_ring_commands(&mut ring_path, border_box);
-      let (ring_mask, ring_placement) = render_mask(
-        &ring_path,
-        Some(paint.transform),
-        Some(Fill::EvenOdd.into()),
-      );
-
-      let mut clip_path = Vec::with_capacity(5);
-      self.append_side_clip_polygon_commands_at(side, &mut clip_path, border_box, Point::ZERO);
-      let (clip_mask, clip_placement) = render_mask(
-        &clip_path,
-        Some(paint.transform),
-        Some(Fill::NonZero.into()),
-      );
-
-      if !ring_mask.is_empty()
-        && let Some((mask, placement)) =
-          intersect_alpha_masks(&pattern_mask, pattern_placement, &clip_mask, clip_placement)
-        && let Some((mask, placement)) =
-          intersect_alpha_masks(&mask, placement, &ring_mask, ring_placement)
-      {
-        paint_mask_with_inverse(
-          paint.canvas,
-          &mask,
-          placement,
-          color,
-          paint.clip_image,
-          paint.inverse,
-          self.image_rendering,
-        );
-      }
     }
   }
 }

--- a/takumi-raster/src/webp/libwebp.rs
+++ b/takumi-raster/src/webp/libwebp.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ffi::CStr, io::Write, mem::MaybeUninit, ops::Range, slice};
+use std::{borrow::Cow, io::Write, mem::MaybeUninit, ops::Range, slice};
 
 use image::RgbaImage;
 use libwebp_sys::*;
@@ -518,17 +518,6 @@ pub fn write_animated_webp<W: Write>(
   )?;
 
   Ok(())
-}
-
-#[allow(dead_code)]
-fn animation_encoder_error_msg(encoder: *mut WebPAnimEncoder) -> String {
-  let ptr = unsafe { WebPAnimEncoderGetError(encoder) };
-  if ptr.is_null() {
-    return "WebP animation encode error".into();
-  }
-  unsafe { CStr::from_ptr(ptr) }
-    .to_string_lossy()
-    .into_owned()
 }
 
 #[cfg(test)]

--- a/takumi-wasm/src/helper.rs
+++ b/takumi-wasm/src/helper.rs
@@ -6,6 +6,3 @@ use std::fmt::Display;
 pub fn map_error<E: Display>(err: E) -> js_sys::Error {
   js_sys::Error::new(&err.to_string())
 }
-
-/// Type alias for JavaScript result.
-pub type JsResult<T> = Result<T, js_sys::Error>;

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -44,17 +44,9 @@ extern "C" {
   #[wasm_bindgen(typescript_type = "RegisteredFamily[]")]
   pub type RegisteredFamiliesType;
 
-  /// JavaScript object representing an image source.
-  #[wasm_bindgen(typescript_type = "ImageSource")]
-  pub type ImageSourceType;
-
   /// JavaScript object representing a measured node tree.
   #[wasm_bindgen(typescript_type = "MeasuredNode")]
   pub type MeasuredNodeType;
-
-  /// JavaScript object representing an animation scene source.
-  #[wasm_bindgen(typescript_type = "AnimationScene")]
-  pub type AnimationSceneType;
 }
 
 /// Options for constructing a `Renderer`.

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -62,6 +62,50 @@ fn load_font_internal(
   }
 }
 
+fn parse_lang(lang: Option<String>) -> Result<Option<Lang>, js_sys::Error> {
+  lang
+    .as_deref()
+    .map(Lang::parse)
+    .transpose()
+    .map_err(map_error)
+}
+
+fn raster_options<'fonts>(
+  resource_cache: &ResourceCache,
+  fonts: &'fonts Fonts,
+  node: Node,
+  options: RenderOptions,
+  images: HashMap<Arc<str>, LoadedImageSource>,
+) -> Result<takumi_raster::RenderOptions<'fonts>, js_sys::Error> {
+  let stylesheet = stylesheet(
+    resource_cache,
+    options.stylesheets,
+    options.keyframes.unwrap_or_default(),
+  );
+  let lang = parse_lang(options.lang)?;
+
+  Ok(
+    takumi_raster::RenderOptions::builder()
+      .viewport(
+        Viewport::new((options.width, options.height)).with_device_pixel_ratio(
+          options
+            .device_pixel_ratio
+            .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
+        ),
+      )
+      .draw_debug_border(options.draw_debug_border.unwrap_or_default())
+      .images(images)
+      .stylesheet(stylesheet)
+      .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
+      .dithering(options.dithering.unwrap_or_default())
+      .node(node)
+      .fonts(fonts)
+      .font_families(options.font_families.map(FontFamily::from_names))
+      .lang(lang)
+      .build(),
+  )
+}
+
 impl Renderer {
   fn read_state(&self) -> Result<RwLockReadGuard<'_, Fonts>, js_sys::Error> {
     self
@@ -152,40 +196,11 @@ impl Renderer {
     options: RenderOptions,
     images: HashMap<Arc<str>, LoadedImageSource>,
   ) -> Result<Vec<u8>, JsValue> {
-    let dithering = options.dithering.unwrap_or_default();
-    let stylesheet = stylesheet(
-      &self.resource_cache,
-      options.stylesheets,
-      options.keyframes.unwrap_or_default(),
-    );
-
-    let lang = options
-      .lang
-      .map(|lang| Lang::parse(&lang).map_err(map_error))
-      .transpose()?;
-
-    let render_options = takumi_raster::RenderOptions::builder()
-      .viewport(
-        Viewport::new((options.width, options.height)).with_device_pixel_ratio(
-          options
-            .device_pixel_ratio
-            .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
-        ),
-      )
-      .draw_debug_border(options.draw_debug_border.unwrap_or_default())
-      .images(images)
-      .stylesheet(stylesheet)
-      .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
-      .dithering(dithering)
-      .node(node)
-      .fonts(fonts)
-      .font_families(options.font_families.map(FontFamily::from_names))
-      .lang(lang)
-      .build();
+    let format = options.format.unwrap_or(OutputFormat::Png);
+    let quality = options.quality;
+    let render_options = raster_options(&self.resource_cache, fonts, node, options, images)?;
 
     let image = render(render_options).map_err(map_error)?;
-
-    let format = options.format.unwrap_or(OutputFormat::Png);
 
     if format == OutputFormat::Raw {
       return Ok(image.into_raw());
@@ -196,7 +211,7 @@ impl Renderer {
     write_image(
       &image,
       &mut buffer,
-      format.into_image_output_format(options.quality),
+      format.into_image_output_format(quality),
     )
     .map_err(map_error)?;
 
@@ -224,10 +239,7 @@ impl Renderer {
     );
     let state = self.read_state()?;
 
-    let lang = options
-      .lang
-      .map(|lang| Lang::parse(&lang).map_err(map_error))
-      .transpose()?;
+    let lang = parse_lang(options.lang)?;
 
     let svg = takumi_svg::render(
       takumi_svg::SvgOptions::builder()
@@ -259,36 +271,10 @@ impl Renderer {
       .transpose()?
       .unwrap_or_default();
 
-    let lang = options
-      .lang
-      .map(|lang| Lang::parse(&lang).map_err(map_error))
-      .transpose()?;
-
     let images = self.images_map(options.images.as_deref())?;
-    let stylesheet = stylesheet(
-      &self.resource_cache,
-      options.stylesheets,
-      options.keyframes.unwrap_or_default(),
-    );
 
     let state = self.read_state()?;
-    let render_options = takumi_raster::RenderOptions::builder()
-      .viewport(
-        Viewport::new((options.width, options.height)).with_device_pixel_ratio(
-          options
-            .device_pixel_ratio
-            .unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO),
-        ),
-      )
-      .draw_debug_border(options.draw_debug_border.unwrap_or_default())
-      .images(images)
-      .stylesheet(stylesheet)
-      .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
-      .node(node)
-      .fonts(&state)
-      .font_families(options.font_families.map(FontFamily::from_names))
-      .lang(lang)
-      .build();
+    let render_options = raster_options(&self.resource_cache, &state, node, options, images)?;
 
     let layout = measure(render_options).map_err(map_error)?;
 
@@ -347,9 +333,7 @@ impl Renderer {
       lang,
     } = from_value(options.into()).map_err(map_error)?;
 
-    let lang = lang
-      .map(|lang| Lang::parse(&lang).map_err(map_error))
-      .transpose()?;
+    let lang = parse_lang(lang)?;
 
     let images = self.images_map(images.as_deref())?;
 


### PR DESCRIPTION
## Why

A repo-wide audit turned up internal traits with a single implementation, dead helpers, and the same option-lowering code pasted across the binding task types. None of it changes rendered output, so it can go without a changeset.

## What

- `takumi-raster`: `BorderRasterization` existed only because `BorderProperties` is a foreign type; its six methods are now free functions in the same module. Removed the unused `animation_encoder_error_msg`.
- `takumi-core`: `MatchableNode` had one implementor (`Node`), so the matcher now works on `Node` directly and the queries live as `pub(crate)` inherent methods.
- `takumi-napi`: the four task `from_options` shared verbatim image-collection, lang-parsing, and device-pixel-ratio code; extracted `collect_images`, `parse_lang`, and `device_pixel_ratio` into `renderer.rs`. Dropped the unused `Deref` impl on `BufferOrSlice`.
- `takumi-wasm`: `render` and `measure` rebuilt the same `RenderOptions` chain inline; extracted `raster_options` and a `parse_lang` helper. Removed the unreferenced `ImageSourceType`/`AnimationSceneType` extern declarations and the unused `JsResult` alias (generated `.d.ts` is unchanged).
- `@takumi-rs/helpers`: `getIconCode` now uses `codePointAt` instead of hand-rolled surrogate math, the `Intl.Segmenter` feature detection is gone (every supported runtime ships it, and the fallback split ZWJ emoji wrong), and `isRenderProp` reuses `isFunctionComponent`.

Verified with CI's clippy invocation, `cargo fmt`, `tsc --noEmit`, oxlint/oxfmt, and the raster, core, helpers, and umbrella fixture suites. Golden fixtures show no svg/webp diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unified rendering and measurement option handling for more consistent viewport, language, and image processing.
  * Improved emoji segmentation and icon code-point handling.
  * Improved React context consumer rendering for function-based content.
  * Streamlined stylesheet matching and border rendering while preserving existing behavior.
* **Maintenance**
  * Removed unused code and simplified internal WebAssembly, WebP, and buffer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->