### PR TITLE
Merge pending changelogs

### DIFF
--- a/.tegami/pdf-archival.md
+++ b/.tegami/pdf-archival.md
@@ -4,6 +4,8 @@ packages:
     type: minor
 ---
 
-### PDF/A output
+### PDF/A and tagged output
 
-Set `pdfa` to `"2b"`, `"2u"`, `"3b"`, `"3u"` or `"4"` to emit archival PDFs with an sRGB output intent and XMP metadata. Documents that cannot conform reject the render instead of writing a broken file.
+Output is now tagged by default, like Chromium's print-to-PDF. The structure tree comes from the HTML semantics: headings, paragraphs, figures with alt text, links, and header/footer artifacts. Decorative `<img alt="">` images are artifacts. `tagged: false` turns the tree off. `tagged: "ua1"` validates against PDF/UA-1.
+
+Set `pdfa` to a level from `"2b"` to `"4"` to emit archival PDFs with an sRGB output intent and XMP metadata. The `a` levels require the structure tree and `metadata.creationDate`. A document that cannot conform rejects the render instead of writing a broken file.

--- a/.tegami/pdf-attachments.md
+++ b/.tegami/pdf-attachments.md
@@ -6,8 +6,4 @@ packages:
 
 ### File attachments
 
-Attach files with `attachments`, the PDF/A-3 shape ZUGFeRD and Factur-X e-invoices use.
-
-- `data` takes bytes or a UTF-8 string
-- `modificationDate` falls back to `metadata.creationDate`
-- invalid `pdfa` combinations are TypeScript type errors
+Attach files with `attachments`, the PDF/A-3 shape ZUGFeRD and Factur-X e-invoices use. `data` takes bytes or a UTF-8 string. `modificationDate` falls back to `metadata.creationDate`. Invalid `pdfa` combinations are TypeScript type errors.

--- a/.tegami/pdf-attachments.md
+++ b/.tegami/pdf-attachments.md
@@ -6,4 +6,4 @@ packages:
 
 ### File attachments
 
-Attach files with `attachments`, the PDF/A-3 shape ZUGFeRD and Factur-X e-invoices use. `data` takes bytes or a UTF-8 string. `modificationDate` falls back to `metadata.creationDate`. Invalid `pdfa` combinations are TypeScript type errors.
+Attach files with `attachments`, the PDF/A-3 shape ZUGFeRD and Factur-X e-invoices use. `data` takes bytes or a UTF-8 string. `modificationDate` falls back to `metadata.creationDate`. Invalid `pdfa` combinations are TypeScript type errors. Without type checking they reject the render at runtime.

--- a/.tegami/pdf-measure.md
+++ b/.tegami/pdf-measure.md
@@ -6,4 +6,4 @@ packages:
 
 ### Measure a tree without rendering
 
-`measure` returns a tree's laid-out size in CSS px. With page options it lays out at the full page width with counter hooks filled, exactly how `render` measures a header or footer band. The height tells you how much margin the band needs.
+`measure` returns a tree's laid-out size in CSS px. With page options it lays out at the full-page width with counter hooks filled, exactly how `render` measures a header or footer band. The height tells you how much margin the band needs.

--- a/.tegami/pdf-measure.md
+++ b/.tegami/pdf-measure.md
@@ -6,4 +6,4 @@ packages:
 
 ### Measure a tree without rendering
 
-`measure` returns a tree's laid-out size in CSS px. With page options it lays out at the full page width and fills counter hooks with three-digit numbers, exactly how `render` measures a header or footer band, so the height tells you how much margin the band needs.
+`measure` returns a tree's laid-out size in CSS px. With page options it lays out at the full page width with counter hooks filled, exactly how `render` measures a header or footer band. The height tells you how much margin the band needs.

--- a/.tegami/pdf-tagged-fixes.md
+++ b/.tegami/pdf-tagged-fixes.md
@@ -1,9 +1,0 @@
----
-packages:
-  takumi-pdf:
-    type: patch
----
-
-### Tagged-output fixes
-
-Link elements now follow the text they annotate instead of preceding it in reading order. `<img alt="">` is emitted as an artifact, so decorative images pass PDF/UA-1 instead of failing alt-text validation. An invalid `creationDate` rejects the render instead of disappearing from the output, and tag-tree faults surface as errors instead of panics.

--- a/.tegami/pdf-tagged-standards.md
+++ b/.tegami/pdf-tagged-standards.md
@@ -1,9 +1,0 @@
----
-packages:
-  takumi-pdf:
-    type: minor
----
-
-### Tagged PDF: PDF/UA-1 and the PDF/A `a` levels
-
-Output is now tagged by default, like Chromium's print-to-PDF: a structure tree built from the HTML semantics — headings, paragraphs, figures with alt text, links, and header/footer artifacts. `tagged: false` turns it off. `tagged: "ua1"`, `pdfa: "2a"` and `pdfa: "3a"` validate the result, and `metadata.creationDate` sets the document date the `a` levels require.

--- a/.tegami/pdf-vendor-krilla.md
+++ b/.tegami/pdf-vendor-krilla.md
@@ -1,9 +1,0 @@
----
-packages:
-  takumi-pdf:
-    type: patch
----
-
-### Vendor krilla and subsetter into the PDF backend
-
-The PDF writer now builds from vendored krilla and subsetter forks on one shared fontations stack, with the embedded-PDF, simple-text, threading and tagged-PDF subsystems removed. Output bytes are unchanged.


### PR DESCRIPTION
## Why
Eight changesets are pending for the 0.3 release. Two describe changes a 0.2 user cannot observe, and the PDF/A levels are split across two entries.

## What
Merges the tagged-output entry into the PDF/A one, drops the krilla-vendoring entry (output-neutral) and the tagged-fixes entry (fixes to a feature first shipped in this release), and unifies the remaining entries on the heading-plus-paragraph style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that tagged PDF output is the default, including HTML-derived structure semantics and tagging options.
  * Documented PDF/A support for levels 2b through 4, including requirements for tagged output and creation dates.
  * Consolidated file-attachment validation guidance.
  * Clarified how page-option counters are populated during measurement.
  * Removed outdated notes covering tagged PDF fixes, standards, and vendor-specific implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->