### PR TITLE
Core: record exact vendored resvg version in lib.rs comment

### DIFF
--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -36,7 +36,7 @@ pub mod style;
 /// Viewport dimensions and device-pixel-ratio resolution.
 pub mod viewport;
 
-/// Vendored resvg 0.48 (see `resvg/mod.rs` for provenance and stripped features).
+/// Vendored resvg 0.48.1 (see `resvg/mod.rs` for provenance and stripped features).
 /// `dead_code` stays allowed until the unused upstream API surface is pruned.
 #[cfg(feature = "svg")]
 #[allow(


### PR DESCRIPTION
## Why
The provenance comment in `lib.rs` says 0.48 while `resvg/mod.rs` records 0.48.1. Follow-up to #1107, which merged before this one-liner landed.

## What
The comment now reads 0.48.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled graphics rendering component’s provenance information to reflect version 0.48.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->