### PR TITLE
PDF: align README with takumi-js style

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **A Rust rendering engine that turns JSX, HTML, and node trees into images. No headless browser required.**
 
-Render OpenGraph cards, animated GIFs, video frames, and vector SVG from Node.js, Cloudflare Workers, browsers, or any Rust application.
+Render OpenGraph cards, animated GIFs, video frames, vector SVG, and paged PDFs from Node.js, Cloudflare Workers, browsers, or any Rust application.
 Drop-in compatible with `next/og`.
 
 [![npm version](https://img.shields.io/npm/v/takumi-js?label=takumi-js)](https://www.npmjs.com/package/takumi-js)
@@ -144,6 +144,26 @@ const svg = await renderSvg(
 );
 
 await writeFile("./output.svg", svg);
+```
+
+### Paged PDF
+
+The same engine writes multi-page vector PDFs through the [takumi-pdf](https://www.npmjs.com/package/takumi-pdf) package: selectable text, embedded subset fonts, page breaks, and repeating headers and footers.
+
+```tsx
+import { render } from "takumi-pdf";
+import { writeFile } from "node:fs/promises";
+
+const pdf = await render(<Invoice data={data} />, {
+  size: "a4",
+  footer: (
+    <div tw="flex w-full justify-center text-[10px] text-gray-500">
+      Page <span className="pageNumber" /> of <span className="totalPages" />
+    </div>
+  ),
+});
+
+await writeFile("invoice.pdf", pdf);
 ```
 
 ### Rust

--- a/takumi-pdf-js/README.md
+++ b/takumi-pdf-js/README.md
@@ -1,6 +1,21 @@
+<div align="center">
+  <img src="https://takumi.kane.tw/logo.svg" alt="Takumi" width="64" />
+
 # takumi-pdf
 
-Render JSX to paged PDF in WebAssembly. No Chromium or native binary.
+**Render JSX to paged, selectable-text PDF. WebAssembly, no Chromium.**
+
+Invoices, reports, and receipts from the Takumi renderer, with CSS layout and vector PDF output.
+
+[Documentation](https://takumi.kane.tw/docs/) · [Playground](https://takumi.kane.tw/playground)
+
+</div>
+
+## Why
+
+Browser-based PDF generation brings the Chromium serverless tax: browser cold starts, browser memory, a large browser binary, and headless-browser work before a document can render. It is a capable screenshot pipeline, but it is still a browser.
+
+`takumi-pdf` uses Takumi's own layout and PDF rendering primitives, compiled to WebAssembly. There is no browser process. Render JSX or a Takumi node tree with CSS and Tailwind classes, then receive vector PDF bytes with selectable, searchable text and embedded subset fonts.
 
 ## Install
 
@@ -13,17 +28,51 @@ bun add takumi-pdf
 ## Quick start
 
 ```tsx
-import { render } from "takumi-pdf";
 import { writeFile } from "node:fs/promises";
+import { googleFonts } from "@takumi-rs/helpers";
+import { render } from "takumi-pdf";
 
-const pdf = await render(<h1>Invoice #1042</h1>);
+const fonts = await googleFonts(["Inter"]);
+
+const pdf = await render(
+  <main tw="flex flex-col gap-8 text-gray-900">
+    <header tw="flex items-start justify-between border-b border-gray-200 pb-6">
+      <div>
+        <h1 tw="text-2xl font-bold">Invoice</h1>
+        <p tw="text-sm text-gray-500">INV-2026-001</p>
+      </div>
+      <p tw="text-right text-sm">
+        Due August 31, 2026
+        <br />
+        $1,250.00
+      </p>
+    </header>
+    <section tw="flex flex-col gap-2 text-sm">
+      <div tw="flex justify-between">
+        <span>Design services</span>
+        <span>$1,250.00</span>
+      </div>
+      <div tw="border-t border-gray-200 pt-2 flex justify-between font-bold">
+        <span>Total</span>
+        <span>$1,250.00</span>
+      </div>
+    </section>
+  </main>,
+  {
+    size: "a4",
+    fonts,
+    footer: (
+      <div tw="flex w-full justify-center text-[10px] text-gray-500">
+        Page <span className="pageNumber" /> of <span className="totalPages" />
+      </div>
+    ),
+  },
+);
 
 await writeFile("invoice.pdf", pdf);
 ```
 
-`render()` returns `Uint8Array` PDF bytes. Output is paged A4 with a 48px margin by default; content flows onto as many pages as it needs. Text stays selectable and searchable, with fonts subset and embedded.
-
-See the [Takumi documentation](https://takumi.kane.tw/docs/) for the shared node and JSX model.
+`render()` returns `Promise<Uint8Array>`. Paged output defaults to A4 with a uniform 48px margin; content flows across as many pages as it needs.
 
 ## Page setup
 
@@ -43,7 +92,7 @@ const pdf = await render(report, {
 
 ## Headers and footers
 
-Headers and footers repeat on every page. Elements with `pageNumber` or `totalPages` in their class list receive the counter as text, the same contract as Chromium print templates.
+Headers and footers repeat on every page. Elements whose class list includes `pageNumber` or `totalPages` receive the counter as text.
 
 ```tsx
 const pdf = await render(report, {
@@ -94,15 +143,14 @@ const pdf = await render(receipt, { viewport: { width: 302 } });
 
 ## Fonts
 
-Pass a font URL or font bytes. Registered fonts are deduplicated across calls.
+Pass a font URL, font bytes, or the `googleFonts` helper. Registered fonts are deduplicated across calls.
 
 ```tsx
+import { googleFonts } from "@takumi-rs/helpers";
+
 const pdf = await render(doc, {
-  fonts: [
-    "https://example.com/Inter-Regular.woff2",
-    { name: "Brand Sans", weight: 700, data: fontBytes },
-  ],
-  fontFamilies: ["Brand Sans", "sans-serif"],
+  fonts: [...(await googleFonts(["Inter"])), { name: "Brand Sans", weight: 700, data: fontBytes }],
+  fontFamilies: ["Brand Sans", "Inter", "sans-serif"],
 });
 ```
 
@@ -115,6 +163,7 @@ const renderer = new PdfRenderer();
 await renderer.registerFont("https://example.com/Inter-Regular.woff2");
 
 const pdf = await renderer.render(doc);
+renderer.free();
 ```
 
 ## Pagination CSS
@@ -148,3 +197,7 @@ const pdf = await render(doc, {
 ```
 
 `@page` CSS rules are not supported. Set page geometry with `size`, `landscape`, and `margin`.
+
+## License
+
+MIT or Apache-2.0

--- a/takumi-pdf-js/README.md
+++ b/takumi-pdf-js/README.md
@@ -32,35 +32,17 @@ import { writeFile } from "node:fs/promises";
 import { googleFonts } from "@takumi-rs/helpers";
 import { render } from "takumi-pdf";
 
-const fonts = await googleFonts(["Inter"]);
-
 const pdf = await render(
-  <main tw="flex flex-col gap-8 text-gray-900">
-    <header tw="flex items-start justify-between border-b border-gray-200 pb-6">
-      <div>
-        <h1 tw="text-2xl font-bold">Invoice</h1>
-        <p tw="text-sm text-gray-500">INV-2026-001</p>
-      </div>
-      <p tw="text-right text-sm">
-        Due August 31, 2026
-        <br />
-        $1,250.00
-      </p>
-    </header>
-    <section tw="flex flex-col gap-2 text-sm">
-      <div tw="flex justify-between">
-        <span>Design services</span>
-        <span>$1,250.00</span>
-      </div>
-      <div tw="border-t border-gray-200 pt-2 flex justify-between font-bold">
-        <span>Total</span>
-        <span>$1,250.00</span>
-      </div>
-    </section>
+  <main tw="flex flex-col gap-4">
+    <h1 tw="text-2xl font-bold">Invoice INV-2026-001</h1>
+    <div tw="flex justify-between border-t border-gray-200 pt-2 font-bold">
+      <span>Total</span>
+      <span>$1,250.00</span>
+    </div>
   </main>,
   {
     size: "a4",
-    fonts,
+    fonts: await googleFonts(["Inter"]),
     footer: (
       <div tw="flex w-full justify-center text-[10px] text-gray-500">
         Page <span className="pageNumber" /> of <span className="totalPages" />


### PR DESCRIPTION
## Why
The takumi-pdf README opened with a bare feature list while the other package READMEs lead with the logo header and a positioning line, and the root README never mentioned PDF output, right as the launch post started driving traffic.

## What
Matches the takumi-pdf README to the takumi-js shape: logo header, tagline, docs and playground links, a short Why section, and a compact invoice quick start with googleFonts and footer page counters. Adds a Paged PDF section and tagline mention to the root README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the README with branded presentation and clearer feature descriptions.
  * Added links to documentation and playground resources.
  * Added a paged PDF quick-start example featuring invoice rendering, A4 sizing, repeating page numbers, and file output.
  * Expanded guidance on Google Fonts, Tailwind classes, asynchronous PDF generation, counter matching, renderer cleanup, and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->