### PR TITLE
Docs: declare the site name to search engines

### DIFF
--- a/docs/app/components/seo.tsx
+++ b/docs/app/components/seo.tsx
@@ -1,4 +1,34 @@
-import { OG_IMAGE, SITE_URL } from "~/layout-config";
+import { OG_IMAGE, SITE_NAME, SITE_URL } from "~/layout-config";
+
+const HOME_URL = `${SITE_URL}/`;
+
+// https://developers.google.com/search/docs/appearance/site-names
+export function SiteJsonLd() {
+  const data = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": `${HOME_URL}#website`,
+        name: SITE_NAME,
+        url: HOME_URL,
+        publisher: { "@id": `${HOME_URL}#organization` },
+      },
+      {
+        "@type": "Organization",
+        "@id": `${HOME_URL}#organization`,
+        name: SITE_NAME,
+        url: HOME_URL,
+        logo: `${SITE_URL}/logo.svg`,
+        sameAs: ["https://github.com/kane50613/takumi", "https://x.com/kanewang_"],
+      },
+    ],
+  };
+
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+  );
+}
 
 export function Seo({
   title,
@@ -11,12 +41,15 @@ export function Seo({
   path: string;
   image?: string;
 }) {
-  const url = `${SITE_URL}${path}`;
+  const url = path ? `${SITE_URL}${path}` : HOME_URL;
   return (
     <>
       <title>{title}</title>
       <meta property="og:title" content={title} />
       <meta property="og:image" content={image} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:image:alt" content={`${title} — ${SITE_NAME}`} />
       {description && (
         <>
           <meta name="description" content={description} />

--- a/docs/app/layout-config.tsx
+++ b/docs/app/layout-config.tsx
@@ -2,8 +2,10 @@ import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 
 export const SITE_URL = "https://takumi.kane.tw";
 
-export const OG_IMAGE =
-  "https://raw.githubusercontent.com/kane50613/takumi/master/example/twitter-images/output/og-image.png";
+// docs/public/images/twitter-images symlinks example/twitter-images/output.
+export const OG_IMAGE = `${SITE_URL}/images/twitter-images/og-image.png`;
+
+export const SITE_NAME = "Takumi";
 
 export const baseOptions: BaseLayoutProps = {
   githubUrl: "https://github.com/kane50613/takumi",

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Introduction to takumi-pdf
 description: Render JSX to paged, selectable-text PDF with takumi-pdf.
 index: true
 icon: BookOpen

--- a/docs/press.config.tsx
+++ b/docs/press.config.tsx
@@ -35,7 +35,7 @@ import { googleFonts } from "takumi-js/helpers";
 import wasmModule from "takumi-js/wasm";
 import { docs } from "./.source/server";
 import sticker from "./public/sticker.svg?raw";
-import { baseOptions } from "./app/layout-config";
+import { baseOptions, SITE_URL } from "./app/layout-config";
 import { Accordion, Accordions } from "./app/components/accordion";
 import { Mermaid } from "./app/components/mdx/mermaid";
 import { TypeTable } from "./app/components/type-table";
@@ -82,8 +82,6 @@ export default defineConfig({
     root() {
       return (
         <>
-          <meta charSet="utf-8" />
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:image:width" content="1200" />
           <meta name="twitter:image:height" content="630" />
@@ -99,6 +97,18 @@ export default defineConfig({
             href="https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400..800;1,400..800&family=Geist+Mono:wght@400&display=swap"
           />
           <Analytics />
+        </>
+      );
+    },
+    page(page) {
+      const url = `${SITE_URL}${page.url}`;
+
+      return (
+        <>
+          {page.data.description && <meta name="description" content={page.data.description} />}
+          <meta property="og:url" content={url} />
+          <meta property="og:image:alt" content={`${page.data.title} — Takumi`} />
+          <link rel="canonical" href={url} />
         </>
       );
     },

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -11,7 +11,7 @@ import { Features } from "~/components/home/features";
 import { Filmstrip } from "~/components/home/filmstrip";
 import { Hero } from "~/components/home/hero";
 import { Showcase } from "~/components/home/showcase";
-import { Seo } from "~/components/seo";
+import { Seo, SiteJsonLd } from "~/components/seo";
 import { baseOptions } from "~/layout-config";
 
 // Source of example/twitter-images/components/home-demo-card.tsx; keep in sync.
@@ -77,6 +77,7 @@ export default function Home() {
   return (
     <HomeLayout className="overflow-x-hidden" {...baseOptions}>
       <Seo title={TITLE} description={DESCRIPTION} path="" />
+      <SiteJsonLd />
 
       <Hero />
       <CodeDemo highlightedHtml={highlightedCodeDemo} />


### PR DESCRIPTION
## Why

Google shows the site name for takumi.kane.tw as **GitHub**. Its strongest signal, a `WebSite` node on the home page, was missing, so it fell back to guessing from weaker cues: the social image lived on `raw.githubusercontent.com` and almost every inbound link points at the repo.

Two smaller problems surfaced next to it. All 39 documentation pages shipped without a `<meta name="description">` or a canonical URL, and `/docs` and `/docs/pdf` shared the title `Introduction`.

## What

- `WebSite` and `Organization` JSON-LD on the home page, the latter carrying `sameAs` so the repo reads as the project's account rather than the site's identity.
- `OG_IMAGE` now points at `takumi.kane.tw`. The file was already served from there: `docs/public/images/twitter-images` symlinks the example output.
- A `meta.page` hook gives every documentation page a description, a canonical URL, an `og:url`, and image alt text.
- The home page canonical gains its trailing slash, matching the sitemap and the JSON-LD.
- Dropped the charset and viewport tags Waku already emits, and renamed the PDF landing page.

Verified against the build output: 42 pages, no duplicate titles, every page carries a canonical and a description.

The site name updates on Google's next crawl, so this needs a URL inspection and a reindex request in Search Console once deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO & Metadata**
  * Added structured WebSite and Organization metadata to improve search result presentation.
  * Improved page titles, descriptions, canonical URLs, Open Graph metadata, and image accessibility details.
  * Updated social preview images to use the site’s local image.

* **Documentation**
  * Renamed the PDF documentation page title to “Introduction to takumi-pdf.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->