### PR TITLE
PDF: convert each font once per renderer

### DIFF
--- a/.tegami/pdf-font-cache.md
+++ b/.tegami/pdf-font-cache.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Convert each font once per renderer
+
+Converting a font for PDF output copies its whole blob and hashes it, and it was happening on every render. A `PdfRenderer` now keeps the converted fonts, so the second document onwards skips the work. A CJK invoice renders in 1.8 ms instead of 2.9 ms.

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -18,7 +18,9 @@ use takumi_core::{
   resources::{font::FontResource, image::ResourceCache},
   style::{FontFamily, Lang},
 };
-use takumi_pdf::{Attachment, MeasureOptions, PdfMetadata, PdfOptions, PdfStandard, Tagging};
+use takumi_pdf::{
+  Attachment, FontCache, MeasureOptions, PdfMetadata, PdfOptions, PdfStandard, Tagging,
+};
 use wasm_bindgen::prelude::*;
 
 use crate::font::Font;
@@ -74,6 +76,9 @@ struct MeasuredSizeOutput {
 pub struct PdfRenderer {
   state: RwLock<Fonts>,
   resource_cache: ResourceCache,
+  /// Converting a font for PDF output copies and hashes its whole blob, so it
+  /// is done once per renderer rather than once per render.
+  font_cache: RwLock<FontCache>,
 }
 
 #[wasm_bindgen]
@@ -84,6 +89,7 @@ impl PdfRenderer {
     Ok(PdfRenderer {
       state: RwLock::new(default_fonts().map_err(map_error)?),
       resource_cache: ResourceCache::default(),
+      font_cache: RwLock::default(),
     })
   }
 
@@ -147,9 +153,15 @@ impl PdfRenderer {
       .try_read()
       .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
 
+    let mut font_cache = self
+      .font_cache
+      .try_write()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
+
     takumi_pdf::render(PdfOptions {
       viewport,
       fonts: &state,
+      font_cache: Some(&mut font_cache),
       node,
       stylesheet: stylesheet(&self.resource_cache, options.stylesheets, Vec::new()),
       images,

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -8,6 +8,8 @@ mod font;
 mod metadata;
 mod options;
 
+use std::sync::RwLock;
+
 use serde_wasm_bindgen::{from_value, to_value};
 use takumi_bindings_common::{build_font_resource, default_fonts, stylesheet};
 use takumi_core::{
@@ -67,16 +69,19 @@ struct MeasuredSizeOutput {
 
 /// A PDF renderer holding registered fonts and a decoded-resource cache.
 ///
-/// State lives behind a lock and every method takes `&self`, mirroring the
-/// other wasm bindings: a panic mid-call can't leave the wasm-bindgen borrow
-/// flag permanently set.
+/// State lives behind a lock so every method can take `&self`. Nothing
+/// contends for it today: an isolate never shares a wasm instance, and the call
+/// into wasm is synchronous, so two requests cannot be inside one. It is
+/// `&self` that the lock buys, and `&self` is what a shared-memory build would
+/// need — `&mut self` on an instance two threads can reach is unsound, and
+/// wasm-bindgen's borrow flag would be the only thing left catching it.
 #[wasm_bindgen]
 pub struct PdfRenderer {
-  state: Fonts,
+  state: RwLock<Fonts>,
   resource_cache: ResourceCache,
   /// Converting a font for PDF output copies and hashes its whole blob, so it
   /// is done once per renderer rather than once per render.
-  font_cache: FontCache,
+  font_cache: RwLock<FontCache>,
 }
 
 #[wasm_bindgen]
@@ -85,21 +90,24 @@ impl PdfRenderer {
   #[wasm_bindgen(constructor)]
   pub fn new() -> Result<PdfRenderer, js_sys::Error> {
     Ok(PdfRenderer {
-      state: default_fonts().map_err(map_error)?,
+      state: RwLock::new(default_fonts().map_err(map_error)?),
       resource_cache: ResourceCache::default(),
-      font_cache: FontCache::default(),
+      font_cache: RwLock::default(),
     })
   }
 
   /// Registers a font (raw bytes or a details object), returning the families
   /// it produced.
   #[wasm_bindgen(js_name = registerFont)]
-  pub fn register_font(&mut self, font: FontType) -> Result<RegisteredFamiliesType, js_sys::Error> {
+  pub fn register_font(&self, font: FontType) -> Result<RegisteredFamiliesType, js_sys::Error> {
     let font: Font = from_value(font.into()).map_err(map_error)?;
+    let mut state = self
+      .state
+      .try_write()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
 
     let registered = match font {
-      Font::Buffer(buffer) => self
-        .state
+      Font::Buffer(buffer) => state
         .register(FontResource::new(buffer.into_vec()))
         .map_err(map_error)?,
       Font::Object(details) => {
@@ -114,7 +122,7 @@ impl PdfRenderer {
         )
         .map_err(map_error)?;
 
-        self.state.register(resource).map_err(map_error)?
+        state.register(resource).map_err(map_error)?
       }
     };
 
@@ -125,7 +133,7 @@ impl PdfRenderer {
   /// `viewport` renders a single fixed page instead.
   #[wasm_bindgen(unchecked_return_type = "Uint8Array<ArrayBuffer>")]
   pub fn render(
-    &mut self,
+    &self,
     node: NodeType,
     options: Option<PdfRenderOptionsType>,
   ) -> Result<Vec<u8>, js_sys::Error> {
@@ -143,10 +151,20 @@ impl PdfRenderer {
       .map(Lang::parse)
       .transpose()
       .map_err(map_error)?;
+    let state = self
+      .state
+      .try_read()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
+
+    let mut font_cache = self
+      .font_cache
+      .try_write()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
+
     takumi_pdf::render(PdfOptions {
       viewport,
-      fonts: &self.state,
-      font_cache: Some(&mut self.font_cache),
+      fonts: &state,
+      font_cache: Some(&mut font_cache),
       node,
       stylesheet: stylesheet(&self.resource_cache, options.stylesheets, Vec::new()),
       images,
@@ -191,9 +209,13 @@ impl PdfRenderer {
       .map(Lang::parse)
       .transpose()
       .map_err(map_error)?;
+    let state = self
+      .state
+      .try_read()
+      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
     let measured = takumi_pdf::measure(MeasureOptions {
       viewport,
-      fonts: &self.state,
+      fonts: &state,
       node,
       stylesheet: stylesheet(&self.resource_cache, options.stylesheets, Vec::new()),
       images,

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -8,8 +8,6 @@ mod font;
 mod metadata;
 mod options;
 
-use std::sync::RwLock;
-
 use serde_wasm_bindgen::{from_value, to_value};
 use takumi_bindings_common::{build_font_resource, default_fonts, stylesheet};
 use takumi_core::{
@@ -74,11 +72,11 @@ struct MeasuredSizeOutput {
 /// flag permanently set.
 #[wasm_bindgen]
 pub struct PdfRenderer {
-  state: RwLock<Fonts>,
+  state: Fonts,
   resource_cache: ResourceCache,
   /// Converting a font for PDF output copies and hashes its whole blob, so it
   /// is done once per renderer rather than once per render.
-  font_cache: RwLock<FontCache>,
+  font_cache: FontCache,
 }
 
 #[wasm_bindgen]
@@ -87,24 +85,21 @@ impl PdfRenderer {
   #[wasm_bindgen(constructor)]
   pub fn new() -> Result<PdfRenderer, js_sys::Error> {
     Ok(PdfRenderer {
-      state: RwLock::new(default_fonts().map_err(map_error)?),
+      state: default_fonts().map_err(map_error)?,
       resource_cache: ResourceCache::default(),
-      font_cache: RwLock::default(),
+      font_cache: FontCache::default(),
     })
   }
 
   /// Registers a font (raw bytes or a details object), returning the families
   /// it produced.
   #[wasm_bindgen(js_name = registerFont)]
-  pub fn register_font(&self, font: FontType) -> Result<RegisteredFamiliesType, js_sys::Error> {
+  pub fn register_font(&mut self, font: FontType) -> Result<RegisteredFamiliesType, js_sys::Error> {
     let font: Font = from_value(font.into()).map_err(map_error)?;
-    let mut state = self
-      .state
-      .try_write()
-      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
 
     let registered = match font {
-      Font::Buffer(buffer) => state
+      Font::Buffer(buffer) => self
+        .state
         .register(FontResource::new(buffer.into_vec()))
         .map_err(map_error)?,
       Font::Object(details) => {
@@ -119,7 +114,7 @@ impl PdfRenderer {
         )
         .map_err(map_error)?;
 
-        state.register(resource).map_err(map_error)?
+        self.state.register(resource).map_err(map_error)?
       }
     };
 
@@ -130,7 +125,7 @@ impl PdfRenderer {
   /// `viewport` renders a single fixed page instead.
   #[wasm_bindgen(unchecked_return_type = "Uint8Array<ArrayBuffer>")]
   pub fn render(
-    &self,
+    &mut self,
     node: NodeType,
     options: Option<PdfRenderOptionsType>,
   ) -> Result<Vec<u8>, js_sys::Error> {
@@ -148,20 +143,10 @@ impl PdfRenderer {
       .map(Lang::parse)
       .transpose()
       .map_err(map_error)?;
-    let state = self
-      .state
-      .try_read()
-      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
-
-    let mut font_cache = self
-      .font_cache
-      .try_write()
-      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
-
     takumi_pdf::render(PdfOptions {
       viewport,
-      fonts: &state,
-      font_cache: Some(&mut font_cache),
+      fonts: &self.state,
+      font_cache: Some(&mut self.font_cache),
       node,
       stylesheet: stylesheet(&self.resource_cache, options.stylesheets, Vec::new()),
       images,
@@ -206,13 +191,9 @@ impl PdfRenderer {
       .map(Lang::parse)
       .transpose()
       .map_err(map_error)?;
-    let state = self
-      .state
-      .try_read()
-      .map_err(|error| js_sys::Error::new(&format!("Renderer state is locked: {error}")))?;
     let measured = takumi_pdf::measure(MeasureOptions {
       viewport,
-      fonts: &state,
+      fonts: &self.state,
       node,
       stylesheet: stylesheet(&self.resource_cache, options.stylesheets, Vec::new()),
       images,

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -91,6 +91,15 @@ use takumi_core::{
 
 use crate::bands::{emit_band, measure_band, prepare_band};
 use crate::emitter::FontMap;
+
+/// Fonts already converted for PDF output, held across renders.
+///
+/// Converting a font copies its blob and hashes it, which is most of the work
+/// of a render that uses a large face. A renderer that outlives one document
+/// keeps one of these beside its font context and passes it to every render;
+/// it grows to the fonts that renderer has drawn with.
+#[derive(Default)]
+pub struct FontCache(FontMap);
 use crate::inline::{build_inline_map, collect_text_boxes};
 use crate::interactive::{add_link_annotations, build_outline, collect_interactive};
 use crate::options::{
@@ -149,7 +158,14 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
     font_families: options.font_families,
     lang: options.lang,
   };
-  let mut fonts = FontMap::new();
+  let mut owned;
+  let fonts = match options.font_cache {
+    Some(cache) => &mut cache.0,
+    None => {
+      owned = FontMap::new();
+      &mut owned
+    }
+  };
   let mut document = {
     let mut builder = ConfigurationBuilder::new();
     let mut validated = false;
@@ -257,7 +273,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let mut forced = Vec::new();
 
       content
-        .emitter(&mut fonts, Some(&inline_map), None)
+        .emitter(fonts, Some(&inline_map), None)
         .collect_atoms(0, Affine::IDENTITY, &mut atoms, &mut forced)?;
       let starts = page_starts(&mut atoms, &mut forced, content.height, window_height);
       let pages = starts.len();
@@ -290,7 +306,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
 
           emit_band(
             tree,
-            &mut fonts,
+            fonts,
             (0.0, BAND_EDGE_PADDING, page.width, header_height),
             tag_collector.is_some(),
             &mut surface,
@@ -313,7 +329,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
             page.margin.left,
             content_top - y0,
           ));
-          let mut emitter = content.emitter(&mut fonts, Some(&inline_map), tag_collector.as_ref());
+          let mut emitter = content.emitter(fonts, Some(&inline_map), tag_collector.as_ref());
 
           emitter.window = Some((y0, y0 + paint_height));
           emitter.line_window = Some((if index == 0 { f32::NEG_INFINITY } else { y0 }, next_start));
@@ -333,7 +349,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
 
           emit_band(
             tree,
-            &mut fonts,
+            fonts,
             (
               0.0,
               page.height - BAND_EDGE_PADDING - footer_height,
@@ -382,7 +398,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let mut surface = page.surface();
 
       surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
-      let mut emitter = content.emitter(&mut fonts, Some(&inline_map), tag_collector.as_ref());
+      let mut emitter = content.emitter(fonts, Some(&inline_map), tag_collector.as_ref());
 
       emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
       surface.pop();

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -19,6 +19,8 @@ use takumi_core::{
 };
 use typed_builder::TypedBuilder;
 
+use crate::FontCache;
+
 /// Errors from [`crate::render`].
 #[derive(Debug)]
 pub enum PdfError {
@@ -116,6 +118,12 @@ pub struct PdfOptions<'g> {
   pub viewport: Option<Viewport>,
   /// The font context.
   pub fonts: &'g Fonts,
+  /// Fonts already converted for PDF output, reused across renders. Converting
+  /// one copies and hashes its whole blob, which is most of a render that uses
+  /// a large face, so a renderer outliving one document should keep a
+  /// [`FontCache`] beside its font context and pass it here.
+  #[builder(default, setter(strip_option))]
+  pub font_cache: Option<&'g mut FontCache>,
   /// The root node to render.
   pub node: Node,
   /// CSS stylesheets to apply before layout.

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -28,9 +28,12 @@ use crate::{helper::map_error, model::*};
 
 /// The main renderer for Takumi image rendering engine.
 ///
-/// State lives behind a lock and every method takes `&self`, mirroring the
-/// napi bindings: a panic mid-call can't leave the wasm-bindgen borrow flag
-/// permanently set, which would otherwise fail all subsequent calls.
+/// State lives behind a lock so every method can take `&self`. Nothing
+/// contends for it today: an isolate never shares a wasm instance, and the call
+/// into wasm is synchronous, so two requests cannot be inside one. It is
+/// `&self` that the lock buys, and `&self` is what a shared-memory build would
+/// need — `&mut self` on an instance two threads can reach is unsound, and
+/// wasm-bindgen's borrow flag would be the only thing left catching it.
 #[wasm_bindgen]
 pub struct Renderer {
   state: RwLock<Fonts>,


### PR DESCRIPTION
Stacked on #1133.

## Why

Handing a font to the PDF writer does two things, both on every render:

- `Font::new` takes a `Data`, and `ShapedRun::font_data()` hands out a `&[u8]`, so `to_vec()` copies the whole blob. The blob behind it is `fontique::Blob`, which is reference-counted, but the borrow erases that.
- `Prehashed::new` then runs SipHash over the same bytes to give `Font` a cheap hash and equality.

On a 5 MB face those measure at 0.43 ms and 1.62 ms respectively, so the hash is the larger half by four times. A CJK invoice spent more time on the pair than on the rest of the render.

The raster and SVG backends do not pay this: they read glyphs through `FontRef::from_index` on a borrowed slice, with nothing owned and nothing hashed. Only krilla's `Font` owns its data.

## What

`PdfOptions` takes an optional `FontCache`, keyed the way the per-render map already was: the blob's stable id and its collection index. The wasm `PdfRenderer` keeps one beside its font context, so it lives and dies with the object JS already disposes.

Handing the blob's `Arc` through instead of copying would recover the smaller half and needs a `fontique` type in takumi-core's public API. The cache removes both halves without it.

## Numbers

| | before | after |
| --- | ---: | ---: |
| CJK invoice, 300 renders | 2.92 ms | 1.77 ms (−39.5%) |
| Latin invoice, 300 renders | 14.70 ms | 14.47 ms |
| wasm warm median, Latin | 26 ms | 26 ms |

The Latin gap is the whole cost of converting a 200 KB subset once. Both figures are native except the last.

Output is unchanged — no golden moved, which is the check that matters for a cache.