### PR TITLE
Core: paint an inset shadow and an inline outline from one place

### DIFF
--- a/.tegami/inline-outline-stroke.md
+++ b/.tegami/inline-outline-stroke.md
@@ -6,6 +6,6 @@ packages:
 
 ### Decide an inline outline's stroke once
 
-`takumi_core::painter::inline_outline_stroke` says whether a `<span>`'s `outline` paints and how to dash it. The raster and SVG backends each spelled out the same dash lengths and the same list of styles an inline outline cannot draw.
+`SizedFontStyle::outline_stroke` says whether a `<span>`'s `outline` paints and how to dash it. The raster and SVG backends each spelled out the same dash lengths and the same list of styles an inline outline cannot draw.
 
-Five items in `takumi_core::layout::inline` no longer leak out of the crate: `ParentFontMetrics`, `ResolvedLineMetrics`, `ResolvedInlineLineState`, `resolve_visual_inline_box`, and `text_fit_line_alignment_correction`. Nothing outside the crate used them.
+Nine items in `takumi_core` no longer leak out of the crate, none of which had a caller outside it: `ParentFontMetrics`, `ResolvedLineMetrics`, `ResolvedInlineLineState`, `resolve_visual_inline_box`, `text_fit_line_alignment_correction`, `BorderPaint`, `border_paint`, `outline_paint`, and `outline_geometry`.

--- a/.tegami/inline-outline-stroke.md
+++ b/.tegami/inline-outline-stroke.md
@@ -1,0 +1,11 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Decide an inline outline's stroke once
+
+`takumi_core::painter::inline_outline_stroke` says whether a `<span>`'s `outline` paints and how to dash it. The raster and SVG backends each spelled out the same dash lengths and the same list of styles an inline outline cannot draw.
+
+Five items in `takumi_core::layout::inline` no longer leak out of the crate: `ParentFontMetrics`, `ResolvedLineMetrics`, `ResolvedInlineLineState`, `resolve_visual_inline_box`, and `text_fit_line_alignment_correction`. Nothing outside the crate used them.

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -13,6 +13,7 @@ use crate::{
   context::RenderContext,
   geometry::Size,
   layout::inline::InlineBrush,
+  painter::StrokeStyle,
   shadow::SizedShadow,
   style::{
     BorderStyle, Color, ComputedStyle, Display, FontFamily, FontSynthesis, Lang, Length,
@@ -115,12 +116,43 @@ pub struct SizedFontStyle<'s> {
 }
 
 impl SizedFontStyle<'_> {
+  /// The stroke this inline box's `outline` runs along its island contour, or
+  /// `None` when it paints none.
+  ///
+  /// An inline outline is a single stroked contour, so `double` and the 3D
+  /// bevels paint nothing: they need more than one pass to draw. The dash
+  /// lengths are the ratios the raster backend has always stroked, kept here so
+  /// the vector backends do not restate them.
+  pub fn outline_stroke(&self) -> Option<StrokeStyle> {
+    let width = self.outline_width;
+
+    if width <= 0.0 || !self.outline_style.is_rendered() {
+      return None;
+    }
+    let (dash, round_cap) = match self.outline_style {
+      BorderStyle::Dotted => (Some([0.0, width * 2.0]), true),
+      BorderStyle::Dashed => (Some([width * 3.0, width * 2.0]), false),
+      BorderStyle::Double
+      | BorderStyle::Groove
+      | BorderStyle::Ridge
+      | BorderStyle::Inset
+      | BorderStyle::Outset => return None,
+      _ => (None, false),
+    };
+
+    Some(StrokeStyle {
+      color: self.outline_color,
+      width,
+      dash,
+      round_cap,
+    })
+  }
+
   /// Hashes every input the `TextStyle` conversion below reads, so shaped
   /// text-only layouts can be cached by content. Keep in sync with
   /// `From<&SizedFontStyle> for TextStyle`.
   pub(crate) fn hash_shaping_inputs(&self, hasher: &mut impl core::hash::Hasher) {
-    use core::hash::Hash;
-    use core::mem::discriminant;
+    use core::{hash::Hash, mem::discriminant};
 
     self.sizing.font_size.to_bits().hash(hasher);
     self.letter_spacing.to_bits().hash(hasher);

--- a/takumi-core/src/layout/background.rs
+++ b/takumi-core/src/layout/background.rs
@@ -7,16 +7,18 @@
 
 use smallvec::{SmallVec, smallvec};
 
-use crate::context::RenderContext;
-use crate::geometry::{ComputedLayout as Layout, Point, Size};
-use crate::layout::node::resolve_image;
-use crate::paint::{
-  collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
-};
-use crate::style::{
-  AutoBackgroundAxis, BackgroundImage, BackgroundOrigin, BackgroundRepeat, BackgroundRepeatStyle,
-  BackgroundSize, BlendMode, IntrinsicSizing, Length, PositionComponent, PositionKeywordX,
-  PositionKeywordY, PositionValue, SizingContext,
+use crate::{
+  context::RenderContext,
+  geometry::{ComputedLayout as Layout, Point, Size},
+  layout::node::resolve_image,
+  paint::{
+    collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
+  },
+  style::{
+    AutoBackgroundAxis, BackgroundImage, BackgroundOrigin, BackgroundRepeat, BackgroundRepeatStyle,
+    BackgroundSize, BlendMode, IntrinsicSizing, Length, PositionComponent, PositionKeywordX,
+    PositionKeywordY, PositionValue, SizingContext,
+  },
 };
 
 /// Where one background layer's tiles land, in border-box coordinates.

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -947,7 +947,7 @@ const DOTTED_ENDPOINT_EPSILON: f32 = 1.0e-2;
 /// the pattern has to run around the whole ring, so it strokes a centerline
 /// instead. Every backend makes this call the same way.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum BorderPaint {
+pub(crate) enum BorderPaint {
   /// Stroke the centerline with the dash pattern for `style`.
   Stroked {
     /// The uniform colour.
@@ -974,7 +974,7 @@ pub enum BorderPaint {
 }
 
 /// Decides how `border` paints. See [`BorderPaint`].
-pub fn border_paint(border: &BorderProperties) -> BorderPaint {
+pub(crate) fn border_paint(border: &BorderProperties) -> BorderPaint {
   let Some(color) = border.has_uniform_visible_color() else {
     return BorderPaint::Sides;
   };

--- a/takumi-core/src/layout/decoration.rs
+++ b/takumi-core/src/layout/decoration.rs
@@ -109,7 +109,7 @@ pub struct OutlineGeometry {
 /// look at alpha; a backend is free to skip the invisible fill.
 ///
 /// Each backend used to guard this differently, and one of them not at all.
-pub fn outline_paint(context: &RenderContext, size: Size<f32>) -> Option<OutlineGeometry> {
+pub(crate) fn outline_paint(context: &RenderContext, size: Size<f32>) -> Option<OutlineGeometry> {
   let style = &context.style;
   let width = Length::from(style.outline_width)
     .to_px(&context.sizing, size.width)
@@ -123,7 +123,7 @@ pub fn outline_paint(context: &RenderContext, size: Size<f32>) -> Option<Outline
 
 /// The outline ring's border geometry and how far it grows past the border box.
 /// Says nothing about whether the outline paints; see [`outline_paint`].
-pub fn outline_geometry(context: &RenderContext, size: Size<f32>) -> OutlineGeometry {
+pub(crate) fn outline_geometry(context: &RenderContext, size: Size<f32>) -> OutlineGeometry {
   let style = &context.style;
   let width = Length::from(style.outline_width)
     .to_px(&context.sizing, size.width)

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -107,12 +107,12 @@ pub struct BuiltInlineLayout<'c> {
 
 impl BuiltInlineLayout<'_> {
   /// Parent font metrics from the first run.
-  pub fn parent_font_metrics(&self) -> Option<ParentFontMetrics> {
+  pub(crate) fn parent_font_metrics(&self) -> Option<ParentFontMetrics> {
     get_parent_font_metrics(&self.layout)
   }
 
   /// Resolved metrics for each line.
-  pub fn line_metrics(&self) -> Vec<ResolvedLineMetrics> {
+  pub(crate) fn line_metrics(&self) -> Vec<ResolvedLineMetrics> {
     resolve_inline_line_metrics(
       &self.layout,
       &self.spans,
@@ -122,7 +122,7 @@ impl BuiltInlineLayout<'_> {
   }
 
   /// Resolved state for each line.
-  pub fn line_states(&self) -> Vec<ResolvedInlineLineState> {
+  pub(crate) fn line_states(&self) -> Vec<ResolvedInlineLineState> {
     resolve_inline_line_states(
       &self.layout,
       &self.spans,
@@ -385,7 +385,7 @@ pub(crate) type InlineLayout = parley::Layout<InlineBrush>;
 
 #[derive(Clone, Copy, Debug)]
 /// x-height and ascent/descent of the parent font.
-pub struct ParentFontMetrics {
+pub(crate) struct ParentFontMetrics {
   pub(crate) x_height: Option<f32>,
   pub(crate) text_metrics: (f32, f32),
 }
@@ -536,7 +536,7 @@ pub(crate) fn get_parent_font_metrics(layout: &InlineLayout) -> Option<ParentFon
 
 #[derive(Clone, Copy, Debug)]
 /// Final vertical metrics computed for one inline line.
-pub struct ResolvedLineMetrics {
+pub(crate) struct ResolvedLineMetrics {
   pub(crate) resolved_ascent: f32,
   pub(crate) resolved_descent: f32,
   pub(crate) resolved_leading: f32,
@@ -1005,7 +1005,7 @@ pub(crate) fn resolved_line_metrics_for_apply(
 
 #[derive(Clone, Copy, Debug)]
 /// Resolved metrics and parent context for a single inline line.
-pub struct ResolvedInlineLineState {
+pub(crate) struct ResolvedInlineLineState {
   pub(crate) adjusted_metrics: LineMetrics,
   /// Vertical shift applied to the baseline.
   pub baseline_shift: f32,
@@ -1082,7 +1082,7 @@ pub struct VisualInlineBox {
 }
 
 /// Resolve a positioned inline box into its painted geometry.
-pub fn resolve_visual_inline_box(
+pub(crate) fn resolve_visual_inline_box(
   inline_box: PositionedInlineBox,
   line_state: Option<ResolvedInlineLineState>,
   spans: &[ProcessedInlineSpan<'_>],
@@ -1622,7 +1622,7 @@ fn text_fit_line_scales(layout: &InlineLayout, max_width: f32, style: &SizedFont
 }
 
 /// Line start and offset correction for a scaled text-fit line.
-pub fn text_fit_line_alignment_correction(
+pub(crate) fn text_fit_line_alignment_correction(
   line: &Line<'_, InlineBrush>,
   line_scale: f32,
   container_width: f32,

--- a/takumi-core/src/layout/inline_box.rs
+++ b/takumi-core/src/layout/inline_box.rs
@@ -5,9 +5,13 @@
 //! container, lay its subtree out again at the size the line gave it. That
 //! decision is the same everywhere; only the drawing differs.
 
-use crate::geometry::{AvailableSpace, ComputedLayout, NodeId, Point, Size};
-use crate::layout::inline::{InlineBoxItem, VisualInlineBox};
-use crate::layout::tree::{LayoutResults, LayoutTree, RenderNode};
+use crate::{
+  geometry::{AvailableSpace, ComputedLayout, NodeId, Point, Size},
+  layout::{
+    inline::{InlineBoxItem, VisualInlineBox},
+    tree::{LayoutResults, LayoutTree, RenderNode},
+  },
+};
 
 /// What an inline box paints.
 pub enum InlineBoxPaint<'n> {

--- a/takumi-core/src/math.rs
+++ b/takumi-core/src/math.rs
@@ -13,7 +13,7 @@
 /// `atan(t)/2π` over one octant, max error ~2.7e-5 turn), both deterministic
 /// and cheaper than a libm `atan2` per pixel.
 #[inline(always)]
-pub fn xy_to_unit_angle(x: f32, y: f32) -> f32 {
+pub(crate) fn xy_to_unit_angle(x: f32, y: f32) -> f32 {
   let x_abs = x.abs();
   let y_abs = y.abs();
   let max = x_abs.max(y_abs);

--- a/takumi-core/src/painter.rs
+++ b/takumi-core/src/painter.rs
@@ -5,18 +5,16 @@
 //! Below it, a rasterizer writes pixels, an SVG writer emits elements, and a
 //! PDF writer emits operators. Only the second half belongs to a backend.
 
-use crate::context::RenderContext;
-use crate::font_style::SizedFontStyle;
-use crate::geometry::Rect;
-use crate::geometry::{ComputedLayout, PathCommand, Point, Size};
-use crate::layout::border::{BorderPaint, BorderProperties, border_dash_pattern, border_paint};
-use crate::layout::decoration::ClipBox;
-use crate::layout::decoration::{OutlineGeometry, outline_paint};
-use crate::layout::inline::DecorationRect;
-use crate::shadow::SizedShadow;
-use crate::style::BoxShadow;
-use crate::style::{
-  Affine, BackgroundClip, BorderStyle, Color, FillRule, Sides, TextDecorationLines,
+use crate::{
+  context::RenderContext,
+  geometry::{ComputedLayout, PathCommand, Point, Rect, Size},
+  layout::{
+    border::{BorderPaint, BorderProperties, border_dash_pattern, border_paint},
+    decoration::{ClipBox, OutlineGeometry, outline_paint},
+    inline::DecorationRect,
+  },
+  shadow::SizedShadow,
+  style::{Affine, BackgroundClip, BoxShadow, Color, FillRule, Sides, TextDecorationLines},
 };
 
 /// A closed shape to fill, in the coordinate space of the box that owns it.
@@ -97,38 +95,6 @@ pub struct StrokeStyle {
   pub dash: Option<[f32; 2]>,
   /// Whether the dashes have round caps, which is how `dotted` draws.
   pub round_cap: bool,
-}
-
-/// The stroke an inline box's `outline` runs along its island contour, or
-/// `None` when it paints none.
-///
-/// An inline outline is a single stroked contour, so `double` and the 3D bevels
-/// paint nothing: they need more than one pass to draw. The dash lengths are the
-/// ratios the raster backend has always stroked, kept here so the vector
-/// backends do not restate them.
-pub fn inline_outline_stroke(style: &SizedFontStyle<'_>) -> Option<StrokeStyle> {
-  let width = style.outline_width;
-
-  if width <= 0.0 || !style.outline_style.is_rendered() {
-    return None;
-  }
-  let (dash, round_cap) = match style.outline_style {
-    BorderStyle::Dotted => (Some([0.0, width * 2.0]), true),
-    BorderStyle::Dashed => (Some([width * 3.0, width * 2.0]), false),
-    BorderStyle::Double
-    | BorderStyle::Groove
-    | BorderStyle::Ridge
-    | BorderStyle::Inset
-    | BorderStyle::Outset => return None,
-    _ => (None, false),
-  };
-
-  Some(StrokeStyle {
-    color: style.outline_color,
-    width,
-    dash,
-    round_cap,
-  })
 }
 
 /// A box's `box-shadow` layers, split by where they fall.

--- a/takumi-core/src/painter.rs
+++ b/takumi-core/src/painter.rs
@@ -6,6 +6,7 @@
 //! PDF writer emits operators. Only the second half belongs to a backend.
 
 use crate::context::RenderContext;
+use crate::font_style::SizedFontStyle;
 use crate::geometry::Rect;
 use crate::geometry::{ComputedLayout, PathCommand, Point, Size};
 use crate::layout::border::{BorderPaint, BorderProperties, border_dash_pattern, border_paint};
@@ -14,7 +15,9 @@ use crate::layout::decoration::{OutlineGeometry, outline_paint};
 use crate::layout::inline::DecorationRect;
 use crate::shadow::SizedShadow;
 use crate::style::BoxShadow;
-use crate::style::{Affine, BackgroundClip, Color, FillRule, Sides, TextDecorationLines};
+use crate::style::{
+  Affine, BackgroundClip, BorderStyle, Color, FillRule, Sides, TextDecorationLines,
+};
 
 /// A closed shape to fill, in the coordinate space of the box that owns it.
 ///
@@ -94,6 +97,38 @@ pub struct StrokeStyle {
   pub dash: Option<[f32; 2]>,
   /// Whether the dashes have round caps, which is how `dotted` draws.
   pub round_cap: bool,
+}
+
+/// The stroke an inline box's `outline` runs along its island contour, or
+/// `None` when it paints none.
+///
+/// An inline outline is a single stroked contour, so `double` and the 3D bevels
+/// paint nothing: they need more than one pass to draw. The dash lengths are the
+/// ratios the raster backend has always stroked, kept here so the vector
+/// backends do not restate them.
+pub fn inline_outline_stroke(style: &SizedFontStyle<'_>) -> Option<StrokeStyle> {
+  let width = style.outline_width;
+
+  if width <= 0.0 || !style.outline_style.is_rendered() {
+    return None;
+  }
+  let (dash, round_cap) = match style.outline_style {
+    BorderStyle::Dotted => (Some([0.0, width * 2.0]), true),
+    BorderStyle::Dashed => (Some([width * 3.0, width * 2.0]), false),
+    BorderStyle::Double
+    | BorderStyle::Groove
+    | BorderStyle::Ridge
+    | BorderStyle::Inset
+    | BorderStyle::Outset => return None,
+    _ => (None, false),
+  };
+
+  Some(StrokeStyle {
+    color: style.outline_color,
+    width,
+    dash,
+    round_cap,
+  })
 }
 
 /// A box's `box-shadow` layers, split by where they fall.

--- a/takumi-core/src/resources/glyph_cache.rs
+++ b/takumi-core/src/resources/glyph_cache.rs
@@ -89,7 +89,7 @@ fn get_or_insert(
 /// The resolved outline or bitmap for `key`, resolving on a miss. Concurrent
 /// misses for the same key resolve once. `resolve` returning `None` caches
 /// nothing and a later call retries.
-pub fn resolved_glyph(
+pub(crate) fn resolved_glyph(
   key: u64,
   resolve: impl Fn() -> Option<ResolvedGlyph>,
 ) -> Option<Arc<ResolvedGlyph>> {

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -7,6 +7,18 @@
 use std::str::{FromStr, from_utf8};
 use std::sync::{Arc, OnceLock, Weak};
 
+use quick_cache::{
+  Weighter,
+  sync::{Cache, GuardResult},
+};
+#[cfg(feature = "svg")]
+use roxmltree::{Document, ParsingOptions};
+use serde::Deserialize;
+use thiserror::Error;
+#[cfg(feature = "svg")]
+use tiny_skia::Pixmap;
+use xxhash_rust::xxh3::{Xxh3, xxh3_64};
+
 #[cfg(feature = "svg")]
 use crate::resvg::{
   apply_filters_to_layer, render as render_svg_tree,
@@ -17,19 +29,6 @@ pub use crate::svg_vector::{
   SvgFill, SvgGradient, SvgGradientStop, SvgLineCap, SvgLineJoin, SvgOp, SvgPaint, SvgSpreadMethod,
   SvgStrokeStyle,
 };
-use quick_cache::{
-  Weighter,
-  sync::{Cache, GuardResult},
-};
-
-#[cfg(feature = "svg")]
-use roxmltree::{Document, ParsingOptions};
-use serde::Deserialize;
-use thiserror::Error;
-#[cfg(feature = "svg")]
-use tiny_skia::Pixmap;
-use xxhash_rust::xxh3::{Xxh3, xxh3_64};
-
 use crate::{
   resources::{
     image_buffer::ImageBuffer,

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -5,7 +5,6 @@
 use std::collections::HashMap;
 
 use parley::{InlineBoxKind, PositionedLayoutItem};
-
 use skrifa::FontRef;
 
 use crate::{
@@ -636,8 +635,7 @@ fn merge_bounds(left: Option<SceneBounds>, right: Option<SceneBounds>) -> Option
 #[cfg(test)]
 mod tests {
   use super::{SceneBounds, bounds_for_rect, merge_bounds};
-  use crate::geometry::Size;
-  use crate::style::Affine;
+  use crate::{geometry::Size, style::Affine};
 
   #[test]
   fn zero_sized_rect_produces_empty_bounds() {

--- a/takumi-core/src/style/properties/conic_gradient.rs
+++ b/takumi-core/src/style/properties/conic_gradient.rs
@@ -1,4 +1,3 @@
-use crate::math;
 use std::{f32::consts::TAU, fmt};
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
@@ -10,10 +9,13 @@ use super::gradient_utils::{
   compute_repeat_setup, gradient_tile_accessors, parse_gradient_stops, resolve_stops_along_axis,
   write_gradient_css,
 };
-use crate::style::{
-  Angle, Color, ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop,
-  Length, MakeComputed, ParseResult, PositionValue, SizingContext, StopPosition, ToCss,
-  unexpected_token,
+use crate::{
+  math,
+  style::{
+    Angle, Color, ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop,
+    Length, MakeComputed, ParseResult, PositionValue, SizingContext, StopPosition, ToCss,
+    unexpected_token,
+  },
 };
 
 const LUT_INDEX_BOUNDARY_EPSILON: f32 = 0.001;

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -3,7 +3,10 @@ use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
 use cssparser::{Parser, ParserInput, RuleBodyParser, Token, match_ignore_ascii_case};
 use parley::Language;
 use paste::paste;
-use serde::{Deserialize, de::Error as DeError, de::IgnoredAny};
+use serde::{
+  Deserialize,
+  de::{Error as DeError, IgnoredAny},
+};
 use smallvec::{SmallVec, smallvec};
 
 use crate::{

--- a/takumi-core/src/svg_vector.rs
+++ b/takumi-core/src/svg_vector.rs
@@ -6,11 +6,11 @@
 use tiny_skia::Pixmap;
 use tiny_skia_path::{NonZeroRect, PathSegment, Transform};
 
-use crate::geometry::{PathCommand, Point};
-use crate::resvg::usvg::{
-  self, ClipPath, Group, ImageKind, Mask, MaskType, Node, Paint, PaintOrder, Tree,
+use crate::{
+  geometry::{PathCommand, Point},
+  resvg::usvg::{self, ClipPath, Group, ImageKind, Mask, MaskType, Node, Paint, PaintOrder, Tree},
+  style::BlendMode,
 };
-use crate::style::BlendMode;
 
 /// One flattened SVG drawing instruction, in SVG canvas coordinates.
 ///

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
+use takumi_bindings_common::stylesheet;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
@@ -15,7 +16,6 @@ use crate::{
     deserialize_keyframes, device_pixel_ratio, parse_lang,
   },
 };
-use takumi_bindings_common::stylesheet;
 
 pub struct MeasureTask {
   pub(crate) node: Option<Node>,

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
+use takumi_bindings_common::stylesheet;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, KeyframesRule, Lang},
@@ -18,7 +19,6 @@ use crate::{
     decode_images, deserialize_keyframes, device_pixel_ratio, parse_lang, webp_lossless,
   },
 };
-use takumi_bindings_common::stylesheet;
 
 pub struct RenderAnimationTask {
   pub(crate) scenes: Option<Vec<(Node, u32)>>,

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
+use takumi_bindings_common::stylesheet;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
@@ -15,7 +16,6 @@ use crate::{
     deserialize_keyframes, device_pixel_ratio, parse_lang,
   },
 };
-use takumi_bindings_common::stylesheet;
 
 pub struct RenderTask {
   pub(crate) draw_debug_border: bool,

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
+use takumi_bindings_common::stylesheet;
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
@@ -14,7 +15,6 @@ use crate::{
     deserialize_keyframes, parse_lang,
   },
 };
-use takumi_bindings_common::stylesheet;
 
 pub struct SvgRenderTask {
   pub(crate) node: Option<Node>,

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -21,8 +21,10 @@ use takumi_core::{
 use takumi_pdf::{Attachment, MeasureOptions, PdfMetadata, PdfOptions, PdfStandard, Tagging};
 use wasm_bindgen::prelude::*;
 
-use crate::font::Font;
-use crate::options::{PdfRenderOptions, decode_images, resolve_geometry};
+use crate::{
+  font::Font,
+  options::{PdfRenderOptions, decode_images, resolve_geometry},
+};
 
 pub(crate) fn map_error(error: impl core::fmt::Debug) -> js_sys::Error {
   js_sys::Error::new(&format!("{error:?}"))

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -12,8 +12,10 @@ use takumi_core::{
 };
 use takumi_pdf::{PageMargins, PageOptions};
 
-use crate::map_error;
-use crate::metadata::{AttachmentInput, MetadataInput, PdfaInput, TaggedInput};
+use crate::{
+  map_error,
+  metadata::{AttachmentInput, MetadataInput, PdfaInput, TaggedInput},
+};
 
 /// An image source with its URL and raw data.
 #[derive(Deserialize)]

--- a/takumi-pdf/src/bands.rs
+++ b/takumi-pdf/src/bands.rs
@@ -1,22 +1,24 @@
 //! Measurement, per-page preparation and emission of the repeated header/footer bands.
 
-use crate::krilla::{
-  geom::{Rect as KrillaRect, Transform},
-  paint::FillRule,
-  surface::Surface,
-  tagging::{Artifact, ArtifactType, ContentTag},
-};
 use takumi_core::{
   layout::node::{Node, NodeKind},
   style::Affine,
   viewport::Viewport,
 };
 
-use crate::counters::{counter_text, substitute_page_counters};
-use crate::emitter::FontMap;
-use crate::options::PdfError;
-use crate::paint::rect_path;
-use crate::tree::{PreparedTree, TreeInputs, prepare_tree};
+use crate::{
+  counters::{counter_text, substitute_page_counters},
+  emitter::FontMap,
+  krilla::{
+    geom::{Rect as KrillaRect, Transform},
+    paint::FillRule,
+    surface::Surface,
+    tagging::{Artifact, ArtifactType, ContentTag},
+  },
+  options::PdfError,
+  paint::rect_path,
+  tree::{PreparedTree, TreeInputs, prepare_tree},
+};
 
 /// A band measured before pagination: the laid-out tree plus whether it must
 /// re-prepare per page (it contains counter hooks).

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -3,21 +3,6 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 #[cfg(feature = "images")]
-use crate::krilla::geom::Size as KrillaSize;
-use crate::krilla::{
-  Data,
-  geom::{Point, Rect as KrillaRect, Transform},
-  mask::{Mask, MaskType},
-  num::NormalizedF32,
-  paint::{
-    Fill, FillRule, LineCap, LinearGradient as KrillaLinearGradient, Paint, Pattern,
-    RadialGradient as KrillaRadialGradient, SpreadMethod, Stroke, StrokeDash, SweepGradient,
-  },
-  surface::Surface,
-  tagging::{Artifact, ArtifactType, ContentTag},
-  text::{Font, GlyphId, Tag},
-};
-#[cfg(feature = "images")]
 use takumi_core::{
   context::RenderContext,
   layout::node::{ImageData, resolve_image},
@@ -37,6 +22,10 @@ use takumi_core::{
     tree::{LayoutResults, RenderNode},
   },
   paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile, resolve_stops_along_axis},
+  painter::{
+    BoxPainter, BoxShadows, FillShape, PaintDevice, StrokeStyle, paint_border,
+    paint_run_decorations,
+  },
   scene::{NodePaint, PaintItemKind, StackingContextNode, build_stacking_contexts},
   shadow::SizedShadow,
   style::{
@@ -46,24 +35,38 @@ use takumi_core::{
   },
 };
 
-use crate::background::{Placement, cycled, place};
-use crate::filter::ColorFilter;
-use crate::glyph::{PdfGlyph, glyph_text_spans};
-use crate::inline::{InlineMap, build_inline_runs, inline_key, node_inline_items, text_line_atoms};
-use crate::options::PdfError;
-use crate::pagination::Atom;
-use crate::paint::{
-  empty_path, expanded_radial_stops, fill_from_rgba, krilla_blend, krilla_path, krilla_stop,
-  krilla_stops, overflow_clip_rect, pop_transforms, rect_path, spread,
-};
+#[cfg(feature = "images")]
+use crate::krilla::geom::Size as KrillaSize;
 #[cfg(feature = "images")]
 use crate::paint::{position_axis, rasterized_image};
-use crate::shadow::{emit_inset_shadows, emit_outer_shadows};
 #[cfg(all(feature = "svg", feature = "images"))]
 use crate::svg;
-use crate::tags::TagCollector;
-use takumi_core::painter::{
-  BoxPainter, BoxShadows, FillShape, PaintDevice, StrokeStyle, paint_border, paint_run_decorations,
+use crate::{
+  background::{Placement, cycled, place},
+  filter::ColorFilter,
+  glyph::{PdfGlyph, glyph_text_spans},
+  inline::{InlineMap, build_inline_runs, inline_key, node_inline_items, text_line_atoms},
+  krilla::{
+    Data,
+    geom::{Point, Rect as KrillaRect, Transform},
+    mask::{Mask, MaskType},
+    num::NormalizedF32,
+    paint::{
+      Fill, FillRule, LineCap, LinearGradient as KrillaLinearGradient, Paint, Pattern,
+      RadialGradient as KrillaRadialGradient, SpreadMethod, Stroke, StrokeDash, SweepGradient,
+    },
+    surface::Surface,
+    tagging::{Artifact, ArtifactType, ContentTag},
+    text::{Font, GlyphId, Tag},
+  },
+  options::PdfError,
+  pagination::Atom,
+  paint::{
+    empty_path, expanded_radial_stops, fill_from_rgba, krilla_blend, krilla_path, krilla_stop,
+    krilla_stops, overflow_clip_rect, pop_transforms, rect_path, spread,
+  },
+  shadow::{emit_inset_shadows, emit_outer_shadows},
+  tags::TagCollector,
 };
 
 /// What a box left on the surface for its caller to unwind.

--- a/takumi-pdf/src/filter.rs
+++ b/takumi-pdf/src/filter.rs
@@ -183,8 +183,9 @@ impl ColorMatrix {
 
 #[cfg(test)]
 mod tests {
-  use super::ColorFilter;
   use takumi_core::style::{Angle, Filter, PercentageNumber};
+
+  use super::ColorFilter;
 
   #[test]
   fn each_function_clamps_before_the_next_one_runs() {

--- a/takumi-pdf/src/glyph.rs
+++ b/takumi-pdf/src/glyph.rs
@@ -2,10 +2,12 @@
 
 use std::ops::Range;
 
-use crate::krilla::text::{Glyph, GlyphId};
 use takumi_core::layout::inline::ShapedRun;
 
-use crate::krilla::surface::Location;
+use crate::krilla::{
+  surface::Location,
+  text::{Glyph, GlyphId},
+};
 
 /// Per-glyph byte ranges into `run_text` for ToUnicode, from the shaper's
 /// cluster segmentation (correct for ligatures and complex scripts).

--- a/takumi-pdf/src/inline.rs
+++ b/takumi-pdf/src/inline.rs
@@ -17,9 +17,7 @@ use takumi_core::{
   scene::{NodePaint, PaintItemKind},
 };
 
-use crate::options::PdfError;
-use crate::pagination::Atom;
-use crate::tree::PreparedTree;
+use crate::{options::PdfError, pagination::Atom, tree::PreparedTree};
 
 /// A text box's inline layout, built once per render and reused by atom
 /// collection and every page's emission.

--- a/takumi-pdf/src/interactive.rs
+++ b/takumi-pdf/src/interactive.rs
@@ -1,16 +1,11 @@
 //! Collection of link, heading and anchor targets, and emission of link
 //! annotations and the outline.
 
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-
-use crate::krilla::{
-  action::{Action, LinkAction},
-  annotation::{Annotation, LinkAnnotation, Target},
-  destination::{Destination, XyzDestination},
-  geom::Rect as KrillaRect,
-  outline::{Outline, OutlineNode},
+use std::{
+  cell::RefCell,
+  collections::{HashMap, HashSet},
 };
+
 use takumi_core::{
   font_style::SizedFontStyle,
   geometry::{
@@ -27,11 +22,19 @@ use takumi_core::{
   style::Affine,
 };
 
-use crate::krilla::page::Page;
-use crate::options::PT_PER_PX;
-use crate::tags::TagCollector;
-use crate::tags::text_content;
-use crate::tree::PreparedTree;
+use crate::{
+  krilla::{
+    action::{Action, LinkAction},
+    annotation::{Annotation, LinkAnnotation, Target},
+    destination::{Destination, XyzDestination},
+    geom::Rect as KrillaRect,
+    outline::{Outline, OutlineNode},
+    page::Page,
+  },
+  options::PT_PER_PX,
+  tags::{TagCollector, text_content},
+  tree::PreparedTree,
+};
 
 /// A hyperlink box in content coordinates.
 pub(crate) struct LinkTarget {

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -75,37 +75,34 @@ mod krilla;
 )]
 mod subsetter;
 
-use crate::krilla::{
-  Document, SerializeSettings,
-  configure::ConfigurationBuilder,
-  destination::XyzDestination,
-  embed::{EmbeddedFile, MimeType},
-  geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
-  page::PageSettings,
-  paint::FillRule,
-};
 use takumi_core::{
   style::{Affine, Lang},
   viewport::Viewport,
 };
 
-use crate::bands::{emit_band, measure_band, prepare_band};
-use crate::emitter::FontMap;
-use crate::inline::{build_inline_map, collect_text_boxes};
-use crate::interactive::{
-  add_link_annotations, build_outline, collect_interactive, destination_targets,
-};
-use crate::options::{
-  BAND_EDGE_PADDING, PT_PER_PX, build_metadata, krilla_datetime, validate_xmp_schemas,
-};
-use crate::pagination::page_starts;
-use crate::paint::rect_path;
-use crate::tags::{TagCollector, build_tag_tree, tag_id};
-use crate::tree::{TreeInputs, prepare_tree};
-
 pub use crate::options::{
   Attachment, AttachmentRelationship, MeasureOptions, MeasuredSize, PageMargins, PageOptions,
   PdfDate, PdfError, PdfMetadata, PdfOptions, PdfStandard, Tagging, XmpProperty, XmpSchema,
+};
+use crate::{
+  bands::{emit_band, measure_band, prepare_band},
+  emitter::FontMap,
+  inline::{build_inline_map, collect_text_boxes},
+  interactive::{add_link_annotations, build_outline, collect_interactive, destination_targets},
+  krilla::{
+    Document, SerializeSettings,
+    configure::ConfigurationBuilder,
+    destination::XyzDestination,
+    embed::{EmbeddedFile, MimeType},
+    geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
+    page::PageSettings,
+    paint::FillRule,
+  },
+  options::{BAND_EDGE_PADDING, PT_PER_PX, build_metadata, krilla_datetime, validate_xmp_schemas},
+  pagination::page_starts,
+  paint::rect_path,
+  tags::{TagCollector, build_tag_tree, tag_id},
+  tree::{TreeInputs, prepare_tree},
 };
 
 /// Lays out a node tree without rendering and returns its size.

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -3,12 +3,6 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use crate::krilla::{
-  configure::{Accessibility, Archival},
-  embed::AssociationKind,
-  error::KrillaError,
-  metadata::{DateTime, Metadata},
-};
 use takumi_core::{
   Fonts,
   error::Error as TakumiError,
@@ -18,6 +12,13 @@ use takumi_core::{
   viewport::Viewport,
 };
 use typed_builder::TypedBuilder;
+
+use crate::krilla::{
+  configure::{Accessibility, Archival},
+  embed::AssociationKind,
+  error::KrillaError,
+  metadata::{DateTime, Metadata},
+};
 
 /// Errors from [`crate::render`].
 #[derive(Debug)]

--- a/takumi-pdf/src/paint.rs
+++ b/takumi-pdf/src/paint.rs
@@ -1,22 +1,25 @@
 //! Path, gradient, decoration and image helpers translating takumi paint into krilla.
 
-use crate::filter::ColorFilter;
-#[cfg(feature = "images")]
-use crate::krilla::image::Image as KrillaImage;
-use crate::krilla::{
-  blend::BlendMode as KrillaBlendMode,
-  color::rgb,
-  geom::{Path as KrillaPath, PathBuilder, Rect as KrillaRect},
-  num::NormalizedF32,
-  paint::{Fill, FillRule, SpreadMethod, Stop},
-  surface::Surface,
-};
 #[cfg(feature = "images")]
 use takumi_core::resources::image::{ImageSource, RenderedImage};
 use takumi_core::{
   context::RenderContext,
   geometry::{ComputedLayout as Layout, PathCommand},
   style::{BlendMode, ComputedStyle, Length, Overflow, PositionComponent, ResolvedGradientStop},
+};
+
+#[cfg(feature = "images")]
+use crate::krilla::image::Image as KrillaImage;
+use crate::{
+  filter::ColorFilter,
+  krilla::{
+    blend::BlendMode as KrillaBlendMode,
+    color::rgb,
+    geom::{Path as KrillaPath, PathBuilder, Rect as KrillaRect},
+    num::NormalizedF32,
+    paint::{Fill, FillRule, SpreadMethod, Stop},
+    surface::Surface,
+  },
 };
 
 /// A degenerate path, for a clip that must hide everything: an empty region is

--- a/takumi-pdf/src/shadow.rs
+++ b/takumi-pdf/src/shadow.rs
@@ -80,16 +80,19 @@ pub(crate) fn emit_inset_shadows(
         .border
         .append_mask_commands(&mut commands, clip.size, CorePoint::ZERO);
 
-      let (hole, hole_size) = clip.border.outset_shadow_box(clip.size, -band.spread);
-
-      hole.append_mask_commands(
-        &mut commands,
-        hole_size,
+      let hole = ClipBox::inset_shadow_hole(
+        clip.border,
+        clip.size,
+        band.spread,
         CorePoint {
-          x: shadow.offset_x + band.spread,
-          y: shadow.offset_y + band.spread,
+          x: shadow.offset_x,
+          y: shadow.offset_y,
         },
       );
+
+      hole
+        .border
+        .append_mask_commands(&mut commands, hole.size, hole.offset);
       fill(
         &commands,
         shadow.color,

--- a/takumi-pdf/src/shadow.rs
+++ b/takumi-pdf/src/shadow.rs
@@ -12,11 +12,13 @@ use takumi_core::{
   style::Color,
 };
 
-use crate::krilla::{
-  paint::{Fill, FillRule},
-  surface::Surface,
+use crate::{
+  krilla::{
+    paint::{Fill, FillRule},
+    surface::Surface,
+  },
+  paint::{fill_from_rgba, krilla_path},
 };
-use crate::paint::{fill_from_rgba, krilla_path};
 
 /// Bands used to fake one blurred edge. Eight is enough that the steps read as
 /// a gradient at the blur radii interfaces actually use.
@@ -191,10 +193,9 @@ fn fill(commands: &[PathCommand], color: Color, alpha: f32, at: (f32, f32), surf
 
 #[cfg(test)]
 mod tests {
-  use super::coverage;
-
-  use super::bands;
   use takumi_core::{shadow::SizedShadow, style::Color};
+
+  use super::{bands, coverage};
 
   #[test]
   fn a_blurred_shadow_has_an_opaque_core() {

--- a/takumi-pdf/src/svg.rs
+++ b/takumi-pdf/src/svg.rs
@@ -8,19 +8,21 @@ use takumi_core::{
   },
 };
 
-use crate::krilla::image::Image as KrillaImage;
-use crate::krilla::{
-  color::rgb,
-  geom::{Path as KrillaPath, Size as KrillaSize, Transform},
-  mask::{Mask, MaskType},
-  num::NormalizedF32,
-  paint::{
-    Fill, FillRule, LineCap, LineJoin, LinearGradient, Paint, Pattern, RadialGradient,
-    SpreadMethod, Stop, Stroke, StrokeDash,
+use crate::{
+  krilla::{
+    color::rgb,
+    geom::{Path as KrillaPath, Size as KrillaSize, Transform},
+    image::Image as KrillaImage,
+    mask::{Mask, MaskType},
+    num::NormalizedF32,
+    paint::{
+      Fill, FillRule, LineCap, LineJoin, LinearGradient, Paint, Pattern, RadialGradient,
+      SpreadMethod, Stop, Stroke, StrokeDash,
+    },
+    surface::Surface,
   },
-  surface::Surface,
+  paint::{krilla_blend, krilla_path},
 };
-use crate::paint::{krilla_blend, krilla_path};
 
 /// Draws `ops` onto `surface` in the current coordinate space and resets the
 /// fill/stroke state afterwards.

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -19,10 +19,12 @@ use takumi_core::{
   viewport::Viewport,
 };
 
-use crate::emitter::{Emitter, FontMap};
-use crate::inline::InlineMap;
-use crate::options::PdfError;
-use crate::tags::TagCollector;
+use crate::{
+  emitter::{Emitter, FontMap},
+  inline::InlineMap,
+  options::PdfError,
+  tags::TagCollector,
+};
 
 /// Shared inputs for laying out an independent node tree: the main content or
 /// a header/footer band.

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -14,7 +14,6 @@ use std::{
 };
 
 use flate2::read::ZlibDecoder;
-
 use takumi_core::{
   Fonts,
   layout::node::{ImageData, ImageSourceInput, Node, RgbaImage},

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use skrifa::{FontRef, MetadataProvider};
-use takumi_core::geometry::{ComputedLayout as Layout, NodeId, Point, Size};
-use takumi_core::layout::inline_box::{InlineBoxPaint, resolve_inline_box};
+use takumi_core::{
+  geometry::{ComputedLayout as Layout, NodeId, Point, Size},
+  layout::inline_box::{InlineBoxPaint, resolve_inline_box},
+};
 
 use crate::{
   BorderProperties, Canvas, Cap, DashPattern, DecorationSegmentParams, PaintSource, Placement,
@@ -16,7 +18,7 @@ use crate::{
     resolve_inline_runs,
   },
   mask_index_from_coord,
-  painter::{StrokeStyle, inline_outline_stroke},
+  painter::StrokeStyle,
   rasterize_layers,
   render::render_node,
   render_mask,
@@ -409,7 +411,7 @@ fn draw_outline_island(
     return Ok(());
   };
 
-  let Some(stroke) = inline_outline_stroke(style) else {
+  let Some(stroke) = style.outline_stroke() else {
     return Ok(());
   };
   let opacity = style.parent.opacity.0;

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -15,13 +15,15 @@ use crate::{
     ProcessedInlineSpan, ShapedRun, VisualInlineBox, outline_island_contour, outline_islands,
     resolve_inline_runs,
   },
-  mask_index_from_coord, rasterize_layers,
+  mask_index_from_coord,
+  painter::{StrokeStyle, inline_outline_stroke},
+  rasterize_layers,
   render::render_node,
   render_mask,
   resources::{font::FontError, glyph::ResolvedGlyph},
   style::{
-    Affine, BackgroundClip, BlendMode, BorderStyle, Color, SizedTextDecorationThickness,
-    TextDecorationLines, TextDecorationSkipInk,
+    Affine, BackgroundClip, BlendMode, Color, SizedTextDecorationThickness, TextDecorationLines,
+    TextDecorationSkipInk,
   },
   unshifted_glyph_mask,
 };
@@ -407,14 +409,12 @@ fn draw_outline_island(
     return Ok(());
   };
 
-  let width = style.outline_width;
-  if width == 0.0 || !style.outline_style.is_rendered() {
+  let Some(stroke) = inline_outline_stroke(style) else {
     return Ok(());
-  }
-
+  };
   let opacity = style.parent.opacity.0;
   draw_with_inline_opacity(canvas, opacity, |canvas| {
-    draw_outline_island_content(outline_rects, canvas, style, transform);
+    draw_outline_island_content(outline_rects, canvas, style, &stroke, transform);
     Ok(())
   })
 }
@@ -423,40 +423,28 @@ fn draw_outline_island_content(
   outline_rects: &[InlineOutlineRect],
   canvas: &mut Canvas,
   style: &SizedFontStyle,
+  outline: &StrokeStyle,
   transform: Affine,
 ) {
-  let width = style.outline_width;
-
-  let path = outline_island_contour(outline_rects, style.outline_offset + width / 2.0);
+  let path = outline_island_contour(outline_rects, style.outline_offset + outline.width / 2.0);
   if path.is_empty() {
     return;
   }
 
-  let mut stroke = Stroke::new(width);
-  match style.outline_style {
-    BorderStyle::Dotted => {
-      stroke.cap = Cap::Round;
-      stroke.dash = Some(DashPattern {
-        intervals: [0.0, width * 2.0],
-        offset: 0.0,
-      });
-    }
-    BorderStyle::Dashed => {
-      stroke.dash = Some(DashPattern {
-        intervals: [width * 3.0, width * 2.0],
-        offset: 0.0,
-      });
-    }
-    BorderStyle::Hidden
-    | BorderStyle::Double
-    | BorderStyle::Groove
-    | BorderStyle::Ridge
-    | BorderStyle::Inset
-    | BorderStyle::Outset => return,
-    _ => {}
+  let mut stroke = Stroke::new(outline.width);
+
+  if let Some(intervals) = outline.dash {
+    stroke.dash = Some(DashPattern {
+      intervals,
+      offset: 0.0,
+    });
   }
+  if outline.round_cap {
+    stroke.cap = Cap::Round;
+  }
+
   let (mask, placement) = render_mask(&path, Some(transform), Some(stroke.into()));
-  canvas.draw_mask(&mask, placement, style.outline_color, BlendMode::Normal);
+  canvas.draw_mask(&mask, placement, outline.color, BlendMode::Normal);
 }
 
 fn draw_merged_outline_rects(

--- a/takumi-raster/src/text_drawing.rs
+++ b/takumi-raster/src/text_drawing.rs
@@ -1,10 +1,9 @@
 use std::{convert::Into, sync::Arc};
 
-use xxhash_rust::xxh3::Xxh3;
-
 use skrifa::color::ColorPalette;
 use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 use tiny_skia::Pixmap;
+use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
   BorderProperties, Canvas, ColorTile, Command, MaskCompositeColor, MaskSamplingOptions,

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -1,10 +1,9 @@
+#[cfg(feature = "rayon")]
+use std::collections::VecDeque;
 use std::{
   borrow::{Borrow, Cow},
   io::Write,
 };
-
-#[cfg(feature = "rayon")]
-use std::collections::VecDeque;
 
 use gif::{Encoder as GifEncoder, Frame as GifFrame, Repeat};
 use image::{

--- a/takumi-svg/src/lib.rs
+++ b/takumi-svg/src/lib.rs
@@ -35,7 +35,11 @@ use quick_xml::{
   events::{BytesEnd, BytesStart, BytesText, Event},
 };
 pub use render::{SvgOptions, render};
-use takumi_core::style::FilterReference;
+use takumi_core::{
+  geometry::Size,
+  shadow::SizedShadow,
+  style::{Affine, Color, Filter, FilterReference, LUMA_WEIGHTS, SEPIA_WEIGHTS, SizingContext},
+};
 
 /// Straight-alpha RGBA color.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,12 +64,6 @@ impl Rgba {
     self.0[3] as f32 / 255.0
   }
 }
-
-use takumi_core::{
-  geometry::Size,
-  shadow::SizedShadow,
-  style::{Affine, Color, Filter, LUMA_WEIGHTS, SEPIA_WEIGHTS, SizingContext},
-};
 
 pub(crate) const IDENTITY: Affine = Affine::IDENTITY;
 

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -2,7 +2,6 @@
 
 use std::{collections::HashMap, io, rc::Rc, sync::Arc};
 
-use takumi_core::painter::{BoxPainter, FillShape, PaintDevice, StrokeStyle, paint_border};
 use takumi_core::{
   Fonts,
   context::RenderContext,
@@ -16,6 +15,7 @@ use takumi_core::{
     node::{ImageData, Node, NodeKind},
     tree::{LayoutTree, RenderNode},
   },
+  painter::{BoxPainter, FillShape, PaintDevice, StrokeStyle, paint_border},
   resources::image::ImageSource,
   scene::build_stacking_contexts,
   style::{

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -22,7 +22,7 @@ use takumi_core::{
     node::TextData,
     tree::RenderNode,
   },
-  painter::{inline_outline_stroke, paint_run_decorations},
+  painter::paint_run_decorations,
   resources::{glyph::ResolvedGlyph, image::to_data_url},
   style::{BackgroundClip, LineJoin, TextDecorationLines},
 };
@@ -250,7 +250,7 @@ fn emit_outline_island(
   };
   // The device skips a transparent stroke, but an inline outline never reaches
   // one, so the emptiness is checked here instead.
-  let Some(stroke) = inline_outline_stroke(style).filter(|s| s.color.0[3] != 0) else {
+  let Some(stroke) = style.outline_stroke().filter(|s| s.color.0[3] != 0) else {
     return Ok(());
   };
   let width = stroke.width;

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -22,9 +22,9 @@ use takumi_core::{
     node::TextData,
     tree::RenderNode,
   },
-  painter::paint_run_decorations,
+  painter::{inline_outline_stroke, paint_run_decorations},
   resources::{glyph::ResolvedGlyph, image::to_data_url},
-  style::{BackgroundClip, BorderStyle, LineJoin, TextDecorationLines},
+  style::{BackgroundClip, LineJoin, TextDecorationLines},
 };
 
 use crate::{
@@ -248,27 +248,16 @@ fn emit_outline_island(
   let Some(ProcessedInlineSpan::Text { style, .. }) = spans.get(first_rect.span_id as usize) else {
     return Ok(());
   };
-  let width = style.outline_width;
-  if width <= 0.0 || !style.outline_style.is_rendered() || style.outline_color.0[3] == 0 {
+  // The device skips a transparent stroke, but an inline outline never reaches
+  // one, so the emptiness is checked here instead.
+  let Some(stroke) = inline_outline_stroke(style).filter(|s| s.color.0[3] != 0) else {
     return Ok(());
-  }
-
-  // Dash geometry mirrors the raster stroke; non-stroked styles (double, the
-  // 3D bevels) paint nothing here, as in the raster backend.
-  let (dasharray, linecap) = match style.outline_style {
-    BorderStyle::Dotted => (Some(format!("0 {}", Num(width * 2.0))), Some("round")),
-    BorderStyle::Dashed => (
-      Some(format!("{} {}", Num(width * 3.0), Num(width * 2.0))),
-      None,
-    ),
-    BorderStyle::Hidden
-    | BorderStyle::Double
-    | BorderStyle::Groove
-    | BorderStyle::Ridge
-    | BorderStyle::Inset
-    | BorderStyle::Outset => return Ok(()),
-    _ => (None, None),
   };
+  let width = stroke.width;
+  let dasharray = stroke
+    .dash
+    .map(|[dash, gap]| format!("{} {}", Num(dash), Num(gap)));
+  let linecap = stroke.round_cap.then_some("round");
 
   let contour = outline_island_contour(island, style.outline_offset + width / 2.0);
   let data = path_data(&contour, [1.0, 0.0, 0.0, 1.0, origin_x, origin_y]);
@@ -282,7 +271,7 @@ fn emit_outline_island(
     .transpose()?;
   doc.stroke_path(
     &data,
-    Rgba(style.outline_color.0),
+    Rgba(stroke.color.0),
     width,
     dasharray.as_deref(),
     linecap,

--- a/takumi/benches/canvas.rs
+++ b/takumi/benches/canvas.rs
@@ -1,5 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::{
   prelude::{
     AlignItems, BackgroundClip, BackgroundImages, BackgroundRepeats, BackgroundSizes, BorderRadius,

--- a/takumi/benches/effects.rs
+++ b/takumi/benches/effects.rs
@@ -1,5 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::{
   prelude::{Fonts, Node, RenderOptions, Viewport},
   render,

--- a/takumi/benches/fixtures.rs
+++ b/takumi/benches/fixtures.rs
@@ -1,5 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::{
   prelude::{
     AlignItems, BackgroundClip, BackgroundImages, BackgroundRepeats, BackgroundSizes, BorderRadius,

--- a/takumi/benches/gradient.rs
+++ b/takumi/benches/gradient.rs
@@ -1,5 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::{
   prelude::{
     BackgroundImages, Fonts, FromCssStr, Length, Node, RenderOptions, Style, StyleDeclaration,

--- a/takumi/benches/svg.rs
+++ b/takumi/benches/svg.rs
@@ -1,5 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::{hint::black_box, path::Path};
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::prelude::{
   AlignItems, BackgroundClip, BackgroundImages, BackgroundRepeats, BackgroundSizes, BorderRadius,
   BorderStyle, Color, ColorInput, Display, FlexWrap, FontResource, FontWeight, Fonts, FromCssStr,

--- a/takumi/benches/text.rs
+++ b/takumi/benches/text.rs
@@ -1,5 +1,6 @@
-use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::{
   prelude::{FontOverride, FontResource, Fonts, GenericFamily, Node, RenderOptions, Viewport},
   render,

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -1,7 +1,8 @@
 use serde_json::{from_value, json};
-use takumi::prelude::{Length::*, *};
-
-use takumi::render;
+use takumi::{
+  prelude::{Length::*, *},
+  render,
+};
 
 use crate::test_utils::{CONTEXT, run_fixture_test};
 


### PR DESCRIPTION
## Why

Three places still decided something twice.

An inset shadow's hole had two helpers in core computing the same geometry. The SVG and raster backends called `ClipBox::inset_shadow_hole`; the PDF backend called `outset_shadow_box` with a negated spread and placed the result by hand.

An inline `outline` had its stroke worked out twice. The raster and SVG backends each wrote out the dotted `0 2w` and dashed `3w 2w` intervals, and each listed the styles an inline outline cannot draw.

Five items in `takumi_core::layout::inline` were `pub` with no caller outside the crate.

## What

PDF cuts the hole with `ClipBox::inset_shadow_hole`.

`takumi_core::painter::inline_outline_stroke` returns the `StrokeStyle` an inline outline paints with, or `None`. Both backends stroke the contour it describes.

`ParentFontMetrics`, `ResolvedLineMetrics`, `ResolvedInlineLineState`, `resolve_visual_inline_box` and `text_fit_line_alignment_correction` are now `pub(crate)`.

No golden moved, in any backend.

## Still not shared, and why

- The raster backend keeps its own text decorations: `text-decoration-skip-ink` needs rasterized glyph coverage, and its subpixel antialiasing is not reproducible from a rect fill.
- The raster backend shades 3D border sides through `shade_3d_border_color`. SVG and PDF paint those as one flat ring. Unifying means implementing the shading in both, which changes what they render.
- `background-clip: border-area` reaches the same result three ways. Blink paints the background before the border and only changes its clip; raster instead makes the background the border's paint source, and SVG and PDF reorder the two.
- An outline still paints under the box's descendants in all three backends. Blink runs `PaintPhase::kOutline` after every descendant's foreground.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved inline text outline rendering across raster and SVG output, including consistent dotted, dashed, and rounded strokes.
  * Added support for resolved outline width, color, dash patterns, and transparency handling.

* **Bug Fixes**
  * Corrected inset shadow hole positioning and sizing in PDF output.
  * Unified inline outline behavior across rendering formats for more consistent results.

* **Refactor**
  * Internal inline-layout details are now restricted to improve API stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->