### PR TITLE
Core: key the glyph caches on font content instead of blob identity

### DIFF
--- a/.tegami/glyph-cache-font-identity.md
+++ b/.tegami/glyph-cache-font-identity.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Key the glyph caches on font content instead of blob identity
+
+`Blob::new` draws its id from a global counter, and that id is part of the key for the shared resolved-glyph and glyph-mask caches, as well as parley's shaping data cache. Registering the same face again produced a fresh id, so a second renderer, or one rebuilt to reclaim memory, missed every glyph the face had already resolved and filled the budget with entries nothing would hit again. The id is now a hash of the decoded font bytes, so identical faces share cache entries no matter how often they are registered.

--- a/.tegami/set-glyph-cache-max-bytes.md
+++ b/.tegami/set-glyph-cache-max-bytes.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core": minor
+  "@takumi-rs/wasm": minor
+---
+
+### Add `setGlyphCacheMaxBytes`
+
+The resolved-glyph and glyph-mask caches share an 8 MiB budget that no binding exposed. `cacheMaxBytes` looks like the knob for it but covers a different set of caches: decoded images, SVG rasters, and parsed stylesheets.
+
+`setGlyphCacheMaxBytes` sets the glyph budget. It is a module-level function rather than a `Renderer` option because those caches live in the module and are shared by every renderer, and the budget is read the first time a cache is used, so the call has to come before the first render.
+
+The default suits Latin text. A CJK outline runs a few kilobytes, so 8 MiB holds on the order of a thousand of them and a page of Chinese re-rasterizes glyphs it evicted a moment earlier.

--- a/.tegami/set-glyph-cache-max-bytes.md
+++ b/.tegami/set-glyph-cache-max-bytes.md
@@ -2,6 +2,7 @@
 packages:
   "@takumi-rs/core": minor
   "@takumi-rs/wasm": minor
+  "takumi-js": minor
 ---
 
 ### Add `setGlyphCacheMaxBytes`
@@ -11,3 +12,5 @@ The resolved-glyph and glyph-mask caches share an 8 MiB budget that no binding e
 `setGlyphCacheMaxBytes` sets the glyph budget. It is a module-level function rather than a `Renderer` option because those caches live in the module and are shared by every renderer, and the budget is read the first time a cache is used, so the call has to come before the first render.
 
 The default suits Latin text. A CJK outline runs a few kilobytes, so 8 MiB holds on the order of a thousand of them and a page of Chinese re-rasterizes glyphs it evicted a moment earlier.
+
+`takumi-js` forwards it too. That one is async, since it has to resolve the backend before it can set anything.

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -34,6 +34,14 @@ import { setGlyphCacheMaxBytes } from "@takumi-rs/core";
 setGlyphCacheMaxBytes(64 * 1024 * 1024);
 ```
 
+`takumi-js` exports it as well. That one is async because it resolves the backend first:
+
+```ts
+import { setGlyphCacheMaxBytes } from "takumi-js";
+
+await setGlyphCacheMaxBytes(64 * 1024 * 1024);
+```
+
 ### Preload Frequently Used Images
 
 Loading images from URLs or bytes during the rendering pass is a bottleneck. Register [Load Images](/docs/load-images) to avoid re-decoding.

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -22,6 +22,18 @@ Decoded images, SVG rasters, and parsed stylesheets share one byte budget, 16 Mi
 const renderer = new Renderer({ cacheMaxBytes: 64 * 1024 * 1024 });
 ```
 
+### Size the Glyph Cache
+
+Resolved glyph outlines and their rasterized masks share a separate 8 MiB budget. These caches belong to the module rather than to a `Renderer`, so `setGlyphCacheMaxBytes` covers every renderer in the process and has to run before the first render — the budget is read when a cache is first used.
+
+The default suits Latin text. A CJK outline runs a few kilobytes, so 8 MiB holds on the order of a thousand of them, and a page of Chinese re-rasterizes glyphs it just evicted:
+
+```ts
+import { setGlyphCacheMaxBytes } from "@takumi-rs/core";
+
+setGlyphCacheMaxBytes(64 * 1024 * 1024);
+```
+
 ### Preload Frequently Used Images
 
 Loading images from URLs or bytes during the rendering pass is a bottleneck. Register [Load Images](/docs/load-images) to avoid re-decoding.

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -22,6 +22,7 @@ use skrifa::{
   raw::types::{F2Dot14, Tag},
 };
 use thiserror::Error;
+use xxhash_rust::xxh3::{Xxh3, xxh3_64};
 
 use crate::{
   context::RenderContext,
@@ -125,7 +126,6 @@ fn resolved_glyph_cache_key(
   skew: Option<f32>,
   glyph_id: u32,
 ) -> u64 {
-  use xxhash_rust::xxh3::Xxh3;
   let mut h = Xxh3::new();
   h.update(&font_id.to_le_bytes());
   h.update(&font_index.to_le_bytes());
@@ -540,7 +540,12 @@ impl<'a> FontSource<'a> {
       load_font(self.bytes, None)?
     };
 
-    Ok(Blob::new(Arc::new(decoded)))
+    // `Blob::new` draws its id from a global counter, and that id keys the shared glyph
+    // caches. Registering the same face again — a second renderer, a rebuilt one — would
+    // then miss every glyph it had already resolved, so the id comes from the content.
+    let id = xxh3_64(&decoded);
+
+    Ok(Blob::from_raw_parts(Arc::new(decoded), id))
   }
 }
 
@@ -852,6 +857,18 @@ mod tests {
     // Registered first, but selected last: a last-resort family never shadows caller fonts.
     assert_eq!(fonts.order, vec!["User Font".to_string()]);
     assert_eq!(fonts.last_resort_order, vec!["Embedded".to_string()]);
+  }
+
+  #[test]
+  fn same_bytes_produce_the_same_blob_id() {
+    let first = FontSource::from(geist_bytes()).into_blob().unwrap();
+    let second = FontSource::from(geist_bytes()).into_blob().unwrap();
+    let other = FontSource::from(geist_mono_bytes()).into_blob().unwrap();
+
+    // The glyph caches key on this id, so a re-registered face has to keep the entries
+    // it already resolved.
+    assert_eq!(first.id(), second.id());
+    assert_ne!(first.id(), other.id());
   }
 
   #[test]

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -862,7 +862,13 @@ mod tests {
   #[test]
   fn same_bytes_produce_the_same_blob_id() {
     let first = FontSource::from(geist_bytes()).into_blob().unwrap();
-    let second = FontSource::from(geist_bytes()).into_blob().unwrap();
+    // Decoded up front rather than during `into_blob`, so the id has to come from the
+    // decoded sfnt and not from whatever the caller happened to hand over.
+    let second = FontSource::from(geist_bytes())
+      .into_decoded()
+      .unwrap()
+      .into_blob()
+      .unwrap();
     let other = FontSource::from(geist_mono_bytes()).into_blob().unwrap();
 
     // The glyph caches key on this id, so a re-registered face has to keep the entries

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -24,3 +24,24 @@ export function getImports(module?: BackendModule): Promise<Imports> {
 
   return importPromise;
 }
+
+/**
+ * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
+ * caching. Defaults to 8 MiB.
+ *
+ * The caches belong to the backend rather than to a renderer, so this budget covers
+ * every render the process makes, and the value is read the first time a cache is
+ * used. Await this before the first render.
+ *
+ * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
+ * the default holds around a thousand of them and a page of Chinese re-rasterizes
+ * glyphs it evicted a moment earlier.
+ */
+export async function setGlyphCacheMaxBytes(
+  bytes: number,
+  options?: { module?: BackendModule },
+): Promise<void> {
+  const backend = await getImports(options?.module);
+
+  backend.setGlyphCacheMaxBytes(bytes);
+}

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -23,6 +23,7 @@ export type {
   MeasuredTextRun,
   OutputFormat,
 } from "@takumi-rs/core";
+export { setGlyphCacheMaxBytes } from "./import";
 export { render, renderAnimation, renderSvg } from "./render";
 
 export type {

--- a/takumi-napi/src/export.ts
+++ b/takumi-napi/src/export.ts
@@ -9,6 +9,8 @@ import type {
 export type * from "../index";
 import { Renderer as RendererInternal } from "../index";
 
+export { setGlyphCacheMaxBytes } from "../index";
+
 import { FontRegistry, prepareRenderInput } from "@takumi-rs/helpers/renderer";
 import type {
   BackendAnimationOptions,

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -23,9 +23,24 @@ use serde::{
 };
 use takumi_bindings_common::build_font_resource;
 use takumi_core::{
-  resources::font::FontResource,
+  resources::{font::FontResource, glyph_cache},
   style::{FontStyle, FromCssStr},
 };
+
+/// Sets the byte budget shared by the resolved-glyph and glyph-mask caches;
+/// `0` stops caching. Defaults to 8 MiB.
+///
+/// These caches live in the module, not in a `Renderer`, so this budget covers
+/// every renderer in the process. The value is read when a cache is first used,
+/// so call this before the first render.
+///
+/// Raise it for scripts with large glyph sets: a CJK outline runs a few
+/// kilobytes, so the default holds around a thousand of them and a page of
+/// Chinese re-rasterizes glyphs it just evicted.
+#[napi(js_name = "setGlyphCacheMaxBytes")]
+pub fn set_glyph_cache_max_bytes(bytes: f64) {
+  glyph_cache::set_glyph_cache_max_bytes(bytes.max(0.0) as usize);
+}
 
 /// A font family produced by `registerFont`, with the faces it contains.
 #[napi(object)]

--- a/takumi-wasm/src/helper.rs
+++ b/takumi-wasm/src/helper.rs
@@ -2,7 +2,25 @@
 
 use std::fmt::Display;
 
+use takumi_core::resources::glyph_cache;
+use wasm_bindgen::prelude::wasm_bindgen;
+
 /// Maps any error to a JavaScript Error object.
 pub fn map_error<E: Display>(err: E) -> js_sys::Error {
   js_sys::Error::new(&err.to_string())
+}
+
+/// Sets the byte budget shared by the resolved-glyph and glyph-mask caches;
+/// `0` stops caching. Defaults to 8 MiB.
+///
+/// These caches live in the module, not in a `Renderer`, so this budget covers
+/// every renderer sharing the module instance. The value is read when a cache
+/// is first used, so call this before the first render.
+///
+/// Raise it for scripts with large glyph sets: a CJK outline runs a few
+/// kilobytes, so the default holds around a thousand of them and a page of
+/// Chinese re-rasterizes glyphs it just evicted.
+#[wasm_bindgen(js_name = setGlyphCacheMaxBytes)]
+pub fn set_glyph_cache_max_bytes(bytes: usize) {
+  glyph_cache::set_glyph_cache_max_bytes(bytes);
 }

--- a/takumi-wasm/src/helper.rs
+++ b/takumi-wasm/src/helper.rs
@@ -21,6 +21,6 @@ pub fn map_error<E: Display>(err: E) -> js_sys::Error {
 /// kilobytes, so the default holds around a thousand of them and a page of
 /// Chinese re-rasterizes glyphs it just evicted.
 #[wasm_bindgen(js_name = setGlyphCacheMaxBytes)]
-pub fn set_glyph_cache_max_bytes(bytes: usize) {
-  glyph_cache::set_glyph_cache_max_bytes(bytes);
+pub fn set_glyph_cache_max_bytes(bytes: f64) {
+  glyph_cache::set_glyph_cache_max_bytes(bytes.max(0.0) as usize);
 }


### PR DESCRIPTION
## Why

The shared resolved-glyph and glyph-mask caches key on `Blob::id()`, which `Blob::new` draws from a global counter. Registering the same face again therefore looks like a different font: a second `Renderer`, or one rebuilt to reclaim memory, misses every glyph that face had already resolved and fills the budget with entries nothing will hit again. Parley's shaping-data cache keys on the same id and pays the same cost.

The related gap: those caches share an 8 MiB budget that no binding exposed. `cacheMaxBytes` looks like the knob for it but covers decoded images, SVG rasters, and parsed stylesheets instead. A CJK outline runs a few kilobytes, so the default holds on the order of a thousand of them, and Chinese or Japanese content re-rasterizes glyphs it evicted a moment earlier with no way to raise the ceiling.

## What

Font blobs now take their id from a hash of the decoded bytes, so identical faces share cache entries however often they are registered.

`setGlyphCacheMaxBytes` is exported from `@takumi-rs/core`, `@takumi-rs/wasm`, and `takumi-js`. It is a module-level function rather than a `Renderer` option because the caches live in the module and are shared by every renderer, and because the budget is read the first time a cache is used, so the call has to come before the first render. The `takumi-js` one is async since it resolves the backend first. The performance docs page covers both points.

Note for review: `takumi-napi/src/export.ts` re-exports the binding's types with `export type *`, so a new runtime value needs an explicit `export` line there. That is the only non-obvious part of the wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `setGlyphCacheMaxBytes` to JavaScript, WebAssembly, and Node (N-API) to configure the shared glyph cache byte budget (default: 8 MiB); setting `0` disables caching.
  * Improved glyph caching so identical font bytes reuse cached glyph data across re-registrations and renderer rebuilds.
* **Documentation**
  * Added guidance on sizing the glyph cache, its shared scope, the default budget, and the requirement to call the setter before the first render/cache use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->