### PR TITLE
CI: ship takumi-pdf dist in artifact, download it for docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,7 @@ jobs:
             takumi-pdf-js/pkg/takumi_pdf_wasm_bg.wasm
             takumi-pdf-js/pkg/takumi_pdf_wasm_bg.wasm.d.ts
             takumi-pdf-js/dist
+            takumi-pdf-js/dist
           if-no-files-found: error
 
   test-wasm:
@@ -851,6 +852,12 @@ jobs:
         with:
           name: image-response-dist
           path: takumi-image-response/dist
+
+      - name: Download takumi-pdf artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pdf-package
+          path: takumi-pdf-js
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --filter ./docs


### PR DESCRIPTION
## Why
Deploy docs fails since the docs twoslash blocks import `takumi-pdf`: the job never downloads the package, and the `pdf-package` artifact only carried the wasm-pack output, not the `dist/` type declarations twoslash resolves.

## What
Adds `takumi-pdf-js/dist` to the artifact and a download step in Deploy docs, mirroring the other package artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * PDF package files are now included in build artifacts.
  * Documentation deployments now retrieve the PDF package automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->