### PR TITLE
Docs: document unknown property handling and node tree scope

### DIFF
--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -25,6 +25,8 @@ icon: Wrench
 | `image(props)`                       | An image node.                |
 | `style(css)`                         | The same style object, typed. |
 
+The `props` argument holds the node's own fields. [Node types](/docs/reference#node-types) lists them.
+
 Length and color shorthands return CSS strings. `vw`/`vh` are viewport width/height, `em`/`rem` are font-relative sizes, `fr` is a grid fraction. See the [MDN CSS values reference](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units).
 
 | Helper                 | Output             |

--- a/docs/content/docs/reference.mdx
+++ b/docs/content/docs/reference.mdx
@@ -6,7 +6,7 @@ icon: BookMarked
 
 ## Node Types
 
-Every node is a `container`, `text`, or `image`.
+Every node is a `container`, `text`, or `image`. A node tree holds content and style only. Fonts, images, and output options are separate arguments to `render`, so a tree stays plain JSON and can come straight out of a structured-output schema.
 
 All nodes accept these fields:
 
@@ -30,7 +30,8 @@ All nodes accept these fields:
     },
     preset: {
       type: "Style",
-      description: "Default HTML element styles (lowest priority)",
+      description:
+        "Default HTML element styles (lowest priority); fromHtml and fromJsx fill it from tagName",
       typeDescriptionLink: "#style-properties",
     },
     tw: {
@@ -105,6 +106,12 @@ Displays a rasterized image or SVG. Adds:
 ## Style Properties
 
 Properties use their camelCase names. Longhands are listed in parentheses. `Supported` means the property follows its CSS spec; a value cell instead lists the accepted keywords.
+
+| Declaration                     | Result                             |
+| :------------------------------ | :--------------------------------- |
+| A name outside this list        | Dropped without an error           |
+| A `--custom` property           | Kept, and readable through `var()` |
+| A listed name, unparsable value | Fails the whole style object       |
 
 ### Layout & display
 


### PR DESCRIPTION
## Why

The supported style properties, what happens to a name outside that list, and the split between a node tree and the resources passed to `render` were only readable from the Rust source.

## What

`reference.mdx` now states that a node tree carries content and style only, adds a table for how a style declaration resolves (unknown name dropped, `--custom` kept, unparsable value fails), and notes that `fromHtml` and `fromJsx` fill `preset` from `tagName`. `helpers.mdx` links `props` to the node fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that node properties contain the node’s own fields.
  * Documented that node trees include only content and styles; fonts, images, and output options are provided separately during rendering.
  * Clarified preset behavior and default styling priority.
  * Added guidance on handling unknown, custom, and invalid style properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->