### PR TITLE
Example: load fonts with googleFonts helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "takumi-pdf"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "krilla",
  "takumi-core",

--- a/bun.lock
+++ b/bun.lock
@@ -122,6 +122,7 @@
     "example/generate-invoice": {
       "name": "example-generate-invoice",
       "dependencies": {
+        "@takumi-rs/helpers": "workspace:*",
         "react": "catalog:",
         "takumi-pdf": "workspace:*",
       },

--- a/example/generate-invoice/index.tsx
+++ b/example/generate-invoice/index.tsx
@@ -1,4 +1,5 @@
 import { mkdir } from "node:fs/promises";
+import { googleFonts } from "@takumi-rs/helpers";
 import { write } from "bun";
 import { render } from "takumi-pdf";
 import { invoice } from "./data";
@@ -14,10 +15,17 @@ const images = [
   },
 ];
 
+const fonts = await googleFonts([
+  { name: "Inter", weight: [400, 500, 600] },
+  { name: "Space Mono", weight: [400, 700] },
+]);
+
 const invoicePdf = await render(<InvoiceDocument data={invoice} />, {
   size: "a4",
   margin: 48,
   images,
+  fonts,
+  fontFamilies: ["Inter"],
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-[#6b7280]">
       Page <span className="pageNumber" /> of <span className="totalPages" />
@@ -30,6 +38,8 @@ await write("output/invoice.pdf", invoicePdf);
 const receiptPdf = await render(<ReceiptDocument data={invoice} />, {
   viewport: { width: 302 },
   images,
+  fonts,
+  fontFamilies: ["Space Mono"],
 });
 
 await write("output/receipt.pdf", receiptPdf);

--- a/example/generate-invoice/index.tsx
+++ b/example/generate-invoice/index.tsx
@@ -25,7 +25,6 @@ const invoicePdf = await render(<InvoiceDocument data={invoice} />, {
   margin: 48,
   images,
   fonts,
-  fontFamilies: ["Inter"],
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-[#6b7280]">
       Page <span className="pageNumber" /> of <span className="totalPages" />

--- a/example/generate-invoice/package.json
+++ b/example/generate-invoice/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "module": "index.tsx",
   "dependencies": {
+    "@takumi-rs/helpers": "workspace:*",
     "react": "catalog:",
     "takumi-pdf": "workspace:*"
   },

--- a/example/generate-invoice/receipt.tsx
+++ b/example/generate-invoice/receipt.tsx
@@ -34,7 +34,7 @@ export function ReceiptDocument({ data }: { data: Invoice }) {
       <div tw="flex flex-col gap-2">
         {data.items.map((item) => (
           <div key={item.description} tw="flex flex-col">
-            <span tw="font-medium">{item.description}</span>
+            <span tw="font-bold">{item.description}</span>
             <div tw="flex justify-between text-[#6b7280]">
               <span>
                 {item.quantity} × {money(item.unitPrice)}

--- a/takumi-pdf/Cargo.toml
+++ b/takumi-pdf/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "takumi-pdf"
-version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Vector PDF output backend for takumi. Emits selectable, searchable text with embedded subset fonts via krilla."


### PR DESCRIPTION
## Why
The generate-invoice example rendered with the built-in fallback font and never showed how to pick real typefaces. The takumi-pdf crate also carried a version despite being unpublished.

## What
Loads Inter and Space Mono through the `googleFonts` helper; the invoice falls back to registration order, the receipt selects Space Mono with `fontFamilies`. Drops the version field from the takumi-pdf crate. The example commit was pushed to #1066 after it squash-merged, so it lands here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved invoice and receipt PDF typography with Inter and Space Mono font support.
  * Receipt PDFs now use Space Mono for a clearer, more distinctive layout.
  * Invoice item descriptions now appear in bold for improved readability.

* **Bug Fixes**
  * Improved font rendering consistency across generated invoice and receipt documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->