### PR TITLE
Docs: refresh the PDF comparison for 0.4

### DIFF
--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -10,13 +10,13 @@ Each harness uses its engine's native template language. Geometry, columns, and 
 
 Warm figures are the median of 20 renders. The [bench source](https://github.com/kane50613/takumi/tree/master/example/pdf-bench) reproduces this table. Run it with `bun bench`.
 
-Environment: Apple M1 Pro, macOS 15.7, Bun 1.3.14, Chrome 150.
+Environment: Apple M1 Pro, macOS 15.7.4, Bun 1.3.14, Chrome 151.
 
-|                               | takumi-pdf 0.3                              | @react-pdf/renderer 4.5.1                             | Puppeteer + Chrome              |
+|                               | takumi-pdf 0.4                              | @react-pdf/renderer 4.5.1                             | Puppeteer + Chrome              |
 | :---------------------------- | :------------------------------------------ | :---------------------------------------------------- | :------------------------------ |
-| Cold start to first PDF       | 160 ms                                      | 504 ms                                                | 0.7–1.7 s                       |
-| Warm render (median)          | 26 ms                                       | 230 ms                                                | 196 ms                          |
-| Output size                   | 25 KB (14 KB with `tagged: false`)          | 16 KB                                                 | 52 KB                           |
+| Cold start to first PDF       | 176 ms                                      | 495 ms                                                | 0.7–2.8 s                       |
+| Warm render (median)          | 26 ms                                       | 236 ms                                                | 198 ms                          |
+| Output size                   | 19 KB (15 KB with `tagged: false`)          | 16 KB                                                 | 52 KB                           |
 | Deploy needs                  | 1.5 MB gzip wasm                            | pure JS                                               | Chrome install (hundreds of MB) |
 | Template language             | JSX, HTML, node trees with CSS and Tailwind | its own primitives (`<View>`, `<Text>`, `StyleSheet`) | HTML with full CSS              |
 | Selectable text, subset fonts | yes                                         | yes                                                   | yes                             |
@@ -28,7 +28,7 @@ These measurements use npm-registry packages and esbuild (`--bundle --minify`, g
 
 |                           | JS bundle (min+gzip) | wasm (gzip)              | `node_modules`                  |
 | :------------------------ | :------------------- | :----------------------- | :------------------------------ |
-| takumi-pdf 0.3            | 10 KB                | 1.50 MB (1.15 MB brotli) | 4.2 MB, 45 files                |
+| takumi-pdf 0.4            | 10 KB                | 1.52 MB (1.16 MB brotli) | 4.2 MB, 45 files                |
 | @react-pdf/renderer 4.5.1 | 493 KB               | —                        | 32 MB, 1998 files               |
 | pdf-lib 1.17.1            | 179 KB               | —                        | 26 MB                           |
 | pdfkit 0.19.1             | 253 KB               | —                        | 23 MB                           |
@@ -43,6 +43,6 @@ Reading the numbers honestly:
 
 - Chrome's cold start includes launching a browser process. It varies with machine state. Its memory spans several processes. A single-process measurement misses this. Chrome performs well after warming. It has the most complete CSS support of the three.
 - react-pdf embeds the same Inter subsets as the other two. Subsetting on every render is most of its warm cost; the standard 14 PDF fonts avoid it. Documents use react-pdf's component set. Existing HTML, JSX, and Tailwind markup cannot be reused.
-- takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `filter: blur()`, `drop-shadow()`, or `backdrop-filter`. A blurred `box-shadow` is approximated with bands, and a blurred `text-shadow` draws sharp. Tagged output is on by default since 0.3 and adds about 10 KB to this invoice. `tagged: false` removes it.
+- takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `filter: blur()`, `drop-shadow()`, or `backdrop-filter`. A blurred `box-shadow` is approximated with bands, and a blurred `text-shadow` draws sharp. Tagged output is on by default and adds about 4 KB to this invoice, down from 10 KB before the structure tree moved into an object stream. `tagged: false` removes it.
 
 Rule of thumb: use Puppeteer to reproduce a complex web page pixel-perfectly. Any renderer suits documents written from scratch for PDF work. Use takumi-pdf to reuse Takumi image components. It suits edge runtimes. It also offers lower per-document latency.


### PR DESCRIPTION
## Why

The comparison page quotes 0.3. Four size changes have landed since, and the page's headline number is now wrong by a quarter.

## What

Re-ran `example/pdf-bench` three times on the same machine and took medians. The wasm figures come from a local build carrying CI's flags — `build-std` with `optimize_for_size`, `immediate-abort`, `simd128` — since a plain release build reads about 10% heavier than what ships.

|                     | 0.3       | 0.4                     |
| ------------------- | --------: | ----------------------: |
| Output size         | 25 KB     | 19 KB                   |
| With `tagged: false`| 14 KB     | 15 KB                   |
| Tagging costs       | ~10 KB    | ~4 KB                   |
| Warm render         | 26 ms     | 26 ms                   |
| wasm gzip           | 1.50 MB   | 1.52 MB                 |

The tagged and untagged files converge because the structure tree now compresses: tagging costs 4 KB where it used to cost 10. The binary grew 18 KB gzipped to do that.

Chrome moved from 150 to 151, so its cold start and warm median shift with it; react-pdf is unchanged within noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PDF comparison benchmarks for takumi-pdf 0.4.
  * Refreshed environment details, performance measurements, and output-size results.
  * Updated bundle size references and tagged-PDF size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->