### PR TITLE
Raster: write per-frame delays into animated PNG output

### DIFF
--- a/.tegami/apng-per-frame-delays.md
+++ b/.tegami/apng-per-frame-delays.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "cargo:takumi-raster": patch
+---
+
+### Write per-frame delays into animated PNG output
+
+Every APNG frame was written with the shortest frame's delay. The delay was set once on the encoder, before the header, so the header's `fcTL` covered the whole animation, on the premise that APNG has no per-frame duration. It does: each frame carries its own `fcTL`, and the `png` crate exposes it as `Writer::set_frame_delay`.
+
+The header now takes the first frame's duration and every later frame gets its own. A 150 ms timeline that renders as frames of 33, 33, 34, 33 and 17 ms used to play back as five 17 ms frames, roughly 1.8× too fast. A short scene followed by a long hold was much worse. WebP and GIF already wrote per-frame delays and are unchanged.

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -383,28 +383,15 @@ pub fn write_animated_png<W: Write>(
   ensure_uniform_frame_dimensions(frames)?;
 
   let frame_count = frames.len() as u32;
-  // APNG doesn't support variable frame duration, so use the minimum across frames.
-  let min_duration_ms = frames
-    .iter()
-    .map(|frame| frame.duration_ms)
-    .min()
-    .unwrap_or(0);
 
-  encode_animated_png(
-    frames.iter().map(Ok),
-    frame_count,
-    min_duration_ms,
-    destination,
-    options,
-  )
+  encode_animated_png(frames.iter().map(Ok), frame_count, destination, options)
 }
 
-/// Streams frames into an animated PNG. `frame_count` and `min_duration_ms` are
-/// passed in because APNG writes both into the header before the first frame.
+/// Streams frames into an animated PNG. `frame_count` is passed in because APNG
+/// writes it into the header before the first frame.
 pub(crate) fn encode_animated_png<W, F, I>(
   mut frames: I,
   frame_count: u32,
-  min_duration_ms: u32,
   destination: &mut W,
   options: AnimatedPngOptions,
 ) -> Result<()>
@@ -427,7 +414,7 @@ where
     .set_animated(frame_count, options.loop_count.unwrap_or(0) as u32)
     .map_err(Error::encode)?;
   encoder
-    .set_frame_delay(min_duration_ms.clamp(0, u16::MAX as u32) as u16, 1000)
+    .set_frame_delay(first.duration_ms.min(u16::MAX as u32) as u16, 1000)
     .map_err(Error::encode)?;
 
   let mut writer = encoder.write_header().map_err(Error::encode)?;
@@ -441,6 +428,9 @@ where
     if frame.image.width() != width || frame.image.height() != height {
       return Err(Error::MixedAnimationFrameDimensions);
     }
+    writer
+      .set_frame_delay(frame.duration_ms.min(u16::MAX as u32) as u16, 1000)
+      .map_err(Error::encode)?;
     writer
       .write_image_data(frame.image.as_raw())
       .map_err(Error::encode)?;
@@ -546,9 +536,7 @@ fn encode_frames<W: Write>(
     AnimationFormat::WebP(options) => encode_animated_webp(frames, destination, options),
     AnimationFormat::Gif(options) => encode_animated_gif(frames, destination, options),
     AnimationFormat::Apng(options) => {
-      let frame_count = spans.len() as u32;
-      let min_duration_ms = spans.iter().map(|span| span.duration_ms).min().unwrap_or(0);
-      encode_animated_png(frames, frame_count, min_duration_ms, destination, options)
+      encode_animated_png(frames, spans.len() as u32, destination, options)
     }
   }
 }
@@ -622,6 +610,44 @@ mod tests {
       image: Bitmap::from_rgba(image),
       duration_ms,
     }
+  }
+
+  #[test]
+  fn write_animated_png_writes_per_frame_delays() {
+    let frames = vec![
+      mk_frame(
+        RgbaImage::from_pixel(2, 2, image::Rgba([255, 0, 0, 255])),
+        120,
+      ),
+      mk_frame(
+        RgbaImage::from_pixel(2, 2, image::Rgba([0, 255, 0, 255])),
+        30,
+      ),
+    ];
+
+    let mut bytes = Vec::new();
+    let encode_result =
+      write_animated_png(&frames, &mut bytes, AnimatedPngOptions { loop_count: None });
+    assert!(encode_result.is_ok(), "failed to encode animated png");
+
+    let decode_result = png::Decoder::new(Cursor::new(&bytes)).read_info();
+    assert!(decode_result.is_ok(), "failed to decode animated png");
+    let mut reader = match decode_result {
+      Ok(reader) => reader,
+      Err(_) => return,
+    };
+
+    let Some(first) = reader.info().frame_control else {
+      panic!("missing frame control for the first png frame");
+    };
+    assert_eq!((first.delay_num, first.delay_den), (120, 1000));
+
+    let second = reader.next_frame_info();
+    assert!(second.is_ok(), "missing frame control for the second frame");
+    let Ok(second) = second else {
+      return;
+    };
+    assert_eq!((second.delay_num, second.delay_den), (30, 1000));
   }
 
   #[test]


### PR DESCRIPTION
## Why

Every APNG frame was written with the shortest frame's delay. `encode_animated_png` computed the minimum duration across frames and set it once on the `png::Encoder` before `write_header`, so it landed in the header's `fcTL` and every later frame inherited it. The comment explaining this said APNG does not support variable frame duration. It does: each frame carries its own `fcTL`, and the `png` crate exposes it as `Writer::set_frame_delay`.

The animation timeline this repo already tests against renders a 150 ms sequence as frames of 33, 33, 34, 33 and 17 ms. As APNG that played back as five 17 ms frames, 85 ms total, about 1.8× too fast. A multi-scene timeline, say a 100 ms scene followed by a 3 s hold, comes out far worse. Nothing errors, the animation is just wrong.

## What

The header delay comes from the first frame, and each subsequent frame gets its own delay written before its image data. `min_duration_ms` is gone from both the eager and the streaming caller.

WebP and GIF already wrote per-frame delays, so they are untouched. No fixture covers APNG output, so there is no golden churn to review.

The new test asserts the two frames decode to different delays. I checked it fails without the per-frame write rather than passing vacuously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animated PNG exports so each frame preserves its specified display duration instead of using the shortest duration for all frames.
  * Improved timing accuracy for animations with frames of different lengths.

* **Tests**
  * Added coverage verifying that APNG frame delays match the configured durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->