### PR TITLE
PDF: fix changeset package id so tegami versions takumi-pdf

### DIFF
--- a/.tegami/pdf-chrome-margin-bands.md
+++ b/.tegami/pdf-chrome-margin-bands.md
@@ -1,8 +1,9 @@
 ---
 packages:
-  "cargo:takumi-pdf": minor
+  takumi-pdf:
+    type: minor
 ---
 
 ### Draw header and footer bands in the page margins
 
-Bands previously reserved their height inside the content window, so a footered document paginated earlier than Chrome's print output. They now lay out at full page width and draw in the margin areas with Chromium's 15pt edge inset; the content window always spans the full margin box.
+Bands previously reserved their height inside the content window, so a footered document paginated earlier than Chrome's print output. They now lay out at full page width and draw in the margin areas with Chromium's 15pt edge inset. The content window always spans the full margin box.

--- a/takumi-pdf-js/CHANGELOG.md
+++ b/takumi-pdf-js/CHANGELOG.md
@@ -1,3 +1,13 @@
+## takumi-pdf@0.1.5
+
+### Write page geometry in PDF points
+
+Pages were sized in CSS px written as pt, so an A4 document came out 33% oversized when printed. Page size, annotations, and outline destinations now convert at 0.75 pt/px. Layout still runs in px.
+
+### Fill the page content box like a browser body
+
+A fit-content root resolved child percentage widths inconsistently across layout passes. Long documents could overlap trailing content and drop pages entirely.
+
 ## takumi-pdf@0.1.1
 
 ### Auto-height viewport


### PR DESCRIPTION
## Why
The margin-bands changeset targeted `cargo:takumi-pdf`, a `publish = false` crate with no version field, so `tegami version` silently skipped it and no Version Packages PR appeared. The two earlier pdf changesets in #1090 had the same id and their notes never reached the changelog.

## What
Retarget the changeset to the npm `takumi-pdf` package and backfill the 0.1.5 changelog entries that were dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF page layout by consistently converting CSS pixels to PDF points.
  * Fixed percentage-width calculations that could cause overlapping content or missing pages.
  * Clarified header and footer band placement within Chromium’s inset margin areas without reducing the content area.

* **Documentation**
  * Added release notes for the latest PDF rendering improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->