### PR TITLE
Core: cache text-node measure results per render

### DIFF
--- a/takumi-core/src/context.rs
+++ b/takumi-core/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, rc::Rc, sync::Arc};
 use typed_builder::TypedBuilder;
 
 use crate::{
-  layout::inline::ShapeCache,
+  layout::inline::{MeasureCache, ShapeCache},
   resources::{font::FontsSnapshot, image::ImageSource},
   style::{Affine, Color, ComputedStyle, SizingContext, StyleSheet},
 };
@@ -40,6 +40,9 @@ pub struct RenderContext {
   /// context derived from the same root.
   #[builder(default)]
   pub(crate) shape_cache: ShapeCache,
+  /// Per-render cache of measured text-node sizes, shared like `shape_cache`.
+  #[builder(default)]
+  pub(crate) measure_cache: MeasureCache,
 }
 
 impl RenderContext {
@@ -60,6 +63,7 @@ impl RenderContext {
       sizing,
       stylesheet: parent.stylesheet.clone(),
       shape_cache: parent.shape_cache.clone(),
+      measure_cache: parent.measure_cache.clone(),
     }
   }
 }

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -5,6 +5,7 @@ use parley::{
   PositionedInlineBox, PositionedLayoutItem, TextStyle, TreeBuilder, YieldData,
 };
 use skrifa::{FontRef, MetadataProvider, raw::TableProvider};
+use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
   context::RenderContext,
@@ -57,6 +58,10 @@ pub struct InlineLayoutRequest<'c> {
 /// text costs one map entry, not a retained layout clone.
 pub(crate) type ShapeCache = Rc<RefCell<HashMap<u64, Option<(InlineLayout, String)>>>>;
 
+/// Per-render map from a text node's measure inputs to its measured size.
+/// Keyed by content hash plus text length as a cheap collision guard.
+pub(crate) type MeasureCache = Rc<RefCell<HashMap<(u64, u32), Size<f32>>>>;
+
 /// Hashes everything shaping depends on: each span's processed text and
 /// style, plus the root style and language.
 fn shape_fingerprint(
@@ -66,7 +71,7 @@ fn shape_fingerprint(
 ) -> u64 {
   use std::hash::{Hash, Hasher};
 
-  let mut hasher = std::collections::hash_map::DefaultHasher::new();
+  let mut hasher = Xxh3::new();
 
   style.hash_shaping_inputs(&mut hasher);
   lang.hash(&mut hasher);

--- a/takumi-core/src/layout/node/text.rs
+++ b/takumi-core/src/layout/node/text.rs
@@ -1,3 +1,7 @@
+use std::hash::Hasher;
+
+use xxhash_rust::xxh3::Xxh3;
+
 use crate::{
   context::RenderContext,
   font_style::SizedFontStyle,
@@ -9,7 +13,65 @@ use crate::{
     },
     node::TextData,
   },
+  style::TextOverflow,
+  text_processing::MaxHeight,
 };
+
+/// Hashes every input the measured size depends on beyond the shaping inputs:
+/// the raw text, the width/height constraints, and the break-time style knobs
+/// (`hash_shaping_inputs` covers only what shaping reads).
+fn measure_cache_key(
+  text: &TextData,
+  context: &RenderContext,
+  font_style: &SizedFontStyle<'_>,
+  max_width: f32,
+  max_height: Option<MaxHeight>,
+) -> (u64, u32) {
+  let style = &context.style;
+  let mut hasher = Xxh3::new();
+
+  hasher.write(text.text.as_bytes());
+  font_style.hash_shaping_inputs(&mut hasher);
+  hasher.write_u32(max_width.to_bits());
+  match max_height {
+    None => hasher.write_u8(0),
+    Some(MaxHeight::Absolute(height)) => {
+      hasher.write_u8(1);
+      hasher.write_u32(height.to_bits());
+    }
+    Some(MaxHeight::Lines(lines)) => {
+      hasher.write_u8(2);
+      hasher.write_u32(lines);
+    }
+    Some(MaxHeight::HeightAndLines(height, lines)) => {
+      hasher.write_u8(3);
+      hasher.write_u32(height.to_bits());
+      hasher.write_u32(lines);
+    }
+  }
+  hasher.write_u8(style.text_transform as u8);
+  hasher.write_u8(style.white_space_collapse as u8);
+  hasher.write_usize(style.tab_size.spaces());
+  hasher.write_u8(style.text_wrap_mode as u8);
+  hasher.write_u8(style.text_wrap_style as u8);
+  hasher.write_u8(style.text_align as u8);
+  match &style.text_overflow {
+    TextOverflow::Clip => hasher.write_u8(0),
+    TextOverflow::Ellipsis => hasher.write_u8(1),
+    TextOverflow::Custom(marker) => {
+      hasher.write_u8(2);
+      hasher.write(marker.as_bytes());
+    }
+  }
+  style.text_indent.amount.hash_bits(&mut hasher);
+  hasher.write_u8(style.text_indent.each_line as u8);
+  hasher.write_u8(style.text_indent.hanging as u8);
+  hasher.write_u8(style.text_fit.mode as u8);
+  hasher.write_u8(style.text_fit.target as u8);
+  hasher.write_u32(style.text_fit.limit.unwrap_or(f32::NAN).to_bits());
+
+  (hasher.finish(), text.text.len() as u32)
+}
 
 pub(crate) fn measure_text_node(
   text: &TextData,
@@ -17,16 +79,19 @@ pub(crate) fn measure_text_node(
   available_space: Size<AvailableSpace>,
   known_dimensions: Size<Option<f32>>,
 ) -> Size<f32> {
+  let (max_width, max_height) =
+    create_inline_constraint(context, available_space, known_dimensions);
+  let font_style = SizedFontStyle::from_style(&context.style, context);
+  let key = measure_cache_key(text, context, &font_style, max_width, max_height);
+
+  if let Some(size) = context.measure_cache.borrow().get(&key) {
+    return *size;
+  }
   let inline_content: InlineItem<'_> = InlineItem::Text {
     text: text.text.as_str().into(),
     context,
     link: None,
   };
-
-  let (max_width, max_height) =
-    create_inline_constraint(context, available_space, known_dimensions);
-  let font_style = SizedFontStyle::from_style(&context.style, context);
-
   let mut built = create_inline_layout(InlineLayoutRequest {
     items: vec![inline_content],
     available_space,
@@ -37,10 +102,8 @@ pub(crate) fn measure_text_node(
     mode: InlineLayoutMode::Measure,
     shape_cacheable: true,
   });
-
   let parent_font_metrics = built.parent_font_metrics();
-
-  measure_inline_layout(
+  let size = measure_inline_layout(
     &mut built.layout,
     &built.spans,
     &built.custom_inline_boxes,
@@ -50,5 +113,8 @@ pub(crate) fn measure_text_node(
       ceil_width: true,
       parent_font_metrics,
     },
-  )
+  );
+
+  context.measure_cache.borrow_mut().insert(key, size);
+  size
 }


### PR DESCRIPTION
## Why
Taffy measures the same text node several times per layout at the same constraints. Each call re-broke lines and re-walked line metrics on the cached shaped layout, about 12% of a paged invoice render.

## What
Adds a per-render measure cache beside the shape cache, keyed by an xxh3 hash of the text, the shaping inputs, the width/height constraints, and the break-time style knobs (wrap, indent, overflow, text-fit). The shape fingerprint also moves from SipHash to xxh3. Invoice render drops 16.9 ms to 14.6 ms; all 224 image and 22 PDF goldens are byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved text layout handling with smarter measurement caching, which can make rendering faster and more responsive.
  * Enhanced cache reuse across nested rendering contexts for more efficient layout calculations.

* **Bug Fixes**
  * Reduced unnecessary re-measurement of text, helping improve consistency in repeated or similar text layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->