### PR TITLE
Docs: add PDF use case and migration guides

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -91,7 +91,7 @@ const png = await render(
   {
     width: 1200,
     height: 630,
-    // [!code highlight:3]
+    // [!code highlight:7]
     fonts: googleFonts([
       {
         name: "Fraunces",

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -62,7 +62,7 @@ import { ImageResponse } from "takumi-js/response";
 
 export function GET() {
   return new ImageResponse(<OgImage />, {
-    // [!code ++]
+    // [!code ++:10]
     images: [
       {
         src: "my-logo",

--- a/docs/content/docs/pdf/attachments.mdx
+++ b/docs/content/docs/pdf/attachments.mdx
@@ -8,10 +8,11 @@ Attach files with `attachments`. They appear in the viewer's attachment panel:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const invoice: ReactNode;
 declare const xml: string;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(invoice, {
   attachments: [
     {
@@ -43,10 +44,11 @@ ZUGFeRD and Factur-X invoices are PDF/A-3 documents with the invoice XML attache
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const invoice: ReactNode;
 declare const xml: string;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(invoice, {
   pdfa: "3b",
   metadata: { title: "Invoice 1042", creationDate: "2026-08-06" },

--- a/docs/content/docs/pdf/attachments.mdx
+++ b/docs/content/docs/pdf/attachments.mdx
@@ -1,6 +1,7 @@
 ---
 title: Attachments
 description: Embed files in the PDF, including PDF/A-3 e-invoice data
+icon: Paperclip
 ---
 
 Attach files with `attachments`. They appear in the viewer's attachment panel:
@@ -71,4 +72,4 @@ A missing field fails the render with the violated rule.
 
 Invalid combinations are **TypeScript type errors**. The PDF/A-2 levels and `"4"` forbid attachments. The PDF/A-3 levels require `mimeType` and `description` on each one.
 
-Full Factur-X conformance also expects its XMP extension schema. Takumi does not write it yet.
+Full Factur-X conformance also expects its `fx:` XMP extension schema. `metadata.xmp` writes it. See [Invoices](/docs/pdf/invoices).

--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -1,6 +1,7 @@
 ---
 title: Comparison
 description: takumi-pdf against Puppeteer and react-pdf, measured.
+icon: Scale
 ---
 
 This comparison benchmarks three JavaScript PDF renderers. The benchmark uses an 80-line invoice. The invoice spans two pages and has a page-number footer.

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -10,10 +10,11 @@ Text embeds as real glyph runs with subset fonts. It stays selectable, searchabl
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const doc: ReactNode;
 declare const fontBytes: Uint8Array;
 // ---cut---
+import { render } from "takumi-pdf";
+
 import { googleFonts } from "@takumi-rs/helpers";
 
 const pdf = await render(doc, {
@@ -30,10 +31,11 @@ The renderer never fetches over the network. Pass pre-fetched bytes for each ima
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const doc: ReactNode;
 declare const logoUrl: string;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const logoBytes = new Uint8Array(await (await fetch(logoUrl)).arrayBuffer());
 
 const pdf = await render(doc, {

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -1,6 +1,7 @@
 ---
 title: Fonts & images
 description: Embed subset fonts and pre-fetched images.
+icon: Type
 ---
 
 ## Fonts

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -1,0 +1,112 @@
+---
+title: From Puppeteer
+description: Replace headless Chrome with a 1.5 MB wasm module.
+icon: Globe
+---
+
+`takumi-pdf` was designed against Puppeteer's `page.pdf()`. The options carry the same names, the header and footer templates use the same class hooks, and pagination follows Chromium's fragmentation rules. Most migrations are a rename.
+
+What changes is the deploy. No browser process, no Chrome install, no page to navigate. The renderer takes a tree and returns bytes, so it runs on Cloudflare Workers.
+
+## Before and after
+
+```ts
+// Puppeteer
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+await page.setContent(html, { waitUntil: "networkidle0" });
+
+const pdf = await page.pdf({
+  format: "A4",
+  margin: { top: "48px", bottom: "64px", left: "48px", right: "48px" },
+  displayHeaderFooter: true,
+  footerTemplate: `<div style="font-size:10px;width:100%;text-align:center">
+    Page <span class="pageNumber"></span> of <span class="totalPages"></span>
+  </div>`,
+  printBackground: true,
+});
+
+await browser.close();
+```
+
+```tsx twoslash
+declare const html: string;
+// ---cut---
+// takumi-pdf
+import { googleFonts } from "@takumi-rs/helpers";
+import { fromHtml } from "@takumi-rs/helpers/html";
+import { render } from "takumi-pdf";
+
+const { node, stylesheets } = fromHtml(html);
+
+const pdf = await render(node, {
+  size: "a4",
+  margin: { top: 48, bottom: 64, left: 48, right: 48 },
+  stylesheets,
+  footer: (
+    <div tw="flex w-full justify-center text-[10px]">
+      Page <span className="pageNumber" /> of <span className="totalPages" />
+    </div>
+  ),
+  fonts: await googleFonts(["Inter"]),
+});
+```
+
+`fromHtml` converts the markup already being fed to `setContent`. JSX and node trees skip that step. Bands take the same input, so a header can be a component instead of a template string.
+
+## Option map
+
+| `page.pdf()`                             | `takumi-pdf`                           |
+| ---------------------------------------- | -------------------------------------- |
+| `format: "A4"`                           | `size: "a4"`                           |
+| `width`, `height`                        | `size: { width, height }`              |
+| `landscape`                              | `landscape`                            |
+| `margin`                                 | `margin`, in CSS px                    |
+| `displayHeaderFooter` + `headerTemplate` | `header`                               |
+| `footerTemplate`                         | `footer`                               |
+| `pageNumber`, `totalPages` classes       | the same classes                       |
+| `date`, `title`, `url` classes           | interpolate the value yourself         |
+| `tagged` (default on)                    | `tagged` (default on)                  |
+| `outline`                                | `outline`                              |
+| `printBackground`                        | always on                              |
+| `path`                                   | write the returned `Uint8Array`        |
+| `timeout`, `waitForFonts`                | not needed: no page to load            |
+| `scale`                                  | not supported: scale the CSS instead   |
+| `pageRanges`                             | not supported                          |
+| `preferCSSPageSize`, `@page`             | not supported: set `size` and `margin` |
+| `omitBackground`                         | not supported                          |
+
+Margins take numbers in CSS px. Chromium's `"0.5in"` strings have no equivalent; `48` is that half inch.
+
+## Fetching moves to your code
+
+Nothing is fetched implicitly. A browser resolved image URLs and web fonts while it loaded the page. Now the fetch is a call you make:
+
+```tsx twoslash
+declare const html: string;
+// ---cut---
+import { prepareImages } from "@takumi-rs/helpers";
+import { fromHtml } from "@takumi-rs/helpers/html";
+import { render } from "takumi-pdf";
+
+const { node, stylesheets } = fromHtml(html);
+const images = await prepareImages({ node });
+
+const pdf = await render(node, { images, stylesheets });
+```
+
+`prepareImages` walks the tree, fetches every remote `<img>`, `background-image`, and `mask-image` URL, and returns the `images` entries. It takes a `fetchCache` to reuse bytes, an `allowUrl` predicate, and a `timeout`.
+
+Fonts come from the `fonts` option rather than a CSS `@font-face` rule. See [Fonts & images](/docs/pdf/fonts-and-images).
+
+A render never reaches for a URL on its own. Timeouts and allow-lists sit in the fetch, where they can be enforced.
+
+## What Chrome still does better
+
+Chrome is a browser. Takumi is a layout engine with a document-shaped CSS subset.
+
+- **No scripts.** Charts and diagrams have to arrive as markup, SVG, or images. A client-side chart library will not run.
+- **Narrower CSS.** No `filter: blur()`, `drop-shadow()`, or `backdrop-filter` in PDF output. A blurred `box-shadow` approximates with bands. Grid and flex, transforms, gradients, masks, and clip paths all work.
+- **No `@page`.** Page geometry lives in the options.
+
+Keep Puppeteer to reproduce a live web page as it appears in a browser. Move to `takumi-pdf` for documents written for print, and see [Comparison](/docs/pdf/comparison) for the measured numbers.

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -4,7 +4,7 @@ description: Replace headless Chrome with a 1.5 MB wasm module.
 icon: Globe
 ---
 
-`takumi-pdf` was designed against Puppeteer's `page.pdf()`. The options carry the same names, the header and footer templates use the same class hooks, and pagination follows Chromium's fragmentation rules. Most migrations are a rename.
+`takumi-pdf` was designed against Puppeteer's `page.pdf()`. Most options have a direct counterpart, header and footer bands use the same class hooks, and pagination follows Chromium's fragmentation rules. Names and input types differ in places, so read the map below.
 
 What changes is the deploy. No browser process, no Chrome install, no page to navigate. The renderer takes a tree and returns bytes, so it runs on Cloudflare Workers.
 

--- a/docs/content/docs/pdf/from-react-pdf.mdx
+++ b/docs/content/docs/pdf/from-react-pdf.mdx
@@ -70,7 +70,7 @@ const pdf = await render(
 
 ## Three differences that bite
 
-**Units are CSS px.** react-pdf measures in pt. Takumi measures in CSS px at 96 dpi. Multiply every number by `96 / 72`, or about `1.333`. A4 is `595 × 842` pt and `794 × 1123` px.
+**Units are CSS px.** react-pdf measures lengths in pt. Takumi measures them in CSS px at 96 dpi. Multiply every length by `96 / 72`, or about `1.333`. A4 is `595 × 842` pt and `794 × 1123` px. Unitless values carry over as they are: `flexGrow`, `opacity`, `fontWeight`.
 
 **Flex direction defaults to row.** react-pdf defaults every container to `column`, unlike the web. CSS defaults to `row`. A stacked layout needs `flex-direction: column` written out.
 
@@ -82,9 +82,10 @@ react-pdf repeats a band by marking a `<View>` as `fixed` inside the page. Takum
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">

--- a/docs/content/docs/pdf/from-react-pdf.mdx
+++ b/docs/content/docs/pdf/from-react-pdf.mdx
@@ -1,0 +1,113 @@
+---
+title: From react-pdf
+description: Trade a private component set for HTML, CSS, and Tailwind.
+icon: Atom
+---
+
+`@react-pdf/renderer` gives React a private set of document primitives: `<Document>`, `<Page>`, `<View>`, `<Text>`, and a `StyleSheet` that accepts part of CSS. `takumi-pdf` renders ordinary markup instead. A component built for an OG image renders to PDF unchanged.
+
+## Before and after
+
+```tsx
+// @react-pdf/renderer
+import { Document, Page, View, Text, StyleSheet, renderToBuffer } from "@react-pdf/renderer";
+
+const styles = StyleSheet.create({
+  page: { padding: 48, fontFamily: "Inter" },
+  row: { flexDirection: "row", justifyContent: "space-between" },
+  label: { fontSize: 10, color: "#6b7280" },
+});
+
+const pdf = await renderToBuffer(
+  <Document>
+    <Page size="A4" style={styles.page}>
+      <View style={styles.row}>
+        <Text style={styles.label}>Invoice</Text>
+        <Text style={styles.label}>INV-0042</Text>
+      </View>
+    </Page>
+  </Document>,
+);
+```
+
+```tsx twoslash
+// takumi-pdf
+import { googleFonts } from "@takumi-rs/helpers";
+import { render } from "takumi-pdf";
+
+const pdf = await render(
+  <div tw="flex justify-between text-[10px] text-gray-500">
+    <span>Invoice</span>
+    <span>INV-0042</span>
+  </div>,
+  { size: "a4", margin: 48, fonts: await googleFonts(["Inter"]) },
+);
+```
+
+## Component map
+
+| `@react-pdf/renderer`                   | `takumi-pdf`                          |
+| --------------------------------------- | ------------------------------------- |
+| `<Document>`                            | none: `render()` takes the tree       |
+| `<Page size="A4">`                      | the `size` option                     |
+| `<View>`                                | `<div>`                               |
+| `<Text>`                                | `<span>`, `<p>`, or bare text         |
+| `<Image src>`                           | `<img src>` plus the `images` option  |
+| `<Link src>`                            | `<a href>`                            |
+| `<Svg>` primitives                      | `<svg>`, or an SVG through `images`   |
+| `StyleSheet.create`                     | `style` objects or `tw` classes       |
+| `Font.register`                         | the `fonts` option                    |
+| `renderToBuffer`                        | `render()` returns a `Uint8Array`     |
+| `renderToStream`, `renderToFile`        | write the returned bytes yourself     |
+| a `fixed` header or footer `<View>`     | the `header` and `footer` options     |
+| `render={({ pageNumber, totalPages })}` | `pageNumber` and `totalPages` classes |
+| the `break` prop                        | `break-before: page`                  |
+| `wrap={false}`                          | `break-inside: avoid`                 |
+| `orphans`, `widows`, `minPresenceAhead` | not supported                         |
+| `Font.registerHyphenationCallback`      | not supported                         |
+| `Font.registerEmojiSource`              | `extractEmojis`, then `prepareImages` |
+| `<PDFViewer>`, `<PDFDownloadLink>`      | not supported: render on the server   |
+
+## Three differences that bite
+
+**Units are CSS px.** react-pdf measures in pt. Takumi measures in CSS px at 96 dpi. Multiply every number by `96 / 72`, or about `1.333`. A4 is `595 × 842` pt and `794 × 1123` px.
+
+**Flex direction defaults to row.** react-pdf defaults every container to `column`, unlike the web. CSS defaults to `row`. A stacked layout needs `flex-direction: column` written out.
+
+**Layout is not implicit.** react-pdf's `<View>` is always a flex container. Plain HTML elements are not, so a `<div>` meant to lay out children needs `display: flex` or `display: grid`. The `tw` shorthand covers this: `tw="flex flex-col"`.
+
+## Page bands
+
+react-pdf repeats a band by marking a `<View>` as `fixed` inside the page. Takumi takes the band as a separate option, and it draws in the margin:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+declare const report: ReactNode;
+// ---cut---
+const pdf = await render(report, {
+  footer: (
+    <div tw="flex w-full justify-center text-[10px] text-gray-500">
+      Page <span className="pageNumber" /> of <span className="totalPages" />
+    </div>
+  ),
+  margin: { top: 48, bottom: 72 },
+});
+```
+
+The counter is a class on an element, not a `render` callback. See [Headers & footers](/docs/pdf/headers-and-footers) for counter styles and for sizing the margin to the band.
+
+## What each side is better at
+
+`@react-pdf/renderer` keeps:
+
+- **A browser build.** `<PDFViewer>` and `<PDFDownloadLink>` render in the tab. Takumi renders on a server or a worker.
+- **Text refinements.** `orphans`, `widows`, and a hyphenation callback have no equivalent.
+- **The standard 14 fonts.** Skipping font embedding produces a smaller file.
+
+`takumi-pdf` brings:
+
+- **Real CSS and Tailwind**, on the same components an image render uses.
+- **Archival output.** PDF/A, PDF/UA, and attachments, validated during the render.
+- **Edge runtimes.** One wasm module, no Node built-ins.
+- **Lower latency.** See [Comparison](/docs/pdf/comparison) for the benchmark.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -8,9 +8,10 @@ icon: PanelTop
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
@@ -26,9 +27,10 @@ Band height depends on layout, so it is hard to guess ahead of time. `measure` l
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { measure, render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { measure, render } from "takumi-pdf";
+
 const footer = (
   <div tw="flex w-full justify-center text-[10px] text-gray-500">
     Page <span className="pageNumber" /> of <span className="totalPages" />
@@ -53,9 +55,10 @@ Add a CSS `@counter-style` name to the class list. It formats the number:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   footer: (
     <div style={{ fontSize: 12 }}>

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -1,6 +1,7 @@
 ---
 title: Headers & footers
 description: Repeat bands on every page with page counters.
+icon: PanelTop
 ---
 
 `header` and `footer` accept any node input. They repeat on every page. Bands lay out at full page width and draw in the page margin areas, like Chromium's print templates. Pick a margin at least as tall as the band, or the band overlaps content, exactly as in Chromium.
@@ -54,15 +55,14 @@ Add a CSS `@counter-style` name to the class list. It formats the number:
 import type { ReactNode } from "react";
 import { render } from "takumi-pdf";
 declare const report: ReactNode;
+// ---cut---
 const pdf = await render(report, {
-  // ---cut---
   footer: (
     <div style={{ fontSize: 12 }}>
       第 <span className="pageNumber trad-chinese-informal" /> 頁,共{" "}
       <span className="totalPages trad-chinese-informal" /> 頁
     </div>
   ),
-  // ---cut-after---
 });
 ```
 

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -2,6 +2,7 @@
 title: Introduction
 description: Render JSX to paged, selectable-text PDF with takumi-pdf.
 index: true
+icon: BookOpen
 ---
 
 `takumi-pdf` renders the same JSX, Tailwind classes, and node trees as image output. It writes a paged vector PDF instead: selectable text, embedded subset fonts, page breaks, and repeating headers and footers. It ships as a WebAssembly module. It runs on Node.js, Bun, and Cloudflare Workers without Chromium.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -42,9 +42,10 @@ await writeFile("invoice.pdf", pdf);
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   size: "letter", // "a4", "letter", or { width, height } in CSS px at 96 dpi
   landscape: true,

--- a/docs/content/docs/pdf/invoices.mdx
+++ b/docs/content/docs/pdf/invoices.mdx
@@ -1,0 +1,127 @@
+---
+title: Invoices
+description: Paged invoices, and the PDF/A-3 container an EU e-invoice needs.
+icon: Receipt
+---
+
+An invoice PDF serves two readers. A person reads the layout. A tax authority's software reads structured data attached inside the same file. `takumi-pdf` writes both halves.
+
+## A plain invoice
+
+Line items flow across pages. A footer carries the page counter. `measure` returns the band's height, so the bottom margin always clears it:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+declare const invoice: { number: string };
+declare function InvoiceDocument(props: { data: typeof invoice }): ReactNode;
+// ---cut---
+import { googleFonts } from "@takumi-rs/helpers";
+import { measure, render } from "takumi-pdf";
+
+const footer = (
+  <div tw="flex w-full justify-between px-12 text-[10px] text-[#6b7280]">
+    <span>Invoice {invoice.number}</span>
+    <span tw="flex">
+      Page <span className="pageNumber" /> of <span className="totalPages" />
+    </span>
+  </div>
+);
+
+const fonts = await googleFonts(["Inter"]);
+const { height } = await measure(footer, { size: "a4", fonts });
+
+const pdf = await render(<InvoiceDocument data={invoice} />, {
+  size: "a4",
+  margin: { top: 48, bottom: height + 32, left: 48, right: 48 },
+  footer,
+  fonts,
+});
+```
+
+Mark each line row `break-inside: avoid` so a row never straddles a page. The Tailwind class is `break-inside-avoid`:
+
+```tsx twoslash
+import "takumi-pdf";
+declare const item: { description: string; amount: string };
+// ---cut---
+<div tw="flex break-inside-avoid gap-3 pt-3 text-xs">
+  <span tw="flex-1">{item.description}</span>
+  <span tw="w-[100px] text-right">{item.amount}</span>
+</div>;
+```
+
+Wrap the totals block the same way. It is the part a reader most expects to see whole.
+
+## Electronic invoices
+
+Factur-X and ZUGFeRD are the same file twice: a readable invoice, plus the invoice as XML attached inside it. The standards pin how that file is packaged.
+
+| The standard requires        | The option              |
+| ---------------------------- | ----------------------- |
+| A PDF/A-3 container          | `pdfa: "3b"`            |
+| The XML attached by name     | `attachments`           |
+| An `fx:` XMP block           | `metadata.xmp`          |
+| A modification date per file | `metadata.creationDate` |
+| Embedded subset fonts        | always on               |
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+import type { XmpSchema } from "takumi-pdf";
+declare const invoice: ReactNode;
+declare const xml: string;
+declare const facturXmp: XmpSchema;
+// ---cut---
+const pdf = await render(invoice, {
+  lang: "en",
+  // [!code highlight:2]
+  pdfa: "3b",
+  tagged: "ua1",
+  metadata: {
+    title: "Invoice INV-2026-0042",
+    creationDate: "2026-08-06",
+    // [!code highlight]
+    xmp: [facturXmp],
+  },
+  attachments: [
+    {
+      name: "factur-x.xml",
+      data: xml,
+      mimeType: "text/xml",
+      description: "Factur-X 1.0 MINIMUM invoice data",
+      relationship: "data",
+    },
+  ],
+});
+```
+
+The renderer validates while it writes. A document that cannot conform fails with the violated rule, instead of producing a file a tax portal rejects.
+
+Takumi does not build the invoice XML. Use a library for the profile, or emit the elements the profile lists. The [e-invoice example](https://github.com/kane50613/takumi/tree/master/example/e-invoice) writes a MINIMUM profile by hand.
+
+### Validating the result
+
+Two validators cover the two halves. Both need Java.
+
+[veraPDF](https://verapdf.org) checks the container:
+
+```bash
+verapdf --flavour 3b --format text invoice.pdf
+verapdf --flavour ua1 --format text invoice.pdf
+```
+
+[Mustang](https://www.mustangproject.org) checks the Factur-X half, both the XML and the packaging:
+
+```bash
+java -jar Mustang-CLI.jar --action validate --source invoice.pdf
+```
+
+Mustang finds the profile through the `fx:` XMP block. Takumi writes the values and the schema description PDF/A demands, so the two cannot drift. It does not check the values: a wrong profile name surfaces in Mustang, not at render time.
+
+## Accessible invoices
+
+Public-sector buyers often require an accessible invoice. `tagged: "ua1"` validates the structure tree against PDF/UA-1 during the render. See [PDF/A](/docs/pdf/pdf-a) for what it needs.
+
+## Reproducible bytes
+
+A fixed `metadata.creationDate` makes the output byte-identical across runs. The same invoice hashes to the same value, which suits archival storage and golden tests.

--- a/docs/content/docs/pdf/invoices.mdx
+++ b/docs/content/docs/pdf/invoices.mdx
@@ -41,9 +41,10 @@ const pdf = await render(<InvoiceDocument data={invoice} />, {
 Mark each line row `break-inside: avoid` so a row never straddles a page. The Tailwind class is `break-inside-avoid`:
 
 ```tsx twoslash
-import "takumi-pdf";
 declare const item: { description: string; amount: string };
 // ---cut---
+import "takumi-pdf";
+
 <div tw="flex break-inside-avoid gap-3 pt-3 text-xs">
   <span tw="flex-1">{item.description}</span>
   <span tw="w-[100px] text-right">{item.amount}</span>
@@ -56,22 +57,25 @@ Wrap the totals block the same way. It is the part a reader most expects to see 
 
 Factur-X and ZUGFeRD are the same file twice: a readable invoice, plus the invoice as XML attached inside it. The standards pin how that file is packaged.
 
-| The standard requires        | The option              |
-| ---------------------------- | ----------------------- |
-| A PDF/A-3 container          | `pdfa: "3b"`            |
-| The XML attached by name     | `attachments`           |
-| An `fx:` XMP block           | `metadata.xmp`          |
-| A modification date per file | `metadata.creationDate` |
-| Embedded subset fonts        | always on               |
+| The standard requires        | The option         |
+| ---------------------------- | ------------------ |
+| A PDF/A-3 container          | `pdfa: "3b"`       |
+| The XML attached by name     | `attachments`      |
+| An `fx:` XMP block           | `metadata.xmp`     |
+| A modification date per file | `modificationDate` |
+| Embedded subset fonts        | always on          |
+
+Each attachment's `modificationDate` falls back to `metadata.creationDate`. Setting the document date once covers both.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 import type { XmpSchema } from "takumi-pdf";
 declare const invoice: ReactNode;
 declare const xml: string;
 declare const facturXmp: XmpSchema;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(invoice, {
   lang: "en",
   // [!code highlight:2]

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -1,6 +1,7 @@
 ---
 title: Links, outline & metadata
 description: Clickable hyperlinks, bookmarks, and document properties.
+icon: Link
 ---
 
 ## Hyperlinks
@@ -11,11 +12,9 @@ Anchors with an `href` become clickable link annotations. They appear on every p
 import { render } from "takumi-pdf";
 
 const pdf = await render(
-  // ---cut---
   <p>
     Pay online at <a href="https://example.com/pay/1042">example.com/pay/1042</a>.
   </p>,
-  // ---cut-after---
 );
 ```
 
@@ -27,12 +26,10 @@ Inline anchors annotate each text run. A link that wraps across lines stays clic
 import { render } from "takumi-pdf";
 
 const pdf = await render(
-  // ---cut---
   <div>
     <a href="#appendix">Jump to the appendix</a>
     <h1 id="appendix">Appendix</h1>
   </div>,
-  // ---cut-after---
 );
 ```
 

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -41,9 +41,10 @@ Set `outline: true` to build PDF bookmarks from `h1`–`h6` headings. Deeper hea
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, { outline: true });
 ```
 
@@ -55,9 +56,10 @@ Clicking a bookmark jumps to the page and position of its heading.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   lang: "en",
   metadata: {

--- a/docs/content/docs/pdf/meta.json
+++ b/docs/content/docs/pdf/meta.json
@@ -5,6 +5,7 @@
   "icon": "FileText",
   "pages": [
     "index",
+    "--- Guides ---",
     "pagination",
     "headers-and-footers",
     "links-and-outline",
@@ -12,6 +13,13 @@
     "fonts-and-images",
     "pdf-a",
     "attachments",
+    "--- Use cases ---",
+    "invoices",
+    "reports",
+    "tickets",
+    "--- Migration ---",
+    "from-puppeteer",
+    "from-react-pdf",
     "comparison"
   ]
 }

--- a/docs/content/docs/pdf/pagination.mdx
+++ b/docs/content/docs/pdf/pagination.mdx
@@ -1,6 +1,7 @@
 ---
 title: Pagination
 description: Control where pages break with CSS.
+icon: Scissors
 ---
 
 Content lays out once at unbounded height. It then splits into pages. Unsplittable atoms never straddle a cut. These atoms include text lines, images, and transformed subtrees. A cut inside an atom moves to its top. This matches browser print fragmentation.
@@ -35,16 +36,15 @@ A box that crosses a page break slices its border and background by default. Set
 import { render } from "takumi-pdf";
 
 const pdf = await render(
-  // ---cut---
   <section
     style={{
       border: "1px solid #d1d5db",
       borderRadius: 8,
+      // [!code highlight]
       boxDecorationBreak: "clone",
     }}
   >
     Long content that continues on the next page.
   </section>,
-  // ---cut-after---
 );
 ```

--- a/docs/content/docs/pdf/pagination.mdx
+++ b/docs/content/docs/pdf/pagination.mdx
@@ -10,7 +10,7 @@ Content lays out once at unbounded height. It then splits into pages. Unsplittab
 
 ```tsx twoslash
 import { render } from "takumi-pdf";
-// ---cut---
+
 const pdf = await render(
   <article>
     <h1 style={{ breakBefore: "page" }}>Chapter two</h1>

--- a/docs/content/docs/pdf/pdf-a.mdx
+++ b/docs/content/docs/pdf/pdf-a.mdx
@@ -1,6 +1,7 @@
 ---
 title: PDF/A
 description: Archival output that validators accept
+icon: Archive
 ---
 
 Render a PDF/A document with `pdfa`.

--- a/docs/content/docs/pdf/pdf-a.mdx
+++ b/docs/content/docs/pdf/pdf-a.mdx
@@ -8,9 +8,10 @@ Render a PDF/A document with `pdfa`.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const invoice: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(invoice, {
   pdfa: "3b",
 });
@@ -48,9 +49,10 @@ Set `tagged: "ua1"` to also validate against PDF/UA-1:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   pdfa: "2a",
   tagged: "ua1",

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -1,0 +1,133 @@
+---
+title: Reports & statements
+description: Long documents with chapters, bookmarks, and running bands.
+icon: FileSpreadsheet
+---
+
+Reports and account statements are long. They break into chapters, repeat a band on every page, and get navigated rather than read straight through.
+
+## Chapters
+
+`break-before: page` starts a section on a fresh page. `break-inside: avoid` keeps a figure with its caption:
+
+```tsx twoslash
+import { render } from "takumi-pdf";
+
+const pdf = await render(
+  <article>
+    <section style={{ breakBefore: "page" }}>
+      <h1>Results</h1>
+      <figure style={{ breakInside: "avoid" }}>
+        <img src="chart.svg" alt="Revenue by quarter" />
+        <figcaption>Revenue by quarter</figcaption>
+      </figure>
+    </section>
+  </article>,
+);
+```
+
+Takumi has no `orphans` or `widows` control. A heading can land alone at the foot of a page. Wrapping the heading and its first paragraph in a `break-inside: avoid` box prevents that.
+
+See [Pagination](/docs/pdf/pagination) for the full set of break properties.
+
+## Bookmarks
+
+`outline: true` turns `h1`–`h6` into PDF bookmarks. A reader opens the sidebar and jumps between chapters. Nesting follows heading depth:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+declare const report: ReactNode;
+// ---cut---
+const pdf = await render(report, {
+  // [!code highlight]
+  outline: true,
+  lang: "en",
+  metadata: { title: "Annual report 2026", authors: ["Acme Inc."] },
+});
+```
+
+A table of contents with working links is `<a href="#section-id">` plus a matching `id`. See [Links, outline & metadata](/docs/pdf/links-and-outline).
+
+## Running bands
+
+A report header usually names the document and the period. A footer usually carries the page counter:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+declare const report: ReactNode;
+// ---cut---
+const pdf = await render(report, {
+  header: (
+    <div tw="flex w-full justify-between px-12 text-[10px] text-gray-500">
+      <span>Annual report 2026</span>
+      <span>Acme Inc.</span>
+    </div>
+  ),
+  footer: (
+    <div tw="flex w-full justify-center text-[10px] text-gray-500">
+      <span className="pageNumber" /> / <span className="totalPages" />
+    </div>
+  ),
+  margin: { top: 64, bottom: 64, left: 48, right: 48 },
+});
+```
+
+Bands draw in the margin, so the margin has to be tall enough. [Headers & footers](/docs/pdf/headers-and-footers) shows how to derive the margin from the band.
+
+## Long tables
+
+Takumi lays out tables as flex rows, and a header row does not repeat across pages on its own. Split the rows into groups and give each group its own header:
+
+```tsx twoslash
+import "takumi-pdf";
+import type { ReactNode } from "react";
+declare const rows: { id: string; label: string; amount: string }[];
+declare function chunk<T>(items: T[], size: number): T[][];
+declare function HeaderRow(): ReactNode;
+// ---cut---
+<div tw="flex flex-col">
+  {chunk(rows, 24).map((group, index) => (
+    <div key={index} tw="flex break-inside-avoid flex-col">
+      <HeaderRow />
+      {group.map((row) => (
+        <div key={row.id} tw="flex break-inside-avoid gap-3 pt-2 text-xs">
+          <span tw="flex-1">{row.label}</span>
+          <span tw="w-[100px] text-right">{row.amount}</span>
+        </div>
+      ))}
+    </div>
+  ))}
+</div>;
+```
+
+`break-inside-avoid` moves a group that no longer fits to the next page, header and all. Pick a group size that underfills a page, or the group stops fitting anywhere and splits again.
+
+## Batches
+
+Statement runs render the same template thousands of times. Construct one `PdfRenderer` and keep it. Fonts register once and are reused for every document:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+declare const accounts: { id: string }[];
+declare function Statement(props: { account: (typeof accounts)[number] }): ReactNode;
+declare function save(id: string, pdf: Uint8Array): Promise<void>;
+// ---cut---
+import { PdfRenderer } from "takumi-pdf";
+import { googleFonts } from "@takumi-rs/helpers";
+
+const renderer = new PdfRenderer();
+const fonts = await googleFonts(["Inter"]);
+
+for (const account of accounts) {
+  const pdf = await renderer.render(<Statement account={account} />, { fonts });
+  await save(account.id, pdf);
+}
+```
+
+Set `tagged: false` when nobody reads these with assistive technology. It drops the structure tree and the file gets smaller.
+
+## Accessibility
+
+Public bodies often have to publish accessible documents. `tagged: "ua1"` validates the structure tree against PDF/UA-1 during the render. It builds on the heading outline above. See [PDF/A](/docs/pdf/pdf-a) for the rest of its inputs.

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -36,9 +36,10 @@ See [Pagination](/docs/pdf/pagination) for the full set of break properties.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   // [!code highlight]
   outline: true,
@@ -55,9 +56,10 @@ A report header usually names the document and the period. A footer usually carr
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const report: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(report, {
   header: (
     <div tw="flex w-full justify-between px-12 text-[10px] text-gray-500">
@@ -81,12 +83,13 @@ Bands draw in the margin, so the margin has to be tall enough. [Headers & footer
 Takumi lays out tables as flex rows, and a header row does not repeat across pages on its own. Split the rows into groups and give each group its own header:
 
 ```tsx twoslash
-import "takumi-pdf";
 import type { ReactNode } from "react";
 declare const rows: { id: string; label: string; amount: string }[];
 declare function chunk<T>(items: T[], size: number): T[][];
 declare function HeaderRow(): ReactNode;
 // ---cut---
+import "takumi-pdf";
+
 <div tw="flex flex-col">
   {chunk(rows, 24).map((group, index) => (
     <div key={index} tw="flex break-inside-avoid flex-col">

--- a/docs/content/docs/pdf/single-page.mdx
+++ b/docs/content/docs/pdf/single-page.mdx
@@ -1,6 +1,7 @@
 ---
 title: Single-page viewport
 description: Fixed one-page PDFs for certificates, cards, and receipts.
+icon: File
 ---
 
 `viewport` renders one fixed page instead of paged output. It behaves like an image render. Percentage heights resolve against the viewport. It clips overflow.

--- a/docs/content/docs/pdf/single-page.mdx
+++ b/docs/content/docs/pdf/single-page.mdx
@@ -8,7 +8,7 @@ icon: File
 
 ```tsx twoslash
 import { render } from "takumi-pdf";
-// ---cut---
+
 const pdf = await render(<div style={{ width: "100%", height: "100%" }}>Certificate</div>, {
   viewport: { width: 1123, height: 794 }, // A4 landscape in px
 });
@@ -20,9 +20,10 @@ Omit `height` to size the single page to its laid-out content. This works like a
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const receipt: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
 ```
 

--- a/docs/content/docs/pdf/tickets.mdx
+++ b/docs/content/docs/pdf/tickets.mdx
@@ -1,0 +1,80 @@
+---
+title: Tickets & receipts
+description: One-page output at an exact paper size, or sized to its content.
+icon: Ticket
+---
+
+Some documents are one page by definition. A ticket, a shipping label, a certificate, a till receipt. `viewport` renders exactly one page and skips pagination entirely. See [Single-page viewport](/docs/pdf/single-page) for how the mode behaves.
+
+## Labels and tickets
+
+Give `viewport` the paper size in CSS px at 96 dpi. Percentage heights resolve against it, so a full-bleed background is `height: "100%"`:
+
+```tsx twoslash
+import { render } from "takumi-pdf";
+declare const qrSvg: Uint8Array;
+// ---cut---
+// 4in × 6in shipping label
+const pdf = await render(
+  <div tw="flex h-full w-full flex-col justify-between bg-white p-6">
+    <span tw="text-2xl font-semibold">ACME · Priority</span>
+    <img src="qr.svg" alt="Tracking code" tw="h-40 w-40 self-center" />
+    <span tw="text-xs text-gray-500">1Z 999 AA1 0123 4567</span>
+  </div>,
+  { viewport: { width: 384, height: 576 }, images: [{ src: "qr.svg", data: qrSvg }] },
+);
+```
+
+Generate the QR or barcode as SVG and pass its bytes through `images`. SVG sources embed as vector paths, so the code stays crisp at any zoom and any print resolution.
+
+Common sizes in CSS px:
+
+| Paper           | Width × height |
+| --------------- | -------------- |
+| A4 portrait     | 794 × 1123     |
+| A4 landscape    | 1123 × 794     |
+| A6 postcard     | 397 × 559      |
+| 4in × 6in label | 384 × 576      |
+| 80mm receipt    | 302 × auto     |
+
+## Receipts
+
+Omit `height` and the page grows to fit the content. A till receipt is one continuous strip, however many lines it has:
+
+```tsx twoslash
+import type { ReactNode } from "react";
+import { render } from "takumi-pdf";
+declare const receipt: ReactNode;
+// ---cut---
+const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
+```
+
+Percentage heights do not resolve in this mode. Nothing knows the final height until the layout finishes.
+
+## Certificates
+
+A certificate is a fixed page with artwork behind the text. Gradients, borders, radii, and transforms all draw as vectors:
+
+```tsx twoslash
+import { render } from "takumi-pdf";
+declare const recipient: string;
+// ---cut---
+const pdf = await render(
+  <div
+    tw="flex h-full w-full flex-col items-center justify-center"
+    style={{ backgroundImage: "linear-gradient(135deg, #eef2ff, #ffffff)" }}
+  >
+    <span tw="text-sm tracking-[0.3em] text-indigo-500">CERTIFICATE OF COMPLETION</span>
+    <span tw="mt-6 text-5xl">{recipient}</span>
+  </div>,
+  { viewport: { width: 1123, height: 794 } },
+);
+```
+
+Overflowing content is clipped, exactly like an image render. Size the text to the box, or measure it first.
+
+## What the mode gives up
+
+`viewport` rejects the paged options as type errors. Everything else carries over, including `pdfa` and `attachments`. See [Single-page viewport](/docs/pdf/single-page).
+
+Rendering the same component as a PNG for email or as a PDF for print is a matter of swapping the renderer. The tree, the CSS, and the Tailwind classes stay as they are.

--- a/docs/content/docs/pdf/tickets.mdx
+++ b/docs/content/docs/pdf/tickets.mdx
@@ -11,9 +11,10 @@ Some documents are one page by definition. A ticket, a shipping label, a certifi
 Give `viewport` the paper size in CSS px at 96 dpi. Percentage heights resolve against it, so a full-bleed background is `height: "100%"`:
 
 ```tsx twoslash
-import { render } from "takumi-pdf";
 declare const qrSvg: Uint8Array;
 // ---cut---
+import { render } from "takumi-pdf";
+
 // 4in × 6in shipping label
 const pdf = await render(
   <div tw="flex h-full w-full flex-col justify-between bg-white p-6">
@@ -43,9 +44,10 @@ Omit `height` and the page grows to fit the content. A till receipt is one conti
 
 ```tsx twoslash
 import type { ReactNode } from "react";
-import { render } from "takumi-pdf";
 declare const receipt: ReactNode;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
 ```
 
@@ -56,9 +58,10 @@ Percentage heights do not resolve in this mode. Nothing knows the final height u
 A certificate is a fixed page with artwork behind the text. Gradients, borders, radii, and transforms all draw as vectors:
 
 ```tsx twoslash
-import { render } from "takumi-pdf";
 declare const recipient: string;
 // ---cut---
+import { render } from "takumi-pdf";
+
 const pdf = await render(
   <div
     tw="flex h-full w-full flex-col items-center justify-center"

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -84,7 +84,7 @@ import { googleFonts } from "takumi-js/helpers";
 const image = await render(<div style={{ fontFamily: "Inter" }}>Hello 你好 こんにちは</div>, {
   width: 1200,
   height: 630,
-  // [!code ++:3]
+  // [!code ++]
   fonts: googleFonts(["Inter", "Noto Sans JP", "Noto Sans TC"]),
 });
 ```


### PR DESCRIPTION
## Why

The PDF section was a flat list of feature guides. Nothing told a reader whether takumi-pdf fits an invoice run, and nothing helped someone already on Puppeteer or react-pdf work out what changes.

## What

Two new sidebar categories. **Use cases**: invoices (Factur-X packaging, veraPDF and Mustang validation), reports (chapters, bookmarks, long tables, batch runs), tickets (single-page output). **Migration**: from Puppeteer and from react-pdf, each with an option map and an honest list of what does not carry over.

Along the way: icons on every PDF page, twoslash cuts no longer hide real code, two `[!code]` spans that covered the wrong lines, and the stale note claiming takumi cannot write the Factur-X XMP schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guides for Puppeteer and React PDF, including API mappings, layout differences, and unsupported features.
  * Added comprehensive guides for invoices, reports, tickets, labels, and single-page PDFs.
  * Expanded coverage of PDF/A, Factur-X/ZUGFeRD, accessibility, pagination, headers, fonts, links, and outlines.
  * Documented image fetching, security controls, validation workflows, and reproducible PDF output.
  * Improved PDF documentation navigation with organized guides, use cases, and migration sections.
  * Corrected code-example highlighting and updated page icons and annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->