### PR TITLE
JS: add `ImageResponse.render` for a fully rendered response

### DIFF
--- a/.tegami/image-response-buffered.md
+++ b/.tegami/image-response-buffered.md
@@ -1,0 +1,13 @@
+---
+packages:
+  npm:takumi-js:
+    type: minor
+---
+
+### Add `ImageResponse.buffered` for a fully rendered response
+
+`ImageResponse.buffered(element, options)` awaits the render and returns a
+`Response` carrying the finished bytes instead of a stream, so the runtime knows
+the body length and the headers carry a strong `ETag` of the image. The
+constructor cannot set one, since its headers are read while the render is still
+in flight.

--- a/.tegami/image-response-render.md
+++ b/.tegami/image-response-render.md
@@ -4,9 +4,9 @@ packages:
     type: minor
 ---
 
-### Add `ImageResponse.buffered` for a fully rendered response
+### Add `ImageResponse.render` for a fully rendered response
 
-`ImageResponse.buffered(element, options)` awaits the render and returns a
+`ImageResponse.render(element, options)` awaits the render and returns a
 `Response` carrying the finished bytes instead of a stream, so the runtime knows
 the body length and the headers carry a strong `ETag` of the image. The
 constructor cannot set one, since its headers are read while the render is still

--- a/docs/content/docs/image-response.mdx
+++ b/docs/content/docs/image-response.mdx
@@ -76,15 +76,15 @@ new ImageResponse(<OgImage />, {
 });
 ```
 
-## Buffered responses and ETag
+## Awaiting the render, and ETag
 
-The constructor hands back a streaming `Response` while the render is still running, which is why its headers can carry no `ETag`. `ImageResponse.buffered` takes the same options and awaits instead, so its body is the finished bytes: the runtime knows the length and can skip chunked encoding, and the headers carry a strong `ETag` hashed from those bytes.
+The constructor hands back a streaming `Response` while the render is still running, which is why its headers can carry no `ETag`. `ImageResponse.render` takes the same options and awaits instead, so its body is the finished bytes: the runtime knows the length and can skip chunked encoding, and the headers carry a strong `ETag` hashed from those bytes.
 
 ```tsx
 import { ImageResponse } from "takumi-js/response";
 
 export function GET() {
-  return ImageResponse.buffered(<OgImage />, {
+  return ImageResponse.render(<OgImage />, {
     width: 1200,
     height: 630,
     headers: { "Cache-Control": "public, max-age=0, must-revalidate" },

--- a/docs/content/docs/image-response.mdx
+++ b/docs/content/docs/image-response.mdx
@@ -76,6 +76,28 @@ new ImageResponse(<OgImage />, {
 });
 ```
 
+## Buffered responses and ETag
+
+The constructor hands back a streaming `Response` while the render is still running, which is why its headers can carry no `ETag`. `ImageResponse.buffered` takes the same options and awaits instead, so its body is the finished bytes: the runtime knows the length and can skip chunked encoding, and the headers carry a strong `ETag` hashed from those bytes.
+
+```tsx
+import { ImageResponse } from "takumi-js/response";
+
+export function GET() {
+  return ImageResponse.buffered(<OgImage />, {
+    width: 1200,
+    height: 630,
+    headers: { "Cache-Control": "public, max-age=0, must-revalidate" },
+  });
+}
+```
+
+Takumi never sees the request, so it cannot answer one with `304 Not Modified`. The `ETag` is what lets your server, framework adapter, or CDN compare `If-None-Match` and skip resending the image.
+
+An `etag` of your own in `headers` is left alone. There is no `ready` promise here: the returned promise rejects with the render error, and `onError` still runs.
+
+The digest comes from global Web Crypto. Node exposes it from version 19 onwards; on Node 18 you need `--experimental-global-webcrypto`.
+
 ## Error handling
 
 `ImageResponse` exposes a `ready` promise: it resolves when the render succeeds and rejects when it fails. Await it to serve a fallback.

--- a/takumi-js/src/response/index.ts
+++ b/takumi-js/src/response/index.ts
@@ -158,14 +158,14 @@ export class ImageResponse extends Response {
    * import { ImageResponse } from "takumi-js/response";
    *
    * export function GET() {
-   *   return ImageResponse.buffered(<OgImage />, { width: 1200, height: 630 });
+   *   return ImageResponse.render(<OgImage />, { width: 1200, height: 630 });
    * }
    * ```
    *
    * @param component - The JSX element to render.
    * @param options - Rendering and response options.
    */
-  static async buffered(component: RenderInput, options?: ImageResponseOptions): Promise<Response> {
+  static async render(component: RenderInput, options?: ImageResponseOptions): Promise<Response> {
     let image: Uint8Array<ArrayBuffer>;
 
     try {

--- a/takumi-js/src/response/index.ts
+++ b/takumi-js/src/response/index.ts
@@ -22,6 +22,44 @@ function defaultErrorHandler(error: unknown) {
   console.error(error);
 }
 
+async function notifyError(error: unknown, options?: ImageResponseOptions) {
+  try {
+    await (options?.onError ?? defaultErrorHandler)(error);
+  } catch (handlerError) {
+    console.error("The onError handler failed.");
+    console.error(handlerError);
+  }
+}
+
+function responseHeaders(options?: ImageResponseOptions) {
+  const headers = new Headers(options?.headers);
+
+  if (!headers.get("content-type")) {
+    headers.set("content-type", contentTypeMap[options?.format ?? "png"]);
+  }
+
+  return headers;
+}
+
+// Web Crypto and `Response` reject a view that could be backed by a SharedArrayBuffer,
+// which no renderer returns; the copy is a fallback the type system asks for.
+function arrayBufferView(image: Uint8Array): Uint8Array<ArrayBuffer> {
+  return image.buffer instanceof ArrayBuffer
+    ? new Uint8Array(image.buffer, image.byteOffset, image.byteLength)
+    : new Uint8Array(image);
+}
+
+async function strongEtag(image: Uint8Array<ArrayBuffer>) {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", image));
+  let hex = "";
+
+  for (const byte of digest) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+
+  return `"${hex}"`;
+}
+
 function buildImageResponse(
   element: RenderInput,
   options?: ImageResponseOptions,
@@ -41,27 +79,20 @@ function buildImageResponse(
     async start(controller) {
       try {
         const image = await render(element, options);
-        controller.enqueue(image as ArrayBufferView<ArrayBuffer>);
+        controller.enqueue(arrayBufferView(image));
         controller.close();
         resolveReady();
       } catch (error) {
         controller.error(error);
 
         rejectReady(error);
-        const errorHandler = options?.onError ?? defaultErrorHandler;
-
-        await errorHandler(error);
+        await notifyError(error, options);
       }
     },
   });
-  const headers = new Headers(options?.headers);
-
-  if (!headers.get("content-type")) {
-    headers.set("content-type", contentTypeMap[options?.format ?? "png"]);
-  }
 
   const response = new Response(stream, {
-    headers,
+    headers: responseHeaders(options),
     status: options?.status,
     statusText: options?.statusText,
   });
@@ -104,6 +135,58 @@ export class ImageResponse extends Response {
 
     super(response.body, response);
     this.ready = response.ready;
+  }
+
+  /**
+   * The awaited counterpart of the constructor: it renders first, then hands back a
+   * `Response` whose body is the finished bytes instead of a stream. That costs an `await`
+   * at the call site and buys a known body length, no stream to pump, and a strong `ETag`
+   * derived from the bytes, which the constructor cannot set because its headers are read
+   * while the render is still in flight.
+   *
+   * Nothing here inspects `If-None-Match`. The `ETag` is what lets a server, adapter, or
+   * CDN answer a conditional request with `304 Not Modified`.
+   *
+   * An `etag` passed through `headers` is left alone. Rejects with the render error, after
+   * `onError` runs.
+   *
+   * The digest comes from global Web Crypto, which Node exposes from 19 onwards (18 needs
+   * `--experimental-global-webcrypto`).
+   *
+   * @example
+   * ```tsx
+   * import { ImageResponse } from "takumi-js/response";
+   *
+   * export function GET() {
+   *   return ImageResponse.buffered(<OgImage />, { width: 1200, height: 630 });
+   * }
+   * ```
+   *
+   * @param component - The JSX element to render.
+   * @param options - Rendering and response options.
+   */
+  static async buffered(component: RenderInput, options?: ImageResponseOptions): Promise<Response> {
+    let image: Uint8Array<ArrayBuffer>;
+
+    try {
+      image = arrayBufferView(await render(component, options));
+    } catch (error) {
+      await notifyError(error, options);
+
+      throw error;
+    }
+
+    const headers = responseHeaders(options);
+
+    if (!headers.has("etag")) {
+      headers.set("etag", await strongEtag(image));
+    }
+
+    return new Response(image, {
+      headers,
+      status: options?.status,
+      statusText: options?.statusText,
+    });
   }
 }
 

--- a/takumi-js/tests/response.test.tsx
+++ b/takumi-js/tests/response.test.tsx
@@ -166,11 +166,11 @@ describe("ImageResponse", () => {
     }
   });
 
-  test("should buffer the bytes and etag them", async () => {
+  test("should return the rendered bytes with an etag", async () => {
     const image = new Uint8Array([1, 2, 3]);
     const renderer = { render: mock(async () => image) } as any;
 
-    const response = await ImageResponse.buffered(<div>Hello</div>, { renderer });
+    const response = await ImageResponse.render(<div>Hello</div>, { renderer });
     const body = new Uint8Array(await response.arrayBuffer());
     const digest = await crypto.subtle.digest("SHA-256", body);
     const hex = Array.from(new Uint8Array(digest), (byte) =>
@@ -185,7 +185,7 @@ describe("ImageResponse", () => {
   test("should keep an etag passed through headers", async () => {
     const renderer = { render: mock(async () => new Uint8Array([1, 2, 3])) } as any;
 
-    const response = await ImageResponse.buffered(<div>Hello</div>, {
+    const response = await ImageResponse.render(<div>Hello</div>, {
       renderer,
       headers: { etag: `"pinned"` },
     });
@@ -204,7 +204,7 @@ describe("ImageResponse", () => {
     const consoleError = spyOn(console, "error").mockImplementation(() => {});
 
     try {
-      await expect(ImageResponse.buffered(<div>Hello</div>, { renderer, onError })).rejects.toBe(
+      await expect(ImageResponse.render(<div>Hello</div>, { renderer, onError })).rejects.toBe(
         error,
       );
     } finally {

--- a/takumi-js/tests/response.test.tsx
+++ b/takumi-js/tests/response.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { createContext, useContext } from "react";
 import ImageResponse from "../src/response";
 import { render } from "../src";
@@ -164,6 +164,54 @@ describe("ImageResponse", () => {
     } finally {
       process.off("unhandledRejection", handler);
     }
+  });
+
+  test("should buffer the bytes and etag them", async () => {
+    const image = new Uint8Array([1, 2, 3]);
+    const renderer = { render: mock(async () => image) } as any;
+
+    const response = await ImageResponse.buffered(<div>Hello</div>, { renderer });
+    const body = new Uint8Array(await response.arrayBuffer());
+    const digest = await crypto.subtle.digest("SHA-256", body);
+    const hex = Array.from(new Uint8Array(digest), (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
+
+    expect(body).toEqual(image);
+    expect(response.headers.get("etag")).toBe(`"${hex}"`);
+    expect(response.headers.get("content-type")).toBe("image/png");
+  });
+
+  test("should keep an etag passed through headers", async () => {
+    const renderer = { render: mock(async () => new Uint8Array([1, 2, 3])) } as any;
+
+    const response = await ImageResponse.buffered(<div>Hello</div>, {
+      renderer,
+      headers: { etag: `"pinned"` },
+    });
+
+    expect(response.headers.get("etag")).toBe(`"pinned"`);
+  });
+
+  test("should reject with the render error even when onError rejects", async () => {
+    const error = new Error("render failed");
+    const renderer = {
+      render: mock(async () => {
+        throw error;
+      }),
+    } as any;
+    const onError = mock(() => Promise.reject(new Error("logging failed")));
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(ImageResponse.buffered(<div>Hello</div>, { renderer, onError })).rejects.toBe(
+        error,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 
   test("should not crash on social template with pre-wrap and emoji", async () => {


### PR DESCRIPTION
## Why

Closes #1050. `new ImageResponse(...)` keeps its `next/og` shape, which means the framework reads its headers while the render is still in flight, so no `ETag` can reach them. Callers who wanted one had to await the response, hash the bytes, and rebuild it. The body is also a `ReadableStream` over a single chunk that is already fully in memory, so the runtime pumps a stream and falls back to chunked encoding for bytes whose length it could have known.

## What

`ImageResponse.render(element, options)` takes the same options and returns `Promise<Response>`. It awaits the render, then builds the response from the finished bytes: no stream, known body length, and a strong `ETag` that is their SHA-256 digest. An `etag` passed through `headers` wins. The constructor is untouched.

Takumi never sees the request, so answering `If-None-Match` with a 304 stays the server's or CDN's job; the `ETag` is what makes that possible.

The digest uses global Web Crypto, which Node exposes from 19 onwards. `engines` stays at `>=18` rather than dropping a runtime in a minor, and a `node:crypto` fallback is deliberately not there: an unconditional `node:` import is the same trap that broke bundler resolution in #952.

Two fixes fell out of the shared helpers: a rejecting `onError` no longer replaces the render error (or escapes as an unhandled rejection from the stream's `start`), and the one `as ArrayBufferView<ArrayBuffer>` cast is now a narrowing helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ImageResponse.render` for producing fully rendered image responses with a strong `ETag`.
  * Automatically sets the image content type and preserves caller-provided `ETag` values.
  * Rendering failures now reject the returned promise while invoking the configured error handler.

* **Bug Fixes**
  * Improved streaming response error propagation and output byte handling.

* **Documentation**
  * Documented rendering, caching behavior, `ETag` generation, and runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->