### PR TITLE
Core: update vendored resvg to 0.48.1

### DIFF
--- a/.tegami/resvg-0-48.md
+++ b/.tegami/resvg-0-48.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: patch
+---
+
+### Vendored resvg updated to 0.48.1
+
+Pulls the upstream parser and filter fixes: nested `svg` transforms are no longer applied twice, a missing `width`/`height` is computed from the viewBox aspect ratio, `href` takes precedence over `xlink:href`, `fr` is inherited for radial gradients referenced via `href`, and oversized filter regions no longer panic.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,15 +231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -497,16 +494,15 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
 ]
 
 [[package]]
@@ -664,6 +660,18 @@ dependencies = [
  "bitflags",
  "bytemuck",
  "read-fonts 0.40.2",
+ "smallvec",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "read-fonts 0.41.0",
  "smallvec",
 ]
 
@@ -848,6 +856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "imagesize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,13 +913,13 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27da593198b20eeba65caeb73c2bbeec3e53ab08fa549898312ce81c4fce5e33"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bumpalo",
  "flate2",
  "float-cmp",
  "gif",
  "image-webp",
- "imagesize",
+ "imagesize 0.14.0",
  "indexmap",
  "pdf-writer",
  "png",
@@ -947,12 +961,6 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libwebp-sys"
@@ -1188,7 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
  "fontique",
- "harfrust",
+ "harfrust 0.10.0",
  "hashbrown",
  "icu_normalizer",
  "icu_properties",
@@ -1461,6 +1469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.2",
+ "once_cell",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,10 +1519,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",
@@ -1559,24 +1579,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rustybuzz"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
-dependencies = [
- "bitflags",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
 
 [[package]]
 name = "ryu"
@@ -1742,6 +1744,16 @@ checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
 dependencies = [
  "bytemuck",
  "read-fonts 0.40.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.41.0",
 ]
 
 [[package]]
@@ -2028,7 +2040,7 @@ dependencies = [
 name = "takumi-wasm"
 version = "0.0.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
@@ -2132,15 +2144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
-
-[[package]]
 name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,28 +2170,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -2210,26 +2195,26 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "data-url",
  "flate2",
  "fontdb",
- "imagesize",
+ "harfrust 0.12.0",
+ "imagesize 0.15.0",
  "kurbo",
  "log",
  "pico-args",
  "roxmltree 0.21.1",
- "rustybuzz",
  "simplecss",
  "siphasher",
+ "skrifa 0.44.0",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
- "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ paste = "1.0"
 precomputed-hash = "0.1"
 quick-xml = "0.41"
 rayon = "1.12"
-rgb = "0.8"
 roxmltree = "0.21.1"
 selectors = "0.39"
 serde_bytes = "0.11"
@@ -65,6 +64,10 @@ features = ["std", "simd"]
 [workspace.dependencies.quick_cache]
 version = "0.7"
 default-features = false
+
+[workspace.dependencies.rgb]
+version = "0.8"
+features = ["bytemuck"]
 
 [workspace.dependencies.png]
 version = "0.18"

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod style;
 /// Viewport dimensions and device-pixel-ratio resolution.
 pub mod viewport;
 
-/// Vendored resvg 0.47 (see `resvg/mod.rs` for provenance and stripped features).
+/// Vendored resvg 0.48 (see `resvg/mod.rs` for provenance and stripped features).
 /// `dead_code` stays allowed until the unused upstream API surface is pruned.
 #[cfg(feature = "svg")]
 #[allow(

--- a/takumi-core/src/resvg/filter/composite.rs
+++ b/takumi-core/src/resvg/filter/composite.rs
@@ -10,9 +10,7 @@ use rgb::RGBA8;
 /// - `src1` and `src2` image pixels should have a **premultiplied alpha**.
 /// - `dest` image pixels will have a **premultiplied alpha**.
 ///
-/// # Panics
-///
-/// When `src1`, `src2` and `dest` have different sizes.
+/// `src1`, `src2` and `dest` dimensions must match.
 pub fn arithmetic(
   k1: f32,
   k2: f32,
@@ -22,8 +20,8 @@ pub fn arithmetic(
   src2: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src1.width == src2.width && src1.width == dest.width);
-  assert!(src1.height == src2.height && src1.height == dest.height);
+  debug_assert!(src1.width == src2.width && src1.width == dest.width);
+  debug_assert!(src1.height == src2.height && src1.height == dest.height);
 
   let calc = |i1, i2, max| {
     let i1 = i1 as f32 / 255.0;

--- a/takumi-core/src/resvg/filter/displacement_map.rs
+++ b/takumi-core/src/resvg/filter/displacement_map.rs
@@ -11,9 +11,7 @@ use crate::resvg::usvg::filter::{ColorChannel, DisplacementMap};
 ///
 /// `sx` and `sy` indicate canvas scale.
 ///
-/// # Panics
-///
-/// When `src`, `map` and `dest` have different sizes.
+/// `src`, `map` and `dest` dimensions must match.
 pub fn apply(
   fe: &DisplacementMap,
   sx: f32,
@@ -22,8 +20,8 @@ pub fn apply(
   map: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src.width == map.width && src.width == dest.width);
-  assert!(src.height == map.height && src.height == dest.height);
+  debug_assert!(src.width == map.width && src.width == dest.width);
+  debug_assert!(src.height == map.height && src.height == dest.height);
 
   let w = src.width as i32;
   let h = src.height as i32;

--- a/takumi-core/src/resvg/filter/iir_blur.rs
+++ b/takumi-core/src/resvg/filter/iir_blur.rs
@@ -26,7 +26,6 @@
 // TODO: Blurs right and bottom sides twice for some reason.
 
 use super::ImageRefMut;
-use rgb::ComponentSlice;
 
 struct BlurData {
   width: usize,
@@ -58,7 +57,7 @@ pub fn apply(sigma_x: f64, sigma_y: f64, src: ImageRefMut) {
     steps: 4,
   };
 
-  let data = ComponentSlice::as_mut_slice(src.data);
+  let data = bytemuck::cast_slice_mut(src.data);
   gaussian_channel(data, &d, 0, buf);
   gaussian_channel(data, &d, 1, buf);
   gaussian_channel(data, &d, 2, buf);

--- a/takumi-core/src/resvg/filter/lighting.rs
+++ b/takumi-core/src/resvg/filter/lighting.rs
@@ -128,16 +128,14 @@ impl Normal {
 ///
 /// Does nothing when `src` is less than 3x3.
 ///
-/// # Panics
-///
-/// - When `src` and `dest` have different sizes.
+/// `src` and `dest` dimensions must match.
 pub fn diffuse_lighting(
   fe: &DiffuseLighting,
   light_source: LightSource,
   src: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src.width == dest.width && src.height == dest.height);
+  debug_assert!(src.width == dest.width && src.height == dest.height);
 
   let light_factor = |normal: Normal, light_vector: Vector3| {
     let k = if normal.normal.approx_zero() {
@@ -173,16 +171,14 @@ pub fn diffuse_lighting(
 ///
 /// Does nothing when `src` is less than 3x3.
 ///
-/// # Panics
-///
-/// - When `src` and `dest` have different sizes.
+/// `src` and `dest` dimensions must match.
 pub fn specular_lighting(
   fe: &SpecularLighting,
   light_source: LightSource,
   src: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src.width == dest.width && src.height == dest.height);
+  debug_assert!(src.width == dest.width && src.height == dest.height);
 
   let light_factor = |normal: Normal, light_vector: Vector3| {
     let h = light_vector + Vector3::new(0.0, 0.0, 1.0);

--- a/takumi-core/src/resvg/filter/mod.rs
+++ b/takumi-core/src/resvg/filter/mod.rs
@@ -368,6 +368,13 @@ fn apply_inner(
     .map(|r| r.to_int_rect())
     .ok_or(Error::InvalidRegion)?;
 
+  // The source pixmap is clamped to `max_bbox` in `render_group`, so the filter
+  // region (derived directly from the unclamped filter rect) can be larger than
+  // the buffer we actually render into.
+  let source_rect =
+    IntRect::from_xywh(0, 0, source.width(), source.height()).ok_or(Error::InvalidRegion)?;
+  let region = crate::resvg::geom::fit_to_rect(region, source_rect).ok_or(Error::InvalidRegion)?;
+
   let mut results: Vec<FilterResult> = Vec::new();
 
   for primitive in filter.primitives() {

--- a/takumi-core/src/resvg/mod.rs
+++ b/takumi-core/src/resvg/mod.rs
@@ -4,7 +4,7 @@
 /*!
 [resvg](https://github.com/linebender/resvg) is an SVG rendering library.
 
-Vendored from resvg 0.47.0 (Apache-2.0 OR MIT), stripped of the `text`,
+Vendored from resvg 0.48.1 (Apache-2.0 OR MIT), stripped of the `text`,
 `svgz`, `system-fonts`, `memmap-fonts` and `writer` features and the CLI.
 */
 
@@ -42,14 +42,7 @@ pub fn render(
   transform: tiny_skia::Transform,
   pixmap: &mut tiny_skia::PixmapMut,
 ) {
-  let target_size = tiny_skia::IntSize::from_wh(pixmap.width(), pixmap.height()).unwrap();
-  let max_bbox = tiny_skia::IntRect::from_xywh(
-    -(target_size.width() as i32) * 2,
-    -(target_size.height() as i32) * 2,
-    target_size.width() * 5,
-    target_size.height() * 5,
-  )
-  .unwrap();
+  let max_bbox = max_filter_bbox(pixmap.width(), pixmap.height());
 
   let ctx = render::Context { max_bbox };
   render::render_nodes(tree.root(), &ctx, transform, pixmap);
@@ -72,14 +65,7 @@ pub fn render_node(
 ) -> Option<()> {
   let bbox = node.abs_layer_bounding_box()?;
 
-  let target_size = tiny_skia::IntSize::from_wh(pixmap.width(), pixmap.height()).unwrap();
-  let max_bbox = tiny_skia::IntRect::from_xywh(
-    -(target_size.width() as i32) * 2,
-    -(target_size.height() as i32) * 2,
-    target_size.width() * 5,
-    target_size.height() * 5,
-  )
-  .unwrap();
+  let max_bbox = max_filter_bbox(pixmap.width(), pixmap.height());
 
   transform = transform.pre_translate(-bbox.x(), -bbox.y());
 
@@ -87,6 +73,18 @@ pub fn render_node(
   render::render_node(node, &ctx, transform, pixmap);
 
   Some(())
+}
+
+fn max_filter_bbox(width: u32, height: u32) -> tiny_skia::IntRect {
+  tiny_skia::IntRect::from_xywh(
+    i32::try_from(width).unwrap_or(i32::MAX).saturating_mul(-2),
+    i32::try_from(height).unwrap_or(i32::MAX).saturating_mul(-2),
+    width.saturating_mul(5),
+    height.saturating_mul(5),
+  )
+  .unwrap_or_else(|| {
+    tiny_skia::IntRect::from_ltrb(i32::MIN / 2, i32::MIN / 2, i32::MAX / 2, i32::MAX / 2).unwrap()
+  })
 }
 
 /// Applies parsed filters to a premultiplied RGBA layer in place.
@@ -148,5 +146,17 @@ impl<T> OptionLog for Option<T> {
       f();
       None
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn max_filter_bbox_is_clamped() {
+    let bbox = super::max_filter_bbox(u32::MAX, u32::MAX);
+    assert_eq!(bbox.left(), i32::MIN / 2);
+    assert_eq!(bbox.top(), i32::MIN / 2);
+    assert_eq!(bbox.right(), i32::MAX / 2);
+    assert_eq!(bbox.bottom(), i32::MAX / 2);
   }
 }

--- a/takumi-core/src/resvg/render.rs
+++ b/takumi-core/src/resvg/render.rs
@@ -70,7 +70,12 @@ fn render_group(
   } else {
     // The bounding box for groups with filters is special and should not be expanded by 2px,
     // because it's already acting as a clipping region.
-    let bbox = bbox.to_int_rect();
+    let bbox = tiny_skia::IntRect::from_xywh(
+      bbox.x().floor() as i32,
+      bbox.y().floor() as i32,
+      bbox.width().ceil().max(1.0) as u32,
+      bbox.height().ceil().max(1.0) as u32,
+    )?;
     // Make sure our filter region is not bigger than 4x the canvas size.
     // This is required mainly to prevent huge filter regions that would tank the performance.
     // It should not affect the final result in any way.
@@ -152,5 +157,25 @@ pub fn convert_blend_mode(mode: crate::resvg::usvg::BlendMode) -> tiny_skia::Ble
     crate::resvg::usvg::BlendMode::Saturation => tiny_skia::BlendMode::Saturation,
     crate::resvg::usvg::BlendMode::Color => tiny_skia::BlendMode::Color,
     crate::resvg::usvg::BlendMode::Luminosity => tiny_skia::BlendMode::Luminosity,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::resvg::usvg;
+
+  // Derived from https://github.com/servo/servo/issues/42258.
+  #[test]
+  fn filter_bbox_outside_int_rect() {
+    let svg = r#"<svg filter="url(#f)"><filter id="f" x="2em"><feFlood/></filter><path d="M0 0H1e8V1"/></svg>"#;
+    let tree = usvg::Tree::from_str(svg, &usvg::Options::default()).unwrap();
+    let mut pixmap = tiny_skia::Pixmap::new(1, 1).unwrap();
+
+    // Just make sure we don't panic.
+    crate::resvg::render(
+      &tree,
+      tiny_skia::Transform::identity(),
+      &mut pixmap.as_mut(),
+    );
   }
 }

--- a/takumi-core/src/resvg/usvg/parser/converter.rs
+++ b/takumi-core/src/resvg/usvg/parser/converter.rs
@@ -456,7 +456,16 @@ fn resolve_svg_size(svg: &SvgNode, opt: &Options) -> (Result<Size, Error>, bool)
       svg.convert_user_length(AId::Height, &state, def)
     };
 
-    Size::from_wh(w, h)
+    // If exactly one of width and height is specified, compute the missing
+    // dimension from the specified one and the viewBox aspect ratio.
+    match (
+      svg.attribute::<Length>(AId::Width),
+      svg.attribute::<Length>(AId::Height),
+    ) {
+      (Some(_), None) => Size::from_wh(w, vbox.height() * w / vbox.width()),
+      (None, Some(_)) => Size::from_wh(vbox.width() * h / vbox.height(), h),
+      (_, _) => Size::from_wh(w, h),
+    }
   } else {
     Size::from_wh(
       svg.convert_user_length(AId::Width, &state, def),
@@ -514,6 +523,18 @@ pub(crate) fn convert_element(node: SvgNode, state: &State, cache: &mut Cache, p
     return;
   }
 
+  // A nested `svg` is handled just like `use`: it must not be wrapped in an
+  // additional `convert_group`, otherwise its `transform` (and other group
+  // properties) would be applied twice, since `convert_svg`
+  // already creates its own group. The outermost `svg` (no parent element)
+  // is intentionally not handled here - it's processed directly in
+  // `convert_doc`.
+  if tag_name == EId::Svg && node.parent_element().is_some() {
+    super::use_node::convert_svg(node, state, cache, parent);
+
+    return;
+  }
+
   if let Some(g) = convert_group(node, state, false, cache, parent, &|cache, g| {
     convert_element_impl(tag_name, node, state, cache, g);
   }) {
@@ -546,12 +567,10 @@ fn convert_element_impl(
     }
     EId::Text => {}
     EId::Svg => {
-      if node.parent_element().is_some() {
-        super::use_node::convert_svg(node, state, cache, parent);
-      } else {
-        // Skip root `svg`.
-        convert_children(node, state, cache, parent);
-      }
+      // Only the outermost `svg` reaches this point; nested `svg` elements are
+      // handled earlier in `convert_element`. The root `svg` itself is
+      // skipped and only its children are converted.
+      convert_children(node, state, cache, parent);
     }
     EId::G => {
       convert_children(node, state, cache, parent);

--- a/takumi-core/src/resvg/usvg/parser/paint_server.rs
+++ b/takumi-core/src/resvg/usvg/parser/paint_server.rs
@@ -476,6 +476,7 @@ fn resolve_rg_attr<'a, 'input>(node: SvgNode<'a, 'input>, name: AId) -> SvgNode<
             | (AId::R,  EId::RadialGradient)
             | (AId::Fx, EId::RadialGradient)
             | (AId::Fy, EId::RadialGradient)
+            | (AId::Fr, EId::RadialGradient)
             // Other attributes can be resolved
             // from any kind of gradient.
             | (AId::GradientUnits, EId::LinearGradient)

--- a/takumi-core/src/resvg/usvg/parser/shapes.rs
+++ b/takumi-core/src/resvg/usvg/parser/shapes.rs
@@ -29,7 +29,10 @@ pub(crate) fn convert_path(node: SvgNode) -> Option<Arc<Path>> {
   for segment in svgtypes::SimplifyingPathParser::from(value) {
     let segment = match segment {
       Ok(v) => v,
-      Err(_) => break,
+      Err(e) => {
+        log::warn!("Error during path parsing: {e}");
+        break;
+      }
     };
 
     match segment {

--- a/takumi-core/src/resvg/usvg/parser/svgtree/parse.rs
+++ b/takumi-core/src/resvg/usvg/parser/svgtree/parse.rs
@@ -228,6 +228,7 @@ pub(crate) fn parse_svg_element<'input>(
   doc: &mut Document<'input>,
 ) -> Result<NodeId, Error> {
   let attrs_start_idx = doc.attrs.len();
+  let mut href_idx: Option<usize> = None;
 
   // Copy presentational attributes first.
   for attr in xml_node.attributes() {
@@ -259,7 +260,28 @@ pub(crate) fn parse_svg_element<'input>(
       continue;
     }
 
-    append_attribute(
+    // SVG 2: when both `href` and `xlink:href` are present, the unprefixed
+    // `href` takes precedence and the XLink one must be ignored, regardless
+    // of their order in the source document.
+    // https://www.w3.org/TR/SVG2/linking.html#XLinkRefAttrs
+    if aid == AId::Href {
+      let is_unprefixed = attr.namespace().is_none();
+      let is_xlink = attr.namespace() == Some(XLINK_NS);
+      if !is_unprefixed && !is_xlink {
+        continue;
+      }
+
+      if let Some(idx) = href_idx {
+        // An `href` was already stored. Only an unprefixed `href` is
+        // allowed to override it; an `xlink:href` is ignored.
+        if is_unprefixed {
+          doc.attrs[idx].value = attr.value_storage().clone();
+        }
+        continue;
+      }
+    }
+
+    let added = append_attribute(
       parent_id,
       tag_name,
       aid,
@@ -267,6 +289,9 @@ pub(crate) fn parse_svg_element<'input>(
       false,
       doc,
     );
+    if added && aid == AId::Href {
+      href_idx = Some(doc.attrs.len() - 1);
+    }
   }
 
   let mut insert_attribute = |aid, value: &str, important: bool| {
@@ -531,9 +556,20 @@ fn resolve_href<'a, 'input: 'a>(
   node: roxmltree::Node<'a, 'input>,
   id_map: &HashMap<&str, roxmltree::Node<'a, 'input>>,
 ) -> Option<roxmltree::Node<'a, 'input>> {
+  // See the comment in `parse_svg_element` about `href` precedence.
+  //
+  // Note: `roxmltree::Node::attribute("href")` matches by local name only and
+  // would return whichever `href`/`xlink:href` comes first, so we have to
+  // filter by namespace explicitly.
   let link_value = node
-    .attribute((XLINK_NS, "href"))
-    .or_else(|| node.attribute("href"))?;
+    .attributes()
+    .find(|a| a.name() == "href" && a.namespace().is_none())
+    .or_else(|| {
+      node
+        .attributes()
+        .find(|a| a.name() == "href" && a.namespace() == Some(XLINK_NS))
+    })
+    .map(|a| a.value())?;
 
   let link_id = svgtypes::IRI::from_str(link_value).ok()?.0;
 

--- a/takumi-core/src/resvg/usvg/parser/use_node.rs
+++ b/takumi-core/src/resvg/usvg/parser/use_node.rs
@@ -200,7 +200,7 @@ pub(crate) fn convert_svg(
 
   if let Some(clip_rect) = get_clip_rect(node, node, state) {
     let mut g = clip_element(node, clip_rect, orig_ts, state, cache);
-    g.abs_transform = parent.abs_transform;
+    g.abs_transform = parent.abs_transform.pre_concat(orig_ts);
     convert_children(node, new_ts, &new_state, cache, false, &mut g);
     g.calculate_bounding_boxes();
     parent.children.push(Node::Group(Box::new(g)));

--- a/takumi-core/src/resvg/usvg/tree/mod.rs
+++ b/takumi-core/src/resvg/usvg/tree/mod.rs
@@ -1590,6 +1590,11 @@ impl Tree {
   /// Size of an image that should be created to fit the SVG.
   ///
   /// `width` and `height` in SVG.
+  ///
+  /// Note that this does not necessarily represent the bounding box of the
+  /// rendered contents. Use
+  /// [`self.root().abs_layer_bounding_box()`](Group::abs_layer_bounding_box)
+  /// to retrieve it instead.
   pub fn size(&self) -> Size {
     self.size
   }

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -51,7 +51,7 @@ from-html = ["dep:takumi-html"]
 criterion.workspace = true
 parley.workspace = true
 rayon.workspace = true
-resvg = "0.47"
+resvg = "0.48"
 serde_json.workspace = true
 
 [dev-dependencies.image]


### PR DESCRIPTION
## Why
The vendored resvg copy was at 0.47.0; upstream 0.48.x landed a batch of parser and filter correctness fixes that apply to our stripped subset.

## What
Ports the applicable 0.47.0 -> 0.48.1 hunks onto the vendored tree: nested `svg` no longer gets its transform applied twice, a missing `width`/`height` is derived from the viewBox aspect ratio, unprefixed `href` wins over `xlink:href`, `fr` is inherited for referenced radial gradients, filter regions are clamped to the source buffer (fixes the feComposite panic), and size asserts became debug asserts. The 0.48 text-stack rewrite (skrifa/harfrust) does not apply since the `text` feature is stripped. Hunks already covered by our earlier local fixes (spotlight region typo, `f32_bound` NaN handling, `use` child transform) were skipped. The registry `resvg` dev-dependency moves to 0.48 so the parity tests compare against the same version; fixture goldens show no render changes.