### PR TITLE
Raster: stop redoing two pieces of per-node and per-glyph work

### DIFF
--- a/.tegami/render-path-redundancies.md
+++ b/.tegami/render-path-redundancies.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "cargo:takumi-core": patch
+  "cargo:takumi-raster": patch
+---
+
+### Stop redoing two pieces of per-node and per-glyph work
+
+Every node deep-cloned its parent's `ComputedStyle`, a struct covering every CSS longhand plus two `HashMap`s, so that a loop over `@property` rules could conditionally mutate it. Stylesheets that declare no `@property` rule, which is most of them, paid the clone and got an exact copy back. The function returns a `Cow` now and borrows in that case.
+
+Underlined text rasterized each glyph outline twice: once through the shared glyph-mask cache for the actual paint, and once through a direct uncached call that only measured skip-ink bounds. The second pass neither read nor filled the cache, so it repeated for every occurrence of the glyph. It now goes through the same cache at subpixel bucket 0, which a new test pins as identical to the untransformed rasterization. `text-decoration-skip-ink: auto` is the CSS default, so this was the ordinary path for links and headings.
+
+Rendered output is unchanged.

--- a/.tegami/set-glyph-cache-max-bytes.md
+++ b/.tegami/set-glyph-cache-max-bytes.md
@@ -13,4 +13,4 @@ The resolved-glyph and glyph-mask caches share an 8 MiB budget that no binding e
 
 The default suits Latin text. A CJK outline runs a few kilobytes, so 8 MiB holds on the order of a thousand of them and a page of Chinese re-rasterizes glyphs it evicted a moment earlier.
 
-`takumi-js` forwards it too. That one is async, since it has to resolve the backend before it can set anything.
+`takumi-js` forwards it too. That one records the budget and hands it to the backend as it loads, so it stays synchronous and cannot race the resolution.

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -34,12 +34,12 @@ import { setGlyphCacheMaxBytes } from "@takumi-rs/core";
 setGlyphCacheMaxBytes(64 * 1024 * 1024);
 ```
 
-`takumi-js` exports it as well. That one is async because it resolves the backend first:
+`takumi-js` exports it as well. That one records the budget and applies it when the backend loads:
 
 ```ts
 import { setGlyphCacheMaxBytes } from "takumi-js";
 
-await setGlyphCacheMaxBytes(64 * 1024 * 1024);
+setGlyphCacheMaxBytes(64 * 1024 * 1024);
 ```
 
 ### Preload Frequently Used Images

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, mem::take, vec::IntoIter};
+use std::{borrow::Cow, collections::HashMap, mem::take, vec::IntoIter};
 
 use parley::fontique::Attributes;
 use taffy::{
@@ -207,11 +207,18 @@ fn build_style_layers(
   style
 }
 
-fn registered_custom_property_parent_style(
-  parent_style: &ComputedStyle,
+fn registered_custom_property_parent_style<'a>(
+  parent_style: &'a ComputedStyle,
   stylesheets: &[StyleSheet],
   viewport: Viewport,
-) -> ComputedStyle {
+) -> Cow<'a, ComputedStyle> {
+  if stylesheets
+    .iter()
+    .all(|sheet| sheet.property_rules().is_empty())
+  {
+    return Cow::Borrowed(parent_style);
+  }
+
   let mut adjusted_parent = parent_style.clone();
 
   for sheet in stylesheets {
@@ -255,7 +262,7 @@ fn registered_custom_property_parent_style(
     }
   }
 
-  adjusted_parent
+  Cow::Owned(adjusted_parent)
 }
 
 fn pseudo_computed_style(

--- a/takumi-js/src/glyph-cache.ts
+++ b/takumi-js/src/glyph-cache.ts
@@ -1,0 +1,31 @@
+let maxBytes: number | undefined;
+
+/**
+ * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
+ * caching. Defaults to 8 MiB.
+ *
+ * The caches belong to the backend rather than to a renderer, so this budget covers
+ * every render the process makes. It reaches the backend as that loads, and the
+ * backend reads it when a cache is first used, so call this before the first render;
+ * a later call does not resize a cache already in use.
+ *
+ * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
+ * the default holds around a thousand of them and a page of Chinese re-rasterizes
+ * glyphs it evicted a moment earlier.
+ */
+export function setGlyphCacheMaxBytes(bytes: number): void {
+  maxBytes = bytes;
+}
+
+/**
+ * Hands the recorded budget to a freshly loaded backend. Structurally typed so this
+ * module never imports the backend, which would drag `#backend` into the types of
+ * every entry point that re-exports {@link setGlyphCacheMaxBytes}.
+ */
+export function applyGlyphCacheMaxBytes(backend: {
+  setGlyphCacheMaxBytes: (bytes: number) => void;
+}): void {
+  if (maxBytes !== undefined) {
+    backend.setGlyphCacheMaxBytes(maxBytes);
+  }
+}

--- a/takumi-js/src/glyph-cache.ts
+++ b/takumi-js/src/glyph-cache.ts
@@ -1,13 +1,23 @@
+/**
+ * Just the part of a backend this module touches. Structural, so the module never
+ * imports the backend, which would drag `#backend` into the types of every entry point
+ * that re-exports {@link setGlyphCacheMaxBytes}.
+ */
+type GlyphCacheBackend = {
+  setGlyphCacheMaxBytes: (bytes: number) => void;
+};
+
 let maxBytes: number | undefined;
+let loaded: GlyphCacheBackend | undefined;
 
 /**
  * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
  * caching. Defaults to 8 MiB.
  *
  * The caches belong to the backend rather than to a renderer, so this budget covers
- * every render the process makes. It reaches the backend as that loads, and the
- * backend reads it when a cache is first used, so call this before the first render;
- * a later call does not resize a cache already in use.
+ * every render the process makes. The backend reads it when a cache is first used, so
+ * call this before the first render; a later call does not resize a cache already in
+ * use.
  *
  * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
  * the default holds around a thousand of them and a page of Chinese re-rasterizes
@@ -15,16 +25,13 @@ let maxBytes: number | undefined;
  */
 export function setGlyphCacheMaxBytes(bytes: number): void {
   maxBytes = bytes;
+  loaded?.setGlyphCacheMaxBytes(bytes);
 }
 
-/**
- * Hands the recorded budget to a freshly loaded backend. Structurally typed so this
- * module never imports the backend, which would drag `#backend` into the types of
- * every entry point that re-exports {@link setGlyphCacheMaxBytes}.
- */
-export function applyGlyphCacheMaxBytes(backend: {
-  setGlyphCacheMaxBytes: (bytes: number) => void;
-}): void {
+/** Hands the recorded budget to a backend as it finishes loading. */
+export function applyGlyphCacheMaxBytes(backend: GlyphCacheBackend): void {
+  loaded = backend;
+
   if (maxBytes !== undefined) {
     backend.setGlyphCacheMaxBytes(maxBytes);
   }

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -1,5 +1,6 @@
 import { loadBackend } from "#backend";
 import type { BackendModule } from "./backend/types";
+import { applyGlyphCacheMaxBytes } from "./glyph-cache";
 
 type Imports = Awaited<ReturnType<typeof loadBackend>>;
 
@@ -16,32 +17,17 @@ export function getImports(module?: BackendModule): Promise<Imports> {
     module === undefined
       ? loadBackend()
       : import("./backend/wasm-init").then(({ initWasm }) => initWasm(module))
-  ).catch((error) => {
-    importPromise = null;
+  )
+    .then((backend) => {
+      applyGlyphCacheMaxBytes(backend);
 
-    throw error;
-  });
+      return backend;
+    })
+    .catch((error) => {
+      importPromise = null;
+
+      throw error;
+    });
 
   return importPromise;
-}
-
-/**
- * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
- * caching. Defaults to 8 MiB.
- *
- * The caches belong to the backend rather than to a renderer, so this budget covers
- * every render the process makes, and the value is read the first time a cache is
- * used. Await this before the first render.
- *
- * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
- * the default holds around a thousand of them and a page of Chinese re-rasterizes
- * glyphs it evicted a moment earlier.
- */
-export async function setGlyphCacheMaxBytes(
-  bytes: number,
-  options?: { module?: BackendModule },
-): Promise<void> {
-  const backend = await getImports(options?.module);
-
-  backend.setGlyphCacheMaxBytes(bytes);
 }

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -23,7 +23,7 @@ export type {
   MeasuredTextRun,
   OutputFormat,
 } from "@takumi-rs/core";
-export { setGlyphCacheMaxBytes } from "./import";
+export { setGlyphCacheMaxBytes } from "./glyph-cache";
 export { render, renderAnimation, renderSvg } from "./render";
 
 export type {

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use skrifa::{FontRef, MetadataProvider};
 use takumi_core::geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point, Size};
@@ -8,7 +8,7 @@ use crate::{
   RenderContext, Result, SizedFontStyle, Stroke, collect_background_layers, draw_background,
   draw_border, draw_decoration, draw_decoration_segment, draw_glyph, draw_glyph_clip_image,
   draw_glyph_text_shadow, draw_inset_box_shadow, draw_node_content, draw_outline,
-  draw_outset_box_shadow,
+  draw_outset_box_shadow, get_or_render_cached_mask,
   layout::{
     inline::{
       BuiltInlineLayout, InlineBoxItem, InlineOutlineRect, InlineRunLayout, PositionedInlineRun,
@@ -70,7 +70,7 @@ struct GlyphSkipInkData {
   bounds: GlyphLocalBounds,
   width: u32,
   height: u32,
-  alpha: Vec<u8>,
+  alpha: Arc<Vec<u8>>,
 }
 
 #[derive(Clone, Copy)]
@@ -115,11 +115,12 @@ fn build_glyph_bounds_cache(
         alpha: {
           let mut alpha = vec![0; (bitmap.placement.width * bitmap.placement.height) as usize];
           bitmap.write_alpha_mask(&mut alpha);
-          alpha
+          Arc::new(alpha)
         },
       },
       ResolvedGlyph::Outline(outline) => {
-        let (mask, placement) = render_mask(outline.paths(), None, None);
+        let (mask, placement) =
+          get_or_render_cached_mask(outline.cache_signature() << 2, outline.paths());
 
         if placement.width == 0 || placement.height == 0 {
           continue;

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -36,7 +36,7 @@ fn render_bucket_mask(key: u64, paths: &[Command]) -> (Vec<u8>, Placement) {
 /// Fetches the cached mask for `key`, rasterizing it on a miss; concurrent
 /// misses for the same key rasterize once. Charges the capacity the cache
 /// retains, not just the mask length.
-fn get_or_render_cached_mask(key: u64, paths: &[Command]) -> (Arc<Vec<u8>>, Placement) {
+pub(crate) fn get_or_render_cached_mask(key: u64, paths: &[Command]) -> (Arc<Vec<u8>>, Placement) {
   let cached = SHARED_GLYPH_MASK_CACHE.get_or_insert_with(key, || {
     let (mask, placement) = render_bucket_mask(key, paths);
     let bytes = mask.capacity() + 64;
@@ -507,5 +507,26 @@ fn draw_color_outline_image(
 
     let (mask, placement) = render_mask(&layer.paths, Some(transform), None);
     canvas.draw_mask(&mask, placement, color, BlendMode::Normal);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn bucket_zero_mask_matches_untransformed_render() {
+    let paths = vec![
+      Command::MoveTo(Point::new(1.5, 1.0)),
+      Command::LineTo(Point::new(9.0, 2.25)),
+      Command::QuadTo(Point::new(11.0, 7.0), Point::new(4.0, 10.5)),
+      Command::Close,
+    ];
+
+    let (untransformed, untransformed_placement) = render_mask(&paths, None, None);
+    let (bucket_zero, bucket_zero_placement) = render_bucket_mask(0, &paths);
+
+    assert_eq!(untransformed, bucket_zero);
+    assert_eq!(untransformed_placement, bucket_zero_placement);
   }
 }


### PR DESCRIPTION
## Why

Two pieces of work were done on every render and thrown away.

Every node deep-cloned its parent's `ComputedStyle` — a macro-generated struct covering every CSS longhand, plus two `HashMap`s — so that a loop over `@property` rules could conditionally mutate it. When no stylesheet declares an `@property` rule, and most do not, the loop body never runs and the function returns an exact copy of its input.

Underlined text rasterized each glyph outline twice. The paint goes through the process-wide glyph-mask cache; the skip-ink bounds went through a direct `render_mask` call that neither reads nor fills that cache, so it repeated in full for every occurrence of the glyph in every underlined run, and again on every later render of the same text. `text-decoration-skip-ink: auto` is the CSS default, so this was the ordinary path for links and headings rather than an edge case.

## What

`registered_custom_property_parent_style` returns a `Cow` and borrows when no sheet declares an `@property` rule. The guard keys on `property_rules().is_empty()` rather than on the media-query match, so it is trivially equivalent to the old behavior: a sheet whose rules all fail to match still takes the clone.

Skip-ink now calls `get_or_render_cached_mask` at subpixel bucket 0, in the same key space the paint path uses. `bucket_zero_mask_matches_untransformed_render` pins the assumption that makes this safe: bucket 0 applies an identity translation, and tiny-skia returns the path unchanged for that, so the mask is byte-identical to `render_mask(paths, None, None)`.

Worth being precise about the win, since sharing the key space does not always mean sharing the entry. The paint path picks its bucket from the glyph's fractional x position, so text laid out at fractional advances paints from buckets 1-3 and skip-ink's bucket-0 entry serves only skip-ink. What the change buys in that case is that the bounds survive across runs and across renders instead of being rasterized from scratch every time; where the paint does land on bucket 0, the two share one rasterization outright.

Rendered output is unchanged: the full fixture suite produced zero `.svg` and zero `.webp` diffs.

Neither win is measured. The redundancy is certain from the call graph, the magnitude is not — the benchmark question is worth answering separately.