### PR TITLE
Core: resolve inline boxes once for every backend

### DIFF
--- a/.tegami/core-inline-box.md
+++ b/.tegami/core-inline-box.md
@@ -1,0 +1,13 @@
+---
+packages:
+  takumi-core:
+    type: minor
+  takumi-pdf:
+    type: patch
+---
+
+### Resolve inline boxes once, for every backend
+
+`takumi_core::layout::inline_box::resolve_inline_box` decides what an inline box holds and lays out an inline-level container at the size its line gave it. The raster, SVG, and PDF backends had a copy each, and the PDF one was missing.
+
+A replaced inline box, such as an `<img>` between two words, now paints its background, border, shadow, and outline in PDF output.

--- a/takumi-core/src/layout/inline_box.rs
+++ b/takumi-core/src/layout/inline_box.rs
@@ -1,0 +1,100 @@
+//! Resolving what an inline box paints.
+//!
+//! An inline box is positioned by the inline layout rather than the paint list,
+//! so every backend has to decide what it holds and, for an inline-level
+//! container, lay its subtree out again at the size the line gave it. That
+//! decision is the same everywhere; only the drawing differs.
+
+use crate::geometry::{AvailableSpace, ComputedLayout, NodeId, Point, Size};
+use crate::layout::inline::{InlineBoxItem, VisualInlineBox};
+use crate::layout::tree::{LayoutResults, LayoutTree, RenderNode};
+
+/// What an inline box paints.
+pub enum InlineBoxPaint<'n> {
+  /// Replaced content, such as an image. The node paints its own chrome and
+  /// content into `layout`.
+  Replaced {
+    /// The node the box wraps.
+    node: &'n RenderNode,
+    /// The box's own layout, in its own coordinate space.
+    layout: ComputedLayout,
+  },
+  /// An inline-level container: `inline-block`, `inline-flex`, `inline-grid`,
+  /// or a float. It carries a scene of its own.
+  Container(Box<InlineSubtree>),
+}
+
+/// An inline-level container, laid out again at the size the line gave it.
+pub struct InlineSubtree {
+  /// The subtree root, cloned so it can own its layout.
+  pub root: RenderNode,
+  /// Layout of the subtree, rooted at [`NodeId::ROOT`].
+  pub results: LayoutResults,
+  /// The size the subtree was laid out at, its margins excluded.
+  pub size: Size<f32>,
+  /// Offset from the box origin to the subtree origin, i.e. its margins.
+  pub margin_offset: Point<f32>,
+}
+
+/// Resolves what `positioned` paints, and where.
+///
+/// The returned point is the box's origin relative to the container's
+/// border-box origin. A box with zero opacity resolves to nothing.
+pub fn resolve_inline_box<'n>(
+  positioned: &VisualInlineBox,
+  item: &InlineBoxItem<'n>,
+  container: ComputedLayout,
+) -> Option<(Point<f32>, InlineBoxPaint<'n>)> {
+  let node = item.render_node;
+
+  if node.context.style.opacity.0 == 0.0 {
+    return None;
+  }
+  let content = container.content_box_offset();
+  let origin = Point {
+    x: content.x + positioned.x,
+    y: content.y + positioned.y,
+  };
+
+  if !node.participates_as_inline_box() {
+    return Some((
+      origin,
+      InlineBoxPaint::Replaced {
+        node,
+        layout: ComputedLayout::from(item),
+      },
+    ));
+  }
+  let size = Size {
+    width: (positioned.width - item.margin.horizontal()).max(0.0),
+    height: (positioned.height - item.margin.vertical()).max(0.0),
+  };
+  let root = node.clone();
+  let results = {
+    let mut tree = LayoutTree::from_render_node(&root);
+
+    tree.compute_layout(Size {
+      width: AvailableSpace::Definite(size.width),
+      height: AvailableSpace::Definite(size.height),
+    });
+    tree.into_results()
+  };
+
+  Some((
+    origin,
+    InlineBoxPaint::Container(Box::new(InlineSubtree {
+      root,
+      results,
+      size,
+      margin_offset: Point {
+        x: item.margin.left,
+        y: item.margin.top,
+      },
+    })),
+  ))
+}
+
+impl InlineSubtree {
+  /// The subtree's root node id.
+  pub const ROOT: NodeId = NodeId::ROOT;
+}

--- a/takumi-core/src/layout/mod.rs
+++ b/takumi-core/src/layout/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod corner_shape;
 pub mod decoration;
 /// Inline-level layout: text shaping, line breaking, and text fitting.
 pub mod inline;
+/// Resolving what an inline box paints.
+pub mod inline_box;
 /// Node Tree
 pub mod node;
 /// Layout tree: render nodes and their computed layout results.

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -26,17 +26,15 @@ use takumi_core::{
 };
 use takumi_core::{
   font_style::SizedFontStyle,
-  geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point as CorePoint, Size},
+  geometry::{ComputedLayout as Layout, NodeId, Point as CorePoint, Size},
   layout::{
     border::{BorderProperties, BorderSide},
     clip::clip_shape_commands,
     decoration::{ClipBox, outline_geometry},
-    inline::{
-      BuiltInlineLayout, InlineBoxItem, InlineRunLayout, ProcessedInlineSpan, ShapedRun,
-      run_decorations,
-    },
+    inline::{BuiltInlineLayout, InlineRunLayout, ProcessedInlineSpan, ShapedRun, run_decorations},
+    inline_box::{InlineBoxPaint, InlineSubtree, resolve_inline_box},
     node::NodeKind,
-    tree::{LayoutResults, LayoutTree, RenderNode},
+    tree::{LayoutResults, RenderNode},
   },
   paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile, resolve_stops_along_axis},
   scene::{NodePaint, PaintItemKind, StackingContextNode, build_stacking_contexts},
@@ -1265,9 +1263,8 @@ impl Emitter<'_> {
     y: f32,
     surface: &mut Surface,
   ) {
-    let offset = layout.content_box_offset();
     // The caller opened a marked-content region for the text around these
-    // boxes. Marked content does not nest, so each image closes it, takes a
+    // boxes. Marked content does not nest, so each box closes it, takes a
     // region of its own, and hands it back.
     let owner_tagged = self.tags.is_some() && has_own_content(owner);
 
@@ -1275,21 +1272,11 @@ impl Emitter<'_> {
       let Some(ProcessedInlineSpan::Box(item)) = built.spans.get(positioned.id as usize) else {
         continue;
       };
-      let node = item.render_node;
-
-      if node.context.style.opacity.0 == 0.0 {
-        continue;
-      }
-      let content = if node.participates_as_inline_box() {
-        InlineBoxContent::Subtree
-      } else if matches!(
-        node.node.as_ref().map(|source| &source.kind),
-        Some(NodeKind::Image(_))
-      ) {
-        InlineBoxContent::Image
-      } else {
+      let Some((offset, paint)) = resolve_inline_box(positioned, item, layout) else {
         continue;
       };
+      let node = item.render_node;
+
       if owner_tagged {
         surface.end_tagged();
       }
@@ -1310,24 +1297,14 @@ impl Emitter<'_> {
       self.color_filter =
         ColorFilter::compose(outer_filter.as_deref(), &node.context.style.filter).map(Rc::new);
 
-      let origin = (x + offset.x + positioned.x, y + offset.y + positioned.y);
+      let origin = (x + offset.x, y + offset.y);
 
-      match content {
-        InlineBoxContent::Image => {
-          if let Some(NodeKind::Image(image)) = node.node.as_ref().map(|source| &source.kind) {
-            self.emit_image(
-              image,
-              &node.context,
-              Layout::from(item),
-              origin.0,
-              origin.1,
-              surface,
-            );
-          }
-        }
-        InlineBoxContent::Subtree => {
-          self.emit_inline_subtree(node, item, Layout::from(item).size, origin, surface)
-        }
+      match paint {
+        InlineBoxPaint::Replaced {
+          node,
+          layout: box_layout,
+        } => self.emit_inline_replaced(node, box_layout, origin, surface),
+        InlineBoxPaint::Container(subtree) => self.emit_inline_subtree(subtree, origin, surface),
       }
       self.color_filter = outer_filter;
       if faded {
@@ -1342,47 +1319,56 @@ impl Emitter<'_> {
     }
   }
 
-  /// Lays out and paints an inline-level container (`inline-block`,
-  /// `inline-flex`, `inline-grid`, or a float) at the position the inline
-  /// layout gave it. The box is not in the paint list, so it needs a layout
-  /// pass and a scene of its own.
+  /// Paints a replaced inline box: its decorations, then its content.
   #[cfg(feature = "images")]
-  fn emit_inline_subtree(
+  fn emit_inline_replaced(
     &mut self,
     node: &RenderNode,
-    item: &InlineBoxItem<'_>,
-    size: Size<f32>,
+    layout: Layout,
     origin: (f32, f32),
     surface: &mut Surface,
   ) {
-    let width = (size.width - item.margin.horizontal()).max(0.0);
-    let height = (size.height - item.margin.vertical()).max(0.0);
+    let (x, y) = origin;
+    let border = BorderProperties::from_context(&node.context, layout.size, layout.border);
+    let (inset, outer) = self.sized_shadows(node, layout.size);
 
-    if width <= 0.0 || height <= 0.0 {
+    self.shadows(&outer, &border, layout, (x, y), surface, false);
+    self.emit_background(node, &border, layout, x, y, surface);
+    self.emit_background_layers(node, &border, layout, x, y, surface);
+    self.shadows(&inset, &border, layout, (x, y), surface, true);
+    self.emit_borders(&border, x, y, layout.size, surface);
+
+    if let Some(NodeKind::Image(image)) = node.node.as_ref().map(|source| &source.kind) {
+      self.emit_image(image, &node.context, layout, x, y, surface);
+    }
+    self.emit_outline(node, layout.size, x, y, surface);
+  }
+
+  /// Paints an inline-level container from the scene it carries. The box is not
+  /// in the paint list, so it needs a stacking context of its own.
+  #[cfg(feature = "images")]
+  fn emit_inline_subtree(
+    &mut self,
+    subtree: Box<InlineSubtree>,
+    origin: (f32, f32),
+    surface: &mut Surface,
+  ) {
+    if subtree.size.width <= 0.0 || subtree.size.height <= 0.0 {
       return;
     }
-    let root = node.clone();
-    let mut tree = LayoutTree::from_render_node(&root);
-
-    tree.compute_layout(Size {
-      width: AvailableSpace::Definite(width),
-      height: AvailableSpace::Definite(height),
-    });
-
-    let results = tree.into_results();
     let Ok(contexts) = build_stacking_contexts(
-      &root,
-      &results,
+      &subtree.root,
+      &subtree.results,
       NodeId::ROOT,
       Affine::IDENTITY,
-      (Some(width), Some(height)),
+      (Some(subtree.size.width), Some(subtree.size.height)),
     ) else {
       return;
     };
     let mut emitter = Emitter {
-      root: &root,
+      root: &subtree.root,
       contexts: &contexts,
-      results: &results,
+      results: &subtree.results,
       fonts: &mut *self.fonts,
       inline: None,
       window: None,
@@ -1390,8 +1376,8 @@ impl Emitter<'_> {
       tags: None,
       color_filter: self.color_filter.clone(),
     };
-    let x = origin.0 + item.margin.left;
-    let y = origin.1 + item.margin.top;
+    let x = origin.0 + subtree.margin_offset.x;
+    let y = origin.1 + subtree.margin_offset.y;
 
     surface.push_transform(&Transform::from_translate(x, y));
     let _ = emitter.emit_context(0, Affine::IDENTITY, surface);
@@ -1820,15 +1806,6 @@ fn has_own_content(node: &RenderNode) -> bool {
     Some(NodeKind::Image(_)) => true,
     _ => false,
   }
-}
-
-/// What an inline box paints: replaced content, or a whole subtree that needs
-/// its own layout pass.
-#[cfg(feature = "images")]
-#[derive(Clone, Copy)]
-enum InlineBoxContent {
-  Image,
-  Subtree,
 }
 
 /// Fills `path` with the child indices leading from `root` to `target`,

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -1,7 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use skrifa::{FontRef, MetadataProvider};
-use takumi_core::geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point, Size};
+use takumi_core::geometry::{ComputedLayout as Layout, NodeId, Point, Size};
+use takumi_core::layout::inline_box::{InlineBoxPaint, resolve_inline_box};
 
 use crate::{
   BorderProperties, Canvas, Cap, DashPattern, DecorationSegmentParams, PaintSource, Placement,
@@ -9,13 +10,10 @@ use crate::{
   draw_border, draw_decoration, draw_decoration_segment, draw_glyph, draw_glyph_clip_image,
   draw_glyph_text_shadow, draw_inset_box_shadow, draw_node_content, draw_outline,
   draw_outset_box_shadow,
-  layout::{
-    inline::{
-      BuiltInlineLayout, InlineBoxItem, InlineOutlineRect, InlineRunLayout, PositionedInlineRun,
-      ProcessedInlineSpan, ShapedRun, VisualInlineBox, outline_island_contour, outline_islands,
-      resolve_inline_runs,
-    },
-    tree::LayoutTree,
+  layout::inline::{
+    BuiltInlineLayout, InlineBoxItem, InlineOutlineRect, InlineRunLayout, PositionedInlineRun,
+    ProcessedInlineSpan, ShapedRun, VisualInlineBox, outline_island_contour, outline_islands,
+    resolve_inline_runs,
   },
   mask_index_from_coord, rasterize_layers,
   render::render_node,
@@ -559,60 +557,47 @@ fn draw_glyph_run_text_shadow(
 pub(crate) fn draw_inline_box(
   inline_box: &VisualInlineBox,
   item: &InlineBoxItem<'_>,
+  container: Layout,
   canvas: &mut Canvas,
   transform: Affine,
 ) -> Result<()> {
-  if item.render_node.context.style.opacity.0 == 0.0 {
-    return Ok(());
-  }
-
-  if item.render_node.participates_as_inline_box() {
-    let mut subtree_root = item.render_node.clone();
-    let mut layout_tree = LayoutTree::from_render_node(&subtree_root);
-
-    let inline_width = (inline_box.width - item.margin.horizontal()).max(0.0);
-    let inline_height = (inline_box.height - item.margin.vertical()).max(0.0);
-
-    layout_tree.compute_layout(Size {
-      width: AvailableSpace::Definite(inline_width),
-      height: AvailableSpace::Definite(inline_height),
-    });
-    let layout_results = layout_tree.into_results();
-    let root_node_id = NodeId::ROOT;
-
-    render_node(
-      &mut subtree_root,
-      &layout_results,
-      root_node_id,
-      canvas,
-      Affine::translation(inline_box.x, inline_box.y)
-        * transform
-        * Affine::translation(item.margin.left, item.margin.top),
-      Size {
-        width: Some(inline_width),
-        height: Some(inline_height),
-      },
-    )?;
-    return Ok(());
-  }
-
-  let Some(node) = &item.render_node.node else {
+  let Some((origin, paint)) = resolve_inline_box(inline_box, item, container) else {
     return Ok(());
   };
 
-  let mut context = item.render_node.context.clone();
-  context.transform = Affine::translation(inline_box.x, inline_box.y) * transform;
+  match paint {
+    InlineBoxPaint::Container(subtree) => {
+      let mut root = subtree.root;
 
-  let layout = item.into();
+      render_node(
+        &mut root,
+        &subtree.results,
+        NodeId::ROOT,
+        canvas,
+        Affine::translation(origin.x, origin.y)
+          * transform
+          * Affine::translation(subtree.margin_offset.x, subtree.margin_offset.y),
+        Size {
+          width: Some(subtree.size.width),
+          height: Some(subtree.size.height),
+        },
+      )
+    }
+    InlineBoxPaint::Replaced { node, layout } => {
+      let Some(source) = &node.node else {
+        return Ok(());
+      };
+      let mut context = node.context.clone();
+      context.transform = Affine::translation(origin.x, origin.y) * transform;
 
-  draw_outset_box_shadow(&context, canvas, layout)?;
-  draw_background(&context, canvas, layout)?;
-  draw_inset_box_shadow(&context, canvas, layout)?;
-  draw_border(&context, canvas, layout)?;
-  draw_node_content(node, &context, canvas, layout)?;
-  draw_outline(&context, canvas, layout)?;
-
-  Ok(())
+      draw_outset_box_shadow(&context, canvas, layout)?;
+      draw_background(&context, canvas, layout)?;
+      draw_inset_box_shadow(&context, canvas, layout)?;
+      draw_border(&context, canvas, layout)?;
+      draw_node_content(source, &context, canvas, layout)?;
+      draw_outline(&context, canvas, layout)
+    }
+  }
 }
 
 pub(crate) fn draw_inline_layout(

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -673,12 +673,14 @@ fn draw_render_node_inline(
     &font_style,
   )?;
 
-  let inline_offset = inline_layout_box.content_box_offset();
-  let inline_transform =
-    Affine::translation(inline_offset.x, inline_offset.y) * node.context.transform;
-
   for (item, positioned) in boxes.zip(positioned_inline_boxes.iter()) {
-    draw_inline_box(positioned, item, canvas, inline_transform)?;
+    draw_inline_box(
+      positioned,
+      item,
+      inline_layout_box,
+      canvas,
+      node.context.transform,
+    )?;
   }
   Ok(())
 }

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -6,11 +6,12 @@ use takumi_core::{
   Fonts,
   context::RenderContext,
   error::Result,
-  geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Point, Rect, Size},
+  geometry::{ComputedLayout as Layout, NodeId, Point, Rect, Size},
   layout::{
     border::{BorderProperties, BorderSide, border_dash_pattern},
     decoration::{ClipBox, outline_geometry},
     inline::{InlineBoxItem, VisualInlineBox},
+    inline_box::{InlineBoxPaint, resolve_inline_box},
     node::{ImageData, Node, NodeKind},
     tree::{LayoutTree, RenderNode},
   },
@@ -638,54 +639,43 @@ pub(crate) fn emit_inline_box(
   container_y: f32,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
-  let node = item.render_node;
-  if node.context.style.opacity.0 == 0.0 {
+  let Some((offset, paint)) = resolve_inline_box(inline_box, item, container_layout) else {
     return Ok(());
+  };
+  let box_x = container_x + offset.x;
+  let box_y = container_y + offset.y;
+
+  match paint {
+    InlineBoxPaint::Container(subtree) => {
+      let origin = Affine::translation(
+        box_x + subtree.margin_offset.x,
+        box_y + subtree.margin_offset.y,
+      );
+      let contexts = build_stacking_contexts(
+        &subtree.root,
+        &subtree.results,
+        NodeId::ROOT,
+        origin,
+        (Some(subtree.size.width), Some(subtree.size.height)),
+      )
+      .map_err(io::Error::other)?;
+
+      emit_scene(&subtree.root, &contexts, &subtree.results, doc)
+    }
+    InlineBoxPaint::Replaced { node, layout } => {
+      let group_transform =
+        element_transform(&node.context, layout.size, box_x, box_y).unwrap_or(IDENTITY);
+      let chrome = emit_box_chrome(node, layout, box_x, box_y, group_transform, doc)?;
+
+      match node.node.as_ref().map(|n| &n.kind) {
+        Some(NodeKind::Image(image)) => emit_image_node(image, node, layout, box_x, box_y, doc)?,
+        Some(NodeKind::Text(text)) => emit_text(text, &node.context, layout, box_x, box_y, doc)?,
+        _ => {}
+      }
+
+      chrome.close(doc)
+    }
   }
-
-  let content_offset = container_layout.content_box_offset();
-  let box_x = container_x + content_offset.x + inline_box.x;
-  let box_y = container_y + content_offset.y + inline_box.y;
-
-  if node.participates_as_inline_box() {
-    // Atomic inline box (inline-block/float): recompute the subtree at the box
-    // size, mirroring the raster backend.
-    let subtree = node.clone();
-    let mut tree = LayoutTree::from_render_node(&subtree);
-    let inline_width = (inline_box.width - item.margin.horizontal()).max(0.0);
-    let inline_height = (inline_box.height - item.margin.vertical()).max(0.0);
-    tree.compute_layout(Size {
-      width: AvailableSpace::Definite(inline_width),
-      height: AvailableSpace::Definite(inline_height),
-    });
-    let results = tree.into_results();
-    let root_id = NodeId::ROOT;
-    // Emit the recomputed subtree through the scene, offset to the box origin.
-    let origin = Affine::translation(box_x + item.margin.left, box_y + item.margin.top);
-    let contexts = build_stacking_contexts(
-      &subtree,
-      &results,
-      root_id,
-      origin,
-      (Some(inline_width), Some(inline_height)),
-    )
-    .map_err(io::Error::other)?;
-    return emit_scene(&subtree, &contexts, &results, doc);
-  }
-
-  // Replaced inline box (e.g. an image): no in-flow layout to recompute.
-  let box_layout: Layout = item.into();
-  let group_transform =
-    element_transform(&node.context, box_layout.size, box_x, box_y).unwrap_or(IDENTITY);
-  let chrome = emit_box_chrome(node, box_layout, box_x, box_y, group_transform, doc)?;
-
-  match node.node.as_ref().map(|n| &n.kind) {
-    Some(NodeKind::Image(image)) => emit_image_node(image, node, box_layout, box_x, box_y, doc)?,
-    Some(NodeKind::Text(text)) => emit_text(text, &node.context, box_layout, box_x, box_y, doc)?,
-    _ => {}
-  }
-
-  chrome.close(doc)
 }
 
 /// Emits an image node's content into its content box. When the element has a


### PR DESCRIPTION
## Why

Deciding what an inline box holds, and laying out an inline-level container at the size its line gave it, was written three times. `takumi-raster/src/inline_drawing.rs`, `takumi-svg/src/render.rs`, and `takumi-pdf/src/emitter.rs` each had a copy, and the SVG one says so in a comment: "mirroring the raster backend". The PDF copy did not exist until the layer below this one, which is how `inline-block` came to paint nothing in PDF output.

Chromium keeps one `BoxFragmentPainter` and swaps the `GraphicsContext` underneath, so screen raster and print-to-PDF cannot drift. This is the first step toward the same shape.

## What

`takumi_core::layout::inline_box::resolve_inline_box` returns the box origin plus either a replaced node or a laid-out subtree. Each backend keeps only its own drawing.

PDF gains what the other two already did: a replaced inline box paints its background, border, shadow, and outline.

The raster call site now passes the container layout instead of pre-folding the content-box offset into the transform, because the offset moved into core. Render output is unchanged: `cargo test -p takumi` rewrites no `.svg` and no `.webp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved inline-box rendering across raster, SVG, and PDF output.
  * PDF output now supports backgrounds, borders, shadows, and outlines on replaced inline content.
  * Inline content is rendered consistently according to its resolved layout and position.

* **Bug Fixes**
  * Corrected inline-box handling across output formats, including nested inline content and replaced elements.
  * Prevented invisible inline boxes from producing unwanted paint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->