### PR TITLE
Review stacked pull requests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,5 +2,11 @@ language: "en-US"
 reviews:
   poem: false
   sequence_diagrams: false
+  # Stacked pull requests target the branch below them, not the default one,
+  # and would otherwise go unreviewed until the stack lands.
+  auto_review:
+    base_branches:
+      - ".*"
   path_filters:
     - "!takumi/tests/fixtures-generated/**"
+    - "!takumi-pdf/tests/fixtures-generated/**"


### PR DESCRIPTION
## Why

CodeRabbit reviews pull requests aimed at the default branch by default, so a stacked branch gets no review until the whole stack lands, which is exactly when the feedback is least useful. #1132, #1133 and #1134 currently sit unreviewed for that reason.

## What

`base_branches: [".*"]` so any base gets a review. The takumi-pdf goldens join the exclusions alongside the takumi ones: they are committed bytes with nothing to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to support pull requests targeting any base branch, including stacked branches.
  * Excluded generated fixture files from automated reviews while preserving existing exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->