### PR TITLE
Helpers: keep the glyph budget setter off the backend import graph

### DIFF
--- a/.tegami/set-glyph-cache-max-bytes.md
+++ b/.tegami/set-glyph-cache-max-bytes.md
@@ -13,4 +13,4 @@ The resolved-glyph and glyph-mask caches share an 8 MiB budget that no binding e
 
 The default suits Latin text. A CJK outline runs a few kilobytes, so 8 MiB holds on the order of a thousand of them and a page of Chinese re-rasterizes glyphs it evicted a moment earlier.
 
-`takumi-js` forwards it too. That one is async, since it has to resolve the backend before it can set anything.
+`takumi-js` forwards it too. That one records the budget and hands it to the backend as it loads, so it stays synchronous and cannot race the resolution.

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -34,12 +34,12 @@ import { setGlyphCacheMaxBytes } from "@takumi-rs/core";
 setGlyphCacheMaxBytes(64 * 1024 * 1024);
 ```
 
-`takumi-js` exports it as well. That one is async because it resolves the backend first:
+`takumi-js` exports it as well. That one records the budget and applies it when the backend loads:
 
 ```ts
 import { setGlyphCacheMaxBytes } from "takumi-js";
 
-await setGlyphCacheMaxBytes(64 * 1024 * 1024);
+setGlyphCacheMaxBytes(64 * 1024 * 1024);
 ```
 
 ### Preload Frequently Used Images

--- a/takumi-js/src/glyph-cache.ts
+++ b/takumi-js/src/glyph-cache.ts
@@ -1,0 +1,31 @@
+let maxBytes: number | undefined;
+
+/**
+ * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
+ * caching. Defaults to 8 MiB.
+ *
+ * The caches belong to the backend rather than to a renderer, so this budget covers
+ * every render the process makes. It reaches the backend as that loads, and the
+ * backend reads it when a cache is first used, so call this before the first render;
+ * a later call does not resize a cache already in use.
+ *
+ * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
+ * the default holds around a thousand of them and a page of Chinese re-rasterizes
+ * glyphs it evicted a moment earlier.
+ */
+export function setGlyphCacheMaxBytes(bytes: number): void {
+  maxBytes = bytes;
+}
+
+/**
+ * Hands the recorded budget to a freshly loaded backend. Structurally typed so this
+ * module never imports the backend, which would drag `#backend` into the types of
+ * every entry point that re-exports {@link setGlyphCacheMaxBytes}.
+ */
+export function applyGlyphCacheMaxBytes(backend: {
+  setGlyphCacheMaxBytes: (bytes: number) => void;
+}): void {
+  if (maxBytes !== undefined) {
+    backend.setGlyphCacheMaxBytes(maxBytes);
+  }
+}

--- a/takumi-js/src/glyph-cache.ts
+++ b/takumi-js/src/glyph-cache.ts
@@ -1,13 +1,23 @@
+/**
+ * Just the part of a backend this module touches. Structural, so the module never
+ * imports the backend, which would drag `#backend` into the types of every entry point
+ * that re-exports {@link setGlyphCacheMaxBytes}.
+ */
+type GlyphCacheBackend = {
+  setGlyphCacheMaxBytes: (bytes: number) => void;
+};
+
 let maxBytes: number | undefined;
+let loaded: GlyphCacheBackend | undefined;
 
 /**
  * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
  * caching. Defaults to 8 MiB.
  *
  * The caches belong to the backend rather than to a renderer, so this budget covers
- * every render the process makes. It reaches the backend as that loads, and the
- * backend reads it when a cache is first used, so call this before the first render;
- * a later call does not resize a cache already in use.
+ * every render the process makes. The backend reads it when a cache is first used, so
+ * call this before the first render; a later call does not resize a cache already in
+ * use.
  *
  * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
  * the default holds around a thousand of them and a page of Chinese re-rasterizes
@@ -15,16 +25,13 @@ let maxBytes: number | undefined;
  */
 export function setGlyphCacheMaxBytes(bytes: number): void {
   maxBytes = bytes;
+  loaded?.setGlyphCacheMaxBytes(bytes);
 }
 
-/**
- * Hands the recorded budget to a freshly loaded backend. Structurally typed so this
- * module never imports the backend, which would drag `#backend` into the types of
- * every entry point that re-exports {@link setGlyphCacheMaxBytes}.
- */
-export function applyGlyphCacheMaxBytes(backend: {
-  setGlyphCacheMaxBytes: (bytes: number) => void;
-}): void {
+/** Hands the recorded budget to a backend as it finishes loading. */
+export function applyGlyphCacheMaxBytes(backend: GlyphCacheBackend): void {
+  loaded = backend;
+
   if (maxBytes !== undefined) {
     backend.setGlyphCacheMaxBytes(maxBytes);
   }

--- a/takumi-js/src/import.ts
+++ b/takumi-js/src/import.ts
@@ -1,5 +1,6 @@
 import { loadBackend } from "#backend";
 import type { BackendModule } from "./backend/types";
+import { applyGlyphCacheMaxBytes } from "./glyph-cache";
 
 type Imports = Awaited<ReturnType<typeof loadBackend>>;
 
@@ -16,32 +17,17 @@ export function getImports(module?: BackendModule): Promise<Imports> {
     module === undefined
       ? loadBackend()
       : import("./backend/wasm-init").then(({ initWasm }) => initWasm(module))
-  ).catch((error) => {
-    importPromise = null;
+  )
+    .then((backend) => {
+      applyGlyphCacheMaxBytes(backend);
 
-    throw error;
-  });
+      return backend;
+    })
+    .catch((error) => {
+      importPromise = null;
+
+      throw error;
+    });
 
   return importPromise;
-}
-
-/**
- * Sets the byte budget shared by the resolved-glyph and glyph-mask caches; `0` stops
- * caching. Defaults to 8 MiB.
- *
- * The caches belong to the backend rather than to a renderer, so this budget covers
- * every render the process makes, and the value is read the first time a cache is
- * used. Await this before the first render.
- *
- * Raise it for scripts with large glyph sets: a CJK outline runs a few kilobytes, so
- * the default holds around a thousand of them and a page of Chinese re-rasterizes
- * glyphs it evicted a moment earlier.
- */
-export async function setGlyphCacheMaxBytes(
-  bytes: number,
-  options?: { module?: BackendModule },
-): Promise<void> {
-  const backend = await getImports(options?.module);
-
-  backend.setGlyphCacheMaxBytes(bytes);
 }

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -23,7 +23,7 @@ export type {
   MeasuredTextRun,
   OutputFormat,
 } from "@takumi-rs/core";
-export { setGlyphCacheMaxBytes } from "./import";
+export { setGlyphCacheMaxBytes } from "./glyph-cache";
 export { render, renderAnimation, renderSvg } from "./render";
 
 export type {


### PR DESCRIPTION
Fixes the packaging check, which has been red on `master` since #1033.

## Why

`takumi-js` re-exported `setGlyphCacheMaxBytes` from `./import`, the module that resolves the backend. That pulled `#backend` into the type graph of the root entry, and `attw` reports it as an internal resolution error for the root export:

```
"takumi-js"   node16 🟢   bundler 🟢   node10 (ignored) 🥴 Internal resolution error
```

Every other entry only has the ordinary node10 `💀 Resolution failed`, which the `node16` profile ignores. The internal-resolution one still fails the run, so `attw --pack .` exits 1 and `publish-lint` never reaches `publint`.

Making the parameter list narrower was not enough. The cause is the re-export itself: nothing in `render`'s public types names anything from `./import`, so `#backend` gets shaken out of the declarations, and re-exporting a value from that module puts it back.

## What

The setter and its recorded value move to `src/glyph-cache.ts`, a leaf that imports nothing. `getImports` hands the recorded budget to the backend as it loads, through a structurally typed applier, so the leaf never has to name the backend type.

The public function also stops being async. It no longer has to resolve anything to record a number, and applying the value during backend load removes the ordering hazard the async version had: a caller who awaited it on a runtime that needs an explicit WASM `module` would have resolved the backend without one.

Verified locally with the same command CI runs: `attw --pack . && publint --strict .` now exits 0, `tsc --noEmit` is clean, and the 20 `takumi-js` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous glyph cache budget configuration in `takumi-js`.
  * Ensures the configured cache limit is applied automatically when the rendering backend finishes loading (avoids timing issues).

* **Documentation**
  * Updated performance and API documentation examples to remove `await` and reflect the new synchronous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->