### PR TITLE
Core: update vendored resvg to 0.48.1

### DIFF
--- a/.tegami/resvg-0-48.md
+++ b/.tegami/resvg-0-48.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: patch
+---
+
+### Vendored resvg updated to 0.48.1
+
+Pulls the upstream parser and filter fixes: nested `svg` transforms are no longer applied twice, a missing `width`/`height` is computed from the viewBox aspect ratio, `href` takes precedence over `xlink:href`, `fr` is inherited for radial gradients referenced via `href`, and oversized filter regions no longer panic.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ paste = "1.0"
 precomputed-hash = "0.1"
 quick-xml = "0.41"
 rayon = "1.12"
-rgb = "0.8"
 roxmltree = "0.21.1"
 selectors = "0.40"
 serde_bytes = "0.11"
@@ -65,6 +64,10 @@ features = ["std", "simd"]
 [workspace.dependencies.quick_cache]
 version = "0.7"
 default-features = false
+
+[workspace.dependencies.rgb]
+version = "0.8"
+features = ["bytemuck"]
 
 [workspace.dependencies.png]
 version = "0.18"

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod style;
 /// Viewport dimensions and device-pixel-ratio resolution.
 pub mod viewport;
 
-/// Vendored resvg 0.47 (see `resvg/mod.rs` for provenance and stripped features).
+/// Vendored resvg 0.48 (see `resvg/mod.rs` for provenance and stripped features).
 /// `dead_code` stays allowed until the unused upstream API surface is pruned.
 #[cfg(feature = "svg")]
 #[allow(

--- a/takumi-core/src/resvg/filter/composite.rs
+++ b/takumi-core/src/resvg/filter/composite.rs
@@ -10,9 +10,7 @@ use rgb::RGBA8;
 /// - `src1` and `src2` image pixels should have a **premultiplied alpha**.
 /// - `dest` image pixels will have a **premultiplied alpha**.
 ///
-/// # Panics
-///
-/// When `src1`, `src2` and `dest` have different sizes.
+/// `src1`, `src2` and `dest` dimensions must match.
 pub fn arithmetic(
   k1: f32,
   k2: f32,
@@ -22,8 +20,8 @@ pub fn arithmetic(
   src2: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src1.width == src2.width && src1.width == dest.width);
-  assert!(src1.height == src2.height && src1.height == dest.height);
+  debug_assert!(src1.width == src2.width && src1.width == dest.width);
+  debug_assert!(src1.height == src2.height && src1.height == dest.height);
 
   let calc = |i1, i2, max| {
     let i1 = i1 as f32 / 255.0;

--- a/takumi-core/src/resvg/filter/displacement_map.rs
+++ b/takumi-core/src/resvg/filter/displacement_map.rs
@@ -11,9 +11,7 @@ use crate::resvg::usvg::filter::{ColorChannel, DisplacementMap};
 ///
 /// `sx` and `sy` indicate canvas scale.
 ///
-/// # Panics
-///
-/// When `src`, `map` and `dest` have different sizes.
+/// `src`, `map` and `dest` dimensions must match.
 pub fn apply(
   fe: &DisplacementMap,
   sx: f32,
@@ -22,8 +20,8 @@ pub fn apply(
   map: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src.width == map.width && src.width == dest.width);
-  assert!(src.height == map.height && src.height == dest.height);
+  debug_assert!(src.width == map.width && src.width == dest.width);
+  debug_assert!(src.height == map.height && src.height == dest.height);
 
   let w = src.width as i32;
   let h = src.height as i32;

--- a/takumi-core/src/resvg/filter/iir_blur.rs
+++ b/takumi-core/src/resvg/filter/iir_blur.rs
@@ -26,7 +26,6 @@
 // TODO: Blurs right and bottom sides twice for some reason.
 
 use super::ImageRefMut;
-use rgb::ComponentSlice;
 
 struct BlurData {
   width: usize,
@@ -58,7 +57,7 @@ pub fn apply(sigma_x: f64, sigma_y: f64, src: ImageRefMut) {
     steps: 4,
   };
 
-  let data = ComponentSlice::as_mut_slice(src.data);
+  let data = bytemuck::cast_slice_mut(src.data);
   gaussian_channel(data, &d, 0, buf);
   gaussian_channel(data, &d, 1, buf);
   gaussian_channel(data, &d, 2, buf);

--- a/takumi-core/src/resvg/filter/lighting.rs
+++ b/takumi-core/src/resvg/filter/lighting.rs
@@ -128,16 +128,14 @@ impl Normal {
 ///
 /// Does nothing when `src` is less than 3x3.
 ///
-/// # Panics
-///
-/// - When `src` and `dest` have different sizes.
+/// `src` and `dest` dimensions must match.
 pub fn diffuse_lighting(
   fe: &DiffuseLighting,
   light_source: LightSource,
   src: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src.width == dest.width && src.height == dest.height);
+  debug_assert!(src.width == dest.width && src.height == dest.height);
 
   let light_factor = |normal: Normal, light_vector: Vector3| {
     let k = if normal.normal.approx_zero() {
@@ -173,16 +171,14 @@ pub fn diffuse_lighting(
 ///
 /// Does nothing when `src` is less than 3x3.
 ///
-/// # Panics
-///
-/// - When `src` and `dest` have different sizes.
+/// `src` and `dest` dimensions must match.
 pub fn specular_lighting(
   fe: &SpecularLighting,
   light_source: LightSource,
   src: ImageRef,
   dest: ImageRefMut,
 ) {
-  assert!(src.width == dest.width && src.height == dest.height);
+  debug_assert!(src.width == dest.width && src.height == dest.height);
 
   let light_factor = |normal: Normal, light_vector: Vector3| {
     let h = light_vector + Vector3::new(0.0, 0.0, 1.0);

--- a/takumi-core/src/resvg/filter/mod.rs
+++ b/takumi-core/src/resvg/filter/mod.rs
@@ -368,6 +368,13 @@ fn apply_inner(
     .map(|r| r.to_int_rect())
     .ok_or(Error::InvalidRegion)?;
 
+  // The source pixmap is clamped to `max_bbox` in `render_group`, so the filter
+  // region (derived directly from the unclamped filter rect) can be larger than
+  // the buffer we actually render into.
+  let source_rect =
+    IntRect::from_xywh(0, 0, source.width(), source.height()).ok_or(Error::InvalidRegion)?;
+  let region = crate::resvg::geom::fit_to_rect(region, source_rect).ok_or(Error::InvalidRegion)?;
+
   let mut results: Vec<FilterResult> = Vec::new();
 
   for primitive in filter.primitives() {

--- a/takumi-core/src/resvg/mod.rs
+++ b/takumi-core/src/resvg/mod.rs
@@ -4,7 +4,7 @@
 /*!
 [resvg](https://github.com/linebender/resvg) is an SVG rendering library.
 
-Vendored from resvg 0.47.0 (Apache-2.0 OR MIT), stripped of the `text`,
+Vendored from resvg 0.48.1 (Apache-2.0 OR MIT), stripped of the `text`,
 `svgz`, `system-fonts`, `memmap-fonts` and `writer` features and the CLI.
 */
 
@@ -42,14 +42,7 @@ pub fn render(
   transform: tiny_skia::Transform,
   pixmap: &mut tiny_skia::PixmapMut,
 ) {
-  let target_size = tiny_skia::IntSize::from_wh(pixmap.width(), pixmap.height()).unwrap();
-  let max_bbox = tiny_skia::IntRect::from_xywh(
-    -(target_size.width() as i32) * 2,
-    -(target_size.height() as i32) * 2,
-    target_size.width() * 5,
-    target_size.height() * 5,
-  )
-  .unwrap();
+  let max_bbox = max_filter_bbox(pixmap.width(), pixmap.height());
 
   let ctx = render::Context { max_bbox };
   render::render_nodes(tree.root(), &ctx, transform, pixmap);
@@ -72,14 +65,7 @@ pub fn render_node(
 ) -> Option<()> {
   let bbox = node.abs_layer_bounding_box()?;
 
-  let target_size = tiny_skia::IntSize::from_wh(pixmap.width(), pixmap.height()).unwrap();
-  let max_bbox = tiny_skia::IntRect::from_xywh(
-    -(target_size.width() as i32) * 2,
-    -(target_size.height() as i32) * 2,
-    target_size.width() * 5,
-    target_size.height() * 5,
-  )
-  .unwrap();
+  let max_bbox = max_filter_bbox(pixmap.width(), pixmap.height());
 
   transform = transform.pre_translate(-bbox.x(), -bbox.y());
 
@@ -87,6 +73,18 @@ pub fn render_node(
   render::render_node(node, &ctx, transform, pixmap);
 
   Some(())
+}
+
+fn max_filter_bbox(width: u32, height: u32) -> tiny_skia::IntRect {
+  tiny_skia::IntRect::from_xywh(
+    i32::try_from(width).unwrap_or(i32::MAX).saturating_mul(-2),
+    i32::try_from(height).unwrap_or(i32::MAX).saturating_mul(-2),
+    width.saturating_mul(5),
+    height.saturating_mul(5),
+  )
+  .unwrap_or_else(|| {
+    tiny_skia::IntRect::from_ltrb(i32::MIN / 2, i32::MIN / 2, i32::MAX / 2, i32::MAX / 2).unwrap()
+  })
 }
 
 /// Applies parsed filters to a premultiplied RGBA layer in place.
@@ -148,5 +146,17 @@ impl<T> OptionLog for Option<T> {
       f();
       None
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn max_filter_bbox_is_clamped() {
+    let bbox = super::max_filter_bbox(u32::MAX, u32::MAX);
+    assert_eq!(bbox.left(), i32::MIN / 2);
+    assert_eq!(bbox.top(), i32::MIN / 2);
+    assert_eq!(bbox.right(), i32::MAX / 2);
+    assert_eq!(bbox.bottom(), i32::MAX / 2);
   }
 }

--- a/takumi-core/src/resvg/render.rs
+++ b/takumi-core/src/resvg/render.rs
@@ -70,7 +70,12 @@ fn render_group(
   } else {
     // The bounding box for groups with filters is special and should not be expanded by 2px,
     // because it's already acting as a clipping region.
-    let bbox = bbox.to_int_rect();
+    let bbox = tiny_skia::IntRect::from_xywh(
+      bbox.x().floor() as i32,
+      bbox.y().floor() as i32,
+      bbox.width().ceil().max(1.0) as u32,
+      bbox.height().ceil().max(1.0) as u32,
+    )?;
     // Make sure our filter region is not bigger than 4x the canvas size.
     // This is required mainly to prevent huge filter regions that would tank the performance.
     // It should not affect the final result in any way.
@@ -152,5 +157,25 @@ pub fn convert_blend_mode(mode: crate::resvg::usvg::BlendMode) -> tiny_skia::Ble
     crate::resvg::usvg::BlendMode::Saturation => tiny_skia::BlendMode::Saturation,
     crate::resvg::usvg::BlendMode::Color => tiny_skia::BlendMode::Color,
     crate::resvg::usvg::BlendMode::Luminosity => tiny_skia::BlendMode::Luminosity,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::resvg::usvg;
+
+  // Derived from https://github.com/servo/servo/issues/42258.
+  #[test]
+  fn filter_bbox_outside_int_rect() {
+    let svg = r#"<svg filter="url(#f)"><filter id="f" x="2em"><feFlood/></filter><path d="M0 0H1e8V1"/></svg>"#;
+    let tree = usvg::Tree::from_str(svg, &usvg::Options::default()).unwrap();
+    let mut pixmap = tiny_skia::Pixmap::new(1, 1).unwrap();
+
+    // Just make sure we don't panic.
+    crate::resvg::render(
+      &tree,
+      tiny_skia::Transform::identity(),
+      &mut pixmap.as_mut(),
+    );
   }
 }

--- a/takumi-core/src/resvg/usvg/parser/converter.rs
+++ b/takumi-core/src/resvg/usvg/parser/converter.rs
@@ -456,7 +456,16 @@ fn resolve_svg_size(svg: &SvgNode, opt: &Options) -> (Result<Size, Error>, bool)
       svg.convert_user_length(AId::Height, &state, def)
     };
 
-    Size::from_wh(w, h)
+    // If exactly one of width and height is specified, compute the missing
+    // dimension from the specified one and the viewBox aspect ratio.
+    match (
+      svg.attribute::<Length>(AId::Width),
+      svg.attribute::<Length>(AId::Height),
+    ) {
+      (Some(_), None) => Size::from_wh(w, vbox.height() * w / vbox.width()),
+      (None, Some(_)) => Size::from_wh(vbox.width() * h / vbox.height(), h),
+      (_, _) => Size::from_wh(w, h),
+    }
   } else {
     Size::from_wh(
       svg.convert_user_length(AId::Width, &state, def),
@@ -514,6 +523,18 @@ pub(crate) fn convert_element(node: SvgNode, state: &State, cache: &mut Cache, p
     return;
   }
 
+  // A nested `svg` is handled just like `use`: it must not be wrapped in an
+  // additional `convert_group`, otherwise its `transform` (and other group
+  // properties) would be applied twice, since `convert_svg`
+  // already creates its own group. The outermost `svg` (no parent element)
+  // is intentionally not handled here - it's processed directly in
+  // `convert_doc`.
+  if tag_name == EId::Svg && node.parent_element().is_some() {
+    super::use_node::convert_svg(node, state, cache, parent);
+
+    return;
+  }
+
   if let Some(g) = convert_group(node, state, false, cache, parent, &|cache, g| {
     convert_element_impl(tag_name, node, state, cache, g);
   }) {
@@ -546,12 +567,10 @@ fn convert_element_impl(
     }
     EId::Text => {}
     EId::Svg => {
-      if node.parent_element().is_some() {
-        super::use_node::convert_svg(node, state, cache, parent);
-      } else {
-        // Skip root `svg`.
-        convert_children(node, state, cache, parent);
-      }
+      // Only the outermost `svg` reaches this point; nested `svg` elements are
+      // handled earlier in `convert_element`. The root `svg` itself is
+      // skipped and only its children are converted.
+      convert_children(node, state, cache, parent);
     }
     EId::G => {
       convert_children(node, state, cache, parent);

--- a/takumi-core/src/resvg/usvg/parser/paint_server.rs
+++ b/takumi-core/src/resvg/usvg/parser/paint_server.rs
@@ -476,6 +476,7 @@ fn resolve_rg_attr<'a, 'input>(node: SvgNode<'a, 'input>, name: AId) -> SvgNode<
             | (AId::R,  EId::RadialGradient)
             | (AId::Fx, EId::RadialGradient)
             | (AId::Fy, EId::RadialGradient)
+            | (AId::Fr, EId::RadialGradient)
             // Other attributes can be resolved
             // from any kind of gradient.
             | (AId::GradientUnits, EId::LinearGradient)

--- a/takumi-core/src/resvg/usvg/parser/shapes.rs
+++ b/takumi-core/src/resvg/usvg/parser/shapes.rs
@@ -29,7 +29,10 @@ pub(crate) fn convert_path(node: SvgNode) -> Option<Arc<Path>> {
   for segment in svgtypes::SimplifyingPathParser::from(value) {
     let segment = match segment {
       Ok(v) => v,
-      Err(_) => break,
+      Err(e) => {
+        log::warn!("Error during path parsing: {e}");
+        break;
+      }
     };
 
     match segment {

--- a/takumi-core/src/resvg/usvg/parser/svgtree/parse.rs
+++ b/takumi-core/src/resvg/usvg/parser/svgtree/parse.rs
@@ -228,6 +228,7 @@ pub(crate) fn parse_svg_element<'input>(
   doc: &mut Document<'input>,
 ) -> Result<NodeId, Error> {
   let attrs_start_idx = doc.attrs.len();
+  let mut href_idx: Option<usize> = None;
 
   // Copy presentational attributes first.
   for attr in xml_node.attributes() {
@@ -259,7 +260,28 @@ pub(crate) fn parse_svg_element<'input>(
       continue;
     }
 
-    append_attribute(
+    // SVG 2: when both `href` and `xlink:href` are present, the unprefixed
+    // `href` takes precedence and the XLink one must be ignored, regardless
+    // of their order in the source document.
+    // https://www.w3.org/TR/SVG2/linking.html#XLinkRefAttrs
+    if aid == AId::Href {
+      let is_unprefixed = attr.namespace().is_none();
+      let is_xlink = attr.namespace() == Some(XLINK_NS);
+      if !is_unprefixed && !is_xlink {
+        continue;
+      }
+
+      if let Some(idx) = href_idx {
+        // An `href` was already stored. Only an unprefixed `href` is
+        // allowed to override it; an `xlink:href` is ignored.
+        if is_unprefixed {
+          doc.attrs[idx].value = attr.value_storage().clone();
+        }
+        continue;
+      }
+    }
+
+    let added = append_attribute(
       parent_id,
       tag_name,
       aid,
@@ -267,6 +289,9 @@ pub(crate) fn parse_svg_element<'input>(
       false,
       doc,
     );
+    if added && aid == AId::Href {
+      href_idx = Some(doc.attrs.len() - 1);
+    }
   }
 
   let mut insert_attribute = |aid, value: &str, important: bool| {
@@ -531,9 +556,20 @@ fn resolve_href<'a, 'input: 'a>(
   node: roxmltree::Node<'a, 'input>,
   id_map: &HashMap<&str, roxmltree::Node<'a, 'input>>,
 ) -> Option<roxmltree::Node<'a, 'input>> {
+  // See the comment in `parse_svg_element` about `href` precedence.
+  //
+  // Note: `roxmltree::Node::attribute("href")` matches by local name only and
+  // would return whichever `href`/`xlink:href` comes first, so we have to
+  // filter by namespace explicitly.
   let link_value = node
-    .attribute((XLINK_NS, "href"))
-    .or_else(|| node.attribute("href"))?;
+    .attributes()
+    .find(|a| a.name() == "href" && a.namespace().is_none())
+    .or_else(|| {
+      node
+        .attributes()
+        .find(|a| a.name() == "href" && a.namespace() == Some(XLINK_NS))
+    })
+    .map(|a| a.value())?;
 
   let link_id = svgtypes::IRI::from_str(link_value).ok()?.0;
 

--- a/takumi-core/src/resvg/usvg/parser/use_node.rs
+++ b/takumi-core/src/resvg/usvg/parser/use_node.rs
@@ -200,7 +200,7 @@ pub(crate) fn convert_svg(
 
   if let Some(clip_rect) = get_clip_rect(node, node, state) {
     let mut g = clip_element(node, clip_rect, orig_ts, state, cache);
-    g.abs_transform = parent.abs_transform;
+    g.abs_transform = parent.abs_transform.pre_concat(orig_ts);
     convert_children(node, new_ts, &new_state, cache, false, &mut g);
     g.calculate_bounding_boxes();
     parent.children.push(Node::Group(Box::new(g)));

--- a/takumi-core/src/resvg/usvg/tree/mod.rs
+++ b/takumi-core/src/resvg/usvg/tree/mod.rs
@@ -1590,6 +1590,11 @@ impl Tree {
   /// Size of an image that should be created to fit the SVG.
   ///
   /// `width` and `height` in SVG.
+  ///
+  /// Note that this does not necessarily represent the bounding box of the
+  /// rendered contents. Use
+  /// [`self.root().abs_layer_bounding_box()`](Group::abs_layer_bounding_box)
+  /// to retrieve it instead.
   pub fn size(&self) -> Size {
     self.size
   }


### PR DESCRIPTION
## Why
The vendored resvg copy is at 0.47.0; upstream 0.48.x fixed several parser and filter bugs that apply to our stripped subset. Revives #1070, whose stacked base went stale.

## What
Ports the applicable 0.47.0 -> 0.48.1 hunks onto the vendored tree: nested `svg` no longer gets its transform applied twice, a missing `width`/`height` is derived from the viewBox aspect ratio, unprefixed `href` wins over `xlink:href`, `fr` is inherited for referenced radial gradients, filter regions are clamped to the source buffer (fixes the feComposite panic), and size asserts became debug asserts. The 0.48 text-stack rewrite does not apply since the `text` feature is stripped. The registry `resvg` dev-dependency is already at 0.48 on master, so the parity tests compare against the same version; fixture goldens show no render changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the rendering engine to improve filter bounds, clipping, transforms, gradients, and image sizing.
  - Fixed SVG handling for inherited dimensions, nested elements, link attributes, and radial gradients.
  - Prevented crashes when rendering large paths, oversized filters, or invalid filter regions.
  - Improved visibility of SVG path parsing errors.

- **Documentation**
  - Updated rendering engine version information and clarified SVG sizing and content-boundary behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->