### PR TITLE
JS: add `imageResponse` for an ETag-carrying response

### DIFF
--- a/.tegami/image-response-etag.md
+++ b/.tegami/image-response-etag.md
@@ -1,0 +1,12 @@
+---
+packages:
+  npm:takumi-js:
+    type: minor
+---
+
+### Add `imageResponse` for an `ETag`-carrying response
+
+`imageResponse(element, options)` awaits the render and returns a `Response` whose
+body is the image bytes and whose `ETag` is their SHA-256 digest. `new
+ImageResponse(...)` cannot set one, since its headers are read while the render is
+still in flight.

--- a/docs/content/docs/image-response.mdx
+++ b/docs/content/docs/image-response.mdx
@@ -76,6 +76,24 @@ new ImageResponse(<OgImage />, {
 });
 ```
 
+## ETag
+
+`imageResponse` renders the image before it builds the `Response`, so it can hash the bytes into a strong `ETag`. Clients revalidate with `If-None-Match` and skip the download while the image is unchanged.
+
+```tsx
+import { imageResponse } from "takumi-js/response";
+
+export function GET() {
+  return imageResponse(<OgImage />, {
+    width: 1200,
+    height: 630,
+    headers: { "Cache-Control": "public, max-age=0, must-revalidate" },
+  });
+}
+```
+
+`new ImageResponse(...)` carries no `ETag`, because a framework reads its headers while the render is still running. `imageResponse` takes the same options, but awaits instead: it has no `ready` promise, the returned promise rejects when the render fails, and `onError` still runs. An `etag` of your own in `headers` is left alone.
+
 ## Error handling
 
 `ImageResponse` exposes a `ready` promise: it resolves when the render succeeds and rejects when it fails. Await it to serve a fallback.

--- a/takumi-js/src/response/index.ts
+++ b/takumi-js/src/response/index.ts
@@ -22,6 +22,35 @@ function defaultErrorHandler(error: unknown) {
   console.error(error);
 }
 
+function responseHeaders(options?: ImageResponseOptions) {
+  const headers = new Headers(options?.headers);
+
+  if (!headers.get("content-type")) {
+    headers.set("content-type", contentTypeMap[options?.format ?? "png"]);
+  }
+
+  return headers;
+}
+
+// Web Crypto and `Response` reject a view that could be backed by a SharedArrayBuffer,
+// which no renderer returns; the copy is a fallback the type system asks for.
+function arrayBufferView(image: Uint8Array): Uint8Array<ArrayBuffer> {
+  return image.buffer instanceof ArrayBuffer
+    ? new Uint8Array(image.buffer, image.byteOffset, image.byteLength)
+    : new Uint8Array(image);
+}
+
+async function strongEtag(image: Uint8Array<ArrayBuffer>) {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", image));
+  let hex = "";
+
+  for (const byte of digest) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+
+  return `"${hex}"`;
+}
+
 function buildImageResponse(
   element: RenderInput,
   options?: ImageResponseOptions,
@@ -41,7 +70,7 @@ function buildImageResponse(
     async start(controller) {
       try {
         const image = await render(element, options);
-        controller.enqueue(image as ArrayBufferView<ArrayBuffer>);
+        controller.enqueue(arrayBufferView(image));
         controller.close();
         resolveReady();
       } catch (error) {
@@ -54,14 +83,9 @@ function buildImageResponse(
       }
     },
   });
-  const headers = new Headers(options?.headers);
-
-  if (!headers.get("content-type")) {
-    headers.set("content-type", contentTypeMap[options?.format ?? "png"]);
-  }
 
   const response = new Response(stream, {
-    headers,
+    headers: responseHeaders(options),
     status: options?.status,
     statusText: options?.statusText,
   });
@@ -104,6 +128,50 @@ export class ImageResponse extends Response {
 
     super(response.body, response);
     this.ready = response.ready;
+  }
+}
+
+/**
+ * Renders the image before the `Response` exists, so its bytes can be hashed into a
+ * strong `ETag`. Clients revalidate with `If-None-Match` and skip the download when the
+ * image is unchanged, which `new ImageResponse(...)` cannot offer: its headers are read
+ * while the render is still in flight.
+ *
+ * An `etag` passed through `headers` wins.
+ *
+ * @example
+ * ```tsx
+ * import { imageResponse } from "takumi-js/response";
+ *
+ * export function GET() {
+ *   return imageResponse(<OgImage />, { width: 1200, height: 630 });
+ * }
+ * ```
+ *
+ * @param component - The JSX element to render.
+ * @param options - Rendering and response options.
+ */
+export async function imageResponse(
+  component: RenderInput,
+  options?: ImageResponseOptions,
+): Promise<Response> {
+  try {
+    const image = arrayBufferView(await render(component, options));
+    const headers = responseHeaders(options);
+
+    if (!headers.has("etag")) {
+      headers.set("etag", await strongEtag(image));
+    }
+
+    return new Response(image, {
+      headers,
+      status: options?.status,
+      statusText: options?.statusText,
+    });
+  } catch (error) {
+    await (options?.onError ?? defaultErrorHandler)(error);
+
+    throw error;
   }
 }
 

--- a/takumi-js/tests/response.test.tsx
+++ b/takumi-js/tests/response.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { createContext, useContext } from "react";
-import ImageResponse from "../src/response";
+import ImageResponse, { imageResponse } from "../src/response";
 import { render } from "../src";
 import type { Node } from "@takumi-rs/helpers";
 
@@ -164,6 +164,44 @@ describe("ImageResponse", () => {
     } finally {
       process.off("unhandledRejection", handler);
     }
+  });
+
+  test("should set an etag matching the rendered bytes", async () => {
+    const renderer = { render: mock(async () => new Uint8Array([1, 2, 3])) } as any;
+
+    const response = await imageResponse(<div>Hello</div>, { renderer });
+    const digest = await crypto.subtle.digest("SHA-256", await response.arrayBuffer());
+    const hex = Array.from(new Uint8Array(digest), (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
+
+    expect(response.headers.get("etag")).toBe(`"${hex}"`);
+    expect(response.headers.get("content-type")).toBe("image/png");
+  });
+
+  test("should keep an etag passed through headers", async () => {
+    const renderer = { render: mock(async () => new Uint8Array([1, 2, 3])) } as any;
+
+    const response = await imageResponse(<div>Hello</div>, {
+      renderer,
+      headers: { etag: `"pinned"` },
+    });
+
+    expect(response.headers.get("etag")).toBe(`"pinned"`);
+  });
+
+  test("should call onError and reject when the render fails", async () => {
+    const error = new Error("render failed");
+    const renderer = {
+      render: mock(async () => {
+        throw error;
+      }),
+    } as any;
+    const onError = mock();
+
+    await expect(imageResponse(<div>Hello</div>, { renderer, onError })).rejects.toBe(error);
+
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 
   test("should not crash on social template with pre-wrap and emoji", async () => {


### PR DESCRIPTION
## Why

Closes #1050. An `ETag` lets clients revalidate a rarely-changing image instead of picking between an aggressive cache that goes stale and no cache at all. Nothing in `takumi-js` could set one: `ImageResponse` hands back its headers before the render finishes, so the only way out was to await the response, hash the bytes, and rebuild it.

## What

New `imageResponse(element, options)` in `takumi-js/response`, taking the same options as `ImageResponse`. It awaits the render, hashes the bytes with `crypto.subtle` (Node 18+, browsers, workerd), and returns a `Response` carrying both. An `etag` passed through `headers` wins. `ImageResponse` itself is untouched, and its one `as ArrayBufferView<ArrayBuffer>` cast is now a shared helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `imageResponse` for fully rendered image responses.
  * Responses now include strong SHA-256 `ETag` headers, enabling `If-None-Match` revalidation.
  * User-provided `ETag` headers are preserved.

* **Bug Fixes**
  * Rendering failures now reject the response promise while still invoking the configured error handler.

* **Documentation**
  * Documented `imageResponse` behavior, `ETag` support, and differences from streaming image responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->