### PR TITLE
PDF: report the measured tree's own size

### DIFF
--- a/.tegami/measure-content-size.md
+++ b/.tegami/measure-content-size.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Report the measured tree's own width
+
+`measure` handed back the width it laid the tree out against, so a box with `width: 100px` measured 793 on an A4 page. It now reports the size the tree itself took.

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -273,10 +273,13 @@ export class PdfRenderer {
   /**
    * Lays out a node tree without rendering and returns its size in CSS px.
    *
-   * With page options the tree lays out at the full page width with unbounded
-   * height, exactly how {@link render} measures a header or footer band
-   * (`pageNumber` / `totalPages` hooks are filled with three-digit counters),
-   * so the height tells you how much margin a band needs.
+   * With page options the tree lays out against the full page width with
+   * unbounded height, exactly how {@link render} measures a header or footer
+   * band (`pageNumber` / `totalPages` hooks are filled with three-digit
+   * counters), so the height tells you how much margin a band needs.
+   *
+   * The returned size is the tree's own, not the space it was laid out
+   * against: a box with `width: 100px` measures 100 wide on any page.
    */
   async measure(node: NodeInput, options: MeasureOptions = {}): Promise<MeasuredSize> {
     const { fonts, images, stylesheets, fontFamilies, ...rest } = options;

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -115,6 +115,9 @@ pub use crate::options::{
 /// `totalPages` class hooks filled with three-digit counters. The returned
 /// height is the band height a page margin needs to accommodate. With a
 /// viewport the tree is measured as-is, counter hooks untouched.
+///
+/// The size is the tree's own, not the space it laid out against: a box with
+/// `width: 100px` measures 100 wide on any page.
 pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
   let inputs = TreeInputs {
     fonts: options.fonts,
@@ -135,9 +138,11 @@ pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
     (None, None) => return Err(PdfError::MissingViewport),
   };
 
+  let size = tree.content_size();
+
   Ok(MeasuredSize {
-    width: tree.width,
-    height: tree.height,
+    width: size.width,
+    height: size.height,
   })
 }
 

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
 use takumi_core::{
   Fonts,
   context::RenderContext,
-  geometry::NodeId,
+  geometry::{NodeId, Size},
   layout::{
     node::Node,
     tree::{LayoutResults, LayoutTree, RenderNode},
@@ -44,6 +44,25 @@ pub(crate) struct PreparedTree {
 }
 
 impl PreparedTree {
+  /// The size the caller's own node laid out at, which is what `measure`
+  /// reports. [`fill_root`] wraps that node in a page-wide box, so the root's
+  /// size only ever gives the page back.
+  pub(crate) fn content_size(&self) -> Size<f32> {
+    self
+      .results
+      .box_children(NodeId::ROOT)
+      .ok()
+      .and_then(|children| children.first())
+      .and_then(|child| self.results.layout(child.node_id).ok())
+      .map_or(
+        Size {
+          width: self.width,
+          height: self.height,
+        },
+        |layout| layout.size,
+      )
+  }
+
   pub(crate) fn emitter<'a>(
     &'a self,
     fonts: &'a mut FontMap,

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -2017,6 +2017,41 @@ fn measure_band_at_page_width() {
   assert!(size.height >= 12.0, "band height {}", size.height);
 }
 
+/// Measuring reports the size the tree laid out at, not the size it was laid
+/// out against. A box narrower than the page measures its own width.
+#[test]
+fn measure_reports_content_width() {
+  let fonts = fonts();
+  let node = || {
+    from_html(
+      r#"<div style="border: 1px solid #000; width: 100px; height: 100px;">A</div>"#,
+      FromHtmlOptions::default(),
+    )
+    .expect("parse node")
+  };
+  let at_page = measure(
+    MeasureOptions::builder()
+      .node(node())
+      .page(PageOptions::A4)
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("measure at page");
+
+  assert_eq!((at_page.width, at_page.height), (100.0, 100.0));
+
+  let at_viewport = measure(
+    MeasureOptions::builder()
+      .node(node())
+      .viewport(Viewport::new((600, Some(400))))
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("measure at viewport");
+
+  assert_eq!((at_viewport.width, at_viewport.height), (100.0, 100.0));
+}
+
 /// Without a page, measurement uses the viewport; omitting both is an error.
 #[test]
 fn measure_viewport_and_missing_viewport() {


### PR DESCRIPTION
Fixes #1159.

## Why

`measure` returned the width it laid the tree out against instead of the width the tree took. With no options it defaults to A4, so every measurement came back 793 wide:

```ts
const { width, height } = await measure(
  <div style={{ border: '1px solid #000', width: 100, height: 100 }}>A</div>,
);
// width: 793, height: 100
```

Height was right because an unbounded page has no height to hand back. Two things combined: `prepare_tree` reports the viewport size whenever it has one, and `fill_root` wraps the caller's node in a page-wide box, so the root's own width is the page either way.

## What

`measure` reports the laid-out size of the node the caller passed, reached through the wrapper. Rendering still sizes pages from the viewport, which is what it needs.

A band template is usually full width, so measuring one is unchanged; `measure_band_at_page_width` still asserts the page width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Measurement results now report the content’s intrinsic size instead of the full available page or viewport dimensions.
  * Page, header, and footer measurements now consistently use the intended layout behavior.
  * Added documentation and examples clarifying measurement results.
* **Tests**
  * Added coverage confirming measured dimensions remain tied to content size across different page and viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->