### PR TITLE
Example: identical invoice templates across pdf bench engines

### DIFF
--- a/.tegami/tw-bare-border-sides.md
+++ b/.tegami/tw-bare-border-sides.md
@@ -1,0 +1,8 @@
+---
+packages:
+  "cargo:takumi-core": patch
+---
+
+### Render bare `border-t`/`border-r`/`border-b`/`border-l`/`border-x`/`border-y`
+
+The side utilities only parsed with a width suffix, so plain `border-b` drew nothing.

--- a/example/pdf-bench/.gitignore
+++ b/example/pdf-bench/.gitignore
@@ -1,1 +1,2 @@
 out-*.pdf
+fonts/

--- a/example/pdf-bench/bench-puppeteer.ts
+++ b/example/pdf-bench/bench-puppeteer.ts
@@ -1,4 +1,9 @@
+import { interFonts } from "./fonts";
 import { items, total } from "./invoice-data";
+
+const fonts = await interFonts();
+const regular = Buffer.from(await Bun.file(fonts.regular).arrayBuffer()).toString("base64");
+const bold = Buffer.from(await Bun.file(fonts.bold).arrayBuffer()).toString("base64");
 
 const t0 = performance.now();
 const puppeteer = (await import("puppeteer-core")).default;
@@ -8,19 +13,24 @@ const rows = items
     (item) => `
     <div class="row" style="break-inside: avoid">
       <span class="description">${item.description}</span>
-      <span>${item.qty}</span>
-      <span>$${(item.qty * item.unit).toFixed(2)}</span>
+      <span class="qty">${item.qty}</span>
+      <span class="price">$${(item.qty * item.unit).toFixed(2)}</span>
     </div>`,
   )
   .join("");
 
 const html = `<!doctype html>
 <html><head><style>
-  body { font-size: 13px; color: #111827; font-family: system-ui, sans-serif; margin: 0 }
+  @font-face { font-family: Inter; font-weight: 400; src: url(data:font/ttf;base64,${regular}) }
+  @font-face { font-family: Inter; font-weight: 700; src: url(data:font/ttf;base64,${bold}) }
+  body { font-size: 13px; color: #111827; font-family: Inter, sans-serif; margin: 0 }
   .header { display: flex; justify-content: space-between; border-bottom: 1px solid #d1d5db; padding-bottom: 16px; margin-bottom: 16px }
   h1 { font-size: 24px; margin: 0 }
-  .row { display: flex; justify-content: space-between; padding: 4px 0 }
-  .description { width: 80% }
+  p { margin: 0 }
+  .row { display: flex; padding: 4px 0 }
+  .description { flex: 1; padding-right: 16px }
+  .qty { width: 32px; text-align: right }
+  .price { width: 90px; text-align: right }
   .total { display: flex; justify-content: space-between; border-top: 1px solid #d1d5db; margin-top: 16px; padding-top: 8px; font-weight: 700 }
 </style></head><body>
   <div class="header"><h1>Invoice INV-2026-001</h1><p>Due August 31, 2026</p></div>
@@ -36,6 +46,7 @@ const browser = await puppeteer.launch({
 async function renderOnce(): Promise<Uint8Array> {
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "load" });
+  await page.evaluateHandle("document.fonts.ready");
   const pdf = await page.pdf({
     format: "a4",
     margin: { top: "48px", right: "48px", bottom: "48px", left: "48px" },

--- a/example/pdf-bench/bench-reactpdf.tsx
+++ b/example/pdf-bench/bench-reactpdf.tsx
@@ -1,12 +1,21 @@
+import { interFonts } from "./fonts";
 import { items, total } from "./invoice-data";
 
+const interPaths = await interFonts();
+
 const t0 = performance.now();
-const { Document, Page, Text, View, StyleSheet, pdf } = await import("@react-pdf/renderer");
+const { Document, Page, Text, View, StyleSheet, Font, pdf } = await import("@react-pdf/renderer");
+
+Font.register({
+  family: "Inter",
+  fonts: [{ src: interPaths.regular }, { src: interPaths.bold, fontWeight: 700 }],
+});
+Font.registerHyphenationCallback((word) => [word]);
 
 // react-pdf styles are in pt (1px at 96 dpi = 0.75pt); values mirror the px
 // used by the takumi and Puppeteer harnesses.
 const styles = StyleSheet.create({
-  page: { padding: 36, fontSize: 9.75 },
+  page: { padding: 36, fontSize: 9.75, fontFamily: "Inter", color: "#111827" },
   header: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -16,8 +25,10 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   title: { fontSize: 18, fontWeight: 700 },
-  row: { flexDirection: "row", justifyContent: "space-between", paddingVertical: 3 },
-  description: { width: "80%" },
+  row: { flexDirection: "row", paddingVertical: 3 },
+  description: { flexGrow: 1, flexShrink: 1, flexBasis: 0, paddingRight: 12 },
+  qty: { width: 24, textAlign: "right" },
+  price: { width: 67.5, textAlign: "right" },
   totalRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -49,8 +60,8 @@ function Invoice() {
         {items.map((item, i) => (
           <View key={i} style={styles.row} wrap={false}>
             <Text style={styles.description}>{item.description}</Text>
-            <Text>{item.qty}</Text>
-            <Text>${(item.qty * item.unit).toFixed(2)}</Text>
+            <Text style={styles.qty}>{item.qty}</Text>
+            <Text style={styles.price}>${(item.qty * item.unit).toFixed(2)}</Text>
           </View>
         ))}
         <View style={styles.totalRow}>

--- a/example/pdf-bench/bench-takumi.tsx
+++ b/example/pdf-bench/bench-takumi.tsx
@@ -1,4 +1,8 @@
+import { interFonts } from "./fonts";
 import { items, total } from "./invoice-data";
+
+const fonts = await interFonts();
+const fontData = [await Bun.file(fonts.regular).bytes(), await Bun.file(fonts.bold).bytes()];
 
 const t0 = performance.now();
 const { render } = await import("takumi-pdf");
@@ -7,15 +11,15 @@ function Invoice() {
   return (
     <main tw="flex flex-col text-[13px] text-gray-900">
       <div tw="flex justify-between border-b border-gray-300 pb-4 mb-4">
-        <h1 tw="text-2xl font-bold">Invoice INV-2026-001</h1>
-        <p>Due August 31, 2026</p>
+        <h1 tw="m-0 text-2xl font-bold">Invoice INV-2026-001</h1>
+        <p tw="m-0">Due August 31, 2026</p>
       </div>
       <div tw="flex flex-col">
         {items.map((item, i) => (
-          <div key={i} tw="flex justify-between py-1" style={{ breakInside: "avoid" }}>
-            <span tw="w-4/5">{item.description}</span>
-            <span>{item.qty}</span>
-            <span>${(item.qty * item.unit).toFixed(2)}</span>
+          <div key={i} tw="flex py-1" style={{ breakInside: "avoid" }}>
+            <span tw="flex-1 pr-4">{item.description}</span>
+            <span tw="w-8 text-right">{item.qty}</span>
+            <span tw="w-[90px] text-right">${(item.qty * item.unit).toFixed(2)}</span>
           </div>
         ))}
       </div>
@@ -29,6 +33,8 @@ function Invoice() {
 
 const options = {
   size: "a4",
+  fonts: fontData,
+  fontFamilies: ["Inter"],
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
       Page <span className="pageNumber" /> of <span className="totalPages" />

--- a/example/pdf-bench/fonts.ts
+++ b/example/pdf-bench/fonts.ts
@@ -1,0 +1,26 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const CSS_URL = "https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap";
+const DIR = join(import.meta.dir, "fonts");
+
+/** Downloads Inter 400/700 as single-file ttf (curl UA skips subsets) and caches them. */
+export async function interFonts(): Promise<{ regular: string; bold: string }> {
+  const regular = join(DIR, "inter-400.ttf");
+  const bold = join(DIR, "inter-700.ttf");
+
+  if ((await Bun.file(regular).exists()) && (await Bun.file(bold).exists())) {
+    return { regular, bold };
+  }
+  const css = await (await fetch(CSS_URL, { headers: { "user-agent": "curl/8" } })).text();
+  const urls = [...css.matchAll(/url\((https:[^)]+\.ttf)\)/g)].map((m) => m[1]!);
+
+  if (urls.length < 2) {
+    throw new Error(`expected 2 ttf urls, got ${urls.length}`);
+  }
+  await mkdir(DIR, { recursive: true });
+  for (const [i, path] of [regular, bold].entries()) {
+    await Bun.write(path, await (await fetch(urls[i]!)).arrayBuffer());
+  }
+  return { regular, bold };
+}

--- a/example/pdf-bench/fonts.ts
+++ b/example/pdf-bench/fonts.ts
@@ -12,7 +12,12 @@ export async function interFonts(): Promise<{ regular: string; bold: string }> {
   if ((await Bun.file(regular).exists()) && (await Bun.file(bold).exists())) {
     return { regular, bold };
   }
-  const css = await (await fetch(CSS_URL, { headers: { "user-agent": "curl/8" } })).text();
+  const cssResponse = await fetch(CSS_URL, { headers: { "user-agent": "curl/8" } });
+
+  if (!cssResponse.ok) {
+    throw new Error(`font css request failed: ${cssResponse.status}`);
+  }
+  const css = await cssResponse.text();
   const urls = [...css.matchAll(/url\((https:[^)]+\.ttf)\)/g)].map((m) => m[1]!);
 
   if (urls.length < 2) {
@@ -20,7 +25,12 @@ export async function interFonts(): Promise<{ regular: string; bold: string }> {
   }
   await mkdir(DIR, { recursive: true });
   for (const [i, path] of [regular, bold].entries()) {
-    await Bun.write(path, await (await fetch(urls[i]!)).arrayBuffer());
+    const fontResponse = await fetch(urls[i]!);
+
+    if (!fontResponse.ok) {
+      throw new Error(`font download failed: ${fontResponse.status}`);
+    }
+    await Bun.write(path, await fontResponse.arrayBuffer());
   }
   return { regular, bold };
 }

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -319,6 +319,12 @@ const TEXT_SHADOW_LG: [TextShadow; 3] = [ts(1.0, 2.0, 26), ts(3.0, 2.0, 26), ts(
 /// Maps a complete utility token to its fixed property.
 pub(crate) static FIXED_PROPERTIES: phf::Map<&str, TailwindProperty> = phf_map! {
   "border" => TailwindProperty::BorderDefault,
+  "border-t" => TailwindProperty::BorderTopWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-r" => TailwindProperty::BorderRightWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-b" => TailwindProperty::BorderBottomWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-l" => TailwindProperty::BorderLeftWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-x" => TailwindProperty::BorderXWidth(LineWidth::Length(Length::Px(1.0))),
+  "border-y" => TailwindProperty::BorderYWidth(LineWidth::Length(Length::Px(1.0))),
   "outline" => TailwindProperty::OutlineDefault,
   "box-border" => TailwindProperty::BoxSizing(BoxSizing::BorderBox),
   "box-content" => TailwindProperty::BoxSizing(BoxSizing::ContentBox),

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -259,6 +259,18 @@ fn test_parse_border_width() {
     Some(TailwindProperty::BorderDefault)
   );
   assert_eq!(
+    TailwindProperty::parse("border-b"),
+    Some(TailwindProperty::BorderBottomWidth(LineWidth::Length(
+      Length::Px(1.0)
+    )))
+  );
+  assert_eq!(
+    TailwindProperty::parse("border-y"),
+    Some(TailwindProperty::BorderYWidth(LineWidth::Length(
+      Length::Px(1.0)
+    )))
+  );
+  assert_eq!(
     TailwindProperty::parse("border-t-2"),
     Some(TailwindProperty::BorderTopWidth(LineWidth::Length(
       Length::Px(2.0)


### PR DESCRIPTION
## Why
The three bench harnesses differed beyond the engine: takumi used its default font while the others used Helvetica or the system font, and the percentage-width description column wrapped only under takumi. The outputs were not visually comparable.

## What
All three harnesses now register the same Inter 400/700 ttf (fetched once via Google Fonts and cached under a gitignored fonts/), use the same fixed-width qty and price columns, and reset heading margins. Outputs now differ only by engine: takumi paginates to 3 pages because its footer band reserves content height, while Chrome prints the footer inside the page margin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bare border utilities so `border-t`, `border-r`, `border-b`, `border-l`, `border-x`, and `border-y` render correctly with 1px widths.

* **Benchmarks**
  * Improved PDF invoice benchmarks with embedded Inter fonts, consistent column alignment, and more reliable font loading before rendering.
  * Updated invoice layouts for clearer description, quantity, and price alignment across rendering approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->