### PR TITLE
Takumi: export FontSource from the prelude

### DIFF
--- a/.tegami/prelude-font-source.md
+++ b/.tegami/prelude-font-source.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi": patch
+---
+
+### Export `FontSource` from the prelude
+
+`FontResource::new` takes anything that converts into a `FontSource`, and naming that type is the only way to reach `FontSource::from_static` or `from_shared`. It was missing from the prelude, so registering an `include_bytes!` face meant going through the semver-exempt `unstable` module.

--- a/takumi/src/lib.rs
+++ b/takumi/src/lib.rs
@@ -59,7 +59,7 @@ pub mod prelude {
     Error, Fonts, Result,
     layout::node::{ImageData, ImageSourceInput, Node, NodeKind, RgbaImage, TextData},
     resources::{
-      font::{FontError, FontOverride, FontResource, GenericFamily, RegisteredFamily},
+      font::{FontError, FontOverride, FontResource, FontSource, GenericFamily, RegisteredFamily},
       image::{ImageCacheMode, ImageSource},
     },
     style::*,


### PR DESCRIPTION
## Why

`FontResource::new` takes an `impl Into<FontSource>`, so naming `FontSource` is the only way to reach `from_static` and `from_shared`. The prelude exports `FontResource` and `FontOverride` but not `FontSource`, which leaves an `include_bytes!` face reachable only through the semver-exempt `unstable` module.

## What

One more name in the prelude re-export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accessing `FontSource` constructors from the prelude when registering embedded font files.
  * Documented the required package configuration for the `cargo:takumi` package.

* **Refactor**
  * Updated the formatting of font-related prelude exports without changing the available public types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->