### PR TITLE
Docs: shorten PDF prose and add bundle size comparison

### DIFF
--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -3,7 +3,11 @@ title: Comparison
 description: takumi-pdf against Puppeteer and react-pdf, measured.
 ---
 
-Three ways to render a PDF from JavaScript, benchmarked on a two-page, 80-line invoice with a page-number footer. Each harness writes the invoice in its engine's native template language with the same geometry (react-pdf's pt values mirror the px used by the other two), so this is an indicative end-to-end comparison, not a pixel-identical one. Warm figures are the median of 20 renders; the [bench source](https://github.com/kane50613/takumi/tree/master/example/pdf-bench) reproduces the table with `bun bench`.
+This comparison benchmarks three JavaScript PDF renderers. The benchmark uses an 80-line invoice. The invoice spans two pages and has a page-number footer.
+
+Each harness uses its engine's native template language. Each harness uses the same geometry. react-pdf's pt values mirror the other renderers' px values. This is an indicative end-to-end comparison. It is not pixel-identical.
+
+Warm figures are the median of 20 renders. The [bench source](https://github.com/kane50613/takumi/tree/master/example/pdf-bench) reproduces this table. Run it with `bun bench`.
 
 Environment: Apple M1 Pro, macOS 15.7, Bun 1.3.14, Chrome 150.
 
@@ -17,10 +21,27 @@ Environment: Apple M1 Pro, macOS 15.7, Bun 1.3.14, Chrome 150.
 | Selectable text, subset fonts | yes                                         | yes (standard fonts not embedded)                     | yes                             |
 | Runs on edge runtimes         | yes (Cloudflare Workers)                    | no (Node)                                             | no                              |
 
+## Bundle and install size
+
+These measurements use npm-registry packages and esbuild (`--bundle --minify`, gzip). Install size comes from a clean `bun add`.
+
+|                           | JS bundle (min+gzip) | wasm (gzip)              | `node_modules`                  |
+| :------------------------ | :------------------- | :----------------------- | :------------------------------ |
+| takumi-pdf 0.1.4          | 10 KB                | 1.66 MB (1.25 MB brotli) | 4.5 MB, 45 files                |
+| @react-pdf/renderer 4.5.1 | 493 KB               | —                        | 32 MB, 1998 files               |
+| pdf-lib 1.17.1            | 179 KB               | —                        | 26 MB                           |
+| pdfkit 0.19.1             | 253 KB               | —                        | 23 MB                           |
+| jspdf 4.2.1               | 248 KB               | —                        | 59 MB                           |
+| Puppeteer + Chrome        | —                    | —                        | Chrome install (hundreds of MB) |
+
+pdf-lib, pdfkit, and jspdf are drawing primitives. You position each text line yourself. They are not in the benchmark above.
+
+takumi-pdf's wasm binary is the largest single JS download. It is also the whole engine. `node_modules` has 45 files.
+
 Reading the numbers honestly:
 
-- Chrome's cold start covers launching a browser process; it varies with machine state, and its memory spreads across several processes that a single-process measurement misses. Once warm, Chrome is a capable renderer with the most complete CSS support of the three.
-- react-pdf's smaller output comes from the standard 14 PDF fonts, which viewers substitute rather than embed. Its cost is the template: documents are written in its own component set, so existing HTML/JSX and Tailwind markup cannot be reused.
-- takumi-pdf reuses OG-image components unchanged, but its CSS coverage is narrower than Chromium's: no `box-shadow`, `filter`, `clip-path`, or masks in PDF output yet.
+- Chrome's cold start includes launching a browser process. It varies with machine state. Its memory spans several processes. A single-process measurement misses this. Chrome performs well after warming. It has the most complete CSS support of the three.
+- react-pdf's smaller output uses the standard 14 PDF fonts. Viewers substitute these fonts instead of embedding them. Documents use react-pdf's component set. Existing HTML, JSX, and Tailwind markup cannot be reused.
+- takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `box-shadow`, `filter`, `clip-path`, or masks yet.
 
-Rule of thumb: pixel-perfect reproduction of an existing complex web page favors Puppeteer; documents written from scratch for PDF work in any of the three; reusing Takumi image components, deploying to edge runtimes, or cutting per-document latency favors takumi-pdf.
+Rule of thumb: use Puppeteer to reproduce a complex web page pixel-perfectly. Any renderer suits documents written from scratch for PDF work. Use takumi-pdf to reuse Takumi image components. It suits edge runtimes. It also offers lower per-document latency.

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -5,7 +5,7 @@ description: Embed subset fonts and pre-fetched images.
 
 ## Fonts
 
-Text embeds as real glyph runs with subset fonts, so it stays selectable, searchable, and copyable. Pass a URL, raw bytes, or the [`googleFonts`](/docs/typography-and-fonts#from-google-fonts) helper:
+Text embeds as real glyph runs with subset fonts. It stays selectable, searchable, and copyable. Pass a URL or raw bytes. You can also use the [`googleFonts`](/docs/typography-and-fonts#from-google-fonts) helper:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -21,11 +21,11 @@ const pdf = await render(doc, {
 });
 ```
 
-`fontFamilies` sets the per-render fallback chain. Registered fonts deduplicate across calls on the same renderer.
+`fontFamilies` sets the fallback chain for each render. Registered fonts deduplicate across calls that use the same renderer.
 
 ## Images
 
-The renderer never fetches over the network. Pass pre-fetched bytes for every image URL the document references:
+The renderer never fetches over the network. Pass pre-fetched bytes for each image URL in the document:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -40,8 +40,8 @@ const pdf = await render(doc, {
 });
 ```
 
-SVG image sources rasterize at 2× the placed size; raster sources embed once per distinct pixel data.
+SVG image sources rasterize at 2× their placed size. Raster sources embed once for each distinct pixel data.
 
 ## Runtimes
 
-`takumi-pdf` is wasm-only and runs on Node.js, Bun, and Cloudflare Workers. The module fits within Workers' free-tier size limit. Import from `takumi-pdf/no-init` to control wasm instantiation yourself.
+`takumi-pdf` is wasm-only. It runs on Node.js, Bun, and Cloudflare Workers. The module fits within the Workers free-tier size limit. Import `takumi-pdf/no-init` to control wasm instantiation.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -3,7 +3,7 @@ title: Headers & footers
 description: Repeat bands on every page with page counters.
 ---
 
-`header` and `footer` take any node input and repeat on every page. Their measured height is carved out of the content window, so band and content never overlap.
+`header` and `footer` accept any node input. They repeat on every page. Their measured height is removed from the content window. Bands never overlap with content.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -21,9 +21,9 @@ const pdf = await render(report, {
 
 ## Page counters
 
-Elements with `pageNumber` or `totalPages` in their class list receive the counter as text, the same contract as Chromium's print header and footer templates.
+Elements with `pageNumber` or `totalPages` receive counter text. This matches Chromium's print header and footer template contract.
 
-Add a CSS `@counter-style` name to the class list to format the number:
+Add a CSS `@counter-style` name to the class list. It formats the number:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -49,4 +49,4 @@ const pdf = await render(report, {
 | `cjk-decimal`                               | `一二`        |
 | `trad-chinese-informal` / `cjk-ideographic` | `十二`        |
 
-Band height is measured once with three-digit counters, so a page count reaching 100 does not shift the layout between pages.
+Band height is measured once with three-digit counters. Reaching 100 pages does not shift the layout between pages.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -4,7 +4,7 @@ description: Render JSX to paged, selectable-text PDF with takumi-pdf.
 index: true
 ---
 
-`takumi-pdf` renders the same JSX, Tailwind classes, and node trees as image output, but writes a paged vector PDF: selectable and searchable text, embedded subset fonts, page breaks, and repeating headers and footers. It ships as a WebAssembly module and runs on Node.js, Bun, and Cloudflare Workers without Chromium.
+`takumi-pdf` renders the same JSX, Tailwind classes, and node trees as image output. It writes a paged vector PDF instead: selectable text, embedded subset fonts, page breaks, and repeating headers and footers. It ships as a WebAssembly module. It runs on Node.js, Bun, and Cloudflare Workers without Chromium.
 
 ```npm
 npm i takumi-pdf
@@ -35,7 +35,7 @@ const pdf = await render(<Invoice data={data} />, {
 await writeFile("invoice.pdf", pdf);
 ```
 
-`render()` accepts JSX, HTML strings converted with `@takumi-rs/helpers`, or JSON node trees, and returns `Uint8Array` PDF bytes. Content lays out at the page's content width and flows onto as many pages as it needs.
+`render()` accepts JSX, HTML strings converted with `@takumi-rs/helpers`, or JSON node trees. It returns `Uint8Array` PDF bytes. Content lays out at the page's content width. It flows onto as many pages as needed.
 
 ## Page setup
 
@@ -57,11 +57,11 @@ const pdf = await render(report, {
 | `landscape` | `boolean`                                      | `false` | Swaps page width and height, including explicit sizes.       |
 | `margin`    | `number` or `{ top?, right?, bottom?, left? }` | `48`    | A number applies to all sides. Missing object sides are `0`. |
 
-`@page` CSS rules are not supported; these options are the page geometry.
+`@page` CSS rules are not supported. Use these options to set the page geometry.
 
 ## Reuse a renderer
 
-`render()` keeps one shared renderer alive. When an application manages several font sets, construct `PdfRenderer` directly:
+`render()` keeps one shared renderer alive. Construct `PdfRenderer` directly for applications that manage several font sets:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -75,4 +75,4 @@ await renderer.registerFont("https://example.com/Inter-Regular.woff2");
 const pdf = await renderer.render(doc);
 ```
 
-Registered fonts deduplicate across calls, so rendering many documents pays the font cost once.
+Registered fonts deduplicate across calls. Rendering many documents pays the font cost once.

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -5,7 +5,7 @@ description: Clickable hyperlinks, bookmarks, and document properties.
 
 ## Hyperlinks
 
-Anchors with an `href` become clickable link annotations, on every page their box touches:
+Anchors with an `href` become clickable link annotations. They appear on every page that their box touches:
 
 ```tsx twoslash
 import { render } from "takumi-pdf";
@@ -19,11 +19,11 @@ const pdf = await render(
 );
 ```
 
-Inline anchors annotate each text run, so a link that wraps across lines stays clickable on both. Block-level anchors annotate their whole box.
+Inline anchors annotate each text run. A link that wraps across lines stays clickable on both lines. Block-level anchors annotate their entire box.
 
 ## Outline
 
-Set `outline: true` to build PDF bookmarks from `h1`–`h6` headings. Deeper headings nest under the previous shallower one, like an HTML document outline:
+Set `outline: true` to build PDF bookmarks from `h1`–`h6` headings. Deeper headings nest under the previous shallower heading. This matches an HTML document outline:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -37,7 +37,7 @@ Clicking a bookmark jumps to the page and position of its heading.
 
 ## Document metadata
 
-`metadata` fills the PDF's document properties; `lang` doubles as the metadata language:
+`metadata` fills the PDF document properties. `lang` also sets the metadata language:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -56,4 +56,4 @@ const pdf = await render(report, {
 });
 ```
 
-All fields are optional. Omitting `metadata` writes no document properties, which keeps output byte-identical across runs for golden testing.
+All fields are optional. Omitting `metadata` writes no document properties. This keeps output byte-identical across runs for golden testing.

--- a/docs/content/docs/pdf/pagination.mdx
+++ b/docs/content/docs/pdf/pagination.mdx
@@ -3,7 +3,7 @@ title: Pagination
 description: Control where pages break with CSS.
 ---
 
-Content lays out once at unbounded height, then splits into pages. Unsplittable atoms (text lines, images, transformed subtrees) never straddle a cut: a cut that would land inside one moves up to its top, matching browser print fragmentation.
+Content lays out once at unbounded height. It then splits into pages. Unsplittable atoms never straddle a cut. These atoms include text lines, images, and transformed subtrees. A cut inside an atom moves to its top. This matches browser print fragmentation.
 
 ## Break properties
 
@@ -25,7 +25,7 @@ const pdf = await render(
 | `break-inside: avoid`         | Keeps the element on one page when it fits.             |
 | `box-decoration-break: clone` | Repeats borders and backgrounds on every page fragment. |
 
-A `break-inside: avoid` box taller than the page window cannot fit any page, so it stops participating in cut avoidance, the same rule browsers apply.
+A `break-inside: avoid` box taller than the page window cannot fit on a page. It stops participating in cut avoidance. Browsers apply the same rule.
 
 ## Split decorations
 

--- a/docs/content/docs/pdf/single-page.mdx
+++ b/docs/content/docs/pdf/single-page.mdx
@@ -3,7 +3,7 @@ title: Single-page viewport
 description: Fixed one-page PDFs for certificates, cards, and receipts.
 ---
 
-`viewport` renders one fixed page instead of paged output, behaving like an image render: percentage heights resolve against the viewport and overflow is clipped.
+`viewport` renders one fixed page instead of paged output. It behaves like an image render. Percentage heights resolve against the viewport. It clips overflow.
 
 ```tsx twoslash
 import { render } from "takumi-pdf";
@@ -15,7 +15,7 @@ const pdf = await render(<div style={{ width: "100%", height: "100%" }}>Certific
 
 ## Content-sized pages
 
-Omit `height` to size the single page to its laid-out content, like a thermal receipt. Percentage heights do not resolve in this mode:
+Omit `height` to size the single page to its laid-out content. This works like a thermal receipt. Percentage heights do not resolve in this mode:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -25,4 +25,4 @@ declare const receipt: ReactNode;
 const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
 ```
 
-`viewport` cannot be combined with `size`, `landscape`, `margin`, `header`, or `footer`; those options exist only for paged output. Hyperlinks, `outline`, and `metadata` work in both modes.
+`viewport` cannot be combined with `size`, `landscape`, `margin`, `header`, or `footer`. Those options work only with paged output. Hyperlinks, `outline`, and `metadata` work in both modes.


### PR DESCRIPTION
## Why
PDF doc pages ran long, comma-chained sentences that read badly against the rest of the docs. The comparison page also had no bundle or install size data.

## What
Rewrites the seven PDF pages into short single-idea sentences. Adds a measured bundle and install size table (esbuild min+gzip, clean `bun add`) covering takumi-pdf, @react-pdf/renderer, pdf-lib, pdfkit, jspdf, and Puppeteer. Numbers, tables, and twoslash blocks are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added bundle, WebAssembly, and installation-size comparisons for PDF tools.
  * Clarified supported font inputs, fallback behavior, image handling, and runtime support.
  * Expanded guidance on headers, footers, page counters, pagination, and single-page rendering.
  * Refined documentation for links, outlines, metadata, rendering, and renderer reuse without changing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->