### PR TITLE
Helpers: raise default fetch timeout to 30s

### DIFF
--- a/.tegami/font-fetch-timeout.md
+++ b/.tegami/font-fetch-timeout.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "npm:@takumi-rs/helpers": patch
+---
+
+### Raise the default fetch timeout to 30 seconds
+
+`AbortSignal.timeout` counts wall-clock time, so a 5-second budget aborted otherwise-healthy font fetches whenever heavy synchronous work (SSG, wasm rendering) blocked the event loop past it.

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import type { Node } from "./types";
 
-const defaultFetchTimeout = 5000;
+const defaultFetchTimeout = 30_000;
 const maxRedirectHops = 5;
 export const defaultMaxFetchBytes = 32 * 1024 * 1024;
 const cssUrlPattern = /url\(\s*(['"]?)(.*?)\1\s*\)/g;
@@ -11,7 +11,7 @@ export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>
 export type FetchOptions = {
   /** Custom fetch implementation. @default globalThis.fetch */
   fetch?: FetchLike;
-  /** Abort the request after this many milliseconds; `0` or negative disables it. @default 5000 */
+  /** Abort the request after this many milliseconds; `0` or negative disables it. @default 30000 */
   timeout?: number;
   /** Caller abort signal, combined with the timeout. */
   signal?: AbortSignal;


### PR DESCRIPTION
## Why
Deploy docs fails every run: `AbortSignal.timeout` counts wall-clock time, and SSG's synchronous og rendering blocks the event loop past the 5-second budget, aborting font fetches that were already answered on the socket (reproduced locally with a healthy fetch plus a 6-second busy loop).

## What
Raises the default fetch timeout in `@takumi-rs/helpers` from 5 to 30 seconds; explicit `timeout` options keep working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default font-fetch timeout from 5 to 30 seconds, reducing failures during temporary processing delays.
  * Updated the timeout documentation to reflect the new default.

* **Chores**
  * Prepared a patch release for the helper package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->