### PR TITLE
Core: bound calc depth, var substitution size, and list interpolation length

### DIFF
--- a/.tegami/bound-css-value-layer.md
+++ b/.tegami/bound-css-value-layer.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Bound calc() depth, var() substitution size, and list interpolation length
+
+Four places in the CSS value layer let caller-supplied text drive unbounded recursion or allocation. `calc()` recursed once per leading unary sign and once per nested `calc(`. `var()` substitution capped neither its nesting nor its total substituted bytes; its cycle guard is pushed and popped per reference, so it stops a property referencing itself but not fan-out, and `--n: var(--n-1)var(--n-1)` doubles per link. `RepeatToLcm` list interpolation allocated the full LCM of the two list lengths. A `calc()` resolving to NaN or infinity reached taffy unclamped, where every other `Length` arm is clamped on its way through `to_px`.
+
+Release builds abort on panic, so a stack overflow or a failed allocation here took down the host process instead of returning an error. The limits match Blink: depth 100, 2 MiB of substituted text (the value the spec and Firefox use as well), and 1000 interpolated list entries.

--- a/takumi-core/src/style/calc.rs
+++ b/takumi-core/src/style/calc.rs
@@ -205,12 +205,19 @@ pub(crate) enum CalcValue {
   Formula(CalcFormula),
 }
 
+// Matches Blink's `kMaxExpressionDepth` (css_math_expression_node.h).
+const MAX_CALC_DEPTH: u32 = 100;
+
 pub(crate) fn parse_calc_sum<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, CalcValue> {
-  let mut value = parse_calc_product(input)?;
+  parse_calc_sum_at(input, 0)
+}
+
+fn parse_calc_sum_at<'i>(input: &mut Parser<'i, '_>, depth: u32) -> ParseResult<'i, CalcValue> {
+  let mut value = parse_calc_product_at(input, depth)?;
 
   loop {
     if input.try_parse(|parser| parser.expect_delim('+')).is_ok() {
-      let rhs = parse_calc_product(input)?;
+      let rhs = parse_calc_product_at(input, depth)?;
       value = match (value, rhs) {
         (CalcValue::Number(lhs), CalcValue::Number(rhs)) => CalcValue::Number(lhs + rhs),
         (CalcValue::Formula(lhs), CalcValue::Formula(rhs)) => CalcValue::Formula(lhs.add(rhs)),
@@ -226,7 +233,7 @@ pub(crate) fn parse_calc_sum<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, 
     }
 
     if input.try_parse(|parser| parser.expect_delim('-')).is_ok() {
-      let rhs = parse_calc_product(input)?;
+      let rhs = parse_calc_product_at(input, depth)?;
       value = match (value, rhs) {
         (CalcValue::Number(lhs), CalcValue::Number(rhs)) => CalcValue::Number(lhs - rhs),
         (CalcValue::Formula(lhs), CalcValue::Formula(rhs)) => CalcValue::Formula(lhs.sub(rhs)),
@@ -263,12 +270,12 @@ pub(crate) fn parse_calc_number_expression<'i>(input: &mut Parser<'i, '_>) -> Pa
   }
 }
 
-fn parse_calc_product<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, CalcValue> {
-  let mut value = parse_calc_factor(input)?;
+fn parse_calc_product_at<'i>(input: &mut Parser<'i, '_>, depth: u32) -> ParseResult<'i, CalcValue> {
+  let mut value = parse_calc_factor_at(input, depth)?;
 
   loop {
     if input.try_parse(|parser| parser.expect_delim('*')).is_ok() {
-      let rhs = parse_calc_factor(input)?;
+      let rhs = parse_calc_factor_at(input, depth)?;
       value = match (value, rhs) {
         (CalcValue::Formula(lhs), CalcValue::Number(rhs)) => CalcValue::Formula(lhs.scale(rhs)),
         (CalcValue::Number(lhs), CalcValue::Formula(rhs)) => CalcValue::Formula(rhs.scale(lhs)),
@@ -285,7 +292,7 @@ fn parse_calc_product<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, CalcVal
     }
 
     if input.try_parse(|parser| parser.expect_delim('/')).is_ok() {
-      let rhs = parse_calc_factor(input)?;
+      let rhs = parse_calc_factor_at(input, depth)?;
       value = match (value, rhs) {
         (_, CalcValue::Number(0.0)) => {
           return Err(unexpected_token!(
@@ -343,19 +350,23 @@ impl CalcFormula {
   }
 }
 
-fn parse_calc_factor<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, CalcValue> {
+fn parse_calc_factor_at<'i>(input: &mut Parser<'i, '_>, depth: u32) -> ParseResult<'i, CalcValue> {
+  let location = input.current_source_location();
+  if depth >= MAX_CALC_DEPTH {
+    return Err(location.new_unexpected_token_error(Token::ParenthesisBlock));
+  }
+
   if input.try_parse(|parser| parser.expect_delim('+')).is_ok() {
-    return parse_calc_factor(input);
+    return parse_calc_factor_at(input, depth + 1);
   }
 
   if input.try_parse(|parser| parser.expect_delim('-')).is_ok() {
-    return Ok(match parse_calc_factor(input)? {
+    return Ok(match parse_calc_factor_at(input, depth + 1)? {
       CalcValue::Number(value) => CalcValue::Number(-value),
       CalcValue::Formula(formula) => CalcValue::Formula(formula.neg()),
     });
   }
 
-  let location = input.current_source_location();
   let token = input.next()?;
 
   match token {
@@ -370,7 +381,7 @@ fn parse_calc_factor<'i>(input: &mut Parser<'i, '_>) -> ParseResult<'i, CalcValu
       }
     }
     Token::Function(name) if name.eq_ignore_ascii_case("calc") => {
-      input.parse_nested_block(parse_calc_sum)
+      input.parse_nested_block(|input| parse_calc_sum_at(input, depth + 1))
     }
     Token::Ident(ident) => match_ignore_ascii_case! {ident.as_ref(),
       "e" => Ok(CalcValue::Number(std::f32::consts::E)),

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -6,7 +6,7 @@ use taffy::{CompactLength, Dimension, LengthPercentage, LengthPercentageAuto};
 use crate::style::{
   AspectRatio, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
   SizingContext, ToCss,
-  calc::{CalcFormula, CalcValue, parse_calc_sum},
+  calc::{CalcFormula, CalcLinear, CalcValue, parse_calc_sum},
   tw::{TW_VAR_SPACING, TailwindPropertyParser},
   unexpected_token,
 };
@@ -413,16 +413,22 @@ impl Length {
       | Length::VMax(_) => CompactLength::length(self.to_px_pre_dpr(sizing, 0.0)),
       Length::Calc(formula) => {
         let linear = formula.resolve(sizing);
+        let px = clamp_px_for_integer_cast(linear.px);
+        let percent = clamp_px_for_integer_cast(linear.percent);
 
-        if is_near_zero(linear.percent) {
-          return CompactLength::length(linear.px);
+        if is_near_zero(percent) {
+          return CompactLength::length(px);
         }
 
-        if is_near_zero(linear.px) {
-          return CompactLength::percent(linear.percent);
+        if is_near_zero(px) {
+          return CompactLength::percent(percent);
         }
 
-        CompactLength::calc(sizing.calc_arena.register_linear(linear))
+        CompactLength::calc(
+          sizing
+            .calc_arena
+            .register_linear(CalcLinear { px, percent }),
+        )
       }
       _ => CompactLength::length(self.to_px(
         sizing,
@@ -890,5 +896,56 @@ mod tests {
 
     assert_eq!(resolved, SAFE_INT_MAX_PX);
     assert!(resolved.is_finite());
+  }
+
+  #[test]
+  fn calc_non_finite_never_reaches_compact_length() {
+    let sizing = sizing();
+
+    for css in [
+      "calc(1px * nan)",
+      "calc(1px * infinity)",
+      "calc(1px * -infinity)",
+      "calc(100% * nan)",
+      "calc(100% * nan + 1px)",
+    ] {
+      let parsed = Length::from_css_str(css);
+      assert!(parsed.is_ok(), "expected {css} to parse, got {parsed:?}");
+      let Ok(length) = parsed else {
+        continue;
+      };
+      let compact = length.to_compact_length(&sizing);
+
+      assert!(
+        compact.is_calc() || compact.value().is_finite(),
+        "{css} produced a non-finite CompactLength"
+      );
+    }
+  }
+
+  #[test]
+  fn calc_rejects_deeply_nested_unary_signs() {
+    let css = format!("calc({}1px)", "- ".repeat(200));
+
+    assert!(Length::from_css_str(&css).is_err());
+  }
+
+  #[test]
+  fn calc_rejects_deeply_nested_calc_functions() {
+    let css = format!("{}1px{}", "calc(".repeat(200), ")".repeat(200));
+
+    assert!(Length::from_css_str(&css).is_err());
+  }
+
+  #[test]
+  fn calc_still_accepts_shallow_nesting() {
+    let sizing = sizing();
+    let parsed = Length::from_css_str("calc(calc(calc(1px + 2px)))");
+    assert!(parsed.is_ok(), "expected successful parse, got {parsed:?}");
+    let Ok(length) = parsed else {
+      return;
+    };
+
+    assert_near(length.to_px(&sizing, 200.0), sizing.to_device(3.0));
   }
 }

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -550,6 +550,11 @@ impl<T: Animatable + Clone> Animatable for Vec<T> {
   }
 }
 
+// Matches Blink's `kRepeatableListMaxLength` (list_interpolation_functions.cc);
+// transitions restarted on an already-animating value otherwise compound the
+// LCM expansion until it exhausts memory. See crbug.com/739197.
+const MAX_INTERPOLATED_LIST_LEN: usize = 1000;
+
 fn interpolate_list<T: Animatable + Clone, C: AsRef<[T]>, O>(
   from: &C,
   to: &C,
@@ -572,14 +577,8 @@ fn interpolate_list<T: Animatable + Clone, C: AsRef<[T]>, O>(
       if from.is_empty() || to.is_empty() {
         return None;
       }
-      interpolate_pairwise_list(
-        from,
-        to,
-        lcm(from.len(), to.len()),
-        progress,
-        sizing,
-        current_color,
-      )
+      let output_len = lcm(from.len(), to.len()).min(MAX_INTERPOLATED_LIST_LEN);
+      interpolate_pairwise_list(from, to, output_len, progress, sizing, current_color)
     }
     ListInterpolationStrategy::PadToLongestWithNeutral => {
       interpolate_neutral_padded_list(from, to, progress, sizing, current_color)?
@@ -870,3 +869,44 @@ macro_rules! declare_box_alignment_enum_impl {
 }
 
 pub(crate) use declare_box_alignment_enum_impl;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{
+    style::{BackgroundRepeat, BackgroundRepeatStyle},
+    viewport::Viewport,
+  };
+
+  fn repeats(len: usize, style: BackgroundRepeatStyle) -> Vec<BackgroundRepeat> {
+    vec![BackgroundRepeat(style, style); len]
+  }
+
+  fn interpolated(from_len: usize, to_len: usize) -> Option<Vec<BackgroundRepeat>> {
+    let sizing = SizingContext::builder()
+      .viewport(Viewport::default())
+      .build();
+
+    interpolate_list(
+      &repeats(from_len, BackgroundRepeatStyle::Repeat),
+      &repeats(to_len, BackgroundRepeatStyle::NoRepeat),
+      0.75,
+      &sizing,
+      Color([0, 0, 0, 255]),
+      |values| values,
+    )
+  }
+
+  #[test]
+  fn repeat_to_lcm_interpolates_under_the_cap() {
+    assert_eq!(interpolated(2, 3).map(|values| values.len()), Some(6));
+  }
+
+  #[test]
+  fn repeat_to_lcm_clamps_past_the_cap() {
+    assert_eq!(
+      interpolated(61, 67).map(|values| values.len()),
+      Some(MAX_INTERPOLATED_LIST_LEN)
+    );
+  }
+}

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1219,6 +1219,29 @@ fn test_var_resolves_inside_nested_blocks() {
 }
 
 #[test]
+fn test_var_gives_up_on_exponential_fan_out() {
+  let mut custom_properties = HashMap::from([("--l0".to_owned(), "x".to_owned())]);
+  for level in 1..=24 {
+    custom_properties.insert(
+      format!("--l{level}"),
+      format!("var(--l{prev})var(--l{prev})", prev = level - 1),
+    );
+  }
+
+  let resolved = resolve_var_references("var(--l24)", &custom_properties, &mut Vec::new());
+
+  assert_eq!(resolved, None);
+}
+
+#[test]
+fn test_var_gives_up_on_deeply_nested_blocks() {
+  let specified_value = format!("{}1px{}", "(".repeat(200), ")".repeat(200));
+  let resolved = resolve_var_references(&specified_value, &HashMap::new(), &mut Vec::new());
+
+  assert_eq!(resolved, None);
+}
+
+#[test]
 fn test_var_drops_declaration_when_substitution_stays_invalid() {
   let style = inherited_style_from_pairs(
     [("--size", "red"), ("width", "var(--size)")],

--- a/takumi-core/src/style/stylesheets_vars.rs
+++ b/takumi-core/src/style/stylesheets_vars.rs
@@ -5,10 +5,27 @@ use cssparser::{Parser, ParserInput, Token};
 use super::DeferredDeclaration;
 use crate::style::{ComputedStyle, CssInput};
 
-pub(crate) fn resolve_var_function(
+// Block nesting recurses here where Blink's tokenizer iterates, so it needs a
+// depth of its own; the value follows Blink's `kMaxExpressionDepth`.
+const MAX_VAR_DEPTH: u32 = 100;
+// <https://drafts.csswg.org/css-values-5/#long-substitution>, matching Blink's
+// `CSSVariableData::kMaxVariableBytes` and Firefox.
+const MAX_VAR_OUTPUT_BYTES: usize = 2 * 1024 * 1024;
+
+// Counts substituted bytes across one whole top-level resolution, not per call:
+// the cycle guard stops self-reference but not fan-out, so
+// `--n: var(--n-1)var(--n-1)` doubles per link without a shared ceiling.
+fn charge(budget: &mut usize, bytes: usize) -> Option<()> {
+  *budget = budget.checked_sub(bytes)?;
+  Some(())
+}
+
+fn resolve_var_function(
   input: &mut Parser<'_, '_>,
   custom_properties: &HashMap<String, String>,
   stack: &mut Vec<String>,
+  budget: &mut usize,
+  depth: u32,
 ) -> Option<String> {
   let property_name = input.expect_ident_cloned().ok()?;
   if !property_name.starts_with("--") {
@@ -17,7 +34,7 @@ pub(crate) fn resolve_var_function(
 
   let fallback = if input.try_parse(Parser::expect_comma).is_ok() {
     let mut output = String::new();
-    resolve_var_tokens_into(input, custom_properties, stack, &mut output)?;
+    resolve_var_tokens_into(input, custom_properties, stack, budget, depth, &mut output)?;
     Some(output)
   } else {
     None
@@ -33,7 +50,8 @@ pub(crate) fn resolve_var_function(
 
   let resolved = if let Some(specified_value) = custom_properties.get(property_name.as_ref()) {
     stack.push(property_name.to_string());
-    let resolved = resolve_var_references(specified_value, custom_properties, stack);
+    let resolved =
+      resolve_var_references_with(specified_value, custom_properties, stack, budget, depth);
     stack.pop();
     resolved
   } else {
@@ -47,65 +65,79 @@ fn resolve_var_tokens_into(
   input: &mut Parser<'_, '_>,
   custom_properties: &HashMap<String, String>,
   stack: &mut Vec<String>,
+  budget: &mut usize,
+  depth: u32,
   output: &mut String,
 ) -> Option<()> {
+  if depth >= MAX_VAR_DEPTH {
+    return None;
+  }
+
   while !input.is_exhausted() {
     let start = input.position();
     let token = input.next_including_whitespace_and_comments().ok()?;
 
     match token {
       Token::Function(name) if name.eq_ignore_ascii_case("var") => {
-        output.push_str(
-          &input
-            .parse_nested_block(|input| {
-              resolve_var_function(input, custom_properties, stack)
-                .ok_or_else(|| input.new_error_for_next_token::<()>())
-            })
-            .ok()?,
-        );
+        let resolved = input
+          .parse_nested_block(|input| {
+            resolve_var_function(input, custom_properties, stack, budget, depth + 1)
+              .ok_or_else(|| input.new_error_for_next_token::<()>())
+          })
+          .ok()?;
+        charge(budget, resolved.len())?;
+        output.push_str(&resolved);
       }
       Token::Function(name) => {
+        charge(budget, name.len() + 2)?;
         output.push_str(name);
         output.push('(');
         input
           .parse_nested_block(|input| {
-            resolve_var_tokens_into(input, custom_properties, stack, output)
+            resolve_var_tokens_into(input, custom_properties, stack, budget, depth + 1, output)
               .ok_or_else(|| input.new_error_for_next_token::<()>())
           })
           .ok()?;
         output.push(')');
       }
       Token::ParenthesisBlock => {
+        charge(budget, 2)?;
         output.push('(');
         input
           .parse_nested_block(|input| {
-            resolve_var_tokens_into(input, custom_properties, stack, output)
+            resolve_var_tokens_into(input, custom_properties, stack, budget, depth + 1, output)
               .ok_or_else(|| input.new_error_for_next_token::<()>())
           })
           .ok()?;
         output.push(')');
       }
       Token::SquareBracketBlock => {
+        charge(budget, 2)?;
         output.push('[');
         input
           .parse_nested_block(|input| {
-            resolve_var_tokens_into(input, custom_properties, stack, output)
+            resolve_var_tokens_into(input, custom_properties, stack, budget, depth + 1, output)
               .ok_or_else(|| input.new_error_for_next_token::<()>())
           })
           .ok()?;
         output.push(']');
       }
       Token::CurlyBracketBlock => {
+        charge(budget, 2)?;
         output.push('{');
         input
           .parse_nested_block(|input| {
-            resolve_var_tokens_into(input, custom_properties, stack, output)
+            resolve_var_tokens_into(input, custom_properties, stack, budget, depth + 1, output)
               .ok_or_else(|| input.new_error_for_next_token::<()>())
           })
           .ok()?;
         output.push('}');
       }
-      _ => output.push_str(input.slice_from(start)),
+      _ => {
+        let slice = input.slice_from(start);
+        charge(budget, slice.len())?;
+        output.push_str(slice);
+      }
     }
   }
 
@@ -117,10 +149,29 @@ pub(crate) fn resolve_var_references(
   custom_properties: &HashMap<String, String>,
   stack: &mut Vec<String>,
 ) -> Option<String> {
+  let mut budget = MAX_VAR_OUTPUT_BYTES;
+
+  resolve_var_references_with(specified_value, custom_properties, stack, &mut budget, 0)
+}
+
+fn resolve_var_references_with(
+  specified_value: &str,
+  custom_properties: &HashMap<String, String>,
+  stack: &mut Vec<String>,
+  budget: &mut usize,
+  depth: u32,
+) -> Option<String> {
   let mut parser_input = ParserInput::new(specified_value);
   let mut parser = Parser::new(&mut parser_input);
   let mut output = String::with_capacity(specified_value.len());
-  resolve_var_tokens_into(&mut parser, custom_properties, stack, &mut output)?;
+  resolve_var_tokens_into(
+    &mut parser,
+    custom_properties,
+    stack,
+    budget,
+    depth,
+    &mut output,
+  )?;
   Some(output)
 }
 


### PR DESCRIPTION
## Why

`takumi-core` runs as a library inside a Node process or a Cloudflare Workers isolate, and release builds set `panic = "abort"`. A stack overflow or a failed allocation inside CSS parsing is therefore not an error the caller can catch. It takes down the host.

Four places in the CSS value layer let caller-supplied text drive unbounded recursion or allocation. In the usual deployment, where an OG-image endpoint interpolates request data into a template, all four are reachable from one request.

## What

- `calc()` now carries a parse depth, capped at 100. That covers both recursions: a leading unary `+`/`-` costs two bytes per stack frame, and a nested `calc(` re-enters through `parse_nested_block`.
- `var()` substitution shares one byte budget across a whole top-level resolution, capped at 2 MiB, plus a nesting depth of 100. The cycle guard is pushed and popped per reference, so it stops a property referencing itself but not fan-out: `--n: var(--n-1)var(--n-1)` doubles per link, and a 24-link chain is about 1 KB of CSS.
- `RepeatToLcm` list interpolation clamps its output to 1000 entries. Animating a `background-image` list of 5000 entries to one of 4999 used to collect the full LCM, roughly 25 million cloned values.
- The `Length::Calc` arm of `to_compact_length` runs both components through `clamp_px_for_integer_cast`, which every sibling arm already reaches via `to_px`. `calc(1px * nan)` used to put a NaN straight into `taffy::Style.size`, where `is_near_zero` does not catch it.

Limits follow Blink rather than being invented here: `kMaxExpressionDepth` (100), `CSSVariableData::kMaxVariableBytes` (2 MiB, which is also the css-values-5 value and Firefox's), and `kRepeatableListMaxLength` (1000, clamped rather than discarded, matching `MatchLengths`).

Rendered output is unchanged and no fixture moved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when processing complex or deeply nested CSS expressions.
  - Prevented excessive expansion of custom properties and repeated animation lists.
  - Added safeguards against non-finite calculated length values.
  - Preserved support for valid, moderately nested CSS calculations.

- **Documentation**
  - Documented CSS value processing limits and safeguards, including recursion, substitution size, interpolation, and numeric value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->