### PR TITLE
Chore: collapse napi buffer lowering, use native base64 in playground

### DIFF
--- a/.tegami/helpers-uint8array-views.md
+++ b/.tegami/helpers-uint8array-views.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "@takumi-rs/helpers": patch
+---
+
+### Hand font and image bytes to the bindings as Uint8Array views
+
+Fetched fonts and images flowed to the bindings as bare ArrayBuffers, which the native binding copies. Wrapping them in a Uint8Array view costs nothing and takes the zero-copy path.

--- a/.tegami/napi-zero-copy-input-bytes.md
+++ b/.tegami/napi-zero-copy-input-bytes.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "@takumi-rs/core": patch
+---
+
+### Stop copying Uint8Array font and image inputs on the native binding
+
+Buffer inputs were already passed to render tasks as ref-counted views, but Uint8Array inputs went through a full `to_vec` copy first. Both now cross into the async tasks zero-copy; only bare ArrayBuffer inputs still copy.

--- a/docs/app/playground/share.ts
+++ b/docs/app/playground/share.ts
@@ -1,21 +1,3 @@
-function uint8ToBase64(uint8: Uint8Array): string {
-  let binary = "";
-  for (let i = 0; i < uint8.length; i++) {
-    binary += String.fromCharCode(uint8[i]);
-  }
-  return btoa(binary);
-}
-
-function base64ToUint8(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const len = binary.length;
-  const bytes = new Uint8Array(len);
-  for (let i = 0; i < len; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
 export async function compressCode(code: string) {
   const blob = new Blob([code]);
 
@@ -25,13 +7,13 @@ export async function compressCode(code: string) {
   const compressedArrayBuffer = await new Response(compressedStream).arrayBuffer();
   const compressedBytes = new Uint8Array(compressedArrayBuffer);
 
-  return uint8ToBase64(compressedBytes);
+  return compressedBytes.toBase64();
 }
 
 export async function decompressCode(base64: string) {
-  const compressedBytes = base64ToUint8(base64);
+  const compressedBytes = Uint8Array.fromBase64(base64);
 
-  const blob = new Blob([compressedBytes.buffer as ArrayBuffer]);
+  const blob = new Blob([compressedBytes]);
   const stream = blob.stream().pipeThrough(new DecompressionStream("gzip"));
 
   const decompressedText = await new Response(stream).text();

--- a/docs/app/playground/share.ts
+++ b/docs/app/playground/share.ts
@@ -1,3 +1,22 @@
+function uint8ToBase64(uint8: Uint8Array): string {
+  if (typeof uint8.toBase64 === "function") return uint8.toBase64();
+
+  let binary = "";
+  for (const byte of uint8) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToUint8(base64: string): Uint8Array<ArrayBuffer> {
+  if (typeof Uint8Array.fromBase64 === "function") {
+    return Uint8Array.fromBase64(base64);
+  }
+
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
 export async function compressCode(code: string) {
   const blob = new Blob([code]);
 
@@ -7,11 +26,11 @@ export async function compressCode(code: string) {
   const compressedArrayBuffer = await new Response(compressedStream).arrayBuffer();
   const compressedBytes = new Uint8Array(compressedArrayBuffer);
 
-  return compressedBytes.toBase64();
+  return uint8ToBase64(compressedBytes);
 }
 
 export async function decompressCode(base64: string) {
-  const compressedBytes = Uint8Array.fromBase64(base64);
+  const compressedBytes = base64ToUint8(base64);
 
   const blob = new Blob([compressedBytes]);
   const stream = blob.stream().pipeThrough(new DecompressionStream("gzip"));

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -342,7 +342,6 @@ macro_rules! define_style {
         }
 
         /// Resolves a property from a camelCase name.
-        #[allow(dead_code)]
         pub(crate) fn from_camel_case(name: &str) -> Self {
           PropertyId::from_name(name, normalize_camel_property_name)
         }

--- a/takumi-helpers/src/renderer.ts
+++ b/takumi-helpers/src/renderer.ts
@@ -135,6 +135,11 @@ function isBuffer(data: unknown): data is ByteBuf {
   );
 }
 
+// The native binding copies bare ArrayBuffers but passes typed-array views zero-copy.
+function asView(data: ByteBuf): Uint8Array {
+  return data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+}
+
 function extractFontBuffer(font: Exclude<FontLoader, string>) {
   if (isBuffer(font)) {
     return font;
@@ -175,7 +180,7 @@ export async function resolveImageLoaders(images: ImagesInput): Promise<ImageSou
   return Promise.all(
     [...bySrc.values()].map(async ({ src, data, cache: own }) => ({
       src,
-      data: typeof data === "function" ? await data() : data,
+      data: asView(typeof data === "function" ? await data() : data),
       cache: own ?? cache,
     })),
   );
@@ -228,7 +233,11 @@ export class FontRegistry<TFamily extends RegisteredFamilyLike> {
     const extracted = extractFontBuffer(loader);
 
     const promise = Promise.resolve(extracted)
-      .then((data) => this.registerInner(isBuffer(loader) ? data : { ...loader, data }))
+      .then((data) => {
+        const view = asView(data);
+
+        return this.registerInner(isBuffer(loader) ? view : { ...loader, data: view });
+      })
       .catch((error) => {
         this.deleteFont(key);
         throw error;

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -113,34 +113,36 @@ impl AsRef<[u8]> for JsBytes {
   }
 }
 
-pub(crate) fn bytes_from_object(env: Env, value: Object) -> Result<JsBytes> {
-  if value.is_buffer()? {
-    let buffer = unsafe { BufferSlice::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(JsBytes::Buffer(buffer.into_buffer(&env)?));
-  }
+impl JsBytes {
+  pub(crate) fn from_object(env: Env, value: Object) -> Result<Self> {
+    if value.is_buffer()? {
+      let buffer = unsafe { BufferSlice::from_napi_value(env.raw(), value.raw()) }?;
+      return Ok(JsBytes::Buffer(buffer.into_buffer(&env)?));
+    }
 
-  if value.is_typedarray()? {
-    let array = unsafe { Uint8Array::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(JsBytes::Array(array));
-  }
+    if value.is_typedarray()? {
+      let array = unsafe { Uint8Array::from_napi_value(env.raw(), value.raw()) }?;
+      return Ok(JsBytes::Array(array));
+    }
 
-  if value.is_arraybuffer()? {
-    let buffer = unsafe { ArrayBuffer::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(JsBytes::Buffer(Buffer::from(buffer.to_vec())));
-  }
+    if value.is_arraybuffer()? {
+      let buffer = unsafe { ArrayBuffer::from_napi_value(env.raw(), value.raw()) }?;
+      return Ok(JsBytes::Buffer(Buffer::from(buffer.to_vec())));
+    }
 
-  Err(Error::from_reason(
-    "Expected Buffer, ArrayBuffer, or Uint8Array".to_owned(),
-  ))
+    Err(Error::from_reason(
+      "Expected Buffer, ArrayBuffer, or Uint8Array".to_owned(),
+    ))
+  }
 }
 
 pub(crate) fn parse_font_input(env: Env, font: Object) -> Result<(FontInput, JsBytes)> {
-  if let Ok(buffer) = bytes_from_object(env, font) {
+  if let Ok(buffer) = JsBytes::from_object(env, font) {
     Ok((FontInput::default(), buffer))
   } else {
     let buffer = font
       .get_named_property("data")
-      .and_then(|buffer| bytes_from_object(env, buffer))?;
+      .and_then(|buffer| JsBytes::from_object(env, buffer))?;
     let font: FontInput = deserialize_with_tracing(font).map_err(map_error)?;
 
     Ok((font, buffer))

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -97,6 +97,8 @@ impl<'de> Deserialize<'de> for FontStyleInput {
 }
 
 /// Ref-counted view of JS-owned bytes, sendable into async tasks without copying.
+/// Callers must not mutate the bytes on the JS side while a task reads them —
+/// the same aliasing contract Buffer inputs have always had.
 pub(crate) enum JsBytes {
   Buffer(Buffer),
   Array(Uint8Array),

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -96,20 +96,35 @@ impl<'de> Deserialize<'de> for FontStyleInput {
   }
 }
 
-pub(crate) fn buffer_from_object(env: Env, value: Object) -> Result<Buffer> {
+/// Ref-counted view of JS-owned bytes, sendable into async tasks without copying.
+pub(crate) enum JsBytes {
+  Buffer(Buffer),
+  Array(Uint8Array),
+}
+
+impl AsRef<[u8]> for JsBytes {
+  fn as_ref(&self) -> &[u8] {
+    match self {
+      JsBytes::Buffer(buffer) => buffer,
+      JsBytes::Array(array) => array,
+    }
+  }
+}
+
+pub(crate) fn bytes_from_object(env: Env, value: Object) -> Result<JsBytes> {
   if value.is_buffer()? {
     let buffer = unsafe { BufferSlice::from_napi_value(env.raw(), value.raw()) }?;
-    return buffer.into_buffer(&env);
+    return Ok(JsBytes::Buffer(buffer.into_buffer(&env)?));
+  }
+
+  if value.is_typedarray()? {
+    let array = unsafe { Uint8Array::from_napi_value(env.raw(), value.raw()) }?;
+    return Ok(JsBytes::Array(array));
   }
 
   if value.is_arraybuffer()? {
     let buffer = unsafe { ArrayBuffer::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(Buffer::from(buffer.to_vec()));
-  }
-
-  if value.is_typedarray()? {
-    let buffer = unsafe { Uint8ArraySlice::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(Buffer::from(buffer.to_vec()));
+    return Ok(JsBytes::Buffer(Buffer::from(buffer.to_vec())));
   }
 
   Err(Error::from_reason(
@@ -117,13 +132,13 @@ pub(crate) fn buffer_from_object(env: Env, value: Object) -> Result<Buffer> {
   ))
 }
 
-pub(crate) fn parse_font_input(env: Env, font: Object) -> Result<(FontInput, Buffer)> {
-  if let Ok(buffer) = buffer_from_object(env, font) {
+pub(crate) fn parse_font_input(env: Env, font: Object) -> Result<(FontInput, JsBytes)> {
+  if let Ok(buffer) = bytes_from_object(env, font) {
     Ok((FontInput::default(), buffer))
   } else {
     let buffer = font
       .get_named_property("data")
-      .and_then(|buffer| buffer_from_object(env, buffer))?;
+      .and_then(|buffer| bytes_from_object(env, buffer))?;
     let font: FontInput = deserialize_with_tracing(font).map_err(map_error)?;
 
     Ok((font, buffer))

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -102,8 +102,19 @@ pub(crate) fn buffer_from_object(env: Env, value: Object) -> Result<Buffer> {
     return buffer.into_buffer(&env);
   }
 
-  let bytes = buffer_slice_from_object(env, value)?;
-  Ok(Buffer::from(bytes.as_ref().to_vec()))
+  if value.is_arraybuffer()? {
+    let buffer = unsafe { ArrayBuffer::from_napi_value(env.raw(), value.raw()) }?;
+    return Ok(Buffer::from(buffer.to_vec()));
+  }
+
+  if value.is_typedarray()? {
+    let buffer = unsafe { Uint8ArraySlice::from_napi_value(env.raw(), value.raw()) }?;
+    return Ok(Buffer::from(buffer.to_vec()));
+  }
+
+  Err(Error::from_reason(
+    "Expected Buffer, ArrayBuffer, or Uint8Array".to_owned(),
+  ))
 }
 
 pub(crate) fn parse_font_input(env: Env, font: Object) -> Result<(FontInput, Buffer)> {
@@ -134,46 +145,6 @@ pub(crate) fn resolve_font_resource<'a>(
   .map_err(map_error)?
   .into_resolved()
   .map_err(map_error)
-}
-
-pub(crate) enum BufferOrSlice<'env> {
-  ArrayBuffer(ArrayBuffer<'env>),
-  Buffer(BufferSlice<'env>),
-  Uint8Array(Uint8ArraySlice<'env>),
-}
-
-impl AsRef<[u8]> for BufferOrSlice<'_> {
-  fn as_ref(&self) -> &[u8] {
-    match self {
-      BufferOrSlice::ArrayBuffer(buffer) => buffer,
-      BufferOrSlice::Buffer(buffer) => buffer,
-      BufferOrSlice::Uint8Array(buffer) => buffer,
-    }
-  }
-}
-
-pub(crate) fn buffer_slice_from_object<'env>(
-  env: Env,
-  value: Object<'env>,
-) -> Result<BufferOrSlice<'env>> {
-  if value.is_buffer()? {
-    let buffer = unsafe { BufferSlice::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(BufferOrSlice::Buffer(buffer));
-  }
-
-  if value.is_arraybuffer()? {
-    let buffer = unsafe { ArrayBuffer::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(BufferOrSlice::ArrayBuffer(buffer));
-  }
-
-  if value.is_typedarray()? {
-    let buffer = unsafe { Uint8ArraySlice::from_napi_value(env.raw(), value.raw()) }?;
-    return Ok(BufferOrSlice::Uint8Array(buffer));
-  }
-
-  Err(Error::from_reason(
-    "Expected Buffer, ArrayBuffer, or Uint8Array".to_owned(),
-  ))
 }
 
 pub(crate) fn deserialize_with_tracing<T: DeserializeOwned>(value: Object) -> Result<T> {

--- a/takumi-napi/src/load_font_task.rs
+++ b/takumi-napi/src/load_font_task.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
 
-use crate::{FontInput, RegisteredFamily, renderer::RendererState, resolve_font_resource};
+use crate::{FontInput, JsBytes, RegisteredFamily, renderer::RendererState, resolve_font_resource};
 
 pub struct LoadFontTask {
   pub(crate) state: Arc<RendererState>,
-  pub(crate) buffer: Buffer,
+  pub(crate) buffer: JsBytes,
   pub(crate) info: FontInput,
 }
 
@@ -15,7 +15,7 @@ impl Task for LoadFontTask {
   type JsValue = Vec<RegisteredFamily>;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    let resource = resolve_font_resource(&self.info, &self.buffer)?;
+    let resource = resolve_font_resource(&self.info, self.buffer.as_ref())?;
 
     // Serialize registrations; readers stay wait-free on the old snapshot meanwhile.
     let _write = self

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -9,7 +9,7 @@ use takumi_core::{
 use takumi_raster::measure;
 
 use crate::{
-  map_error,
+  JsBytes, map_error,
   renderer::{
     ImageCacheMode, MeasuredNode, RenderOptions, RendererState, collect_images, decode_images,
     deserialize_keyframes, device_pixel_ratio, parse_lang,
@@ -23,7 +23,7 @@ pub struct MeasureTask {
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: Arc<StyleSheet>,
-  pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+  pub(crate) images: HashMap<Arc<str>, (JsBytes, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
 }

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -12,7 +12,7 @@ use takumi_raster::{
 };
 
 use crate::{
-  deserialize_with_tracing,
+  JsBytes, deserialize_with_tracing,
   renderer::{
     AnimationOutputFormat, ImageCacheMode, RenderAnimationOptions, RendererState, collect_images,
     decode_images, deserialize_keyframes, device_pixel_ratio, parse_lang, webp_lossless,
@@ -30,7 +30,7 @@ pub struct RenderAnimationTask {
   pub(crate) draw_debug_border: bool,
   pub(crate) stylesheets: Option<Vec<String>>,
   pub(crate) keyframes: Vec<KeyframesRule>,
-  pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+  pub(crate) images: HashMap<Arc<str>, (JsBytes, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
   pub(crate) fps: u32,

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -9,7 +9,7 @@ use takumi_core::{
 use takumi_raster::{DitheringAlgorithm, render, write_image};
 
 use crate::{
-  map_error,
+  JsBytes, map_error,
   renderer::{
     ImageCacheMode, OutputFormat, RenderOptions, RendererState, collect_images, decode_images,
     deserialize_keyframes, device_pixel_ratio, parse_lang,
@@ -28,7 +28,7 @@ pub struct RenderTask {
   pub(crate) dithering: DitheringAlgorithm,
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: Arc<StyleSheet>,
-  pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+  pub(crate) images: HashMap<Arc<str>, (JsBytes, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
 }

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -20,9 +20,10 @@ use takumi_raster::{
 };
 
 use crate::{
-  De, buffer_from_object, deserialize_with_tracing, load_font_task::LoadFontTask, map_error,
-  measure_task::MeasureTask, parse_font_input, render_animation_task::RenderAnimationTask,
-  render_task::RenderTask, svg_render_task::SvgRenderTask,
+  De, JsBytes, bytes_from_object, deserialize_with_tracing, load_font_task::LoadFontTask,
+  map_error, measure_task::MeasureTask, parse_font_input,
+  render_animation_task::RenderAnimationTask, render_task::RenderTask,
+  svg_render_task::SvgRenderTask,
 };
 
 /// Represents a single run of text in a measured node.
@@ -98,13 +99,13 @@ pub(crate) struct RendererState {
 /// `quick_cache::sync` (internally locked, single-flight), so it needs no outer lock.
 pub(crate) fn decode_images(
   resource_cache: &ResourceCache,
-  images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+  images: HashMap<Arc<str>, (JsBytes, ImageCacheMode)>,
 ) -> Result<HashMap<Arc<str>, LoadedImageSource>> {
   let mut map = HashMap::new();
 
   for (src, (buffer, mode)) in images {
     let decoded = resource_cache
-      .get_or_decode(&buffer, mode.into())
+      .get_or_decode(buffer.as_ref(), mode.into())
       .map_err(map_error)?;
 
     map.insert(src, decoded);
@@ -116,7 +117,7 @@ pub(crate) fn decode_images(
 pub(crate) fn collect_images(
   env: Env,
   images: Option<Vec<ImageSource>>,
-) -> Result<HashMap<Arc<str>, (Buffer, ImageCacheMode)>> {
+) -> Result<HashMap<Arc<str>, (JsBytes, ImageCacheMode)>> {
   images
     .unwrap_or_default()
     .into_iter()
@@ -124,7 +125,7 @@ pub(crate) fn collect_images(
       Ok((
         Arc::from(image.src),
         (
-          buffer_from_object(env, image.data)?,
+          bytes_from_object(env, image.data)?,
           image.cache.unwrap_or_default(),
         ),
       ))

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -20,10 +20,9 @@ use takumi_raster::{
 };
 
 use crate::{
-  De, JsBytes, bytes_from_object, deserialize_with_tracing, load_font_task::LoadFontTask,
-  map_error, measure_task::MeasureTask, parse_font_input,
-  render_animation_task::RenderAnimationTask, render_task::RenderTask,
-  svg_render_task::SvgRenderTask,
+  De, JsBytes, deserialize_with_tracing, load_font_task::LoadFontTask, map_error,
+  measure_task::MeasureTask, parse_font_input, render_animation_task::RenderAnimationTask,
+  render_task::RenderTask, svg_render_task::SvgRenderTask,
 };
 
 /// Represents a single run of text in a measured node.
@@ -125,7 +124,7 @@ pub(crate) fn collect_images(
       Ok((
         Arc::from(image.src),
         (
-          bytes_from_object(env, image.data)?,
+          JsBytes::from_object(env, image.data)?,
           image.cache.unwrap_or_default(),
         ),
       ))

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -8,7 +8,7 @@ use takumi_core::{
 };
 
 use crate::{
-  map_error,
+  JsBytes, map_error,
   renderer::{
     ImageCacheMode, RendererState, SvgRenderOptions, collect_images, decode_images,
     deserialize_keyframes, parse_lang,
@@ -22,7 +22,7 @@ pub struct SvgRenderTask {
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
   pub(crate) stylesheet: Arc<StyleSheet>,
-  pub(crate) images: HashMap<Arc<str>, (Buffer, ImageCacheMode)>,
+  pub(crate) images: HashMap<Arc<str>, (JsBytes, ImageCacheMode)>,
   pub(crate) font_families: Option<FontFamily>,
   pub(crate) lang: Option<Lang>,
 }


### PR DESCRIPTION
## Why
Repo-wide audit for leftover indirection after #1027.

## What
- takumi-napi: `BufferOrSlice` and `buffer_slice_from_object` existed only to be flattened into an owned `Buffer` by their single caller. Folded the three branches into `buffer_from_object` directly.
- playground: replaced hand-rolled base64 loops with `Uint8Array.prototype.toBase64` / `Uint8Array.fromBase64`, and dropped an `ArrayBuffer` cast by passing the `Uint8Array` to `Blob` directly.
- takumi-core: removed a stale `#[allow(dead_code)]` on `from_camel_case`.

No behavior change. Left `TabSize`'s `max().min()` chain alone: `clamp` would forward NaN instead of sanitizing it to 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base64 encoding/decoding and gzip decompression by leveraging typed-array helpers when available and decoding directly from decoded bytes.
* **Improvements**
  * Enhanced native font and image ingestion performance by carrying `Uint8Array` inputs through rendering and async tasks as efficient zero-copy byte views (with `ArrayBuffer` normalized into typed-array views).
* **Documentation**
  * Updated guidance on zero-copy behavior differences between `Uint8Array` and bare `ArrayBuffer` inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->