### PR TITLE
PDF: measure a tree's laid-out size before rendering

### DIFF
--- a/.tegami/pdf-measure.md
+++ b/.tegami/pdf-measure.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Measure a tree without rendering
+
+`measure` returns a tree's laid-out size in CSS px. With page options it lays out at the full page width and fills counter hooks with three-digit numbers, exactly how `render` measures a header or footer band, so the height tells you how much margin the band needs.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -21,7 +21,7 @@ const pdf = await render(report, {
 
 ## Sizing the margin
 
-Band height depends on layout, so it is hard to guess ahead of time. `measure` lays out a tree the same way `render` measures a band: full page width, with `pageNumber` and `totalPages` both filled as 999. Use the height to pick a margin:
+Band height depends on layout, so it is hard to guess ahead of time. `measure` lays out a tree the same way `render` measures a band: full page width, counter hooks filled with three-digit numbers. Use the height to pick a margin:
 
 ```tsx twoslash
 import type { ReactNode } from "react";

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -19,6 +19,29 @@ const pdf = await render(report, {
 });
 ```
 
+## Sizing the margin
+
+Band height depends on layout, so it is hard to guess ahead of time. `measure` lays out a tree the same way `render` measures a band: full page width, counter hooks filled with three-digit numbers. Use the height to pick a margin:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { measure, render } from "takumi-pdf";
+declare const report: ReactNode;
+// ---cut---
+const footer = (
+  <div tw="flex w-full justify-center text-[10px] text-gray-500">
+    Page <span className="pageNumber" /> of <span className="totalPages" />
+  </div>
+);
+const { height } = await measure(footer, { size: "a4" });
+const pdf = await render(report, {
+  footer,
+  margin: { top: 48, bottom: Math.max(48, height + 20) },
+});
+```
+
+Bands sit 20px in from the paper edge, so leave that on top of the measured height.
+
 ## Page counters
 
 Elements with `pageNumber` or `totalPages` receive counter text. This matches Chromium's print header and footer template contract.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -21,7 +21,7 @@ const pdf = await render(report, {
 
 ## Sizing the margin
 
-Band height depends on layout, so it is hard to guess ahead of time. `measure` lays out a tree the same way `render` measures a band: full page width, counter hooks filled with three-digit numbers. Use the height to pick a margin:
+Band height depends on layout, so it is hard to guess ahead of time. `measure` lays out a tree the same way `render` measures a band: full page width, with `pageNumber` and `totalPages` both filled as 999. Use the height to pick a margin:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -41,6 +41,8 @@ const pdf = await render(report, {
 ```
 
 Bands sit 20px in from the paper edge, so leave that on top of the measured height.
+
+Passing `viewport` instead of a page size measures the tree as-is. Counter hooks stay empty.
 
 ## Page counters
 

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -69,6 +69,29 @@ type ViewportOptions = {
   footer?: never;
 };
 
+/**
+ * Options for {@link PdfRenderer.measure}: page geometry (or a viewport) plus
+ * layout resources. Margins do not affect the result.
+ */
+export type MeasureOptions = (
+  | { size?: PageSize; landscape?: boolean; viewport?: never }
+  | { viewport: ViewportInput; size?: never; landscape?: never }
+) & {
+  /** Fonts to register before layout, deduped across calls. */
+  fonts?: FontLoader[];
+  /** Pre-fetched images for `src` URLs in the tree. */
+  images?: ImagesInput;
+  /** CSS stylesheets to apply before layout. */
+  stylesheets?: string[];
+  /** Per-render font stack: ordered family names used as the fallback chain. */
+  fontFamilies?: string[];
+  /** Default BCP-47 language tag applied to the root. */
+  lang?: string;
+};
+
+/** A node tree's laid-out size in CSS px. */
+export type MeasuredSize = { width: number; height: number };
+
 /** Document metadata written to the PDF's info dictionary. */
 export type PdfMetadata = {
   /** The document title. */
@@ -168,6 +191,30 @@ export class PdfRenderer {
     });
   }
 
+  /**
+   * Lays out a node tree without rendering and returns its size in CSS px.
+   *
+   * With page options the tree lays out at the full page width with unbounded
+   * height, exactly how {@link render} measures a header or footer band
+   * (`pageNumber` / `totalPages` hooks are filled with three-digit counters),
+   * so the height tells you how much margin a band needs.
+   */
+  async measure(node: NodeInput, options: MeasureOptions = {}): Promise<MeasuredSize> {
+    const { fonts, images, stylesheets, fontFamilies, ...rest } = options;
+    const [main, resources] = await Promise.all([
+      resolveNode(node),
+      this.fonts.resolveResources(fonts, images, fontFamilies),
+    ]);
+    const sheets = [...(stylesheets ?? []), ...main.stylesheets];
+
+    return this.inner.measure(main.node, {
+      ...rest,
+      stylesheets: sheets.length > 0 ? sheets : undefined,
+      images: resources.images,
+      fontFamilies: resources.fontFamilies,
+    });
+  }
+
   /** Registers a font ahead of time, deduped against earlier registrations. */
   registerFont(font: FontLoader) {
     return this.fonts.register(font);
@@ -185,4 +232,10 @@ let shared: PdfRenderer | undefined;
 export function render(node: NodeInput, options?: RenderOptions): Promise<Uint8Array> {
   shared ??= new PdfRenderer();
   return shared.render(node, options);
+}
+
+/** Measures with a lazily created shared {@link PdfRenderer}. */
+export function measure(node: NodeInput, options?: MeasureOptions): Promise<MeasuredSize> {
+  shared ??= new PdfRenderer();
+  return shared.measure(node, options);
 }

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -91,6 +91,25 @@ test("rejects an unknown size keyword", () => {
   expect(renderer.render(doc, { size: "tabloid" as "a4" })).rejects.toThrow("unknown page size");
 });
 
+test("measures a band at full page width with counters filled", async () => {
+  const footer = container({
+    style: { display: "flex", columnGap: 3, fontSize: 12 },
+    children: [text("Page"), container({ className: "pageNumber" })],
+  });
+  const size = await renderer.measure(footer, { size: { width: 400, height: 300 } });
+
+  expect(size.width).toBe(400);
+  expect(size.height).toBeGreaterThanOrEqual(12);
+});
+
+test("measure defaults to paged A4", async () => {
+  const size = await renderer.measure(doc);
+
+  // A4 at 96 dpi is 793.7px wide; the layout viewport truncates to 793.
+  expect(size.width).toBe(793);
+  expect(size.height).toBeGreaterThan(0);
+});
+
 test("rejects viewport combined with paged options", () => {
   expect(
     renderer.render(doc, {

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -1,0 +1,116 @@
+import type { Node } from "@takumi-rs/helpers";
+
+export type ByteBuf = Uint8Array | ArrayBuffer | Buffer;
+
+/** Cache policy for a decoded image. Defaults to `"auto"`. */
+export type ImageCacheMode = "auto" | "none";
+
+export type FontDetails = {
+  name?: string;
+  data: ByteBuf;
+  weight?: number;
+  style?: "normal" | "italic" | "oblique" | `oblique ${number}deg` | (string & {});
+  /**
+   * Logical family this font is a coverage subset of. Subsets sharing a
+   * `subsetOf` are kept as distinct families and `font-family: {subsetOf}`
+   * expands to all of them, so each script routes to the subset that covers it.
+   */
+  subsetOf?: string;
+  /** CSS generic family keyword this font resolves for. */
+  generic?: string;
+};
+
+export type Font = FontDetails | ByteBuf;
+
+export type RegisteredFace = {
+  weight: number;
+  style: string;
+  width: number;
+  index: number;
+};
+
+export type RegisteredFamily = {
+  name: string;
+  faces: RegisteredFace[];
+};
+
+export type ImageSource = {
+  src: string;
+  data: ByteBuf;
+  /** Cache policy for the decoded image. Defaults to `"auto"`. */
+  cache?: ImageCacheMode;
+};
+
+/** Explicit page or viewport dimensions in CSS px (96 dpi). */
+export type Dimensions = { width: number; height: number };
+
+/** Viewport for single-page output. A missing height sizes the page to the content. */
+export type ViewportInput = { width: number; height?: number };
+
+/** A page size: a preset name (case-insensitive) or explicit dimensions. */
+export type PageSize = "a4" | "letter" | Dimensions;
+
+/** A page margin in CSS px: one number for all sides, or per-side values (missing sides are zero). */
+export type PageMargin = number | { top?: number; right?: number; bottom?: number; left?: number };
+
+export type PdfMetadata = {
+  title?: string;
+  description?: string;
+  authors?: string[];
+  keywords?: string[];
+  creator?: string;
+  /** UTC creation date, `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS`. */
+  creationDate?: string;
+};
+
+/** PDF/A conformance level. Validation failures reject the render. */
+export type Pdfa = "2a" | "2b" | "2u" | "3a" | "3b" | "3u" | "4";
+
+/** Structure-tree emission: off, on (default), or validated against PDF/UA-1. */
+export type Tagged = boolean | "ua1";
+
+export type PdfRenderOptions = {
+  /**
+   * Fixed viewport for single-page output. Mutually exclusive with the paged
+   * fields (`size`, `landscape`, `margin`, `header`, `footer`).
+   */
+  viewport?: ViewportInput;
+  /** Page size for paged output. Defaults to A4. */
+  size?: PageSize;
+  /** Swaps the page's width and height, including explicit sizes. */
+  landscape?: boolean;
+  /** Page margin in CSS px. Defaults to a uniform 48 (half an inch). */
+  margin?: PageMargin;
+  /**
+   * Band repeated at the top of every page. Nodes classed `pageNumber` /
+   * `totalPages` receive the counters.
+   */
+  header?: Node;
+  /** Band repeated at the bottom of every page; same class hooks as `header`. */
+  footer?: Node;
+  /** Pre-fetched images keyed by URL. */
+  images?: ImageSource[];
+  /** CSS stylesheets to apply before layout. */
+  stylesheets?: string[];
+  /** Per-render font stack: ordered family names used as the fallback chain. */
+  fontFamilies?: string[];
+  /** Default BCP-47 language tag applied to the root. */
+  lang?: string;
+  /** Document metadata written to the PDF's info dictionary. */
+  metadata?: PdfMetadata;
+  /** Generates a PDF outline (bookmarks) from `h1`–`h6` headings. */
+  outline?: boolean;
+  /** PDF/A conformance level. */
+  pdfa?: Pdfa;
+  /** Structure-tree emission: `false`, `true` (default) or `"ua1"`. */
+  tagged?: Tagged;
+};
+
+/** Options for `measure`: page geometry (or a viewport) plus layout resources. */
+export type MeasureOptions = Pick<
+  PdfRenderOptions,
+  "viewport" | "size" | "landscape" | "images" | "stylesheets" | "fontFamilies" | "lang"
+>;
+
+/** A node tree's laid-out size in CSS px. */
+export type MeasuredSize = { width: number; height: number };

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -107,10 +107,11 @@ export type PdfRenderOptions = {
 };
 
 /** Options for `measure`: page geometry (or a viewport) plus layout resources. */
-export type MeasureOptions = Pick<
-  PdfRenderOptions,
-  "viewport" | "size" | "landscape" | "images" | "stylesheets" | "fontFamilies" | "lang"
->;
+export type MeasureOptions = (
+  | { size?: PageSize; landscape?: boolean; viewport?: never }
+  | { viewport: ViewportInput; size?: never; landscape?: never }
+) &
+  Pick<PdfRenderOptions, "images" | "stylesheets" | "fontFamilies" | "lang">;
 
 /** A node tree's laid-out size in CSS px. */
 export type MeasuredSize = { width: number; height: number };

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -18,13 +18,13 @@ use takumi_core::{
   layout::node::Node,
   resources::{
     font::FontResource,
-    image::{ImageCacheMode, ResourceCache},
+    image::{ImageCacheMode, ImageSource as DecodedImage, ResourceCache},
   },
   style::{FontFamily, FontStyle as CssFontStyle, FromCssStr, Lang},
   viewport::Viewport,
 };
 use takumi_pdf::{
-  PageMargins, PageOptions, PdfDate, PdfMetadata, PdfOptions, PdfStandard, Tagging,
+  MeasureOptions, PageMargins, PageOptions, PdfDate, PdfMetadata, PdfOptions, PdfStandard, Tagging,
 };
 use wasm_bindgen::prelude::*;
 
@@ -351,6 +351,62 @@ impl TryFrom<MetadataInput> for PdfMetadata {
   }
 }
 
+fn decode_images(
+  cache: &ResourceCache,
+  sources: Option<Vec<ImageSource>>,
+) -> Result<HashMap<Arc<str>, DecodedImage>, js_sys::Error> {
+  let mut images = HashMap::new();
+
+  for source in sources.unwrap_or_default() {
+    let image = cache
+      .get_or_decode(&source.data, source.cache.unwrap_or_default())
+      .map_err(map_error)?;
+
+    images.insert(source.src, image);
+  }
+  Ok(images)
+}
+
+/// Splits the options into single-page viewport or paged geometry, rejecting
+/// a mix of both.
+fn resolve_geometry(
+  options: &PdfRenderOptions,
+) -> Result<(Option<Viewport>, Option<PageOptions>), js_sys::Error> {
+  let paged_field_set = options.size.is_some()
+    || options.landscape.is_some()
+    || options.margin.is_some()
+    || options.header.is_some()
+    || options.footer.is_some();
+
+  match options.viewport {
+    Some(_) if paged_field_set => Err(js_sys::Error::new(
+      "viewport is mutually exclusive with the paged options (size, landscape, margin, header, footer)",
+    )),
+    Some(input) => Ok((
+      Some(Viewport::new((
+        input.width as u32,
+        input.height.map(|height| height as u32),
+      ))),
+      None,
+    )),
+    None => Ok((
+      None,
+      Some(resolve_page(
+        options.size.as_ref(),
+        options.landscape.unwrap_or(false),
+        options.margin.as_ref(),
+      )?),
+    )),
+  }
+}
+
+/// The size returned by [`PdfRenderer::measure`].
+#[derive(serde::Serialize)]
+struct MeasuredSizeOutput {
+  width: f32,
+  height: f32,
+}
+
 /// A PDF renderer holding registered fonts and a decoded-resource cache.
 ///
 /// State lives behind a lock and every method takes `&self`, mirroring the
@@ -420,44 +476,8 @@ impl PdfRenderer {
       .transpose()?
       .unwrap_or_default();
 
-    let mut images = HashMap::new();
-
-    for source in options.images.unwrap_or_default() {
-      let image = self
-        .resource_cache
-        .get_or_decode(&source.data, source.cache.unwrap_or_default())
-        .map_err(map_error)?;
-
-      images.insert(source.src, image);
-    }
-
-    let paged_field_set = options.size.is_some()
-      || options.landscape.is_some()
-      || options.margin.is_some()
-      || options.header.is_some()
-      || options.footer.is_some();
-    let (viewport, page) = match options.viewport {
-      Some(_) if paged_field_set => {
-        return Err(js_sys::Error::new(
-          "viewport is mutually exclusive with the paged options (size, landscape, margin, header, footer)",
-        ));
-      }
-      Some(input) => (
-        Some(Viewport::new((
-          input.width as u32,
-          input.height.map(|height| height as u32),
-        ))),
-        None,
-      ),
-      None => (
-        None,
-        Some(resolve_page(
-          options.size.as_ref(),
-          options.landscape.unwrap_or(false),
-          options.margin.as_ref(),
-        )?),
-      ),
-    };
+    let (viewport, page) = resolve_geometry(&options)?;
+    let images = decode_images(&self.resource_cache, options.images)?;
     let lang = options
       .lang
       .as_deref()
@@ -484,6 +504,51 @@ impl PdfRenderer {
       outline: options.outline.unwrap_or(false),
       standard: options.pdfa.map(PdfStandard::from).unwrap_or_default(),
       tagged: options.tagged.map(Tagging::from).unwrap_or_default(),
+    })
+    .map_err(map_error)
+  }
+
+  /// Lays out a node tree without rendering and returns its size in CSS px.
+  /// Page options lay out at the full page width, like a header/footer band;
+  /// `pageNumber` / `totalPages` hooks are filled with three-digit counters.
+  #[wasm_bindgen]
+  pub fn measure(
+    &self,
+    node: JsValue,
+    options: Option<js_sys::Object>,
+  ) -> Result<JsValue, js_sys::Error> {
+    let node: Node = from_value(node).map_err(map_error)?;
+    let options: PdfRenderOptions = options
+      .map(|options| from_value(options.into()).map_err(map_error))
+      .transpose()?
+      .unwrap_or_default();
+    let (viewport, page) = resolve_geometry(&options)?;
+    let images = decode_images(&self.resource_cache, options.images)?;
+    let lang = options
+      .lang
+      .as_deref()
+      .map(Lang::parse)
+      .transpose()
+      .map_err(map_error)?;
+    let state = self
+      .state
+      .try_read()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
+    let measured = takumi_pdf::measure(MeasureOptions {
+      viewport,
+      fonts: &state,
+      node,
+      stylesheet: stylesheet(&self.resource_cache, options.stylesheets, Vec::new()),
+      images,
+      page,
+      font_families: options.font_families.map(FontFamily::from_names),
+      lang,
+    })
+    .map_err(map_error)?;
+
+    to_value(&MeasuredSizeOutput {
+      width: measured.width,
+      height: measured.height,
     })
     .map_err(map_error)
   }

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -501,13 +501,13 @@ impl PdfRenderer {
     options: Option<PdfRenderOptionsType>,
   ) -> Result<Vec<u8>, js_sys::Error> {
     let node: Node = from_value(node.into()).map_err(map_error)?;
-    let options: PdfRenderOptions = options
+    let mut options: PdfRenderOptions = options
       .map(|options| from_value(options.into()).map_err(map_error))
       .transpose()?
       .unwrap_or_default();
 
+    let images = decode_images(&self.resource_cache, options.images.take())?;
     let (viewport, page) = resolve_geometry(&options)?;
-    let images = decode_images(&self.resource_cache, options.images)?;
     let lang = options
       .lang
       .as_deref()
@@ -548,12 +548,12 @@ impl PdfRenderer {
     options: Option<MeasureOptionsType>,
   ) -> Result<MeasuredSizeType, js_sys::Error> {
     let node: Node = from_value(node.into()).map_err(map_error)?;
-    let options: PdfRenderOptions = options
+    let mut options: PdfRenderOptions = options
       .map(|options| from_value(options.into()).map_err(map_error))
       .transpose()?
       .unwrap_or_default();
+    let images = decode_images(&self.resource_cache, options.images.take())?;
     let (viewport, page) = resolve_geometry(&options)?;
-    let images = decode_images(&self.resource_cache, options.images)?;
     let lang = options
       .lang
       .as_deref()

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -32,6 +32,36 @@ fn map_error(error: impl core::fmt::Debug) -> js_sys::Error {
   js_sys::Error::new(&format!("{error:?}"))
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = include_str!("./dts-header.d.ts");
+
+#[wasm_bindgen]
+extern "C" {
+  /// JavaScript object representing a layout node.
+  #[wasm_bindgen(typescript_type = "Node")]
+  pub type NodeType;
+
+  /// JavaScript type for font input (details object or raw buffer).
+  #[wasm_bindgen(typescript_type = "Font")]
+  pub type FontType;
+
+  /// JavaScript type for the families produced by `registerFont`.
+  #[wasm_bindgen(typescript_type = "RegisteredFamily[]")]
+  pub type RegisteredFamiliesType;
+
+  /// JavaScript object representing render options.
+  #[wasm_bindgen(typescript_type = "PdfRenderOptions")]
+  pub type PdfRenderOptionsType;
+
+  /// JavaScript object representing measure options.
+  #[wasm_bindgen(typescript_type = "MeasureOptions")]
+  pub type MeasureOptionsType;
+
+  /// JavaScript object representing a measured size.
+  #[wasm_bindgen(typescript_type = "MeasuredSize")]
+  pub type MeasuredSizeType;
+}
+
 /// Details for loading a custom font.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -432,8 +462,8 @@ impl PdfRenderer {
   /// Registers a font (raw bytes or a details object), returning the families
   /// it produced.
   #[wasm_bindgen(js_name = registerFont)]
-  pub fn register_font(&self, font: JsValue) -> Result<JsValue, js_sys::Error> {
-    let font: Font = from_value(font).map_err(map_error)?;
+  pub fn register_font(&self, font: FontType) -> Result<RegisteredFamiliesType, js_sys::Error> {
+    let font: Font = from_value(font.into()).map_err(map_error)?;
     let mut state = self
       .state
       .try_write()
@@ -459,18 +489,18 @@ impl PdfRenderer {
       }
     };
 
-    to_value(&registered).map_err(map_error)
+    Ok(to_value(&registered).map_err(map_error)?.unchecked_into())
   }
 
   /// Renders a node tree to PDF bytes. Without options the output is paged A4;
   /// `viewport` renders a single fixed page instead.
-  #[wasm_bindgen]
+  #[wasm_bindgen(unchecked_return_type = "Uint8Array<ArrayBuffer>")]
   pub fn render(
     &self,
-    node: JsValue,
-    options: Option<js_sys::Object>,
+    node: NodeType,
+    options: Option<PdfRenderOptionsType>,
   ) -> Result<Vec<u8>, js_sys::Error> {
-    let node: Node = from_value(node).map_err(map_error)?;
+    let node: Node = from_value(node.into()).map_err(map_error)?;
     let options: PdfRenderOptions = options
       .map(|options| from_value(options.into()).map_err(map_error))
       .transpose()?
@@ -514,10 +544,10 @@ impl PdfRenderer {
   #[wasm_bindgen]
   pub fn measure(
     &self,
-    node: JsValue,
-    options: Option<js_sys::Object>,
-  ) -> Result<JsValue, js_sys::Error> {
-    let node: Node = from_value(node).map_err(map_error)?;
+    node: NodeType,
+    options: Option<MeasureOptionsType>,
+  ) -> Result<MeasuredSizeType, js_sys::Error> {
+    let node: Node = from_value(node.into()).map_err(map_error)?;
     let options: PdfRenderOptions = options
       .map(|options| from_value(options.into()).map_err(map_error))
       .transpose()?
@@ -546,11 +576,14 @@ impl PdfRenderer {
     })
     .map_err(map_error)?;
 
-    to_value(&MeasuredSizeOutput {
-      width: measured.width,
-      height: measured.height,
-    })
-    .map_err(map_error)
+    Ok(
+      to_value(&MeasuredSizeOutput {
+        width: measured.width,
+        height: measured.height,
+      })
+      .map_err(map_error)?
+      .unchecked_into(),
+    )
   }
 }
 

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -800,13 +800,9 @@ pub struct MeasuredSize {
 /// With [`MeasureOptions::page`] set the tree lays out like a header/footer
 /// band in [`render`]: full page width, unbounded height, `pageNumber` /
 /// `totalPages` class hooks filled with three-digit counters. The returned
-/// height is the band height a page margin needs to accommodate.
+/// height is the band height a page margin needs to accommodate. With a
+/// viewport the tree is measured as-is, counter hooks untouched.
 pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
-  let viewport = match (&options.page, options.viewport) {
-    (Some(page), _) => Viewport::new((page.width as u32, None)),
-    (None, Some(viewport)) => viewport,
-    (None, None) => return Err(PdfError::MissingViewport),
-  };
   let inputs = TreeInputs {
     fonts: options.fonts,
     stylesheet: options.stylesheet,
@@ -814,7 +810,17 @@ pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
     font_families: options.font_families,
     lang: options.lang,
   };
-  let tree = prepare_band(&inputs, &options.node, 999, 999, viewport)?;
+  let tree = match (options.page, options.viewport) {
+    (Some(page), _) => prepare_band(
+      &inputs,
+      &options.node,
+      999,
+      999,
+      Viewport::new((page.width as u32, None)),
+    )?,
+    (None, Some(viewport)) => prepare_tree(&inputs, options.node, viewport)?,
+    (None, None) => return Err(PdfError::MissingViewport),
+  };
 
   Ok(MeasuredSize {
     width: tree.width,

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -757,6 +757,71 @@ fn emit_band(
   Ok(())
 }
 
+/// Inputs for [`measure`], built with [`MeasureOptions::builder`].
+#[derive(TypedBuilder)]
+pub struct MeasureOptions<'g> {
+  /// The viewport to lay out in. Required unless [`Self::page`] is set.
+  #[builder(default, setter(strip_option))]
+  pub viewport: Option<Viewport>,
+  /// The font context.
+  pub fonts: &'g Fonts,
+  /// The node tree to measure.
+  pub node: Node,
+  /// CSS stylesheets to apply before layout.
+  #[builder(default)]
+  pub stylesheet: Arc<StyleSheet>,
+  /// Resources fetched externally, keyed by URL.
+  #[builder(default)]
+  pub images: HashMap<Arc<str>, ImageSource>,
+  /// Lays out at the full page width with unbounded height, exactly how
+  /// [`render`] measures a header/footer band. Margins do not affect the
+  /// result.
+  #[builder(default, setter(strip_option))]
+  pub page: Option<PageOptions>,
+  /// Per-render font fallback chain (family names in order).
+  #[builder(default)]
+  pub font_families: Option<FontFamily>,
+  /// Default BCP-47 language tag applied to the root.
+  #[builder(default)]
+  pub lang: Option<Lang>,
+}
+
+/// A node tree's laid-out size in px.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeasuredSize {
+  /// The layout width.
+  pub width: f32,
+  /// The laid-out content height.
+  pub height: f32,
+}
+
+/// Lays out a node tree without rendering and returns its size.
+///
+/// With [`MeasureOptions::page`] set the tree lays out like a header/footer
+/// band in [`render`]: full page width, unbounded height, `pageNumber` /
+/// `totalPages` class hooks filled with three-digit counters. The returned
+/// height is the band height a page margin needs to accommodate.
+pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
+  let viewport = match (&options.page, options.viewport) {
+    (Some(page), _) => Viewport::new((page.width as u32, None)),
+    (None, Some(viewport)) => viewport,
+    (None, None) => return Err(PdfError::MissingViewport),
+  };
+  let inputs = TreeInputs {
+    fonts: options.fonts,
+    stylesheet: options.stylesheet,
+    images: Rc::new(options.images),
+    font_families: options.font_families,
+    lang: options.lang,
+  };
+  let tree = prepare_band(&inputs, &options.node, 999, 999, viewport)?;
+
+  Ok(MeasuredSize {
+    width: tree.width,
+    height: tree.height,
+  })
+}
+
 /// Renders a node tree to a PDF: single-page at the viewport size, or paged
 /// when [`PdfOptions::page`] is set.
 pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -19,7 +19,8 @@ use takumi_core::{
 };
 use takumi_html::{FromHtmlOptions, from_html};
 use takumi_pdf::{
-  PageMargins, PageOptions, PdfDate, PdfMetadata, PdfOptions, PdfStandard, Tagging, render,
+  MeasureOptions, PageMargins, PageOptions, PdfDate, PdfMetadata, PdfOptions, PdfStandard, Tagging,
+  measure, render,
 };
 
 fn fonts() -> Fonts {
@@ -884,4 +885,65 @@ fn report_links_outline() {
   ] {
     assert!(haystack.contains(needle), "missing {needle} in pdf");
   }
+}
+
+/// Measuring at a page lays out at the full page width; counter hooks are
+/// filled with three-digit numbers so a counter-only band measures its real
+/// height.
+#[test]
+fn measure_band_at_page_width() {
+  let fonts = fonts();
+  let band = from_html(
+    r#"<div style="display: flex; justify-content: center; font-size: 12px;">
+      Page <span class="pageNumber"></span> of <span class="totalPages"></span>
+    </div>"#,
+    FromHtmlOptions::default(),
+  )
+  .expect("parse band");
+  let size = measure(
+    MeasureOptions::builder()
+      .node(band)
+      .page(PageOptions::A4)
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("measure band");
+
+  assert_eq!(size.width, PageOptions::A4.width.floor());
+  assert!(size.height >= 12.0, "band height {}", size.height);
+}
+
+/// Without a page, measurement uses the viewport; omitting both is an error.
+#[test]
+fn measure_viewport_and_missing_viewport() {
+  let fonts = fonts();
+  let node = || {
+    from_html(
+      r#"<div style="font-size: 16px;">A line of wrapped text that needs several rows at a narrow width</div>"#,
+      FromHtmlOptions::default(),
+    )
+    .expect("parse node")
+  };
+  let narrow = measure(
+    MeasureOptions::builder()
+      .node(node())
+      .viewport(Viewport::new((120, None)))
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("measure at viewport");
+  let wide = measure(
+    MeasureOptions::builder()
+      .node(node())
+      .viewport(Viewport::new((600, None)))
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("measure at wide viewport");
+
+  assert!(narrow.height > wide.height);
+  assert!(
+    measure(MeasureOptions::builder().node(node()).fonts(&fonts).build()).is_err(),
+    "expected MissingViewport"
+  );
 }


### PR DESCRIPTION
## Why
Band height is a layout result, so callers cannot know how much margin a header or footer needs before rendering (#1097). The renderer already computes it internally; there was no way to ask.

## What
`measure` in takumi-pdf, the wasm binding, and takumi-pdf: lays out a tree and returns `{ width, height }` in CSS px. With page options it lays out at the full page width and fills counter hooks with three-digit numbers, the same path `render` uses to measure a band, so the height maps directly to the margin a band needs. Viewport mode measures at a fixed width instead. Docs show sizing the margin from the measured height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIs to measure laid-out content width and height without generating PDF output.
  * Supports page-based or viewport-based dimensions, fonts, images, stylesheets, and language settings.
  * Measurement results help size headers, footers, and other layout bands before rendering.
  * Added typed interfaces for configuring measurements and reading measured dimensions.

* **Documentation**
  * Documented page-width layout and counter-based measurement behavior.
  * Added guidance for sizing header and footer margins using measured content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->