### PR TITLE
Core: bound untrusted-input allocations and repeat loops

### DIFF
--- a/.tegami/untrusted-input-dos.md
+++ b/.tegami/untrusted-input-dos.md
@@ -1,0 +1,11 @@
+---
+packages:
+  takumi-core:
+    type: patch
+  takumi-raster:
+    type: patch
+---
+
+### Bound allocations and loops driven by untrusted input
+
+Three denial-of-service paths are closed. SVG rasterization and canvas allocation now cap at 16M pixels and return an error past it, instead of aborting on a huge allocation. A `background-size` past `i32::MAX` no longer wraps a repeat step negative and loops forever.

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -107,8 +107,8 @@ pub enum Error {
   #[error("WebP error: {0}")]
   WebPError(#[from] WebPError),
 
-  /// Invalid viewport dimensions (e.g., width or height is 0).
-  #[error("Invalid viewport: width or height cannot be 0")]
+  /// Invalid viewport dimensions (e.g., zero-sized or over the pixel budget).
+  #[error("Invalid viewport dimensions")]
   InvalidViewport,
 
   /// RGBA buffer length does not match `width * height * 4`.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -41,6 +41,12 @@ use crate::{
   style::{ImageScalingAlgorithm, IntrinsicSizing, SizingContext, StyleSheet},
 };
 
+const MAX_RASTER_PIXELS: u64 = 16 << 20;
+
+fn within_raster_pixel_budget(width: u32, height: u32) -> bool {
+  u64::from(width) * u64::from(height) <= MAX_RASTER_PIXELS
+}
+
 /// Represents the state of an image resource.
 pub(crate) type ImageResult = Result<ImageSource, ImageError>;
 
@@ -406,6 +412,10 @@ impl SvgSource {
   }
 
   fn rasterize(&self, width: u32, height: u32) -> Result<Arc<ImageBuffer>, ImageError> {
+    if !within_raster_pixel_budget(width, height) {
+      return Err(ImageError::InvalidPixmapSize);
+    }
+
     let mut pixmap = Pixmap::new(width, height).ok_or(ImageError::InvalidPixmapSize)?;
 
     let original_size = self.tree.size();
@@ -1426,6 +1436,19 @@ mod tests {
     assert_eq!(height, 4);
     assert_matches!(algo, ImageScalingAlgorithm::Pixelated);
     Ok(())
+  }
+
+  #[cfg(feature = "svg")]
+  #[test]
+  fn svg_rasterization_rejects_oversized_target() {
+    let source: ImageSource = "<svg width=\"1\" height=\"1\"/>"
+      .parse::<SvgSource>()
+      .unwrap()
+      .into();
+
+    let result = source.render_for_layout(4097, 4096, ImageScalingAlgorithm::Auto, 0);
+
+    assert_matches!(result, Err(ImageError::InvalidPixmapSize));
   }
 
   #[test]

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -20,16 +20,20 @@ pub fn collect_repeat_tile_positions(
     return SmallVec::default();
   }
 
-  let area_end = i32::try_from(area_size).unwrap_or(i32::MAX);
-  let tile_size = i32::try_from(tile_size).unwrap_or(i32::MAX);
+  // The arithmetic runs in i64 so a dimension near the u32 range neither
+  // wraps nor drops tiles; every emitted position also fits the area, which
+  // callers keep within the canvas pixel budget.
+  let area_end = i64::from(area_size);
+  let tile_size = i64::from(tile_size);
   let start = if origin > 0 {
-    origin.rem_euclid(tile_size) - tile_size
+    i64::from(origin).rem_euclid(tile_size) - tile_size
   } else {
-    origin
+    i64::from(origin)
   };
 
-  successors(Some(start), |&x| x.checked_add(tile_size))
+  successors(Some(start), |&x| Some(x + tile_size))
     .take_while(|&x| x < area_end)
+    .filter_map(|x| i32::try_from(x).ok())
     .collect()
 }
 

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -20,14 +20,16 @@ pub fn collect_repeat_tile_positions(
     return SmallVec::default();
   }
 
-  let mut start = origin;
-  if start > 0 {
-    let n = ((start as f32) / tile_size as f32).ceil() as i32;
-    start -= n * tile_size as i32;
-  }
+  let area_end = i32::try_from(area_size).unwrap_or(i32::MAX);
+  let tile_size = i32::try_from(tile_size).unwrap_or(i32::MAX);
+  let start = if origin > 0 {
+    origin.rem_euclid(tile_size) - tile_size
+  } else {
+    origin
+  };
 
-  successors(Some(start), |&x| Some(x + tile_size as i32))
-    .take_while(|&x| x < area_size as i32)
+  successors(Some(start), |&x| x.checked_add(tile_size))
+    .take_while(|&x| x < area_end)
     .collect()
 }
 
@@ -242,6 +244,14 @@ mod tests {
       let reparsed = BackgroundRepeat::from_css_str(&parsed.to_css_string()).unwrap();
       assert_eq!(parsed, reparsed, "failed for {css}");
     }
+  }
+
+  #[test]
+  fn oversized_repeat_tile_does_not_wrap_into_an_infinite_iterator() {
+    assert_eq!(
+      collect_repeat_tile_positions(100, u32::MAX, 0).as_slice(),
+      &[0]
+    );
   }
 
   #[test]

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -47,6 +47,12 @@ use crate::{
   style::{Affine, BlendMode, Color, ImageScalingAlgorithm},
 };
 
+const MAX_PIXMAP_PIXELS: u64 = 16 << 20;
+
+fn within_pixmap_pixel_budget(size: Size<u32>) -> bool {
+  u64::from(size.width) * u64::from(size.height) <= MAX_PIXMAP_PIXELS
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct SamplingOptions {
   pub logical_to_source: Affine,
@@ -107,9 +113,13 @@ pub(crate) struct CanvasSubcanvas {
 
 impl Canvas {
   /// Creates a canvas backed by a `size`-sized pixmap, or `None` when the pixmap
-  /// cannot be allocated (zero size, or dimensions large enough to overflow the
-  /// pixel-buffer length).
+  /// cannot be allocated (zero size, over the pixel budget, or dimensions large
+  /// enough to overflow the pixel-buffer length).
   pub(crate) fn try_new(size: Size<u32>) -> Option<Self> {
+    if !within_pixmap_pixel_budget(size) {
+      return None;
+    }
+
     let image = Pixmap::new(size.width, size.height)?;
     Some(Self {
       image,
@@ -132,6 +142,10 @@ impl Canvas {
   }
 
   fn acquire_offscreen(size: Size<u32>) -> Result<Pixmap> {
+    if !within_pixmap_pixel_budget(size) {
+      return Err(Error::InvalidViewport);
+    }
+
     Pixmap::new(size.width, size.height).ok_or_else(|| {
       Error::encode(ImageError::Parameter(ParameterError::from_kind(
         ParameterErrorKind::DimensionMismatch,

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -769,6 +769,21 @@ mod tests {
   }
 
   #[test]
+  fn viewport_over_pixel_budget_errors_before_allocating() {
+    let fonts = Fonts::default();
+    let options = RenderOptions::builder()
+      .fonts(&fonts)
+      .viewport(Viewport::new((4097, 4096)))
+      .node(Node::container([]))
+      .build();
+
+    assert!(matches!(
+      render(options),
+      Err(crate::Error::InvalidViewport)
+    ));
+  }
+
+  #[test]
   fn ordinary_viewport_still_renders() {
     let fonts = Fonts::default();
     let options = RenderOptions::builder()


### PR DESCRIPTION
## Why

Three paths let untrusted input take the process down: an SVG raster target sized from CSS could trigger an allocation abort, canvas and offscreen pixmaps had no size ceiling, and a `background-size` past `i32::MAX` wrapped the repeat step negative and looped forever.

## What

SVG rasterization and pixmap allocation cap at 16M pixels and return an error past it. Repeat tile positions use checked arithmetic, so an oversized tile yields one tile instead of a hang. Found and patched by a Codex security pass; each fix carries a regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added safeguards against denial-of-service risks from excessively large SVG rasterization, canvas allocations, and viewport sizes.
  * Requests exceeding the 16-million-pixel processing limit are rejected safely before resource allocation.
  * Prevented overflow and wraparound issues when rendering backgrounds with very large tiles.

* **Bug Fixes**
  * Improved handling of invalid or oversized rendering dimensions with consistent errors.
  * Added regression coverage for oversized SVGs, viewports, and background tiles.

* **Documentation**
  * Documented the new rendering limits and related security protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->