### PR TITLE
Chore: ignore twoslash-only docs deps in knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -15,7 +15,13 @@
         "app/playground/worker.ts"
       ],
       "ignore": ["public/**", "app/playground/templates/**", "src/app.css"],
-      "ignoreDependencies": ["@takumi-rs/core", "@takumi-rs/wasm", "twoslash"]
+      "ignoreDependencies": [
+        "@takumi-rs/core",
+        "@takumi-rs/helpers",
+        "@takumi-rs/wasm",
+        "takumi-pdf",
+        "twoslash"
+      ]
     },
     "takumi-helpers": {
       "entry": ["tests/**/*.test.{ts,tsx}"],


### PR DESCRIPTION
## Why
knip flags `takumi-pdf` and `@takumi-rs/helpers` in docs as unused: they are imported only inside twoslash code blocks, which knip does not scan.

## What
Adds both to the docs workspace's `ignoreDependencies`, next to the existing twoslash-only entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project analysis configuration to better recognize supported documentation dependencies.
  * Reduced false-positive reports for packages used by the documentation workspace.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->