### PR TITLE
PDF: file attachments via attachments option

### DIFF
--- a/.tegami/pdf-attachments.md
+++ b/.tegami/pdf-attachments.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### File attachments
+
+Attach files with `attachments`: name, bytes or UTF-8 string, mime type, description, and an `AFRelationship`. Combined with `pdfa: "3b"` this produces the PDF/A-3 shape that ZUGFeRD and Factur-X e-invoices use; `modificationDate` falls back to `metadata.creationDate` to keep output deterministic.

--- a/.tegami/pdf-attachments.md
+++ b/.tegami/pdf-attachments.md
@@ -6,4 +6,8 @@ packages:
 
 ### File attachments
 
-Attach files with `attachments`: name, bytes or UTF-8 string, mime type, description, and an `AFRelationship`. Combined with `pdfa: "3b"` this produces the PDF/A-3 shape that ZUGFeRD and Factur-X e-invoices use; `modificationDate` falls back to `metadata.creationDate` to keep output deterministic. Invalid combinations are TypeScript type errors: the PDF/A-2 levels and `"4"` forbid attachments, and the PDF/A-3 levels require a mime type and description on each one.
+Attach files with `attachments`, the PDF/A-3 shape ZUGFeRD and Factur-X e-invoices use.
+
+- `data` takes bytes or a UTF-8 string
+- `modificationDate` falls back to `metadata.creationDate`
+- invalid `pdfa` combinations are TypeScript type errors

--- a/.tegami/pdf-attachments.md
+++ b/.tegami/pdf-attachments.md
@@ -6,4 +6,4 @@ packages:
 
 ### File attachments
 
-Attach files with `attachments`: name, bytes or UTF-8 string, mime type, description, and an `AFRelationship`. Combined with `pdfa: "3b"` this produces the PDF/A-3 shape that ZUGFeRD and Factur-X e-invoices use; `modificationDate` falls back to `metadata.creationDate` to keep output deterministic.
+Attach files with `attachments`: name, bytes or UTF-8 string, mime type, description, and an `AFRelationship`. Combined with `pdfa: "3b"` this produces the PDF/A-3 shape that ZUGFeRD and Factur-X e-invoices use; `modificationDate` falls back to `metadata.creationDate` to keep output deterministic. Invalid combinations are TypeScript type errors: the PDF/A-2 levels and `"4"` forbid attachments, and the PDF/A-3 levels require a mime type and description on each one.

--- a/docs/content/docs/pdf/attachments.mdx
+++ b/docs/content/docs/pdf/attachments.mdx
@@ -1,0 +1,66 @@
+---
+title: Attachments
+description: Embed files in the PDF, including PDF/A-3 e-invoice data
+---
+
+Attach files with `attachments`. They appear in the viewer's attachment panel:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+declare const invoice: ReactNode;
+declare const xml: string;
+// ---cut---
+const pdf = await render(invoice, {
+  attachments: [
+    {
+      name: "factur-x.xml",
+      data: xml,
+      mimeType: "application/xml",
+      description: "Factur-X invoice data",
+      relationship: "alternative",
+    },
+  ],
+});
+```
+
+`data` takes raw bytes as a `Uint8Array`, or a string encoded as UTF-8.
+
+`relationship` states how the file relates to the document. It becomes the PDF/A-3 `AFRelationship`:
+
+| Value           | Meaning                                          |
+| --------------- | ------------------------------------------------ |
+| `"source"`      | The document was created from this file.         |
+| `"alternative"` | An alternative representation of the document.   |
+| `"data"`        | The file backs a visual presentation in the PDF. |
+| `"supplement"`  | Additional resources for the document.           |
+| `"unspecified"` | No clear relationship. The default.              |
+
+## Electronic invoices
+
+ZUGFeRD and Factur-X invoices are PDF/A-3 documents with the invoice XML attached. Combine `attachments` with `pdfa`:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+declare const invoice: ReactNode;
+declare const xml: string;
+// ---cut---
+const pdf = await render(invoice, {
+  pdfa: "3b",
+  metadata: { title: "Invoice 1042", creationDate: "2026-08-06" },
+  attachments: [
+    {
+      name: "factur-x.xml",
+      data: xml,
+      mimeType: "application/xml",
+      description: "Factur-X invoice data",
+      relationship: "alternative",
+    },
+  ],
+});
+```
+
+The PDF/A-3 levels require each attachment to carry a `mimeType`, a `description`, and a modification date. `modificationDate` falls back to `metadata.creationDate`. A missing requirement fails the render with the violated rule.
+
+Full Factur-X conformance also expects its XMP extension schema. Takumi does not write it yet.

--- a/docs/content/docs/pdf/attachments.mdx
+++ b/docs/content/docs/pdf/attachments.mdx
@@ -61,6 +61,14 @@ const pdf = await render(invoice, {
 });
 ```
 
-The PDF/A-3 levels require each attachment to carry a `mimeType`, a `description`, and a modification date. `modificationDate` falls back to `metadata.creationDate`. A missing requirement fails the render with the violated rule.
+The PDF/A-3 levels require three fields on each attachment:
+
+- `mimeType`
+- `description`
+- a modification date: `modificationDate`, or the `metadata.creationDate` fallback
+
+A missing field fails the render with the violated rule.
+
+Invalid combinations are **TypeScript type errors**. The PDF/A-2 levels and `"4"` forbid attachments. The PDF/A-3 levels require `mimeType` and `description` on each one.
 
 Full Factur-X conformance also expects its XMP extension schema. Takumi does not write it yet.

--- a/docs/content/docs/pdf/meta.json
+++ b/docs/content/docs/pdf/meta.json
@@ -11,6 +11,7 @@
     "single-page",
     "fonts-and-images",
     "pdf-a",
+    "attachments",
     "comparison"
   ]
 }

--- a/docs/content/docs/pdf/pdf-a.mdx
+++ b/docs/content/docs/pdf/pdf-a.mdx
@@ -76,7 +76,7 @@ The structure tree comes from the HTML semantics:
 
 Set `tagged: false` to skip the tree when file size matters more than accessibility.
 
-Invalid combinations are TypeScript type errors. `pdfa: "2a"` and `pdfa: "3a"` forbid `tagged: false`. `pdfa: "4"` forbids `tagged: "ua1"`, because PDF/UA-1 is PDF 1.7-only and PDF/A-4 is PDF 2.0.
+Invalid combinations are TypeScript type errors. `pdfa: "2a"` and `pdfa: "3a"` forbid `tagged: false`. `pdfa: "4"` forbids `tagged: "ua1"`, because PDF/UA-1 is PDF 1.7-only and PDF/A-4 is PDF 2.0. The `2` levels and `"4"` forbid `attachments`. See [Attachments](/docs/pdf/attachments).
 
 Validators require inputs the renderer cannot supply:
 

--- a/docs/content/docs/pdf/pdf-a.mdx
+++ b/docs/content/docs/pdf/pdf-a.mdx
@@ -31,7 +31,7 @@ Conforming output includes an sRGB output intent and XMP metadata. Fonts are alw
 
 The `u` levels add no output cost. Takumi always writes ToUnicode maps.
 
-PDF/A-3 allows arbitrary file attachments. ZUGFeRD and Factur-X electronic invoices expect `"3b"`.
+PDF/A-3 allows arbitrary file attachments. ZUGFeRD and Factur-X electronic invoices expect `"3b"`. See [Attachments](/docs/pdf/attachments).
 
 PDF/A-1 is not offered. It prohibits transparency.
 

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -111,6 +111,28 @@ export type PdfMetadata = {
   creationDate?: string;
 };
 
+/** A file attached to the PDF, shown in the viewer's attachment panel. */
+export type Attachment = {
+  /** File name in the PDF, e.g. "factur-x.xml". */
+  name: string;
+  /** The file's bytes, or a string encoded as UTF-8. */
+  data: Uint8Array | string;
+  /** IANA media type, e.g. "application/xml". The PDF/A-3 levels require one. */
+  mimeType?: string;
+  /** Human-readable description. The PDF/A-3 levels require one. */
+  description?: string;
+  /**
+   * How the file relates to the document (the PDF/A-3 AFRelationship).
+   * Defaults to "unspecified".
+   */
+  relationship?: "source" | "data" | "alternative" | "supplement" | "unspecified";
+  /**
+   * UTC modification date, `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS`; falls back
+   * to `metadata.creationDate`. The PDF/A-3 levels require one.
+   */
+  modificationDate?: string;
+};
+
 /** Levels based on PDF 1.7, where PDF/UA-1 tagging can combine. */
 type Pdfa17 = "2b" | "2u" | "3b" | "3u";
 
@@ -148,6 +170,8 @@ export type RenderOptions = (PagedOptions | ViewportOptions) &
     metadata?: PdfMetadata;
     /** Generates a PDF outline (bookmarks) from `h1`–`h6` headings. */
     outline?: boolean;
+    /** Files attached to the document. */
+    attachments?: Attachment[];
   };
 
 function isNode(value: NodeInput): value is Node {

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -133,23 +133,36 @@ export type Attachment = {
   modificationDate?: string;
 };
 
-/** Levels based on PDF 1.7, where PDF/UA-1 tagging can combine. */
-type Pdfa17 = "2b" | "2u" | "3b" | "3u";
+/** An attachment under the PDF/A-3 levels, which require the descriptive fields. */
+export type ArchivalAttachment = Attachment & {
+  mimeType: string;
+  description: string;
+};
 
 /**
  * Standards conformance. Invalid combinations are type errors: the `a` levels
- * imply a structure tree so `tagged: false` is rejected, and PDF/A-4 is
- * PDF 2.0 while PDF/UA-1 is PDF 1.7-only, so they cannot combine.
+ * imply a structure tree so `tagged: false` is rejected, PDF/A-4 is PDF 2.0
+ * while PDF/UA-1 is PDF 1.7-only so they cannot combine, and only the
+ * PDF/A-3 levels (or plain PDF) accept attachments.
  */
 type ConformanceOptions =
   | {
-      /** PDF/A conformance level. Validation failures reject the render. */
-      pdfa?: Pdfa17;
+      pdfa?: never;
       /** Structure tree: off, on (default), or validated against PDF/UA-1. */
       tagged?: boolean | "ua1";
+      /** Files attached to the document. */
+      attachments?: Attachment[];
     }
-  | { pdfa: "2a" | "3a"; tagged?: true | "ua1" }
-  | { pdfa: "4"; tagged?: boolean };
+  | {
+      /** PDF/A conformance level. Validation failures reject the render. */
+      pdfa: "2b" | "2u";
+      tagged?: boolean | "ua1";
+      attachments?: never;
+    }
+  | { pdfa: "2a"; tagged?: true | "ua1"; attachments?: never }
+  | { pdfa: "3b" | "3u"; tagged?: boolean | "ua1"; attachments?: ArchivalAttachment[] }
+  | { pdfa: "3a"; tagged?: true | "ua1"; attachments?: ArchivalAttachment[] }
+  | { pdfa: "4"; tagged?: boolean; attachments?: never };
 
 export type RenderOptions = (PagedOptions | ViewportOptions) &
   ConformanceOptions & {
@@ -170,8 +183,6 @@ export type RenderOptions = (PagedOptions | ViewportOptions) &
     metadata?: PdfMetadata;
     /** Generates a PDF outline (bookmarks) from `h1`–`h6` headings. */
     outline?: boolean;
-    /** Files attached to the document. */
-    attachments?: Attachment[];
   };
 
 function isNode(value: NodeInput): value is Node {

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -146,22 +146,22 @@ test("embeds attachments from string and Uint8Array data", async () => {
   expect(bytes).toContain("/AFRelationship");
 });
 
-test("rejects duplicate attachment names", () => {
+test("rejects duplicate attachment names", async () => {
   const attachment = { name: "dup.txt", data: "x" };
 
-  expect(renderer.render(doc, { attachments: [attachment, attachment] })).rejects.toThrow(
+  await expect(renderer.render(doc, { attachments: [attachment, attachment] })).rejects.toThrow(
     "DuplicateAttachment",
   );
 });
 
-test("rejects an invalid attachment mime type", () => {
-  expect(
+test("rejects an invalid attachment mime type", async () => {
+  await expect(
     renderer.render(doc, { attachments: [{ name: "a.txt", data: "x", mimeType: "nope" }] }),
   ).rejects.toThrow("InvalidMimeType");
 });
 
-test("rejects an invalid attachment modificationDate", () => {
-  expect(
+test("rejects an invalid attachment modificationDate", async () => {
+  await expect(
     renderer.render(doc, {
       attachments: [{ name: "a.txt", data: "x", modificationDate: "yesterday" }],
     }),

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -118,3 +118,52 @@ test("rejects viewport combined with paged options", () => {
     } as never),
   ).rejects.toThrow("mutually exclusive");
 });
+
+test("embeds attachments from string and Uint8Array data", async () => {
+  const pdf = await renderer.render(doc, {
+    pdfa: "3b",
+    metadata: { title: "Invoice", creationDate: "2026-08-06" },
+    attachments: [
+      {
+        name: "factur-x.xml",
+        data: '<invoice total="1290"/>',
+        mimeType: "application/xml",
+        description: "Factur-X invoice data",
+        relationship: "alternative",
+      },
+      {
+        name: "readings.csv",
+        data: new TextEncoder().encode("a,b\n1,2"),
+        mimeType: "text/csv",
+        description: "Raw readings",
+      },
+    ],
+  });
+  const bytes = decoder.decode(pdf);
+
+  expect(bytes).toContain("factur-x.xml");
+  expect(bytes).toContain("readings.csv");
+  expect(bytes).toContain("/AFRelationship");
+});
+
+test("rejects duplicate attachment names", () => {
+  const attachment = { name: "dup.txt", data: "x" };
+
+  expect(renderer.render(doc, { attachments: [attachment, attachment] })).rejects.toThrow(
+    "DuplicateAttachment",
+  );
+});
+
+test("rejects an invalid attachment mime type", () => {
+  expect(
+    renderer.render(doc, { attachments: [{ name: "a.txt", data: "x", mimeType: "nope" }] }),
+  ).rejects.toThrow("InvalidMimeType");
+});
+
+test("rejects an invalid attachment modificationDate", () => {
+  expect(
+    renderer.render(doc, {
+      attachments: [{ name: "a.txt", data: "x", modificationDate: "yesterday" }],
+    }),
+  ).rejects.toThrow("modificationDate");
+});

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -63,6 +63,28 @@ export type PdfMetadata = {
   creationDate?: string;
 };
 
+/** A file attached to the PDF, shown in the viewer's attachment panel. */
+export type Attachment = {
+  /** File name in the PDF, e.g. "factur-x.xml". */
+  name: string;
+  /** The file's bytes, or a string encoded as UTF-8. */
+  data: Uint8Array | string;
+  /** IANA media type, e.g. "application/xml". The PDF/A-3 levels require one. */
+  mimeType?: string;
+  /** Human-readable description. The PDF/A-3 levels require one. */
+  description?: string;
+  /**
+   * How the file relates to the document (the PDF/A-3 AFRelationship).
+   * Defaults to "unspecified".
+   */
+  relationship?: "source" | "data" | "alternative" | "supplement" | "unspecified";
+  /**
+   * UTC modification date, `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS`; falls back
+   * to `metadata.creationDate`. The PDF/A-3 levels require one.
+   */
+  modificationDate?: string;
+};
+
 /** PDF/A conformance level. Validation failures reject the render. */
 export type Pdfa = "2a" | "2b" | "2u" | "3a" | "3b" | "3u" | "4";
 
@@ -104,6 +126,8 @@ export type PdfRenderOptions = {
   pdfa?: Pdfa;
   /** Structure-tree emission: `false`, `true` (default) or `"ua1"`. */
   tagged?: Tagged;
+  /** Files attached to the document. */
+  attachments?: Attachment[];
 };
 
 /** Options for `measure`: page geometry (or a viewport) plus layout resources. */

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -24,7 +24,8 @@ use takumi_core::{
   viewport::Viewport,
 };
 use takumi_pdf::{
-  MeasureOptions, PageMargins, PageOptions, PdfDate, PdfMetadata, PdfOptions, PdfStandard, Tagging,
+  Attachment, AttachmentRelationship, MeasureOptions, PageMargins, PageOptions, PdfDate,
+  PdfMetadata, PdfOptions, PdfStandard, Tagging,
 };
 use wasm_bindgen::prelude::*;
 
@@ -223,6 +224,80 @@ struct PdfRenderOptions {
   /// Structure-tree emission: `false`, `true` (default) or `"ua1"` to also
   /// validate against PDF/UA-1.
   tagged: Option<TaggedInput>,
+  /// Files attached to the document.
+  attachments: Option<Vec<AttachmentInput>>,
+}
+
+/// A file attached to the document.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AttachmentInput {
+  name: String,
+  data: AttachmentData,
+  mime_type: Option<String>,
+  description: Option<String>,
+  relationship: Option<RelationshipInput>,
+  /// UTC modification date as `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS`.
+  modification_date: Option<String>,
+}
+
+/// Attachment bytes, or a string encoded as UTF-8.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AttachmentData {
+  Bytes(ByteBuf),
+  Text(String),
+}
+
+/// AFRelationship names accepted from JS.
+#[derive(Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum RelationshipInput {
+  Source,
+  Data,
+  Alternative,
+  Supplement,
+  Unspecified,
+}
+
+impl From<RelationshipInput> for AttachmentRelationship {
+  fn from(relationship: RelationshipInput) -> Self {
+    match relationship {
+      RelationshipInput::Source => Self::Source,
+      RelationshipInput::Data => Self::Data,
+      RelationshipInput::Alternative => Self::Alternative,
+      RelationshipInput::Supplement => Self::Supplement,
+      RelationshipInput::Unspecified => Self::Unspecified,
+    }
+  }
+}
+
+impl TryFrom<AttachmentInput> for Attachment {
+  type Error = js_sys::Error;
+
+  fn try_from(input: AttachmentInput) -> Result<Self, Self::Error> {
+    let modification_date = input
+      .modification_date
+      .as_deref()
+      .map(|value| {
+        parse_date(value).ok_or_else(|| {
+          js_sys::Error::new("invalid modificationDate: expected YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS")
+        })
+      })
+      .transpose()?;
+
+    Ok(Self {
+      name: input.name,
+      data: match input.data {
+        AttachmentData::Bytes(bytes) => bytes.into_vec(),
+        AttachmentData::Text(text) => text.into_bytes(),
+      },
+      mime_type: input.mime_type,
+      description: input.description,
+      relationship: input.relationship.map(Into::into).unwrap_or_default(),
+      modification_date,
+    })
+  }
 }
 
 /// `tagged` values accepted from JS.
@@ -534,6 +609,12 @@ impl PdfRenderer {
       outline: options.outline.unwrap_or(false),
       standard: options.pdfa.map(PdfStandard::from).unwrap_or_default(),
       tagged: options.tagged.map(Tagging::from).unwrap_or_default(),
+      attachments: options
+        .attachments
+        .unwrap_or_default()
+        .into_iter()
+        .map(Attachment::try_from)
+        .collect::<Result<_, _>>()?,
     })
     .map_err(map_error)
   }

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -63,6 +63,7 @@ use crate::krilla::{
   color::rgb,
   configure::{Accessibility, Archival, ConfigurationBuilder},
   destination::XyzDestination,
+  embed::{AssociationKind, EmbeddedFile, MimeType},
   error::KrillaError,
   geom::{
     Path as KrillaPath, PathBuilder, Point, Rect as KrillaRect, Size as KrillaSize, Transform,
@@ -133,6 +134,10 @@ pub enum PdfError {
   MissingViewport,
   /// The requested archival standard could not be configured.
   InvalidStandard,
+  /// An attachment's mime type is not a valid `type/subtype` pair.
+  InvalidMimeType(String),
+  /// Two attachments share the same file name.
+  DuplicateAttachment(String),
 }
 
 impl From<TakumiError> for PdfError {
@@ -251,6 +256,56 @@ pub struct PdfOptions<'g> {
   /// `A3a`) force it on.
   #[builder(default)]
   pub tagged: Tagging,
+  /// Files attached to the document, shown in the viewer's attachment panel.
+  /// The PDF/A-3 levels require each to carry a mime type, a description, and
+  /// a modification date ([`PdfMetadata::creation_date`] is the fallback).
+  #[builder(default)]
+  pub attachments: Vec<Attachment>,
+}
+
+/// A file attached to the document.
+#[derive(Clone)]
+pub struct Attachment {
+  /// The file name in the PDF, e.g. `factur-x.xml`.
+  pub name: String,
+  /// The file's bytes.
+  pub data: Vec<u8>,
+  /// IANA media type, e.g. `application/xml`.
+  pub mime_type: Option<String>,
+  /// Human-readable description.
+  pub description: Option<String>,
+  /// How the file relates to the document (the PDF/A-3 AFRelationship).
+  pub relationship: AttachmentRelationship,
+  /// UTC modification date; falls back to [`PdfMetadata::creation_date`].
+  pub modification_date: Option<PdfDate>,
+}
+
+/// How an attached file relates to the document it is embedded in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AttachmentRelationship {
+  /// The document was created from this file.
+  Source,
+  /// The file was used to derive a visual presentation in the document.
+  Data,
+  /// An alternative representation of the document.
+  Alternative,
+  /// Additional resources for the document.
+  Supplement,
+  /// No clear relationship, or it is not known.
+  #[default]
+  Unspecified,
+}
+
+impl AttachmentRelationship {
+  fn association_kind(self) -> AssociationKind {
+    match self {
+      Self::Source => AssociationKind::Source,
+      Self::Data => AssociationKind::Data,
+      Self::Alternative => AssociationKind::Alternative,
+      Self::Supplement => AssociationKind::Supplement,
+      Self::Unspecified => AssociationKind::Unspecified,
+    }
+  }
 }
 
 /// Document metadata for the PDF's info dictionary. [`PdfOptions::lang`]
@@ -311,17 +366,19 @@ fn build_metadata(metadata: &PdfMetadata, lang: Option<Lang>) -> Metadata {
     result = result.language(lang.as_str().to_string());
   }
   if let Some(date) = metadata.creation_date {
-    result = result.creation_date(
-      DateTime::new(date.year)
-        .month(date.month)
-        .day(date.day)
-        .hour(date.hour)
-        .minute(date.minute)
-        .second(date.second)
-        .utc_offset_hour(0),
-    );
+    result = result.creation_date(krilla_datetime(date));
   }
   result
+}
+
+fn krilla_datetime(date: PdfDate) -> DateTime {
+  DateTime::new(date.year)
+    .month(date.month)
+    .day(date.day)
+    .hour(date.hour)
+    .minute(date.minute)
+    .second(date.second)
+    .utc_offset_hour(0)
 }
 
 /// Per-side page margins in px.
@@ -870,6 +927,32 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
   } else if tag_collector.is_some() && inputs.lang.is_some() {
     // Tagged standards check the document language even without metadata.
     document.set_metadata(build_metadata(&PdfMetadata::default(), inputs.lang));
+  }
+
+  let fallback_date = options.metadata.as_ref().and_then(|m| m.creation_date);
+
+  for attachment in options.attachments {
+    let mime_type = match attachment.mime_type {
+      Some(mime) => Some(MimeType::new(&mime).ok_or(PdfError::InvalidMimeType(mime))?),
+      None => None,
+    };
+    let file = EmbeddedFile {
+      path: attachment.name.clone(),
+      mime_type,
+      description: attachment.description,
+      association_kind: attachment.relationship.association_kind(),
+      data: attachment.data.into(),
+      modification_date: attachment
+        .modification_date
+        .or(fallback_date)
+        .map(krilla_datetime),
+      compress: None,
+      location: None,
+    };
+
+    document
+      .embed_file(file)
+      .ok_or(PdfError::DuplicateAttachment(attachment.name))?;
   }
   match options.page {
     Some(page) => {

--- a/takumi-pdf/tests/fixtures-generated/invoice-pdfa-3b-attachment.pdf
+++ b/takumi-pdf/tests/fixtures-generated/invoice-pdfa-3b-attachment.pdf
@@ -1,0 +1,487 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<</Type/Pages/Count 2/Kids[111 0 R 112 0 R]>>
+endobj
+2 0 obj
+<</Type/OutputIntent/DestOutputProfile 120 0 R/S/GTS_PDFA1/OutputConditionIdentifier(Custom)/OutputCondition(sRGB)/RegistryName()/Info(sRGB v4.2)>>
+endobj
+3 0 obj
+[2 0 R]
+endobj
+4 0 obj
+<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[104 0 R]/ParentTree<</Nums[0 5 0 R 1 6 0 R]>>/ParentTreeNextKey 2>>
+endobj
+5 0 obj
+[7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 11 0 R 11 0 R 11 0 R 11 0 R 11 0 R 11 0 R 12 0 R 13 0 R 13 0 R 14 0 R 15 0 R 16 0 R 16 0 R 16 0 R 16 0 R 17 0 R 17 0 R 18 0 R 19 0 R 19 0 R 19 0 R 19 0 R 20 0 R 20 0 R 21 0 R 22 0 R 22 0 R 22 0 R 22 0 R 23 0 R 23 0 R 24 0 R 25 0 R 25 0 R 25 0 R 25 0 R 26 0 R 26 0 R 27 0 R 28 0 R 28 0 R 28 0 R 28 0 R 29 0 R 29 0 R 30 0 R 31 0 R 31 0 R 31 0 R 31 0 R 32 0 R 32 0 R 33 0 R 34 0 R 34 0 R 34 0 R 34 0 R 35 0 R 35 0 R 36 0 R 37 0 R 37 0 R 37 0 R 37 0 R 38 0 R 38 0 R 39 0 R 40 0 R 40 0 R 41 0 R 42 0 R 42 0 R 42 0 R 42 0 R 43 0 R 43 0 R 44 0 R 45 0 R 45 0 R 45 0 R 45 0 R 46 0 R 46 0 R 47 0 R 48 0 R 48 0 R 48 0 R 48 0 R 49 0 R 49 0 R 50 0 R 51 0 R 51 0 R 51 0 R 51 0 R 52 0 R 52 0 R 53 0 R 54 0 R 54 0 R 55 0 R 56 0 R 56 0 R 56 0 R 56 0 R 57 0 R 57 0 R 58 0 R 59 0 R 59 0 R 59 0 R 59 0 R 60 0 R 60 0 R 61 0 R 62 0 R 62 0 R 62 0 R 62 0 R 63 0 R 63 0 R 64 0 R 65 0 R 65 0 R 65 0 R 65 0 R 66 0 R 66 0 R 67 0 R 68 0 R 68 0 R 68 0 R 68 0 R 69 0 R 69 0 R 70 0 R 71 0 R 71 0 R 71 0 R 71 0 R 72 0 R 72 0 R 73 0 R 74 0 R 75 0 R 75 0 R 75 0 R 75 0 R 76 0 R 76 0 R 77 0 R 78 0 R 78 0 R 78 0 R 78 0 R 79 0 R 79 0 R 80 0 R 81 0 R 81 0 R 82 0 R 83 0 R 83 0 R 83 0 R 83 0 R 84 0 R 84 0 R 85 0 R 86 0 R 86 0 R 86 0 R 86 0 R 87 0 R 87 0 R 88 0 R 89 0 R 90 0 R 90 0 R 90 0 R 90 0 R]
+endobj
+6 0 obj
+[87 0 R 87 0 R 88 0 R 89 0 R 90 0 R 90 0 R 90 0 R 90 0 R 91 0 R 91 0 R 92 0 R 93 0 R 93 0 R 93 0 R 93 0 R 94 0 R 94 0 R 95 0 R 96 0 R 96 0 R 96 0 R 96 0 R 97 0 R 97 0 R 98 0 R 99 0 R 99 0 R 99 0 R 99 0 R 100 0 R 100 0 R 101 0 R 101 0 R 102 0 R 102 0 R 103 0 R 103 0 R]
+endobj
+7 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[0]/Pg 111 0 R>>
+endobj
+8 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[1]/Pg 111 0 R>>
+endobj
+9 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[2]/Pg 111 0 R>>
+endobj
+10 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[3]/Pg 111 0 R>>
+endobj
+11 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[4 5 6 7 8 9 10]/Pg 111 0 R>>
+endobj
+12 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[11]/Pg 111 0 R>>
+endobj
+13 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[12 13]/Pg 111 0 R>>
+endobj
+14 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[14]/Pg 111 0 R>>
+endobj
+15 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[15]/Pg 111 0 R>>
+endobj
+16 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[16 17 18 19]/Pg 111 0 R>>
+endobj
+17 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[20 21]/Pg 111 0 R>>
+endobj
+18 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[22]/Pg 111 0 R>>
+endobj
+19 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[23 24 25 26]/Pg 111 0 R>>
+endobj
+20 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[27 28]/Pg 111 0 R>>
+endobj
+21 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[29]/Pg 111 0 R>>
+endobj
+22 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[30 31 32 33]/Pg 111 0 R>>
+endobj
+23 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[34 35]/Pg 111 0 R>>
+endobj
+24 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[36]/Pg 111 0 R>>
+endobj
+25 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[37 38 39 40]/Pg 111 0 R>>
+endobj
+26 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[41 42]/Pg 111 0 R>>
+endobj
+27 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[43]/Pg 111 0 R>>
+endobj
+28 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[44 45 46 47]/Pg 111 0 R>>
+endobj
+29 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[48 49]/Pg 111 0 R>>
+endobj
+30 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[50]/Pg 111 0 R>>
+endobj
+31 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[51 52 53 54]/Pg 111 0 R>>
+endobj
+32 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[55 56]/Pg 111 0 R>>
+endobj
+33 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[57]/Pg 111 0 R>>
+endobj
+34 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[58 59 60 61]/Pg 111 0 R>>
+endobj
+35 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[62 63]/Pg 111 0 R>>
+endobj
+36 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[64]/Pg 111 0 R>>
+endobj
+37 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[65 66 67 68]/Pg 111 0 R>>
+endobj
+38 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[69 70]/Pg 111 0 R>>
+endobj
+39 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[71]/Pg 111 0 R>>
+endobj
+40 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[72 73]/Pg 111 0 R>>
+endobj
+41 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[74]/Pg 111 0 R>>
+endobj
+42 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[75 76 77 78]/Pg 111 0 R>>
+endobj
+43 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[79 80]/Pg 111 0 R>>
+endobj
+44 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[81]/Pg 111 0 R>>
+endobj
+45 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[82 83 84 85]/Pg 111 0 R>>
+endobj
+46 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[86 87]/Pg 111 0 R>>
+endobj
+47 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[88]/Pg 111 0 R>>
+endobj
+48 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[89 90 91 92]/Pg 111 0 R>>
+endobj
+49 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[93 94]/Pg 111 0 R>>
+endobj
+50 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[95]/Pg 111 0 R>>
+endobj
+51 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[96 97 98 99]/Pg 111 0 R>>
+endobj
+52 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[100 101]/Pg 111 0 R>>
+endobj
+53 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[102]/Pg 111 0 R>>
+endobj
+54 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[103 104]/Pg 111 0 R>>
+endobj
+55 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[105]/Pg 111 0 R>>
+endobj
+56 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[106 107 108 109]/Pg 111 0 R>>
+endobj
+57 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[110 111]/Pg 111 0 R>>
+endobj
+58 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[112]/Pg 111 0 R>>
+endobj
+59 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[113 114 115 116]/Pg 111 0 R>>
+endobj
+60 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[117 118]/Pg 111 0 R>>
+endobj
+61 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[119]/Pg 111 0 R>>
+endobj
+62 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[120 121 122 123]/Pg 111 0 R>>
+endobj
+63 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[124 125]/Pg 111 0 R>>
+endobj
+64 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[126]/Pg 111 0 R>>
+endobj
+65 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[127 128 129 130]/Pg 111 0 R>>
+endobj
+66 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[131 132]/Pg 111 0 R>>
+endobj
+67 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[133]/Pg 111 0 R>>
+endobj
+68 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[134 135 136 137]/Pg 111 0 R>>
+endobj
+69 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[138 139]/Pg 111 0 R>>
+endobj
+70 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[140]/Pg 111 0 R>>
+endobj
+71 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[141 142 143 144]/Pg 111 0 R>>
+endobj
+72 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[145 146]/Pg 111 0 R>>
+endobj
+73 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[147]/Pg 111 0 R>>
+endobj
+74 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[148]/Pg 111 0 R>>
+endobj
+75 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[149 150 151 152]/Pg 111 0 R>>
+endobj
+76 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[153 154]/Pg 111 0 R>>
+endobj
+77 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[155]/Pg 111 0 R>>
+endobj
+78 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[156 157 158 159]/Pg 111 0 R>>
+endobj
+79 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[160 161]/Pg 111 0 R>>
+endobj
+80 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[162]/Pg 111 0 R>>
+endobj
+81 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[163 164]/Pg 111 0 R>>
+endobj
+82 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[165]/Pg 111 0 R>>
+endobj
+83 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[166 167 168 169]/Pg 111 0 R>>
+endobj
+84 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[170 171]/Pg 111 0 R>>
+endobj
+85 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[172]/Pg 111 0 R>>
+endobj
+86 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[173 174 175 176]/Pg 111 0 R>>
+endobj
+87 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[177<</Type/MCR/MCID 0/Pg 112 0 R>>178<</Type/MCR/MCID 1/Pg 112 0 R>>]/Pg 111 0 R>>
+endobj
+88 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[179<</Type/MCR/MCID 2/Pg 112 0 R>>]/Pg 111 0 R>>
+endobj
+89 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[180<</Type/MCR/MCID 3/Pg 112 0 R>>]/Pg 111 0 R>>
+endobj
+90 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[181<</Type/MCR/MCID 4/Pg 112 0 R>>182<</Type/MCR/MCID 5/Pg 112 0 R>>183<</Type/MCR/MCID 6/Pg 112 0 R>>184<</Type/MCR/MCID 7/Pg 112 0 R>>]/Pg 111 0 R>>
+endobj
+91 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[8 9]/Pg 112 0 R>>
+endobj
+92 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[10]/Pg 112 0 R>>
+endobj
+93 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[11 12 13 14]/Pg 112 0 R>>
+endobj
+94 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[15 16]/Pg 112 0 R>>
+endobj
+95 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[17]/Pg 112 0 R>>
+endobj
+96 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[18 19 20 21]/Pg 112 0 R>>
+endobj
+97 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[22 23]/Pg 112 0 R>>
+endobj
+98 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[24]/Pg 112 0 R>>
+endobj
+99 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[25 26 27 28]/Pg 112 0 R>>
+endobj
+100 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[29 30]/Pg 112 0 R>>
+endobj
+101 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[31 32]/Pg 112 0 R>>
+endobj
+102 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[33 34]/Pg 112 0 R>>
+endobj
+103 0 obj
+<</Type/StructElem/S/P/P 104 0 R/K[35 36]/Pg 112 0 R>>
+endobj
+104 0 obj
+<</Type/StructElem/S/Document/P 4 0 R/K[7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 75 0 R 76 0 R 77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R 87 0 R 88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R 97 0 R 98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R]>>
+endobj
+105 0 obj
+[/ICCBased 120 0 R]
+endobj
+106 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 105 0 R>>/Font<</f0 108 0 R>>>>
+endobj
+107 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 105 0 R>>/Font<</f0 108 0 R>>>>
+endobj
+108 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/UELGNI+Archivo-SemiBold/Encoding/Identity-H/DescendantFonts[109 0 R]/ToUnicode 115 0 R>>
+endobj
+109 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/UELGNI+Archivo-SemiBold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 110 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 652 1 1 717 2 2 282 3 3 728 4 4 794 5 5 672 6 6 570 7 7 732 8 8 721 9 9 583 10 10 541 11 11 314 12 12 598 13 13 861 14 14 561 15 15 362 16 16 200 17 17 336 18 18 695 19 20 576 21 21 577 22 23 576 24 24 575 25 26 576 27 27 584 28 28 529 29 29 252 30 30 547 31 31 300 32 33 575 34 34 592 35 35 556 36 36 298 37 37 670 38 38 724 39 39 782 40 40 529 41 41 357 42 42 546 43 43 252 44 44 671 45 45 709 46 46 619 47 47 357 48 48 250 49 49 444 50 50 706 51 51 543 52 52 592 53 53 966 54 54 307 55 55 580 56 56 686 57 57 667 58 58 844 59 59 584 60 60 333 61 61 841 62 62 592 63 63 591 64 64 609 65 65 732 66 66 782 67 67 592 68 68 300 69 69 585 70 70 954 71 71 758 72 72 245 73 73 636 74 74 998 75 75 509]>>
+endobj
+110 0 obj
+<</Type/FontDescriptor/FontName/UELGNI+Archivo-SemiBold/Flags 131076/FontBBox[-29 -192 953 736]/ItalicAngle 0/Ascent 878/Descent -210/CapHeight 686/StemV 144.2/CIDSet 114 0 R/FontFile2 116 0 R>>
+endobj
+111 0 obj
+<</Type/Page/Resources 106 0 R/MediaBox[0 0 595.27563 841.88983]/StructParents 0/Parent 1 0 R/Contents 117 0 R>>
+endobj
+112 0 obj
+<</Type/Page/Resources 107 0 R/MediaBox[0 0 595.27563 841.88983]/StructParents 1/Parent 1 0 R/Contents 118 0 R>>
+endobj
+113 0 obj
+<</Type/Filespec/F(factur-x.xml)/UF(factur-x.xml)/EF<</F 119 0 R/UF 119 0 R>>/AFRelationship/Alternative/Desc(Factur-X invoice data)>>
+endobj
+114 0 obj
+<</Length 13/Filter/FlateDecode>>
+stream
+xœûÿ
+>  6Ä	è
+endstream
+endobj
+115 0 obj
+<</Length 671/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm”IoÛ0FïúÓƒ€äš"))	^"À‡,ˆƒöìˆcW€M	Zş÷ù“ èÁ6¸Ì¼yÒ¯Û›…k?øÆüTôÆC;õ5ß¬v]’¦ë¶NìÇgfÇî²:ÜS×·õÀ#­6ëoÆ$M7¾>N/{ş·eÉ‡Æm1h5c{JÒô½|OWx@1'Ú8öc3I]'iú‹û¡iı=eIš>z·jO!¹!™Iš½öm½å‘öw½D¢7É4¹¦…âw}Úuñğö<Œ|Úø}K»ÜÔÉN"¢ÙšaìÏt»&Ç{¬¼ôûÆèê’ì·ÅíÔuGI’ŠOÙ»ø;òÏ»ÓL„?ŸŠ%e_ŞÏË³ßO­»@†ëÖñĞíjîwşÀÉƒRJÍé¡ªªj"ş³^æ8ö±¯ÿìú¸=›ÓƒR¹GÒ‘ìÈ€,È‚JPÊAh*A [İE*åÜ$kKÄ[E**Ğ´=‚ä–
+çà…(¥~f¿%~&ÁÏÜ‚àgK?S€àg$üŒÄƒŸQ?ƒšeğ+P—~¥Ü)~¨|&~rü4Îiø¸kñÃ9¿YkøğÓğÓ¨§†_¬5ür¹~¹œƒ_)à§Q%-ı?¼~9ü4ü¬Ü	¿\ò?D0ğ+Ğ1?ZéŸø¡›~%Œü4Œü
+äb‚ŸVäià—ÃÁÀ/Gåü,Ş:#~²~ZÖ¤…|ÄEú(ùÂ³ÀÛ`ái‘“…§ÅİV<Ñ+Ïµ³ÒGdoåˆjYé£D@K!é£œ“>¢vV<Q;+ÿÃE!2+Â0	3ószÕSß³ãÈŒ£*Ì¥ÆóçìíÚ.œŠŸ8´/ó?ĞKõUl•6
+endstream
+endobj
+116 0 obj
+<</Length 5930/Filter/FlateDecode>>
+stream
+xœYtÕ™şïiF–dÉ²4zZ²F£‡_zF²$[¶“Ø±9vüŠóp'vl'NlçeÒ4hK(”äğÏm·	 ¦»]
+†İRh{ØÓRNIÛS
+]è¶”G»[êRbiÏÉÆ	t{ÎZG+itïÿÿû¿ÿû¯ @	œ
+Ê&¦ï9©=ñ Ü`›³Í?pÀ ›œeîG9 [= ¸'÷Ï{kvØ¶ ĞôÌîÑnı¯W *n€{ö›…!ø6€½
+ œF÷¯ûR%€½€º<;sh®ëáßŒpë à³Çg'é›op©€9d p3~( ¡Ô tœÎÃù˜¸é_œË ÅÜvÔá…Ğmrág–ÖEò/çó9Œry°4Ï7q4`–fˆ¬fô¼guB$&F½^Ï ©ÌX¤!yë­'şëHÌpıg£;[ÖNXsÈçÑtRàüf DæƒŸà,Pd6A—9³K½ÅuÅYP^±Íû„H‹b4€É*úÉ3==g&o¿=Ô±Z#¡Ûq¶óÎ#‡ïêœ©ˆ÷ÅÙú¾xYEÌ/âŸá¨»¼b4"Ìòd—³¬Áh"±˜(ò"§ã}Œnxàbß¹kæ¶D¾`Öxâ}q[`¸5µEx«ëzÕ>yü\—£q{'ğ:{j(Ånš»[#Ìtî¶ŒÃ§/ìOá,¨¤=°Ë6åö¡©Üè^œ9?óäLñ^/Î‚¼à	ÍœFC8»ôü5E?áÛp¶à9°IˆFE ã‘×ëãV—9<rË?wmîW
+V&ÇÙÜ>š5Ğk):»Ô‹îRóL©M“›şü">€“<B\"ó$|.šşÄ#‚¦ÑüÔÙî‹çnÚtcm&¼nkmí–ÖèÆÚS=7©;ÏøçlòğÖH«[œì2nœŒò­‘­‡ÄæÆü"¦±„“ËKŒ58°4)±ÛÇkğÛ™‘ùR‹ÛÈ‰•óãJ¦<Ü¤îC»sÿTá1)	7Š,½ßfö°d¶ªü"ú¶Àbq ‹Qb›-Îõz}JŒ¦±YÍòItF£ÉA±FšÄ`Ò!gÔnVVµx¸5"çjè»•è¨©Öiv›ÔÁáÎ´TñMjK]Š—+0–a§QYÖŠre‰Ñ«ò%}ƒGt2Äème
+M¹Jo,+Q²Îd(Ğâ+¥ùEÄá‡À$íß+êxQˆ¬Àò:ƒQXşq¸ŞÔ´Æ8ºm›ÑTÚj_£EÆî¸c,÷+ÖÔ/cä |ùEÄVĞ®ŠV!\šöI°]6T;8—LÎn>”LÚJÙl©ô_šß1r<•:>²c>5æÙP¯©ßà)^ˆ‡[ ('¶‚_Â˜I ¾4/FVÇë¤t¡é+†-{”Œ®.á
+´] ¶×Ì«ÙÊr{ÀV¸mXCbè­3{X×Æ–Ü¨Çæa•ÎzOî'«†Ë;Ub+T€÷ª²	t‹‚Aƒ)¡¸<âûgëëgû3ÑÜ=Ø÷›ªºc|SöM­Íkö‰Å='ìp‡×rj‹×é™Ñ.à(µÆŠ»F;±ôWìš•#íNipe6ÆSâÊ°¦ÏRk£©C:wÌû#±y
+ ŞÂ €Ğ‹K‰;uòäItë©S¹ƒ§N³÷áetH@ˆ§’á¡r í=/îÇÙÜs({77‰wşŒ`+ÎB)€ 
+:^Lã¸ Ø]_ûºcS¿«á®1tqeré—  .¿ˆõxlàaÅ{ñ+ĞÂ¬`FŒÀ°£~Õ9§#b2ˆŒoØ0&ƒ©hdß`¢¡!‘hlL„âñP8SÇ¶ÅëL–Maq0Ã›,¦úø¶ØîDD¨¯"	”BAQ†âßJ \!ÙœÈI»ĞÈALSÒvxuå^®ZWo8UZ
+U«Ÿ-)×ièäÀÀİckn¾g@œİ»mmÙãúZ­!w~ìnÀ ä±/€"Ë\PÄè2}1Å×Ëù±œ$;‚©á5.®i{jÃºú.Ñ!Ú×\İ¾½®a²Ã6›Ã^oÄl¨]]×ì»mĞ›ØÙèlâ®u
+»9µ§¥uO|Ì•ä=	Kxù$ˆøëğÔ’XEÓ8ÆŸ¤$¿ÂKÌh0Ã±‚3¶ÖUÓ0ø½Şˆeáµ3-ë6‡õ\²ÛoªãJP;çïlŒ[*›:ülM…%àª–´Ûj«ÒmöPwk“³Ìé,; "ùE\Š@ÕŞ(,öìà¬J;é¡úúÍäº¹>Ôé‚Á@X§«¹›¦¦nêá–¯cÂø†h×„ Œg¢™	)gd¯±"ÆD5W*¿¸ÌÆÅ½¯¦*†-\‘«û@âDº^læ\¢Á¶[öÊõDrbÍº‰¤=R)®oœVÃimyDŒÄkıåcÆ ïª1°µ\™%1¨ío¬JUieeıë‡‚Äª  6ã,”$ œÈ±ËŞQİ6èÏGïºÚ×Š•ı9é©ŞuàÈçš¤İ´ `¶‚euö_Iv„ÊÃMŞHWİµÅbU`4wÏÚÜ9Ô%Õªƒ!R½±k$}E	&R§Ó8¨?5@ëÊi9]¦cúO|kŞÓ%-¦†¤ş½¥÷Kài|iè]Ëüü<™›[zk–ŞD]ÆVp¯æGIÊ|ºpk0ªèİ‹ïß$ö¦'Œ~¾:j±Äê\~óG²¯HVqcÔ²x7$Jë3K„oŒU ‚A ø¹¤g	ÿ°ƒŸ—˜,_Äœ]ágay¹åÌóé9–[•¨²}ÃÉŠ(ïŠØ+"Ns•C5W¾œ{C¥q‡‰í±ä>ul¼Í›p8ı5q[™¥L‹NÌœW–«C»2öÆ	ÇÖ1^ÌøUëÆ5˜_íR®Îxãr¦‡uHîkªnßîo˜\“Ú!Ñ@RÊu¯”÷êÄhÉôİk‡95ÑÜ6'°÷öA/ã’w‚s%Ü·\«´ø°PU¬ïE¨›Åó>~¥6Dlù°y‡İt7Êh¢x,¥5Q‹Æî¯ô‹&“¨NÎï9,ãÌ/ùÛª«§¼íÑR_ºÆÈwÔkâí<`på±[!Mdİb¾¯¦›è'USÒ4M\Dô–OÏE¿¼`Lˆ®ĞæãíÇSSvÅv6µŒ¥N¥·ÂZ]AÓº`“Ì¬ÔÅ‡ã:^­r¤B±õÕºZ“›-·j4r%ã_ÃWuŠêËúe*ÓÈråcåÎ€Í¬ñòå6-ÉÈ¿„jğëE¬^ ^z9L•]şï¢Â¿gAÆ+ş•}ÄPfw$:ÑõÒ"qs€ÿÎÆv­[;_D»SQ>díùE|3Î’ú-!ƒÈL‰È€¦ÑÔÖÓ­§û2™Óm§ÕÉ£[ĞÅ\÷¦Mİè±\Ï–£IÀàÏŸÄ¿Á`úíúQ…ªiò¬4…nÁ±õ B§Øw__ß}û¦ïí¸;÷İhw¬¢"ÖvÇl¶X÷é£¨ëşcÇÏuu;şù‡<g~çHmN“C)‡#5”4&6§cä;%Æ°K(òI_¦ŠP‡†ú¢'@Õ³5.Å‹§v1Ú2¹\¦T©e='.j=áµO¨Ğf£×„5—uÑ¸Që­òj–r¥5©25çw£~ƒğ‘© „¢"~·wh¨·Û›æù´÷Üğ['æßŞÖxÇ7>t¦(%>ÕHêCïLB\š<FùÌ7ÏLÒ{ÿîâÂWÓG6ÿÈ#—sÿùÄ.-2˜¤rZæñ¥%q®³8Klà(A_äD½@!ÙG·<"S((9Å(dñ#œÍU)­¦…Ñ¢F¯,õ’<#Œú,Î 	ˆ÷qŒ^ğ(‚hFTÔ·Äs?Œï|«U¦R«årZW&'}äW¿Š`AYéñjÑ@) Âò¸Wšˆ¢âX^·ø*N¼†Ó³³KÏªÛ.äÁ¯[õ…àó…Zî»¶oóæ¾n_#Ï7úğëÄaom'ë~ğL# Îÿ6ßYÜ½¾Èß$éÄOØ2Zãt(#¬iŞTOHıòdŒ¬ßdÄÑ¥ç¹t`H£;ÑR¨ĞûDeéÿÆ²S¦ıe§LèÎî¸ãòJÊ âW=ØÁ·:‡Vj¤nùªºLrêH|sÄ!8½®ÄHjñ·Õ¢ÑÏ¿ú²£šz_ÁÙšŒàk®UÉşVsõŒ?TQcÚoôšêjŠõR‡/-+Ù*¶eş_¾rqáæñ¥Ü¶7~œû×w6ÜOjZ¾Wck‘#I}ıD8‰Õ_¥P¸e\ÉXû…–a!º-%1åQ‰ıÕ"aÊÇñÓmÕÕÉù;æ	Q¾‹”|{\SßÁ{;Dµ¯±ÆrØ’_¤à)¤f´C}ºwZ^šP%ú¿?^@ŒæöH§Ï×Ú}¾v¡Úª²Ûªl6ôa¤Ãçëˆ^oy·¢¢Êj%D›¸­m9nc[k·³3(uø-qi –ÛrÅ'ñ€ZúDˆj €_%½#Aª°R\XÉÒCnÍdLÉ¨¶²B1šFFĞ…±µ|S•Œ‘˜Œc¹A‚÷¢R”¡R¢q^Ò”ÔçË¶Àò´5LËK-uœ¥it¡iï@JÛÑˆPc‡65°·©"n1Ô™"ƒÍåï|ŒĞÇï”7FLuK\Í5oMdå%%º’Lbk“K¡ØÅ0\sPz¯\‘	´p³K¡ D°ƒ)v6zJâJÏS<¥úËÜ%¿ëìŞ‘Î¢IÔöæ›¹§sw¢’Ü_Šg$ªÍ«O ¤R&DÒ”Ğ+Òw¹û'•ÎAÎ@h”ILöĞõÈÛæYånìÚÔÕè®Ş0–ŠvÖ\Ç7Õø›]Åw7\¯¶ˆİ1ZMa•ŒZZÖªµ{­¬±²nm0Ô4™Â¢j¥½Ê¨ãÌ—Ù`rø×ºvÉvg9¹Šïˆ¨ŒÅDÂZO‘p80«Ë¼8M«U”+TÌôNcJËÊ™k]Ckµ´aŒ³¹Ó†H@§­ÌèsK½h[`ûº¤¡Í’;Š¾Ä¦Ò&Û†®ÊÜ×VÔì¥¢šÕ}¦šgt”{µ˜½”Ë³Nıg©Ù*øò 6ÂèqQ`«–~1;K6§ øU¨… é}>¡ŸXò@Ee{z4'£še Ï?ˆæçç¯Äó•ĞFrƒ«d±Ä4‹¸zYÉ]^Ïğ«<påAIñÄ	ıVF9>O—Ü©mQax¢À4•~»Æ"ª««Ûğ¥\ÎÌ•%ìœON™ÆX“ö•FÛ½@.ß‰[ğ8ˆ°6­èÀøU½·)‹“ƒ´bÿÍÚmAˆ¬jÉùS-¹ñ.>í*Möz·Ç'îi·ÇŒ¼µ…\«°»}kbõ¿OuûëŸûŞ®ãÌÿfvV¥?Sğ‰ŠxUPª®ªğúS{ Ş]§P°¢ñ
+cÚï©+/+5t5øÛk†JÍZ«Õn2ÙÑT¸®.ª³×—O8%«Î0uô^î,ZŸ{
+ggœÉ½½ê„²X8"‚uœ.s5Ÿ>{gsï ÓR/òå^‘4×¢¤¹´…®õjâ½Zn¡/®H­¾{§¯Zê™uìş®Ÿ¥²ˆZïÃÚåJ$'9¸JäÒQ…EW·Êg%`$·G…ÍÂ€…QÿÑé¯ĞX¢5L— c~ÇÎùduuÛR+Rk}j±Ã»¬Ötç‡¥.J`ÓXäI»LÓİ‡6}ÒÓøˆ s†*NN¶K'pîü"F«´ìJo]Ô²úÌ¾úëâq1v}ı^u`ËZ¯×loAÏç{ÄJ‹ºˆ³P-uŸæ¡âúU£"ñ
+úşÂ—g(šÆrLÉehâ&
+/ärÏÌ?}v†bäX†ä4u gsë•¼W«®¨01è©Â•Íf.AO-õ¢ç4Fës«si@„+ğŸ°Fb¿Õjo•îã}Ä’ÌƒçNvĞ
+Ñ2ƒÖ]¿^Æ(0Õ~ø¾ëdªŠ¦U%i¬Éı‡±ÖA•×ğ4²å~§ñ¸KÕ.·U.½ÿ±>Ò1îÿ1Aa¾Î4¨‰ü0ü,uÇåıÄ·DLÖ <Á'GÂ J'±,*}úéÑgùÉ®—^Ú%AúóÔSx†`Ï22WÎS¨åFŠÿÛ}×•]¨¤êYÒœ®êÀĞ¯nøŞdçéó##]ã§[ìua#–—ÕÔ{B°²¶{ºYÍqNf…6'ZúªÍzGÒ·ı¡½Gßqám­¬¹m½Á^]Qîh+ïŞüämÇ¾>¬İú•ñuã­5z«ƒÖÛµJ[¬6Üì-«2pú2‹ºT^BW78ùµ¡ß˜Ê}#}û¾ĞÔóğµ>Z¢)éR¨Dëu6Úå,·BNïÑëX#å¿ˆˆhFkFÊÿAæşŒŒ	tÍX}îÖ1Òë†5©·ùÎˆ¶áÏ@Qo“»^]ªø¹¾Vß¤Ë+s{å¼ŒüFE&ï‚Ô#Rò y{^¹”’“¬¹ò/ƒo†~2È
+üKÈPVñƒÁIÈà× ƒ
+~¼±ªPJñ ø¨ahÁağ¡½Ğ/  ˜Âßn†QÜu¸*q3Ò³	"Ò{ÍÀíĞ‚u ‡ËĞ‚yğ¡:ÄMÀMPƒ{À‡ëÀ…j ğıÁ?ƒvJ~r?‡fì¥ô½@‰ r¼,hêà£üoÑ3ÆÏAWBîê‡°	 ÁëÀBXß~*²>ê‚*ª4ä>Ü:<ZØ§´VdS7î 7µ JüPğgÈàĞKıüh‰DÜ!ø<<?…7%Ñ(Z@ÿËq¾?ÇßÅ¯à?RÔê›Ô{2lVv³ìÛ²ŸÊ~'·Èİòùyù›tİAï§o¥_¤/3f&Â¤™aæzæó-æó®Â­H)*~©ø¸¤­dWÉ%RÚ”>å¬ò1•]Vµ«N©Q]RıI-ªçÔ×©Ï–ÚK#…xCöë_ëÂkß‘¬ ¾P#pÂ7Šcx¡8¦ ¿(e«î‘ƒ©‹cœÈ[3°QR4d¬ 3:S—€=V« †¾_«WK‘}Tk JYa-ÌÀ,‡ƒ00	sà„„¤§úaÆÁ	-pvÃ$LÁ˜'ôÀA˜½0»¥o´Àa˜ƒI˜ƒpœP%Í4³p’„ LÀ”tÇaØØ3°‚Ğûá LÁ.8‡Àıpfa‚W­Xı)ú`öÃ¬˜†1è…q˜€Ã0£p"€„ )è†.Øºjÿ§æ„qÉş)˜’–gù[ß¼Úº)É£à„98£0&İO,ÛN˜=àü«{üÕOÚ‹ş&^vÂz•|<µâë‚§J€äáÕ³Ì­Ì_ğ>‰mÁÎ6i¿$}’mspT²•D¾pÇ4LÁn‡pÆaœpH»"–¸’{û 2ÒÎÈ:®˜9sÅuàü”·ÃÔ}ÖºŸøõŒÂ”ë]0-}r´ˆ¯‚×Û 6Iã9H‚ó*‚İŞgaA@²aZòØA˜PÙ™ÿ×wŠ5!?uWÕ€b%  êÀ5PAƒ†`6C/ô@; v€l`° #Xal´ÌPëa”ƒ õ…í ‚mĞ	pCÔĞrğÀFèt )ˆA6@¢ :¡j!ı ?$a+Œ€x–µ>8#ß3²g„üø$ÊßxQvü/Ão˜İ
+endstream
+endobj
+117 0 obj
+<</Length 10925/Filter/FlateDecode>>
+stream
+xœí][,·q~ß_1ò%Q+=M²ÙlÆŠËvœ80òç! (Á® +úÿÈºğVÜ®Os÷ùåœog§kfë+^¾b‘üóE»Ë¡¶ûãğ‡¹<^ì~Ükgw“½ú½jÌıº©C]Â“é§»oîşıîÛwÿöùçïşğëùÍeıÅ/¾øÍ¯ïş|Yï½¬—õr¨ø¸¯ß}µ^¾ú¿Ëz«ı¦.ëıº¹Õ‡Ş.ë½rûæÖıò_}{÷Å——õòåwï¾^/f»|ùõEYuÙÜz1îòåã|ú§u]ÿ´®j¹zuh³+zI/WµÚò5³\ø’Ù7zm[®Î‡×6O/Yz[zi_®JÅOp¦ı„ôšï3á5ÍŸ`—ÿüò÷w¿ıòîw¿ıÃ€‹6å÷Õ6@ğ‘¹¬÷v/ÁE³_¬½<^Œõ<TÀ`oÿ·éÿ»oî¾¾û#}¹ëz¯ÍêÌªtúš~¿×öâœ¹ßÍğWîãEï—5Dÿ§ÓkñïJÿ–_ì½xí°—=Äşà¡6F&ğSSPƒMA­şX×¡- ˜¾rŞ”.Ú‚5î¢ŒJá¿—«ôı¢1ò¿]Œº_×UiA©Ì¢ğm_/ú¿ÔFìw5µ/ŠB[¹Å®á}Ü(ôº\¹èEÙÔÌ(öµZ¶Ux»Ö‹!ÃÚ,–ÕÛBßPÛEëğyŞá]õ¾ğCn9î½÷«Î^ñåÛÍÊÆŒZ4¾}>Öè¢‰&*õ\*ıEm{Ş¯e^5†é\Í¶˜5±G¯ÚEóß¾/Ú…¿ØÙ='³ :Rr”ï
+³/åŸà–äoµŞhUmÍ*öûº(xEíÅ‰Ïœ«G[IsşÛ†ñğJ„—ÅàcğæOò°’©6S©¶æ¢võšTÿhÑ[şó¥ÚÎ¡èº­câIş	w9ÃšÂ(ıš©«)®›ùşÂÑôy¾ÂP¨<=Ôhİôı¶oíáÑ§~Š&Ü}¦/ôQ@ÖMñG?†GŸú	>
+A›>>oqÓsß]U ãPO€›å¿œÑfÙÿù©•o3[ù¶_´Ö¡‘_µ²!=÷T+FşOi°ız¹ªØ ‡­üÛåÊ]‚^ÏûC¡ã•µè¿s:” àíî¾¹zÔ¬ šÕ>íL>ızÑ«|º}ıëº·|^S?ê–ë‘Øµyü£åJCâ÷ËUqÇ¾/WMo½¦Ìrå?„yu˜‰Ù83¹êUÅ.¹üÆ¿2şmÕàd½–Æ‹îŸø¾c"ğñbÔNE°'a$EªÑwß\”İ‡mËˆlï¨ßgF½Ú7êÆÄ`‡vPÄ|¡5šíÉĞŸDĞãe[i°)Ğ’D¤@xÑ”¶íDD¶{Ãš›FÛ^@üÍrå¼GlçÙ„»†BƒÎá˜|şxÙâ©DÈCB7‡wß\¶ÕÛ¶""Û¶Ãñ1uê¢¹Ñ_µ‰ºÍ¨ŠêÊï¦'aÅÔ%µë/Wm„@Ü J„ß|Ú§øx±î@bJ´%$İD˜ÃÛv""Û½NÁOU´«O³¹{cÌ–QµÅ2«ıË»‰-Ÿ`ÔÓ-U¦²Êˆ*G˜ğƒ™LDîíÂF
+!Xî¾¹Xç‡m{‘mß	&µN¦è8ÕV~µ÷û¾gR¨Çı0é&çLã;ĞĞg)a‘lühšŸ·\wÌr¹W›¦G—eót«Tp|¡ŸQréºìf¹_®ØÂŞ=ıíßû„º°G1:#²{Â-(„?d´Ñl6,"Tè6³:m#˜šÚßìEoîıÍ»×åªª¡ÚCÕe>5‡7©åŠãpŞ·ö½±•ÔoHùŒô|êÑ·ã0Mk4á;c–9Ë^õš'~²\c–yÕiQÁÕoÊ«Íûô^¿ï]úF/n‡°‰ˆÚ…İ)€«`ÈÛ…ZP„ôèÚÙÍ÷ıM€Í†Ê
+İfÖe m¾zvóu0!R‡ÒaFÄC˜95›ŒéŠè
+Eo%hA|;ÈæšÕ ³ºGĞÔE˜ØB‚¶UçõjF¾Byrr
+œ3Ì%‚Hg$9^ “S£¶;mï=·éÙ)`12¤Ò<7ä2Í¢}µD¾uV•şÇÙ
+ğË§~÷Y¢ùêË¡_^:Ë×j«ÕUïáy»ÀÒ„eeK{¼ä\ØşÖ!«Ù°)ÊÒÜ@á,S7ü„'*#;%¤Q¹Xˆä¯°á*fÑ•ãÓôõ²I@°Ü˜|wn‚^L%ÅÆS¡Ø´’£Ğh1Á8jÛÉmw‡Î}z†16jÑ/ÿ÷¼Ì :0¤mÀm%&$8Up>fGm[¡mÛ#gjúwS&7wWió¼*@ZÑ?9my“èµ
+EŸ&$²Ğ²…i»QÛNFh»ÛÔæ&z}š¦j½K{<Ö8tËkƒl÷=Q ©Ee6é\z~£‹¾T #”M
+¢óv"Ñ.„&êFm{¡mßŸ¹ißÆ>Æè#t®WrrtuØ¤1?Î²‹Ã4…¹`â!«ãJed“Â…æ£ÈV@F¯2N ¥hEåëYPû$£÷1³{š ĞS³·›½‹Û®*J“çeNU¾Ñ“ …‚CJŞJèP€·@å;fV ÍêAS3‹~e‚ŞòN†)oæa¤3’/DÊwĞ¶ŒÈöŞ#QÏ‹È"2´ª%ê\o =–½.¦NËjµU0W‘ÿ¿T~ÊªùG‹®ÖBš~İ/×¼*UWu?nÑuz7¼VPâƒç*¶00Å¤—B"!)ˆ„`#Å6hÛ‰ˆlw»|3[±åÁø÷ËÕYŠ¯«LYåÌé
+ÀŸgI„SëBŒ8ûÉHH H ’Ôß m+"²m{DÏ­iU&û±wÕß¤‘ƒ|Šº,úªDàÉ„Dß·‘æ´íDD¶»ÕÎÖ|Äá_5ßàô[¢]Ò|ƒ¶½ˆÈ¶ï…Ï>[óQø˜-V]@-öŠä@#ğHØy€÷)ğnX~ş~y‰h³
+´ fç,¿ğ5RQF@5ºÍ¬Ê@¥sÓ”öb”Â(·¯± âI*BÁ“ K¨Z<CÑ[	…ZßN Dè Y-0«{³E(ôvD(8fñTØ!ˆtF’ã‚P„Úî ´½÷HôÓE(°ø¼M9LƒC.:5ĞÑ[SŒ–*Ñ).¦}•I_«ˆ§êKˆT\¡ÈvBR|q„úrÔ¶“Úîõæf®/³8û`ô%’•…gÈHH H õå¨m+#´m{D«éú’†…7¢/ÁÏ0İ§ZìEO&$ú¾åõå¨m'#´İm¬zº¾DµÚ`GàS‹BEAŠx,AL`
+•-éõÓ”Ã+‡cóg‰\!PEÚö2BÛ¾$s@ÁŠAbŒRõÊ¡¨"ë™¡•Ceú¸<•üš1‚BéQ¤,"·(<Ğ‚Bt¡rÛ(ÇĞCn3»g Œ¹)F{1p6ÆU9wË‡ö\å=	sy^İK(z+¡ğ@âÛ	 r3«% fu Ùûà‰ ã]~Âˆ<¿?W±EçÂ¼˜ô‚g$9\ †Û íBÛ{¼éÛ¹‘½ÈĞOÛ«œ,ƒ
+›e¡OöÀ§Õi2½Ó¡~ºĞ‚!ç ©„³èÖÏ_‘V˜aó²[B‘¸„$ª… ñ5hÛÉmw;äé¾óùpÄ§á¼ì–‘@@$‰¯AÛVFhÛöˆ>¦‹/ìÙ·}[o(í<]{E7Ã$™WİŠLHt}Ki¯AÛNFh»ÛVıtí…j%Ôô÷Öeê}BÑ&Uáõ¦Ï3ÕÖĞœW¢S ÔÖ m/#´¨=‰jú†j³İmKe¾¡WÎ‹£ûÛL^o!Ïñ
+YEVD©`“j1PH¤“òŞÿ×ÈÉÇ)‚„n3«2Ğ†îìmĞæà…¼¸’Š‚OÕ‚Ñ x5'!Şj(<Ğ‚øv¨ÇÌj	€YİcGÏÖ‚ÈñGÜIv<°™1DWQ¼A8—ˆ·UÕ>¯PÉ	ÃAÛ„¶÷“fº0Ì6†E´r£ašÔÿx)üÙjùG'Óòó'N•U'î†&bP’E‡Wˆ·pÕ´U¨$šäŞ m'#´İíp·ér/ß…I‡f«aq÷pğú9¦ªmAùQµÍÂp¾l—¥èàâl]¬E‰À‹2	ñ6°š¿
+•Œ“.´me„¶m/"ìt]ˆ½¼^]««³†·çµD:Û··%¬>À{ÆYMDªÂHB…x“WCe‰JòIqÚv2BÛİîbŸ®8)8”ƒXdç-[»û×›cÄ›İbÅáœp!únŸnK4á@JtĞ¶—Úö½pqÓ•(Í;oŞ0øt”%mxˆçÎŸ½âÇk²ÚŒ)q(ÕJ<®*è¡B7š¥?±¢x››w´—-m,j5Ï<ï=j5^šKûù·:” àíPå™Õ@³ºGĞÔ¬¢_™ 7°âÇ›ù0ˆ„ÎHr¸@	»AÛ2"ÛˆÚSË×ÙÂÙ‹İSE$•“3Y¯òÕ×DÔ?cÜ^6QŒì÷Oê”£K$ø˜XÜ.Ï’…×ÒÿåéÕÌ‘¿ üòäß\İ§AÇÑ”‡Æ¸¼@4íŠ,G é§>FnõF§>Ö+n|ßÀó^/Ni?ù<he ¦xm´£„¤–'´PRäƒ¶ˆÈvo|´j¶"ï´àsu2o`D}™à_ÒÉƒ¶­ˆÈ¶íñ4·ğQ'·İlÒÜ¶¸iÖ©8àl¼äÅÜ™H@KiÚAÛNDd»ÛàÌlMKDj•NZ{².1KmTdUæC°ÊE²W< gLZH‘@rvĞ¶Ùö½HÙfËYkg_(gëpxƒ«ªG‘©ˆìQ ğ@
+zÎªê	_ ²ĞCn3»e Û¹)]{Ù6<`İåöÈgQ8Ó¥Pà
+Eo%hA|;ÜƒfµÀ¬î´Ï–ÜHĞÛÙ	N†i8İv“!ˆtF’ã‚PzÚî ´½÷HœšìŒòX¤¥´}¡†VWM’ô¦3zZ©İŒ(Íi·õÎÉê˜Õr•-³Zµcª—Ü²µ7}fW#“ı6Øe>öTE	Áºƒ®èÉP„¤€å¨m'#´İíşéŠ2Ì¦¤Éˆº„®ÖÉ‘@@$JÒQÛVFhÛöˆöÓ%)#od?%øİh“¡èÉ„Dß·¡µíd„¶{u_§«QäğöšŞ¬ZW ´@úÚÛ&ÇæÕ‡×¨7Gm{¡mß‹…¹÷½‡˜ÄX0Ú¹î¶Iqµ]ó–"åÒ£HPD‡)Px …ôBıf=›õlÖ™õhã`öí"›ÛP¿Y_l’ÜÎÕoÑ“0£©PôVBáÄ·@ı6fVK ÌêA³o!‚ŒßáZ:)ù3§R…¼‰"¹DæŒ$¯ìx´İAh{ï18ıj¤02ô³e¯ËIne_ÂÚ!Ÿ³J»'{XTuKE7›4Ö†7\qNøÄQ‡’'RR¡HXBÅB(œ´íd„¶»½±.§²Pùpä'Ö‘‚			D’œ´me„¶mè}ºœÂnı†¾yU«àl˜‡U(º3!‘€–(ÒTƒ¶ŒĞv·Åºéš
+‰ÔZè˜;‹5\X˜­æ§XÖ…(ùJà«.ìM€%b…  ¡5hÛËmû^€Ó…Mà´o…Vµc²{L Ã‹Ë,¡x*»û*u¯#À^@«ˆÈ®GŒ@©P€,Æ–àŒn4»e ¹‰5ë.›OTïdÍ>Ì.AÿÅrUÒªáŠÖª3É~İ\nU=ıòâí†kƒÏí®†Â%<!!x‚uWƒ¶½ˆÈ¶ï„£›¾ÁÃñj\œ˜äy^Œ£¬¡^EäxÂ;qé‡=ëó1cTû¾`¨¾½÷äÎ+Ğó(Ò× 
+´ èw ó
+·Û“YÖ2t›YŸ6Zfï©¶zû¯–ş¼ú¹éQá‰_f=ry]¼á.4¼'nh^µÎî­®.‹ÎûáØ(V*)Váj]ß.ıÚ\Y5½ş}ÕEÛÄŞ¸ùğ3kBT?Š±§k…ZP´sjNøš iüè¡F·™İ2Ğö³sÉ–kòí7ŸœšH7†L"x£B\.(<Ğ*B7†äï Y-*ê°3;‘Lì¼şŞpnHéa—ˆ+)j7W¨$sÈ£¶;ˆ€:äMÏ!#{#ç£—‰£ì|ô"Kxã1éö©»¹ª|Å­Ç¥Ï:'b"d×
+qAG*ã	Ñ£¶Œ¸®§oÓÑy¼}0‰h$ã ²*ÄU5-*‰ÄDô¨m+#®ëé==MÃÂ9ªÜ8—cdˆ‹5‡—¨¤SĞ£¶Œ¸¬§Cáô4Q¨ÕêßÃ1éyîP¸rùMTüŒÍ%z…0ÀÌÎ¨m/#®øé„ÉôD4O 7%.9eQòäÉ}ñö-LAß²z!^²</(y©‹(%¥)ß,€Bz¡~ãåŠ€jt›YÊæˆKnr*úb©H›²È,¶ÈÔDúNUu\Ç>ª×‘ 
+´€ÊƒĞ¹ Í†Ìj	PyÌÙ±ÎVu´üf¶w€“aîL¥âÂÚİ*	"u7h»ƒ¸B¨C¢š®î²²àYê@+ÌÂ©$C\"R\¡2$H Úv2âJ¡NÈèéíC¬B2â\ŠD2Ä%$5-*‰$6hÛÊˆ+…:D›é+…ŞÆÆğ3L¤©#C\åÑx¼D%G¤Ğm;q‘P‡ÃmºB£"¡÷0õ±ù°D§@;)²AÛ^F\Ô	;]‘qiĞ‹ö`t±›·,ïq	PMP@ÁA92N ¥d:iyïıM€œDHE!Œn4KË{biÈ17Uh/+C”öª8]¯•‡gîÔ"Wç¢JLèP€·@y8fV Íêgn¶<¤j·±{<Óv^Ma„‘ÏHòºÀiÃAÛ2"Û{Ácº6,ë?ãÔ,˜Öój# #!‰@hR|ƒ¶ˆÈv·ûõÓ_ßqêÈZ	¼xÃYKH`R`œ¤á m+"²m;á×éÒ{w½íe<·íß.FöîlL˜tİ‘‚ú‹n*ÉkI&m9hÛ‰ˆl÷º¯¦kK
+‚Ş±éc“l‰f!HsÚö""Û¾.zºæ¤¡öáœ¹§š‹_pà\Ø"œš>í õ EÚ"â[Ù …ZP¨3x;×sôP£ÛÌú´Ñ17Ùh/;Ôs_•Şl-ñlQ½jBÎ”xà\˜÷ÓJP†ø¦]@áÄ· ‰7hVK ÌêgS“‹~eÎŞÎ
+ 8¦ê´$“!¾ò¶vw…J‚PåÚî ´½÷H´³U²úëÙê×Ùê»qØÙêĞÊ@ZÑZ[†ø.ãº½U¨l¡(ÏGm;¡íîĞ¹Ï–ç|ªhF_FõCëiâ‹k¯V¨äEó¨m+#´m{<Í­–T&—oélup6èZË_1Ü¸½D%Q(|Gm;¡ínƒ›{ÙO“ÕÖÙêcªCbXˆÔ¼£¶½ŒĞ¶ïEŠŸ­y)R>à³ÕoTº|ëxMVD|ë ğ@
+‘ŠJwslÖ±Y7fÖe ‰	µÎMZwÙwı×sNê£†â%>!¡ø#ê£m{¡mßÇérb<^7cT•ÌOçÃdÛp²‹Ro8\á"œ¬°O?Y!ğ(_ã(<Ğ‚¢kÁşÉi6«Ù¬3«3 ÄÃìÍÔûá>Ú£ÒQ6|<M
+Áâs³oôs>S!}‡¿äè„cİ ïIÛ]\{jë¡P¾û]:NçÌ«½bŒä´*q([Â9%V'|M€<xîÿİhÖe@hõ³ğ.¼tãun>z7¦_£“JLèP€·Àü˜Y- 4«»¤ÍÎÀiOYMZí"wbŠÂ»@ûŒ$·ôPú}Ğ¶ŒÈöŞ¥pzş9|ö|ª™HaME}Ü‚ËÙ˜.İP–SÌË¾¯
+oêÃ¸L>IAW3ºxèB{=‹.·³`€¸‰)ÆÈ}‰ 2’bIˆ9J(Úv""Ûı±`zF9Éf‹²rÀA„†&)%=hÛŠˆlÛ.ÓÓsÒ4‚<Ÿ“4g1o=V"ğgB"-S”“´íDD¶ûmvzRš˜|/W¬¼•ÓÆfÚƒÓ”Ï´íED¶}7¦'9œÖ/)´jOåĞUFG:;º©Õ•y•~Ìt êQ¤4"ÎQ
+´ o ¦ÌO@5ºÍ¬Î@9jrfúâLÌü\•¶î¹"¬7fG%¼º 8©B\ª(<Ğ‚øv Íj	€Yİ%MÍÖ€HÚÑ€àb˜=Çğ.—hÔÎ®PIjÀQÛ„¶÷.…zº¨§0 ¯0ÜTˆËEj†+TÆj´QÛNFh»ßW›é-‹™F£!q9(×“Ô¼T¨d5Ú¨m+#´m»LoÓ5öğoJ£·a<V!®÷hü^¢’)Ôh£¶ŒĞv¿ÍÚé™üˆOc›K|
+¼£bµíe„¶}7.öéŠæp/,ÂDğk–	İ°h(x©ŠˆWã…ZPˆ¨sOøš )İĞCn3ë2 îÜô¡½8¬QzSO
+ÆË¹j1º/è%İ—Px ñíP-™Õ ³ºËØ1[-"c¯;x¦ğ¼Œ—Ä<#Éã3$mwÚŞ»ìùéB1+<ëBOñÔÔú>O: à\]i„¹?¯ª%‰JH¢VÒ…ƒ¶ŒĞv·KÖët]˜…È‡£¨xU-!`#!!IÒ…ƒ¶­ŒĞ¶í2=wÿ}Ğ…T·ù6P?Ã<×ÓâêÚÆã%*9"E8hÛÉm÷[«®‘C­Öî		ÏÅVš.~ıšw2U·Ï}%JêIÚö2â²ì^h˜é¢¦j›²róîÉÁpLºâ¯³*ÇõØ5C¥M*¿@¡Pdq=v@5ºÍ,­ÊÉõØznşÏ^ÔcßR™©÷suVô.LÀy}&¡èÁ„Â-ˆo'€:kÌ¬– ˜Õ]Òìl…¤/œ­YtÎ§ë¬è]˜óIBöŒ$ÌÎ´İAh{ï²·O×YÙˆæè;`¦Ì¼€’Pä#!‰Ai’Sƒ¶ŒĞv¿óuÓåT±æc;ûi‹3p^‰IhKH R œt× m+#´m»!qL×]Ø·kº«›®‡"(%ì ¯v?ås´ì½l66g¼ ŠPjE×W(“HeK9É¸AÛNFh»ßKøé2CâwŞØ”[âYˆÒvƒ¶½ŒĞ¶ïÅ‹™~×9Oµ‹W+¼ä`€&NÒ*0wYıî{ˆˆ[ÖøxÇ]ÍN@×]2N ¥$;iïıM€œ‹H…ÄŒn4Kk|r9±™}ÓúÁm#?«¢Psâz@‘¼—öí1&t(ÀÛ	 ü3«€fu—´©yE¿2io`™÷íadÃ‘äq’Ÿƒ¶eD¶÷.{f¶üDúHtì­¬×ë7TJmğGbÙg1¢è%=Z,Òø™dÉvõíõ¶AXI¬^rË†Û¥Ä}1¸÷¾øJÕa‘gËaŞ½P"ˆ„¤ˆ"äğ m'"²İ¶Ùr8Ìgu‘wï!B6˜$•;hÛŠˆlÛ.Ósk•á!ä­¬.ò¾=ğU‰À“	‰¾o9"Y:hÛ‰ˆl÷[ëÜ{s|š»½—=™†xímcól‰DlÒœƒ¶½ˆÈ¶ïƒ›­99œ3Mƒ¾e½¹LU´	ˆ^ò"?…ı•¯d=ŠDFÄ7»
+´ l û.Lè¡F·™ÕâenšÓ^Şhç6n§ê>ğ.Z…Êß×(<ĞÚˆŞõ6dVK€6öHó³ußÛÚ.†	3­eˆ¯Í­]¡’£¶;ˆ7v(ÜÖéâ/ÛØõ×Ù?®Ù»~`²C3%D«|â‘ëW¡²‰¢JµídÄ{3{MXMWÉr>Uä¢3£Ü¡µ·ñ­Çµ[+T"wÔ¶•o­ì¥§‹\Şxµûç–r«“»¥¢ºyr=C+gâËŒnJT²‰rxÔ¶“o¿ì±m¦ËaŞ~ùC:·}LœH¡€byÔ¶—ïÈì…Ê6],SÇ`Œé^-å¶›n¢9úøéJI{1ƒóE’"òGÂ-(4ì9ë´'|Í÷•Ìî+™Hè&³ñí„›°µ—ÃÙÛÊ„?9W¬G×F±=T¡è¾„Â-ˆo'€b}Ì¬– ˜Õ]ÆöÙb{;÷§—ã4Â»DûŒ$Ï‘^´İAh{ï²85¯5Ğ(/®f‚ÚŸY´O»3#*ógù_3ıÒïãÈîz^`Şâw_œ"TVCwÆ±şÅivQçFíhÊÕ³Á‡½\@uAZqµ×µÊ¦vU-r«Ê-r§¼‚¼]–ê½‹ólËC›ÚôD±n>EÃÇ¦E]l>Š+!©9
+Í–4ü m'#´İN§_zÍcôËÿ=Q¸ƒƒ¿•<˜àUÁû$Üm[¡mÛcÇN¿€<{çòn)õÙÊ<º<
+¥è¶
+E§&$ÒĞÒEÊ|Ğ¶“Úî66;ı*q¢ó£:¼vLeH
+L“ğ´íe„¶}7¦ßN‘`Œ;^RİMÓñë),ºG]œºíéNğš¥€¼62N ¥EIëY)û¤ı˜YŸ!fßIâ^
+®¼)$­[ªÎìDÎ¢4¥Ë»ÁG%&t(ÀÛ	 ¨3«€fu—³ÙW’g¯_yŞ…9,¯C1Â¨g$y\`†Äì m‘í½ËŞôÛH¾HÑ?.×´„Zz6:—÷2f»™lUZœË³_.æ¹Re<¨67ú&Î«öaşÍgŒ€ß„¤ˆ"‡ôÔ m'"²İïË§ß)’GÖS9ŒlÄ©9/š1B6˜$m6hÛŠˆlÛ.ÓÓï¡!àTƒŸaRÍ«YŒÀ“	‰¾o9"A6hÛ‰ˆl÷[ëôÛDˆC­6èÿ²;$Š½©yf°¾["»7"KÇ½|šQK|qAòmĞ¶Ùöİ¸™~÷OÿôóEÆM¼d#øÖ®˜W5Õ4àµ+‹+"{mGÂ-(È:¯76»±ÙmÌì–6Höé`{“Ö|¼V6»ñîOßóu«é¶ÖòrÖpËlu„Bök¾Ù•ºŸt1lukk–Û§ü,…Nº 6xîãÌöÏèv…ë²Ãu¿\±ÿ;1ÕÏH¼Ä'$Ÿ`„Ö¨m/#´í»ñ8ılŒÇ«qñ€ı¼ÓÂ@Ê»º§ÊîÃk?Ÿd—ô†PÉ·öÊl=ı6ìÀÆ£ÈZDÎ(<Ğ‚¢ŸÁÎj£Q- ‡İfÖg@Ù·aû}ûhoÃÎ5†ûÀôrÖs~Ê¿¦©6mÖËæ@úLE]}Z-¥¶j£_v™6{ê2m¾q[6&]º5æwğ•2#gVf…¦ğ(6˜ˆR¦˜’À(šÕ9•Y'|M€<Æ8YºÍì–¡™Æ†’ŠpJ¾-vR5iì3·¼‡dttnÌoFUˆx …ZßN ÒØƒfµÀ¬îr6=œ½Ú,ğrL!B€—ˆË4jW¨dÓÙ£¶;mï]ç§³ój¦îåÚÙÁIØ$ŸJJ‡‹µ)-^f·)‹ÉBÇïÓd¯{£v%fùìjE]Ñ›¸Y‚&f:#ñâÊ”:|*TfÁGm;¡íşP0?ä“G6B>8(­Ô¼T¨d³à£¶­ŒĞ¶í2=?N#È~ìİ,ø¤ñƒœ
+©jpV…¸Ş¤qy‰J’0>jÛÉm÷›ëü48MİvÅ…\œtCş;':+KËsšœ"íº¥±9¸Ä°	”C´íe„¶}7Ræ'¾1R´kë–ß0Tä‰“ìĞ­:NòÁÿ5Ãu×£È^@jå8BãDTê8ƒ¼JĞC…LSNI^%q³ïÙVk*l*÷êd«¢'ÎŞ¢ £Ò#ğN‰Ğw<”ˆà(GMk¡iİemöEÛÌÚë—6‹a"ÍEGŒ(ò”/PDzpØ~’ı½KãôË¶‰ÇS/QëŒ÷¯|¡ğ
+Ór.)b„´ePf[ˆ’mÃö]’ı~§=ıÂí"n>íÆUFHDˆ’ŠD	”’~¶o;ìÛ.åÓoŞæ.ÿ”2³aÍEFŒĞ—ìPĞ’E:nØ¾ë@²ßo¿Ó/ßf2µÚü_\ÓôôA‰_*jRõ+ËºÁÙ´L¹$í†íû$û¾<ÓoèNÁsèö@ˆ÷qz¢xÂH?ÕY§•<İ°LézìPp×%ŒOI¨”lç¬Wù}Sf#Â‡ŞnË‘ş³ïùV+VÈÜ°Gª[ÑÍ¨bh-«€ÑŒOI(>ÃÄëKìëûºOãìË¿™Æ·³ª‰şFuAKA„v‘ Ì‚ÈÊÙ}Hâ‡ì}b§ßNÌrÅù±3)RƒRƒˆ
+=ŸA™0‘\”¥/ú×…ø!ışù˜~à ò?á´ò%È	Z* ø2ƒ¢‡E6PT¾èClâ‡Ø>aÓÌºâ·v€:çü´ˆSÀèÛv(‘èC¥ù¢q]ˆòD“œ~Ø`š3ıÖ_0–Ù#•æ‹>Äw!¤wƒgúñƒ<Fû—ƒPÊsbrôL„?¾ûÕwßÿÏ×ÿõÕ÷—/ Š.îy¼Xoïµ³»ÁW²WTøqÿİ}s÷ïwß¶.%C/öæqow:³]ÂY©5Ñğ8á³7?û?†~uÏ~÷ÒL{Â7³ğÍR¸ŒxeWÊí›Èx­lDÇ®İfaf·_t8ŸÄYÀC	›³7ÿÇwâÿa
+·_âµÑH¸|¡ Ï[SélÛlö‹9ÊÚÃ+/A±|yqmuúe@Õæ¦¸G §š­Oeå},ãï>ïWùo*Ç§~¡İæ7Z‘L¸ª¢¸1~ã*!•öÂ„%­r‡ÀwËU5öiw×¯fF¾Ù/[Vª9Ë}«]®7_T»€ş´jEG´É½°4Të/áL÷öJ´í©î³Òâ´ƒ_§’Rá$„öºoCéhY'nˆø7“yØWæá·íé,¤å„$Ö×«çNı§ÅUL¤ÕÚ_4’/±SpFŞS÷›âú ü˜Ÿ.6/Ñ­öv%*?]Œ}2ÜrİŠKıŠÍ5yYï–œjOÉ#º\O_•|ÌşçLC^ÍüKr‹|ş‡JŸPÌa²ÇÚC )Æ3v9Æ«¶øÄûÚ¶C¡™ÚN¾ÆË_Ÿ~ıÅrİ¥ëÚóÛ¥0ô+ŠFŠíKz©vbdæw/Ñ’CöÖlQŠ®*Ï·9Íµ#].ø³ÅFn<üå×EÁÎ9äøã!Û;Ó.²äÑSl±kÏ‘&ÉbãLu"•–:ùó¦-òçq&?ÌFÁÆö|›@î_µT9öçÙ	ät;}¶íÍÎ¤\[>KJ÷€æMC¹&ÄuÍŞïä(õ1/#å?“†¬¯¯ˆÅîÿ©£Ü)à²—è¬ítí©™íÏ|r“¢iËË'9‡ËN+_µ`
+æÑ1€çõM²ÍpI¼
+wÆşóSES=Ú¹NK:ì—Ä§³	Êf=÷‹o¶üP”÷î-ª§ÿK6§ F‡)$™ª®²è4²¢\
+Jé…jàhR—åjöÜÏŸ/WşŞùi}s|^ÌaêYägKêFÕbŠ¾fÀÉıná%Î­:–a7=ÿ'³}æ4ä3>².‚Ê-éwMùe£‡°¼‚ä2öÑ¿ÏÎó ¥<ŠÎ•{ğ²)dê?òVWË0©§k§á×ñDóUã}¶XÔ]Õ}·¨b´¯Ï¾M]iZL›îñw‹)Èÿv­ôÀï%’Úœ^Şºì~]•·u·Å³F¤/ßqÿ„‹G«¯²/˜øl±Åû
+ÿ‘ßlçÓÕ>3î­1Ò„¦€pV²¢5Øàñ&‰ãC&gë¢R’şL¡”‹¯Õlç<™zi¤ÿwKUJUV^×şààıWòw­ó|´øüİ×4ôÆÙG=S#åM”¾*OR;ry2aÙlãÄÈ.vR_›N;*¦*5#N]P=!ŠxZ²Âˆ*/^´‡‰5=ho½Œ¯¼nŠ÷ûK¢+/î“7ä
+.ûĞyZPIı*U´6ÚpîtË“O·’¦ÁSÎ¨Èn~jş•vŞsf…¬Sü¥a8],B¾iƒ‹j˜æMHÿ³ã
+Øÿ¨«eÿ
+endstream
+endobj
+118 0 obj
+<</Length 3528/Filter/FlateDecode>>
+stream
+xœÍ\Y·~Ÿ_AI1 ÊîYÍ+V¤èŠb"`<xóXl‚]^ëÿ#à]¼&;mÂ/»ßôL³ØUÅb}E6EL!M×£ÖFst‡„ÔG¦„äàê-¸ÊºµìÿÃÍá‡/‡_9*"hqˆ)D…‘GÅ•FŸï.>ôù7D”M¸aˆòP#‰F¿}ş‚¸D”¬ì¸Êİ!©EşxÛıH•,¡m¡‡ò}Å§Ãâª”¹–BÚT‰ÚzÈ„Ÿ7‡ë‡OWœV_k9­ÙÖ™5Ÿï.³6k d%twõ»'!ÛÛs:û+ïÛß€³5Y¶$€o…(Xïâï/_^üôî‡÷ˆ¼zõöı»Ã‡ŸŞ=ª’4A…ˆ½h ë%€î®r÷$t¸AšmjŸoŸ”D÷QRêïâT&[ÕĞÛ2Ãş³uõp¸ATÈmBÆ0‘#u±¤®|ûk¨¾ÃÛKDĞåıÅ5A”¡ËkD}»QiÇ…àèòîççW„+ŒéÑc¤‘şa/æH!’ÆK
+› 9Á,B…ï\&˜ÙÛÙºúû¦ÂÊ”B_c¦’˜©ökÂfÊ6·jÿ»+Â9f¡¥/˜Ç6)ÇTz1¾'Ïp’çî¨‘˜i{É¨(–JLyÓ…³Õ6KÒ³R…9©»—›q-7M^à^şxøpyøôè£%¹ìZIŠ†t~
+`ß½»CÁ_ª¶	QC„#ğºOpI}¾C«NÛ@ÿ$ vŸ¯«‹ÃZ‰Ø&Da"Fê;©+öù	¥c?è:
+ààùzº°êÒj›5„AÈĞ»ä>êJ}>/Ké?_W‡$”Ù&ÄabFêRû¨+ædwƒ.{¨U	İ]=Tæy1g”9'• åÚç5JÒ3çòÕF¥íT¾PFé‘s¾‚	ÛÎJ”ÅY™‰ı& Ÿ“Z%‡´Ëj©N‹ º»zÈİ“PÌiÏoŸoŸŒhfÑlDniÒ„“MÉ~LÊŒ¹°wôúa_ñ]#¥„{ƒ1B"lù	™Ÿ]{k:£¼È2“Î¹ë3L‰Í+µÒE©„Ì¹mÈ£İ…ï1#ÅRêì’ßÓKg¶øX¥7ĞYÀ¾1»†Oéå!jƒa°¦t¦op–Ãu0YñâÃ3Ã*¸‚7õK÷ƒ{ì-tcpëG¥78T0¥è0‘]}ÙÏI’¥b¾ëVCo? »Víz@Jª7C„ˆ¡“°©S:åy:`T“£”²b]šœ)Ü^10hx–Îªq,„ó¯D¼&*¿ç”“ÌS~gŠ:[80qÏ¯Ø Da2+S:«Y £Ê¿É"^ªX’Ë<ÀU†µW#”ğ S®É)æ<(™ñ¼ä¾oò®{$ªµAˆÂ Ä=héAÂ¹rLA9SÇ2ä”d} )‚ªZåAÕ·À/`À‘éòcxÎƒ–U´J­MçW€(+¡[ê Š&îµ¬²_Ö¹}Û×Ú×µÎ-fsdJ\¹{¡ÔˆSíLŠM²:ª¡×!€ö®ò÷$	òùí³>
+í³¡	ål†M¸².²Û2¦ìN–º³q._Á0$2ì¡k°D–7Â(Díª¦“å`Xg´?ãÅÇşoÃ’JbÍ‰÷€%Äv@ú"0“e¦›éökÌKzİË§	³KU Ño°Ïr´N3TäéÀïv,­%ƒG^ìŒXCoe ûÎÑu¤D¾7Q#…Œ§=|C_û#^xíb‘‚·«Œym1ºÊ÷`rgNíÍâ©³EƒY ì«kØÄ©7#…ˆ¡íÍtN&©¥åÔ¢³Ò<kúHºœÔé«†^¡ ìĞ³Y"¾„¨ŒB†Cš‘éÄ7š•ÑÕ‡íQhWx‰µT¸¡.@	0Å®‚"(Uğ§cî“áşøìÔ½oú®›$¼AˆÁ(Ä=‰N'ÀÑ“8§´.º%Ü¸N‘°P$9×ƒÀÎ‘é¹ÛİÀŠ
+RBwW•|0pKJSñÄÂÛ>¼}Që7s‹µ6 ±°şJ·Ü’W…ÙœN0¹/½ôZÄ"-½AèÔ »«‡Ü=	z¹¡}6@¾}6´"ŸN/ƒGôÒ«;äîiµB?*2ì¡k°H/·Ã DíºÎ§—Ş°ÎhÇ¸á¢ˆ%ä}O«ÅØú3(ofşÙTÔ8ÑFªğJJû'¬dgË HIq[w/7bVÜ4u N)'Ÿ9l^„t§İÈ¨àÖGKÌ;“3»Ò#,¨&šfÔƒÕ® Y÷Ş¤é\`eiyB7 ìÃîD~‹5„AÈxÎó‰|TïËÃƒV=óJëŒz­ØÕu×.‘‡o"†0CÓÉù<<Ì´œéAš=\…<½ä¸;a÷¦	|)­Bè4àÀ`=ãFÂ¾EˆÂ d<tÕ|ÂìÏh~·à$Ãª6-Œ÷4t¦Ã’NÕSéL~>ê[»ë‘£ob†01CçÑó9z|Õ"uSì9/®„‚şï™’,ZÛî¼W+6™¹ ¹}šÛ§Ú§µŞ2·ä+lGdN^¨Í‰oøŠêSâWxI1r¼ÄDü/åZPñõ3¼0î[ûóìáŒğvQù";“ÄTEe÷Ve£Øöw8È[°ôuÄK˜wÌcC4:×qüm}ènË0Å³BÌ!fä¡œÌgŞC®øZ-J×­.F$³µÅ%×-¬‹’¸‘jÇ¬‡šFt% ¯¹»gG”¼#6|´r—–†ãÎz«5à±Ûfà­=¯ùXğ†£–™û¥ŞÜâw8L)¦4Vº¯µN-aJNJµ¦Î"÷Š[´ò›	ÅãƒÍ\Cßáó}‡å‡<e—Ñs?©Şiæ 5#L­†I;5CŒëKÈ‡ ­r
+Ôy^VØ}¿\ÈÁ¸O†¼m¡%ä' »-C›ù~Î	ğ¶…g	¡lç1¬°`F˜ø¹h§™òu•5^Ko’¹¼(›$É¥4¢z5Á^k«¥kJ¥ÂÅ{¼ğrR²ÒÊí69s‹]Îa0Ô¦Ö9$Ó¥šíP«ß§'x­®ğ8÷KFa¯ñ¹ùLìª—ğªöéâÍı×_ÿëóWôÖM¤´ÕÀF„3`ü•[p…ÚÄı
+Ú¬=}…ú_‘B—w9 ]şgPZ~|Ù+s²n"ã|84ÒôV€&ôL°ÿC+Ò˜³*‹¸aT8¤%S«ˆÇó0\•PÜ–@¸lş»_†ÿ6JÄluØX€ÿİÍÿ‡Gê<º‚¹D¼x7‹â%¥9ÌÅø4‘Æ×U4ÑE»’Ô»A M1·{;Ìó‰6FÂ–0‚Ğl£¤‚¿v=®òıÌ!ì«håi÷xa.şdüf¦çs‰V“ó^Ê½¡6ÃZ
+Û¼­ØÓa4®uéìVÀÈèxÙ¨Ì“ˆÄiyw-j9.F3¼ÃLŒw’¶§‰|ÁœT§XvãğûÉv$ÙáU‹ÑÆÉŠ~ãZ:k¦ÿ«j‰5òªÑ”û®tgª0õ{|Czÿ¾GÊ¾ÁãR1ålÊç˜‹“ ğ²kÇ Z<‚ªÉVR´İQ=º<ç&w5ê8éÿ+ØÿšN¼yÕÒß?M³nkô‰>¬›|¼‹'~×èšyìÀ=½©ûñë·x‘§æ‹ãªˆR4ô&zF˜FìÃÕ©CE‰šuÖ»ÀOá‚WØp¦É
+j:s]M3È©mÌš˜µ'^{Çà ¹m_?„ŞS…vï~"£E¥ª38‹w¦a™Â°\M„÷óğâ>XMJó\a¢ØuÔ¨üR\Çl«_|"î{¨Ís=%í1Ì_=ØßäL¯0KÊ›JàĞ 
+ûÄ!Úº¶ŞÇ~$Ê1†ãµÈ<Ò´b}}ØWÿp°š:o+v–~øl}ÂäÆùƒëO¼çh•gWR]z’—£Š·ƒ3Ÿ;¤ü±:; .£]³ò’Ğ¿v†T:ì`dö«{L‡·¥ñ|¶@Ö“‹Îy†ëÔ”›8ÓèçSÄA‡G[iì½©]VŞºoÕÂ²^5q4UJ„.¡_â%õÖqçè¼Èaê,òÎa”b^MªäqXØ¢Ü*°œ­ã&ò?™­s0™ÇT0­–‚?âwñ3Èÿ+>TS’ÁÁÊhŒ,å«|şë§1$2Ç8êjÖ‹tmÚ`¿vÕJÂ‚ »æ-‘ÃÑ=¦Ål_	zSŸ%Y$ˆMxüˆyaü!´Æ>bZì}DÙªìH5¢[)kæYä)=·V]kfÅï
+ıE½‰t*gú½à¼—ĞÔPÈJäp£¯ÕxSÄñóCy>Oña$=ş™]	qÊèlåœ,½4Ô¿9°(¼¯ä¼‹ú®y~GC…=ÚşzÉS¯Ë>êLıì	ÑØÕ”¤èòdƒl%¼Î<[Á ½4AÛ1¦ª4ÓM]9:AŠRZM²uíîªZÛmïuíÈç‡”û´NÜŞ#]p½»l§Y)-…‚óKÚ]dÍşüœÎn87İœÃt+s:ë<e X:•¹ß;”*+±õèy¶N‰ºi+T›Â¡®±ÿ'º°ÿ@v]4
+endstream
+endobj
+119 0 obj
+<</Length 23/Type/EmbeddedFile/Subtype/application#2Fxml/Params<</Size 23/ModDate(D:20260806000000Z)>>>>
+stream
+<invoice total="1290"/>
+endstream
+endobj
+120 0 obj
+<</Length 314/N 3/Range[0 1 0 1 0 1]/Filter/FlateDecode>>
+stream
+xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vİ÷BšË¡©hˆFk	¢ÙÆú‚ !
+¢­Õ †’‹¯ZPÏò~xx^Ş—”ç¼QİŠ¶ùµx"©¹^PñÒÏ cº!ÌåH0
+ ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;Q?V.ø_îtFÀà3LËEÆK¶)y	ğëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ĞŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzçm\‡Ğ8rœÏSÇiœúµ­öşfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
+endstream
+endobj
+121 0 obj
+<</Title(Invoice)/ModDate(D:20260806000000Z)/CreationDate(D:20260806000000Z)>>
+endobj
+122 0 obj
+<</Length 3916/Type/Metadata/Subtype/XML>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Invoice</rdf:li></rdf:Alt></dc:title><xmp:ModifyDate>2026-08-06T00:00:00+00:00</xmp:ModifyDate><xmp:CreateDate>2026-08-06T00:00:00+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-08-06T00:00:00+00:00</stEvt:when><stEvt:instanceID>M7VACEhP/i0WdcuyDc42uQ==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-08-06T00:00:00+00:00</stEvt:when><stEvt:instanceID>M7VACEhP/i0WdcuyDc42uQ==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>3</pdfaid:part><pdfaid:conformance>B</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>M7VACEhP/i0WdcuyDc42uQ==</xmpMM:InstanceID><xmpMM:DocumentID>M7VACEhP/i0WdcuyDc42uQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+123 0 obj
+<</Type/Catalog/Pages 1 0 R/Metadata 122 0 R/OutputIntents 3 0 R/StructTreeRoot 4 0 R/MarkInfo<</Marked true/Suspects false>>/Names<</EmbeddedFiles<</Names[(factur-x.xml)113 0 R]>>>>/AF[113 0 R]>>
+endobj
+124 0 obj
+<</Length 352/Type/XRef/Filter/FlateDecode/Size 125/Root 123 0 R/Info 121 0 R/ID[(M7VACEhP/i0WdcuyDc42uQ==)(M7VACEhP/i0WdcuyDc42uQ==)]/W[1 2 2]>>
+stream
+xœĞ?H•qFñó,şÉ¼jz¯zÍô^Ì°E·$p(„¢p« ÁIqP§ (È¡!"ˆ‚"
+!ˆ¡!D¡5h‰– ‚‚¸r–Ïô¾ü¾ÏjµĞ
+á¼ü„¤^Ş@êö!õ? §dA^ËHã9¹-~w¤(³òLü­i\Våäh£\–GòÒ<&7å-¤P'ŞR¸/_ -C2';òÒzVîÊgH[·\•§òrlRVä#¤İ•í—ä‰|‡tŒÊ’ìBŠ./ÎÈ¦|ƒ”\^Z'tä¢øP§+»NËº|‚t·Éuy.6-{nÙVå=HO‡Üòr|JîÈ¤·G\ÔûJşANœ‘{¾’,‹…ú·Å[*¯X¼â¹U‹W-^µxÕâ¸%ï!ƒ¼ vÇğy©ÈKÈèäd“xßX‹lÉ_È¸§¯A}hÍYëÇRƒ<xÙœ‡CÁ"MÛ
+endstream
+endobj
+startxref
+38255
+%%EOF

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -768,6 +768,12 @@ fn attachments() {
   assert!(haystack.contains("factur-x.xml"), "missing file spec name");
   assert!(haystack.contains("/EmbeddedFiles"), "missing name tree");
   assert!(haystack.contains("/AFRelationship"), "missing association");
+  // Scoped to the embedded file's Params dict: the Info dict also carries a
+  // /ModDate, so a document-wide match would not prove the fallback.
+  assert!(
+    haystack.contains("/Params<</Size 23/ModDate(D:20260806000000Z)>>"),
+    "missing attachment modification date fallback"
+  );
 
   let fonts = fonts();
   let duplicate = render(
@@ -794,6 +800,67 @@ fn attachments() {
   );
 
   assert!(matches!(invalid_mime, Err(PdfError::InvalidMimeType(mime)) if mime == "not-a-mime"));
+
+  // PDF/A-2 forbids arbitrary attachments; PDF/A-3 requires the descriptive
+  // fields and a date. These reach the render through Rust and wasm callers,
+  // which the TypeScript union cannot guard.
+  let a2b = render(
+    PdfOptions::builder()
+      .node(text("a2b", 16.0))
+      .page(PageOptions::A4)
+      .standard(PdfStandard::A2b)
+      .metadata(metadata())
+      .attachments(vec![attachment()])
+      .fonts(&fonts)
+      .build(),
+  );
+
+  assert!(
+    matches!(a2b, Err(PdfError::Krilla(_))),
+    "A-2b must reject attachments"
+  );
+
+  for stripped in [
+    Attachment {
+      mime_type: None,
+      ..attachment()
+    },
+    Attachment {
+      description: None,
+      ..attachment()
+    },
+  ] {
+    let incomplete = render(
+      PdfOptions::builder()
+        .node(text("incomplete", 16.0))
+        .page(PageOptions::A4)
+        .standard(PdfStandard::A3b)
+        .metadata(metadata())
+        .attachments(vec![stripped])
+        .fonts(&fonts)
+        .build(),
+    );
+
+    assert!(
+      matches!(incomplete, Err(PdfError::Krilla(_))),
+      "A-3b must require the field"
+    );
+  }
+
+  let dateless = render(
+    PdfOptions::builder()
+      .node(text("dateless", 16.0))
+      .page(PageOptions::A4)
+      .standard(PdfStandard::A3b)
+      .attachments(vec![attachment()])
+      .fonts(&fonts)
+      .build(),
+  );
+
+  assert!(
+    matches!(dateless, Err(PdfError::Krilla(_))),
+    "A-3b must require a date when the metadata fallback is absent"
+  );
 }
 
 /// The report renders tagged under PDF/UA-1 and PDF/A-2a: heading structure,

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -19,8 +19,8 @@ use takumi_core::{
 };
 use takumi_html::{FromHtmlOptions, from_html};
 use takumi_pdf::{
-  MeasureOptions, PageMargins, PageOptions, PdfDate, PdfMetadata, PdfOptions, PdfStandard, Tagging,
-  measure, render,
+  Attachment, AttachmentRelationship, MeasureOptions, PageMargins, PageOptions, PdfDate, PdfError,
+  PdfMetadata, PdfOptions, PdfStandard, Tagging, measure, render,
 };
 
 fn fonts() -> Fonts {
@@ -725,6 +725,75 @@ fn archival_standards() {
   });
 
   assert!(String::from_utf8_lossy(&a4).starts_with("%PDF-2.0"));
+}
+
+/// The invoice carries a machine-readable XML attachment under PDF/A-3b:
+/// the file spec, association kind, and name tree all serialize, and the
+/// modification date falls back to the metadata creation date.
+#[test]
+fn attachments() {
+  let attachment = || Attachment {
+    name: "factur-x.xml".to_string(),
+    data: b"<invoice total=\"1290\"/>".to_vec(),
+    mime_type: Some("application/xml".to_string()),
+    description: Some("Factur-X invoice data".to_string()),
+    relationship: AttachmentRelationship::Alternative,
+    modification_date: None,
+  };
+  let metadata = || PdfMetadata {
+    title: Some("Invoice".to_string()),
+    creation_date: Some(PdfDate {
+      year: 2026,
+      month: 8,
+      day: 6,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    }),
+    ..PdfMetadata::default()
+  };
+  let a3b = run_pdf_fixture("invoice-pdfa-3b-attachment", |fonts| {
+    PdfOptions::builder()
+      .node(html_fixture("invoice.html"))
+      .page(PageOptions::A4.with_margin(36.0))
+      .footer(html_fixture("invoice-footer.html"))
+      .standard(PdfStandard::A3b)
+      .metadata(metadata())
+      .attachments(vec![attachment()])
+      .fonts(fonts)
+      .build()
+  });
+  let haystack = String::from_utf8_lossy(&a3b);
+
+  assert!(haystack.contains("factur-x.xml"), "missing file spec name");
+  assert!(haystack.contains("/EmbeddedFiles"), "missing name tree");
+  assert!(haystack.contains("/AFRelationship"), "missing association");
+
+  let fonts = fonts();
+  let duplicate = render(
+    PdfOptions::builder()
+      .node(text("dup", 16.0))
+      .page(PageOptions::A4)
+      .attachments(vec![attachment(), attachment()])
+      .fonts(&fonts)
+      .build(),
+  );
+
+  assert!(matches!(duplicate, Err(PdfError::DuplicateAttachment(name)) if name == "factur-x.xml"));
+
+  let invalid_mime = render(
+    PdfOptions::builder()
+      .node(text("mime", 16.0))
+      .page(PageOptions::A4)
+      .attachments(vec![Attachment {
+        mime_type: Some("not-a-mime".to_string()),
+        ..attachment()
+      }])
+      .fonts(&fonts)
+      .build(),
+  );
+
+  assert!(matches!(invalid_mime, Err(PdfError::InvalidMimeType(mime)) if mime == "not-a-mime"));
 }
 
 /// The report renders tagged under PDF/UA-1 and PDF/A-2a: heading structure,


### PR DESCRIPTION
## Why
ZUGFeRD and Factur-X e-invoices are PDF/A-3 documents with the invoice XML attached, and takumi-pdf had no way to embed a file. The vendored krilla already carried the full embed path, unwired.

## What
Adds `attachments` (name, bytes or UTF-8 string, mime type, description, AFRelationship) through the Rust options, wasm binding, and JS types. Invalid `pdfa` combinations are TypeScript type errors and the same rules are enforced at render time for Rust/wasm callers; `modificationDate` falls back to `metadata.creationDate` so output stays deterministic. New byte-golden passes veraPDF A-3b; the Factur-X fx XMP schema is deliberately out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for embedding file attachments in generated PDFs.
  * Supports binary and UTF-8 text data with filename, MIME type, description, relationship, and modification-date metadata.
  * Added PDF/A-3, ZUGFeRD, and Factur-X attachment support.
  * Attachments are supported for standard PDF and PDF/A-3; unsupported PDF/A profiles reject them.
  * Attachment dates can fall back to the document creation date when omitted.

* **Bug Fixes**
  * Added validation for invalid MIME types, duplicate filenames, invalid dates, and missing required metadata.

* **Documentation**
  * Added attachment documentation and PDF documentation navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->