### PR TITLE
PDF: only treat known counter-style names as counter styles

### DIFF
--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -159,9 +159,11 @@ struct PdfRenderOptions {
   landscape: Option<bool>,
   /// Page margin in CSS px: one number or per-side values.
   margin: Option<MarginInput>,
-  /// Band repeated at the top of every page (`{page}`/`{pages}` in text).
+  /// Band repeated at the top of every page. Nodes classed `pageNumber` /
+  /// `totalPages` receive the counters, optionally formatted by a
+  /// `@counter-style` name in the same class list.
   header: Option<Node>,
-  /// Band repeated at the bottom of every page.
+  /// Band repeated at the bottom of every page; same class hooks as `header`.
   footer: Option<Node>,
   /// Pre-fetched images keyed by URL.
   images: Option<Vec<ImageSource>>,

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -161,7 +161,7 @@ struct PdfRenderOptions {
   margin: Option<MarginInput>,
   /// Band repeated at the top of every page. Nodes classed `pageNumber` /
   /// `totalPages` receive the counters, optionally formatted by a
-  /// `@counter-style` name in the same class list.
+  /// supported `@counter-style` name in the same class list.
   header: Option<Node>,
   /// Band repeated at the bottom of every page; same class hooks as `header`.
   footer: Option<Node>,

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -319,7 +319,6 @@ fn prepare_tree(
   })
 }
 
-/// The `@counter-style` names [`format_counter`] understands.
 const COUNTER_STYLES: [&str; 7] = [
   "decimal",
   "decimal-leading-zero",

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -319,6 +319,17 @@ fn prepare_tree(
   })
 }
 
+/// The `@counter-style` names [`format_counter`] understands.
+const COUNTER_STYLES: [&str; 7] = [
+  "decimal",
+  "decimal-leading-zero",
+  "lower-roman",
+  "upper-roman",
+  "cjk-decimal",
+  "trad-chinese-informal",
+  "cjk-ideographic",
+];
+
 /// Formats a page counter in a CSS `@counter-style` named style. Unknown
 /// styles fall back to `decimal`.
 fn format_counter(value: usize, style: &str) -> String {
@@ -426,7 +437,7 @@ fn counter_text(node: &Node, page: usize, pages: usize) -> Option<String> {
   };
   let style = classes
     .split_whitespace()
-    .find(|class| *class != "pageNumber" && *class != "totalPages")
+    .find(|class| COUNTER_STYLES.contains(class))
     .unwrap_or("decimal");
 
   Some(format_counter(value, style))

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -126,7 +126,7 @@ pub struct PdfOptions<'g> {
   pub page: Option<PageOptions>,
   /// Band repeated at the top of every page. Nodes classed `pageNumber` /
   /// `totalPages` receive the counters, optionally formatted by a
-  /// `@counter-style` name in the same class list (e.g. `cjk-decimal`). The
+  /// supported `@counter-style` name in the same class list (e.g. `cjk-decimal`). The
   /// band's height is carved out of the content window.
   #[builder(default, setter(strip_option))]
   pub header: Option<Node>,

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -153,7 +153,7 @@ fn paged_footer_counters() {
         from_html(
           r#"<div style="display: flex; column-gap: 3px; font-size: 12px; color: #141414;">
             Page <span class="pageNumber"></span> of <span class="totalPages"></span>,
-            page <span class="pageNumber trad-chinese-informal"></span> in Chinese,
+            page <span class="pageNumber muted trad-chinese-informal"></span> in Chinese,
             <span class="pageNumber lower-roman"></span> in roman
           </div>"#,
           FromHtmlOptions::default(),


### PR DESCRIPTION
## Why
A counter hook picked the first class that was not `pageNumber`/`totalPages` as its counter style, so a utility class like `muted` ahead of `cjk-decimal` silently reset the format to decimal.

## What
Style lookup now matches against the list of names `format_counter` understands and ignores everything else. The wasm binding's header/footer docs also drop the stale `{page}`/`{pages}` wording, and the footer fixture pins the utility-class case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how page numbers and total pages can be styled in PDF headers and footers.
  * Documented optional formatting using supported counter styles.

* **Bug Fixes**
  * Improved counter-style handling by recognizing supported styles and defaulting to decimal formatting for unsupported styles.
  * Updated paged footer formatting for Chinese page numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->