### PR TITLE
PDF: size-optimize serialization and subsetting crates

### DIFF
--- a/.tegami/pdf-wasm-opt-levels.md
+++ b/.tegami/pdf-wasm-opt-levels.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Shrink the WebAssembly binary by 5%
+
+Size-optimize the PDF serialization and font subsetting crates. The shipped wasm drops about 220KB with render speed and output bytes unchanged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,19 @@ opt-level = "s"
 [profile.release.package.skrifa]
 opt-level = "s"
 
+# PDF serialization and font subsetting: runs once per document, never per
+# pixel. Only reachable from takumi-pdf-wasm (napi graph excludes krilla).
+[profile.release.package.krilla]
+opt-level = "s"
+[profile.release.package.subsetter]
+opt-level = "z"
+[profile.release.package.write-fonts]
+opt-level = "z"
+[profile.release.package.pdf-writer]
+opt-level = "z"
+[profile.release.package.xmp-writer]
+opt-level = "z"
+
 # Shaping (per text run) and layout/geometry (per render) — never per pixel.
 # opt-s/z, perf-neutral on the napi bench.
 [profile.release.package.harfrust]


### PR DESCRIPTION
## Why
The PDF serialization stack (krilla, subsetter, write-fonts, pdf-writer, xmp-writer) had no opt-level overrides, so per-document code was compiled at opt-level 3 and dominated avoidable wasm size.

## What
krilla builds at opt-s, the pure subsetting/writer crates at opt-z. Shipped wasm drops 220KB raw (−5.3%) / 67KB gz; A/B interleaved benches (600-row paged doc and the invoice bench) are within noise and output PDFs are byte-identical. krilla at opt-z and takumi-pdf at s/z measured 2–6% slower on paged renders, so those stay as-is. Not in the napi or takumi-wasm graphs, so image bindings are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced the WebAssembly bundle size by approximately 5% through optimized PDF serialization and font subsetting.
  - PDF rendering speed remains unchanged.

- **Compatibility**
  - Generated PDF output remains byte-for-byte unchanged.

- **Documentation**
  - Added documentation describing the optimization settings and measured results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->