### PR TITLE
NAPI, WASM: type render output as ArrayBuffer-backed

### DIFF
--- a/.tegami/render-return-arraybuffer.md
+++ b/.tegami/render-return-arraybuffer.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core": patch
+  "@takumi-rs/wasm": patch
+---
+
+### Type render output as backed by `ArrayBuffer`
+
+`render` and `renderAnimation` declared their output as `Buffer` / `Uint8Array` over `ArrayBufferLike`, so passing the bytes straight to `new Response(...)` failed to typecheck. They now declare `Buffer<ArrayBuffer>` / `Uint8Array<ArrayBuffer>`, which `BodyInit` accepts.

--- a/takumi-js/src/response/index.ts
+++ b/takumi-js/src/response/index.ts
@@ -41,7 +41,7 @@ function buildImageResponse(
     async start(controller) {
       try {
         const image = await render(element, options);
-        controller.enqueue(image as ArrayBufferView<ArrayBuffer>);
+        controller.enqueue(image);
         controller.close();
         resolveReady();
       } catch (error) {

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -436,7 +436,7 @@ impl Renderer {
   /// Renders a node tree into an image buffer asynchronously.
   #[napi(
     ts_args_type = "source: Node, options?: RenderOptions, signal?: AbortSignal",
-    ts_return_type = "Promise<Buffer>"
+    ts_return_type = "Promise<Buffer<ArrayBuffer>>"
   )]
   pub fn render(
     &self,
@@ -511,7 +511,7 @@ impl Renderer {
   /// Renders a sequential scene animation into a buffer asynchronously.
   #[napi(
     ts_args_type = "options: RenderAnimationOptions, signal?: AbortSignal",
-    ts_return_type = "Promise<Buffer>"
+    ts_return_type = "Promise<Buffer<ArrayBuffer>>"
   )]
   pub fn render_animation(
     &self,

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -172,7 +172,7 @@ impl Renderer {
   }
 
   /// Renders a node tree into an image buffer.
-  #[wasm_bindgen]
+  #[wasm_bindgen(unchecked_return_type = "Uint8Array<ArrayBuffer>")]
   pub fn render(
     &self,
     node: NodeType,
@@ -316,7 +316,7 @@ impl Renderer {
   }
 
   /// Renders a sequential animation timeline into a buffer.
-  #[wasm_bindgen(js_name = renderAnimation)]
+  #[wasm_bindgen(js_name = renderAnimation, unchecked_return_type = "Uint8Array<ArrayBuffer>")]
   pub fn render_animation(&self, options: RenderAnimationOptionsType) -> Result<Vec<u8>, JsValue> {
     let RenderAnimationOptions {
       scenes,


### PR DESCRIPTION
## Why
`render` / `renderAnimation` type their output over `ArrayBufferLike`, so passing the bytes to `new Response(...)` fails to typecheck (#1060).

## What
The napi `ts_return_type` and wasm `unchecked_return_type` attributes now declare `Buffer<ArrayBuffer>` / `Uint8Array<ArrayBuffer>`, matching what the bindings actually return. The `ImageResponse` cast that papered over this is gone.

Fixes #1060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rendered image outputs to use standard `ArrayBuffer`-backed types.
  * Rendered images can now be passed directly to web `Response` objects.
  * Improved type declarations for standard and WebAssembly rendering, including animated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->