### PR TITLE
CI: exclude node_modules manifests from the cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
   "takumi-wasm",
   "example/rust",
 ]
+# cargo doesn't need this. tegami reads every Cargo.toml under a member, so
+# @napi-rs/cli's vendored `napi-derive` fixture crate shadows the real dependency.
+exclude = ["**/node_modules/**"]
 
 [workspace.dependencies]
 arc-swap = "1"


### PR DESCRIPTION
## Why

Every master push has failed the Version PR job since `@napi-rs/cli` 3.7.4 landed. Its `napi-derive` test fixture ships a `Cargo.toml`, and tegami scans every directory under a workspace member for manifests, so it picks the fixture up as a member and rewrites the root manifest's `napi-derive` to `0.0.0`. That leaves a `[dependencies]` table in a virtual manifest, which `cargo update --workspace` rejects with exit 101.

## What

Exclude `node_modules` from the workspace so tegami's member scan skips vendored manifests. cargo ignores the entry; `cargo metadata` still resolves the same nine members.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workspace configuration to ignore embedded JavaScript dependency directories during project tooling scans.
  * Prevented bundled test fixtures from being mistaken for active project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->