### PR TITLE
Core: parse bare tailwind border side utilities as 1px

### DIFF
--- a/.tegami/tw-bare-border-sides.md
+++ b/.tegami/tw-bare-border-sides.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Render bare `border-t`/`border-r`/`border-b`/`border-l`/`border-x`/`border-y`
+
+The side utilities only parsed with a width suffix, so plain `border-b` drew nothing.

--- a/example/pdf-bench/.gitignore
+++ b/example/pdf-bench/.gitignore
@@ -1,1 +1,2 @@
 out-*.pdf
+fonts/

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -319,6 +319,12 @@ const TEXT_SHADOW_LG: [TextShadow; 3] = [ts(1.0, 2.0, 26), ts(3.0, 2.0, 26), ts(
 /// Maps a complete utility token to its fixed property.
 pub(crate) static FIXED_PROPERTIES: phf::Map<&str, TailwindProperty> = phf_map! {
   "border" => TailwindProperty::BorderDefault,
+  "border-t" => TailwindProperty::BorderTopWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-r" => TailwindProperty::BorderRightWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-b" => TailwindProperty::BorderBottomWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-l" => TailwindProperty::BorderLeftWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-x" => TailwindProperty::BorderXWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-y" => TailwindProperty::BorderYWidth(LineWidth::Length(Length::Px(1.0))),
   "outline" => TailwindProperty::OutlineDefault,
   "box-border" => TailwindProperty::BoxSizing(BoxSizing::BorderBox),
   "box-content" => TailwindProperty::BoxSizing(BoxSizing::ContentBox),

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -259,6 +259,18 @@ fn test_parse_border_width() {
     Some(TailwindProperty::BorderDefault)
   );
   assert_eq!(
+    TailwindProperty::parse("border-b"),
+    Some(TailwindProperty::BorderBottomWidth(LineWidth::Length(
+      Length::Px(1.0)
+    )))
+  );
+  assert_eq!(
+    TailwindProperty::parse("border-y"),
+    Some(TailwindProperty::BorderYWidth(LineWidth::Length(
+      Length::Px(1.0)
+    )))
+  );
+  assert_eq!(
     TailwindProperty::parse("border-t-2"),
     Some(TailwindProperty::BorderTopWidth(LineWidth::Length(
       Length::Px(2.0)


### PR DESCRIPTION
## Why
Tailwind's bare side utilities (`border-b`, `border-t`, …) mean a 1px border. The map only had width-suffixed forms, so `border-b border-gray-300` silently drew nothing while `border-b-2` worked.

## What
Adds the six bare side tokens to the fixed-property map as 1px widths. The existing width-without-style pass already supplies `solid`, matching Tailwind's preflight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for bare border-side utilities: `border-t`, `border-r`, `border-b`, `border-l`, `border-x`, and `border-y`.
  * These utilities now apply a 1px border width to the specified side or sides.

* **Bug Fixes**
  * Improved handling of border width utilities without explicit values.

* **Tests**
  * Added coverage for bottom and vertical border utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->