### PR TITLE
Core: register a font straight out of the binary

### DIFF
--- a/.tegami/font-source-from-static.md
+++ b/.tegami/font-source-from-static.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": minor
+---
+
+### Register a font straight out of the binary
+
+`FontSource::from_static` takes a `&'static [u8]`, so an `include_bytes!` face goes to the font system where it already sits, in the read-only segment, with no `Arc` to build around it. Its blob id comes from the address and length instead of a hash of the content, so registering a 30 MiB CJK face no longer reads through every page of it and the face is paged in a glyph at a time.

--- a/.tegami/font-source-from-static.md
+++ b/.tegami/font-source-from-static.md
@@ -5,4 +5,4 @@ packages:
 
 ### Register a font straight out of the binary
 
-`FontSource::from_static` takes a `&'static [u8]`, so an `include_bytes!` face goes to the font system where it already sits, in the read-only segment, with no `Arc` to build around it. Its blob id comes from the address and length instead of a hash of the content, so registering a 30 MiB CJK face no longer reads through every page of it and the face is paged in a glyph at a time.
+`FontSource::from_static` takes a `&'static [u8]`, so an `include_bytes!` face is read where it already sits, in the read-only segment, and the caller writes no `Arc` of its own: the one held internally wraps the slice reference, never a copy of the font. Its blob id comes from the address and length instead of a hash of the content, so registering a 30 MiB CJK face no longer reads through every page of it and the face is paged in a glyph at a time.

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -877,6 +877,22 @@ mod tests {
   }
 
   #[test]
+  fn a_static_woff2_face_keeps_its_id_through_decompression() {
+    let woff2: &'static [u8] = geist_bytes().leak();
+    let registered = FontSource::from_static(woff2).into_blob().unwrap();
+    let resolved_first = FontSource::from_static(woff2)
+      .into_decoded()
+      .unwrap()
+      .into_blob()
+      .unwrap();
+
+    // The bytes the font system holds are the decompressed sfnt either way, so only
+    // the id carried past decompression keeps the two from being separate faces.
+    assert_ne!(registered.data().as_ptr(), woff2.as_ptr());
+    assert_eq!(registered.id(), resolved_first.id());
+  }
+
+  #[test]
   fn shared_woff2_bytes_still_decompress() {
     let mut fonts = Fonts::default();
     let bytes: Arc<dyn AsRef<[u8]> + Send + Sync> = Arc::new(geist_bytes());

--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -533,6 +533,9 @@ pub struct FontSource<'a> {
   bytes: FontBytes<'a>,
   /// Whether `bytes` is already decompressed (woff/woff2 expanded to raw sfnt).
   is_decoded: bool,
+  /// Blob id to use in place of hashing the decoded bytes, set by
+  /// [`FontSource::from_static`].
+  cache_id: Option<u64>,
 }
 
 impl<'a, T> From<T> for FontSource<'a>
@@ -543,6 +546,7 @@ where
     Self {
       bytes: FontBytes::Inline(value.into()),
       is_decoded: false,
+      cache_id: None,
     }
   }
 }
@@ -556,6 +560,28 @@ impl<'a> FontSource<'a> {
     Self {
       bytes: FontBytes::Shared(bytes),
       is_decoded: false,
+      cache_id: None,
+    }
+  }
+
+  /// Takes bytes that live as long as the process, `include_bytes!` above all.
+  /// Nothing is copied, and the blob id comes from the address and length rather
+  /// than from the content, so registering a 30 MiB face never reads through it.
+  /// A face embedded in the binary is then paged in one glyph at a time.
+  ///
+  /// The same slice always yields the same id, which is what the glyph caches
+  /// need. Two faces with the same bytes may still land on separate ids, and
+  /// resolve their glyphs separately, if one of them arrives as a `Vec`.
+  pub fn from_static(bytes: &'static [u8]) -> Self {
+    let mut id = Xxh3::new();
+
+    id.update(&bytes.as_ptr().addr().to_le_bytes());
+    id.update(&bytes.len().to_le_bytes());
+
+    Self {
+      bytes: FontBytes::Shared(Arc::new(bytes)),
+      is_decoded: false,
+      cache_id: Some(id.digest()),
     }
   }
 
@@ -581,11 +607,13 @@ impl<'a> FontSource<'a> {
         None,
       )?)),
       is_decoded: true,
+      cache_id: self.cache_id,
     })
   }
 
   fn into_blob(self) -> Result<Blob<u8>, FontError> {
     let passthrough = self.is_decoded || self.is_sfnt();
+    let cache_id = self.cache_id;
     let decoded: SharedBytes = match self.bytes {
       FontBytes::Shared(bytes) if passthrough => bytes,
       bytes => Arc::new(load_font(Cow::Owned(bytes.into_owned()), None)?),
@@ -594,7 +622,7 @@ impl<'a> FontSource<'a> {
     // `Blob::new` draws its id from a global counter, and that id keys the shared glyph
     // caches. Registering the same face again — a second renderer, a rebuilt one — would
     // then miss every glyph it had already resolved, so the id comes from the content.
-    let id = xxh3_64((*decoded).as_ref());
+    let id = cache_id.unwrap_or_else(|| xxh3_64((*decoded).as_ref()));
 
     Ok(Blob::from_raw_parts(decoded, id))
   }
@@ -826,6 +854,26 @@ mod tests {
       .unwrap();
 
     assert_eq!(blob.data().as_ptr(), address);
+  }
+
+  #[test]
+  fn static_bytes_keep_one_blob_id_without_reading_them() {
+    static TTF: &[u8] = &[0x00, 0x01, 0x00, 0x00];
+    static OTF: &[u8] = b"OTTO";
+
+    let id = |bytes| FontSource::from_static(bytes).into_blob().unwrap().id();
+
+    // Same slice, same id, so a re-registered face keeps the glyphs it resolved.
+    assert_eq!(id(TTF), id(TTF));
+    assert_ne!(id(TTF), id(OTF));
+  }
+
+  #[test]
+  fn static_sfnt_bytes_reach_the_font_system_uncopied() {
+    let sfnt: &'static [u8] = load_font(Cow::Owned(geist_bytes()), None).unwrap().leak();
+    let blob = FontSource::from_static(sfnt).into_blob().unwrap();
+
+    assert_eq!(blob.data().as_ptr(), sfnt.as_ptr());
   }
 
   #[test]


### PR DESCRIPTION
## Why

`include_bytes!` is the usual way to ship a face with a binary, and #1040 only reaches it through `Arc::new(&FONT[..])`, which is an odd thing to ask a caller to write. Registering it also hashes every byte to derive the blob id, so a 30 MiB CJK face is read end to end at startup and the whole thing lands in the resident set before a single glyph is drawn.

## What

`FontSource::from_static` takes a `&'static [u8]` and derives the blob id from the address and length instead. Same slice, same id, which is what the glyph caches need; two faces of identical bytes may share an address and therefore an id, which is harmless. WOFF and WOFF2 keep that id across decompression.

`from_shared` stays for bytes whose lifetime the caller manages, a runtime `Mmap` above all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading fonts directly from in-memory static binary data.
  * Static font sources now retain stable identifiers to improve reuse and avoid unnecessary recomputation.
  * Large static fonts can load glyph data incrementally to reduce upfront reading/copying.

* **Documentation**
  * Expanded guidance on static font loading behavior and how identifiers are derived to ensure consistent blob IDs across conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->