### PR TITLE
Docs: refresh PDF comparison benchmarks for 0.3

### DIFF
--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -11,23 +11,23 @@ Warm figures are the median of 20 renders. The [bench source](https://github.com
 
 Environment: Apple M1 Pro, macOS 15.7, Bun 1.3.14, Chrome 150.
 
-|                               | takumi-pdf 0.2                              | @react-pdf/renderer 4.5.1                             | Puppeteer + Chrome              |
+|                               | takumi-pdf 0.3                              | @react-pdf/renderer 4.5.1                             | Puppeteer + Chrome              |
 | :---------------------------- | :------------------------------------------ | :---------------------------------------------------- | :------------------------------ |
-| Cold start to first PDF       | 188 ms                                      | 591 ms                                                | 1.7–6.8 s                       |
-| Warm render (median)          | 26 ms                                       | 279 ms                                                | 201 ms                          |
-| Output size                   | 15 KB                                       | 16 KB                                                 | 52 KB                           |
-| Deploy needs                  | 1.4 MB gzip wasm                            | pure JS                                               | Chrome install (hundreds of MB) |
+| Cold start to first PDF       | 160 ms                                      | 504 ms                                                | 0.7–1.7 s                       |
+| Warm render (median)          | 26 ms                                       | 230 ms                                                | 196 ms                          |
+| Output size                   | 25 KB (14 KB with `tagged: false`)          | 16 KB                                                 | 52 KB                           |
+| Deploy needs                  | 1.5 MB gzip wasm                            | pure JS                                               | Chrome install (hundreds of MB) |
 | Template language             | JSX, HTML, node trees with CSS and Tailwind | its own primitives (`<View>`, `<Text>`, `StyleSheet`) | HTML with full CSS              |
 | Selectable text, subset fonts | yes                                         | yes                                                   | yes                             |
 | Runs on edge runtimes         | yes (Cloudflare Workers)                    | no (Node)                                             | no                              |
 
 ## Bundle and install size
 
-These measurements use npm-registry packages and esbuild (`--bundle --minify`, gzip). Install size comes from a clean `bun add`.
+These measurements use npm-registry packages and esbuild (`--bundle --minify`, gzip). Install size comes from a clean `bun add`. The takumi-pdf 0.3 wasm numbers come from the CI release artifact.
 
 |                           | JS bundle (min+gzip) | wasm (gzip)              | `node_modules`                  |
 | :------------------------ | :------------------- | :----------------------- | :------------------------------ |
-| takumi-pdf 0.1.4          | 10 KB                | 1.66 MB (1.25 MB brotli) | 4.5 MB, 45 files                |
+| takumi-pdf 0.3            | 10 KB                | 1.50 MB (1.15 MB brotli) | 4.2 MB, 45 files                |
 | @react-pdf/renderer 4.5.1 | 493 KB               | —                        | 32 MB, 1998 files               |
 | pdf-lib 1.17.1            | 179 KB               | —                        | 26 MB                           |
 | pdfkit 0.19.1             | 253 KB               | —                        | 23 MB                           |
@@ -42,6 +42,6 @@ Reading the numbers honestly:
 
 - Chrome's cold start includes launching a browser process. It varies with machine state. Its memory spans several processes. A single-process measurement misses this. Chrome performs well after warming. It has the most complete CSS support of the three.
 - react-pdf embeds the same Inter subsets as the other two. Subsetting on every render is most of its warm cost; the standard 14 PDF fonts avoid it. Documents use react-pdf's component set. Existing HTML, JSX, and Tailwind markup cannot be reused.
-- takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `box-shadow`, `filter`, `clip-path`, or masks yet.
+- takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `box-shadow`, `filter`, `clip-path`, or masks yet. Tagged output is on by default since 0.3 and adds about 10 KB to this invoice. `tagged: false` removes it.
 
 Rule of thumb: use Puppeteer to reproduce a complex web page pixel-perfectly. Any renderer suits documents written from scratch for PDF work. Use takumi-pdf to reuse Takumi image components. It suits edge runtimes. It also offers lower per-document latency.


### PR DESCRIPTION
## Why
The comparison page still shows 0.2 numbers. The 0.3 output is different: tagged output is on by default and the wasm shrank.

## What
Re-runs the pdf-bench suite on the documented environment and updates both tables. Cold start drops to 160 ms, output grows to 25 KB from the default structure tree (14 KB with `tagged: false`, noted inline), and the wasm numbers now come from the CI release artifact: 1.50 MB gzip, 1.15 MB brotli.