### PR TITLE
Core: build an inline layout request from its content box

### DIFF
--- a/.tegami/inline-layout-request-ctor.md
+++ b/.tegami/inline-layout-request-ctor.md
@@ -1,0 +1,11 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Build an inline layout request from the box it fills
+
+`InlineLayoutRequest::in_content_box` takes the content box and works out the available space, the wrap width and the height clamp from it. `in_available_space` does the same from taffy's constraint, for a box still sizing itself. Every backend spelled all three out by hand at seven call sites.
+
+`create_inline_constraint` and `resolve_inline_max_height` no longer leave the crate; the constructors call them.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -50,6 +50,60 @@ pub struct InlineLayoutRequest<'c> {
   pub shape_cacheable: bool,
 }
 
+impl<'c> InlineLayoutRequest<'c> {
+  /// A request that lays `items` into a content box. The available space, the
+  /// wrap width and the height clamp all follow from the box, so a caller only
+  /// says what it is laying out and whether it is measuring.
+  pub fn in_content_box(
+    items: Vec<InlineItem<'c>>,
+    content: Size<f32>,
+    style: &'c SizedFontStyle<'c>,
+    context: &'c RenderContext,
+    mode: InlineLayoutMode,
+  ) -> Self {
+    Self {
+      items,
+      available_space: Size {
+        width: AvailableSpace::Definite(content.width),
+        height: AvailableSpace::Definite(content.height),
+      },
+      max_width: content.width,
+      max_height: resolve_inline_max_height(style, content.height),
+      style,
+      context,
+      mode,
+      shape_cacheable: true,
+    }
+  }
+
+  /// A request measured against taffy's own constraint, which is what a layout
+  /// pass hands down: the box may still be sizing itself, so the wrap width
+  /// comes from the available space and `box-sizing` rather than from a
+  /// content box that does not exist yet.
+  pub fn in_available_space(
+    items: Vec<InlineItem<'c>>,
+    available_space: Size<AvailableSpace>,
+    known_dimensions: Size<Option<f32>>,
+    style: &'c SizedFontStyle<'c>,
+    context: &'c RenderContext,
+    mode: InlineLayoutMode,
+  ) -> Self {
+    let (max_width, max_height) =
+      create_inline_constraint(context, available_space, known_dimensions);
+
+    Self {
+      items,
+      available_space,
+      max_width,
+      max_height,
+      style,
+      context,
+      mode,
+      shape_cacheable: true,
+    }
+  }
+}
+
 /// A per-render cache of shaped text-only parley layouts, keyed by a hash of
 /// the span texts and styles. Shaping is width-independent for pure text
 /// (inline boxes bake in measured sizes, so they bypass the cache); line
@@ -1763,7 +1817,7 @@ pub fn create_inline_layout<'c>(request: InlineLayoutRequest<'c>) -> BuiltInline
 }
 
 /// Resolve the max height constraint from line clamping and content box height.
-pub fn resolve_inline_max_height(
+pub(crate) fn resolve_inline_max_height(
   font_style: &SizedFontStyle,
   content_box_height: f32,
 ) -> Option<MaxHeight> {
@@ -2650,7 +2704,7 @@ pub fn run_decorations(
 }
 
 /// Resolve the inline layout's max width and optional max height from available space and known dimensions.
-pub fn create_inline_constraint(
+pub(crate) fn create_inline_constraint(
   context: &RenderContext,
   available_space: Size<AvailableSpace>,
   known_dimensions: Size<Option<f32>>,

--- a/takumi-pdf/src/inline.rs
+++ b/takumi-pdf/src/inline.rs
@@ -5,11 +5,11 @@ use std::collections::HashMap;
 use takumi_core::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{AvailableSpace, ComputedLayout as Layout, Size},
+  geometry::ComputedLayout as Layout,
   layout::{
     inline::{
       BuiltInlineLayout, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineRunLayout,
-      collect_inline_items, create_inline_layout, resolve_inline_max_height, resolve_inline_runs,
+      collect_inline_items, create_inline_layout, resolve_inline_runs,
     },
     node::{NodeKind, TextData},
     tree::RenderNode,
@@ -172,19 +172,13 @@ pub(crate) fn build_inline_runs<'c>(
     return Ok(None);
   }
 
-  let built = create_inline_layout(InlineLayoutRequest {
+  let built = create_inline_layout(InlineLayoutRequest::in_content_box(
     items,
-    available_space: Size {
-      width: AvailableSpace::Definite(content.width),
-      height: AvailableSpace::Definite(content.height),
-    },
-    max_width: content.width,
-    max_height: resolve_inline_max_height(font_style, content.height),
-    style: font_style,
+    content,
+    font_style,
     context,
-    mode: InlineLayoutMode::Draw,
-    shape_cacheable: true,
-  });
+    InlineLayoutMode::Draw,
+  ));
   let runs = resolve_inline_runs(&built, context, layout).map_err(PdfError::Font)?;
 
   Ok(Some((built, runs)))

--- a/takumi-pdf/src/interactive.rs
+++ b/takumi-pdf/src/interactive.rs
@@ -8,13 +8,10 @@ use std::{
 
 use takumi_core::{
   font_style::SizedFontStyle,
-  geometry::{
-    AvailableSpace, ComputedLayout as Layout, Point as CorePoint, Size, transformed_rect_extents,
-  },
+  geometry::{ComputedLayout as Layout, Point as CorePoint, Size, transformed_rect_extents},
   layout::{
     inline::{
-      InlineItem, InlineLayoutMode, InlineLayoutRequest, collect_inline_items,
-      create_inline_layout, resolve_inline_max_height,
+      InlineItem, InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,
     },
     tree::RenderNode,
   },
@@ -303,19 +300,13 @@ fn collect_inline_links(
   {
     return;
   }
-  let built = create_inline_layout(InlineLayoutRequest {
+  let built = create_inline_layout(InlineLayoutRequest::in_content_box(
     items,
-    available_space: Size {
-      width: AvailableSpace::Definite(content.width),
-      height: AvailableSpace::Definite(content.height),
-    },
-    max_width: content.width,
-    max_height: resolve_inline_max_height(&font_style, content.height),
-    style: &font_style,
+    content,
+    &font_style,
     context,
-    mode: InlineLayoutMode::Measure,
-    shape_cacheable: true,
-  });
+    InlineLayoutMode::Measure,
+  ));
   let (runs, _) = built.measure_runs(layout);
 
   for run in runs {

--- a/takumi-raster/src/node_paint.rs
+++ b/takumi-raster/src/node_paint.rs
@@ -5,7 +5,7 @@
 //! tiny-skia, and the SVG backend emits the same geometry as vector paths.
 
 use takumi_core::{
-  geometry::{AvailableSpace, ComputedLayout as Layout, Point, Point as CorePoint, Size},
+  geometry::{ComputedLayout as Layout, Point, Point as CorePoint},
   layout::decoration::ClipBox,
   painter::{BoxPainter, FillShape, PaintDevice},
   style::{Color, ImageScalingAlgorithm},
@@ -20,10 +20,7 @@ use super::{
 use crate::{
   Result,
   layout::{
-    inline::{
-      InlineItem, InlineLayoutMode, InlineLayoutRequest, create_inline_layout,
-      resolve_inline_max_height,
-    },
+    inline::{InlineItem, InlineLayoutMode, InlineLayoutRequest, create_inline_layout},
     node::{ImageData, Node, NodeKind, TextData},
   },
   style::{Affine, BackgroundClip, BlendMode},
@@ -357,27 +354,19 @@ fn draw_text_node_content(
     return Ok(());
   }
 
-  let max_height = resolve_inline_max_height(&font_style, size.height);
-
   let inline_text: InlineItem<'_> = InlineItem::Text {
     text: text.text.as_str().into(),
     context,
     link: None,
   };
 
-  let built = create_inline_layout(InlineLayoutRequest {
-    items: vec![inline_text],
-    available_space: Size {
-      width: AvailableSpace::Definite(size.width),
-      height: AvailableSpace::Definite(size.height),
-    },
-    max_width: size.width,
-    max_height,
-    style: &font_style,
+  let built = create_inline_layout(InlineLayoutRequest::in_content_box(
+    vec![inline_text],
+    size,
+    &font_style,
     context,
-    mode: InlineLayoutMode::Draw,
-    shape_cacheable: true,
-  });
+    InlineLayoutMode::Draw,
+  ));
 
   draw_inline_layout(context, canvas, layout, &built, &font_style)?;
 

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -12,10 +12,7 @@ use crate::{
   AnimationFrame, Bitmap, Canvas, DitheringAlgorithm, Error, Fonts, RenderContext, Result,
   SizedFontStyle, apply_dithering,
   layout::{
-    inline::{
-      InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_constraint,
-      create_inline_layout,
-    },
+    inline::{InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout},
     node::Node,
     tree::{LayoutResults, LayoutTree, RenderNode},
   },
@@ -246,28 +243,17 @@ fn collect_measure_result(
 
         if current.should_create_inline_layout() {
           let font_style = SizedFontStyle::from_style(&current.context.style, &current.context);
-          let (max_width, max_height) = create_inline_constraint(
-            &current.context,
+          let built = create_inline_layout(InlineLayoutRequest::in_available_space(
+            collect_inline_items(current),
             Size {
               width: AvailableSpace::Definite(layout.content_box_width()),
               height: AvailableSpace::Definite(layout.content_box_height()),
             },
             Size::NONE,
-          );
-
-          let built = create_inline_layout(InlineLayoutRequest {
-            items: collect_inline_items(current),
-            available_space: Size {
-              width: AvailableSpace::Definite(layout.content_box_width()),
-              height: AvailableSpace::Definite(layout.content_box_height()),
-            },
-            max_width,
-            max_height,
-            style: &font_style,
-            context: &current.context,
-            mode: InlineLayoutMode::Measure,
-            shape_cacheable: true,
-          });
+            &font_style,
+            &current.context,
+            InlineLayoutMode::Measure,
+          ));
           let (measured_runs, measured_boxes) = built.measure_runs(layout);
           runs.extend(measured_runs.into_iter().map(|run| MeasuredTextRun {
             text: run.text.to_string(),

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -1,7 +1,5 @@
 use takumi_core::{
-  geometry::{
-    AvailableSpace, ComputedLayout as Layout, NodeId, Point, Size, transformed_rect_extents,
-  },
+  geometry::{ComputedLayout as Layout, NodeId, Point, Size, transformed_rect_extents},
   scene::{NodePaint, PaintItem, PaintItemKind, SceneBounds, StackingContextNode},
 };
 use tiny_skia::{Pixmap, PixmapMut};
@@ -15,7 +13,7 @@ use crate::{
   layout::{
     inline::{
       InlineLayoutMode, InlineLayoutRequest, ProcessedInlineSpan, collect_inline_items,
-      create_inline_layout, resolve_inline_max_height,
+      create_inline_layout,
     },
     tree::{LayoutResults, RenderNode},
   },
@@ -656,21 +654,13 @@ fn draw_render_node_inline(
 
   let font_style = SizedFontStyle::from_style(&node.context.style, &node.context);
 
-  let max_height = resolve_inline_max_height(&font_style, layout.content_box_height());
-
-  let built = create_inline_layout(InlineLayoutRequest {
-    items: collect_inline_items(node),
-    available_space: Size {
-      width: AvailableSpace::Definite(layout.content_box_width()),
-      height: AvailableSpace::Definite(layout.content_box_height()),
-    },
-    max_width: layout.content_box_width(),
-    max_height,
-    style: &font_style,
-    context: &node.context,
-    mode: InlineLayoutMode::Draw,
-    shape_cacheable: true,
-  });
+  let built = create_inline_layout(InlineLayoutRequest::in_content_box(
+    collect_inline_items(node),
+    layout.content_box_size(),
+    &font_style,
+    &node.context,
+    InlineLayoutMode::Draw,
+  ));
   let inline_layout_box = layout;
 
   let boxes = built.spans.iter().filter_map(|span| match span {

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -11,13 +11,12 @@ use std::{io, sync::Arc};
 use takumi_core::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::{AvailableSpace, ComputedLayout as Layout, Point, Size},
+  geometry::{ComputedLayout as Layout, Point},
   layout::{
     inline::{
       InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineOutlineRect, InlineRunLayout,
       PositionedInlineRun, ProcessedInlineSpan, collect_inline_items, create_inline_layout,
-      outline_island_contour, outline_islands, resolve_inline_max_height, resolve_inline_runs,
-      run_decorations,
+      outline_island_contour, outline_islands, resolve_inline_runs, run_decorations,
     },
     node::TextData,
     tree::RenderNode,
@@ -80,23 +79,17 @@ pub(crate) fn emit_text(
     return Ok(());
   }
 
-  let built = create_inline_layout(InlineLayoutRequest {
-    items: vec![InlineItem::Text {
+  let built = create_inline_layout(InlineLayoutRequest::in_content_box(
+    vec![InlineItem::Text {
       text: text.text.as_str().into(),
       context,
       link: None,
     }],
-    available_space: Size {
-      width: AvailableSpace::Definite(content.width),
-      height: AvailableSpace::Definite(content.height),
-    },
-    max_width: content.width,
-    max_height: resolve_inline_max_height(&font_style, content.height),
-    style: &font_style,
+    content,
+    &font_style,
     context,
-    mode: InlineLayoutMode::Draw,
-    shape_cacheable: true,
-  });
+    InlineLayoutMode::Draw,
+  ));
 
   let runs = resolve_inline_runs(&built, context, layout).map_err(font_error)?;
   emit_runs(
@@ -127,19 +120,13 @@ pub(crate) fn emit_inline_content(
   }
   let content = layout.content_box_size();
 
-  let built = create_inline_layout(InlineLayoutRequest {
-    items: collect_inline_items(node),
-    available_space: Size {
-      width: AvailableSpace::Definite(content.width),
-      height: AvailableSpace::Definite(content.height),
-    },
-    max_width: content.width,
-    max_height: resolve_inline_max_height(&font_style, content.height),
-    style: &font_style,
+  let built = create_inline_layout(InlineLayoutRequest::in_content_box(
+    collect_inline_items(node),
+    content,
+    &font_style,
     context,
-    mode: InlineLayoutMode::Draw,
-    shape_cacheable: true,
-  });
+    InlineLayoutMode::Draw,
+  ));
 
   let runs = resolve_inline_runs(&built, context, layout).map_err(font_error)?;
   emit_runs(


### PR DESCRIPTION
## Why

Seven call sites across the three backends built the same `InlineLayoutRequest` by hand:

```rust
create_inline_layout(InlineLayoutRequest {
  items: collect_inline_items(node),
  available_space: Size {
    width: AvailableSpace::Definite(content.width),
    height: AvailableSpace::Definite(content.height),
  },
  max_width: content.width,
  max_height: resolve_inline_max_height(&font_style, content.height),
  style: &font_style,
  context,
  mode: InlineLayoutMode::Draw,
  shape_cacheable: true,
});
```

Five of the eight fields follow from the content box, so every site restated the same derivation.

## What

`InlineLayoutRequest::in_content_box` derives the available space, the wrap width and the height clamp from the box. Six sites use it.

The seventh is raster's measure pass, which is handed taffy's constraint rather than a content box that does not exist yet. `in_available_space` covers it, folding in the `create_inline_constraint` call it made separately.

`create_inline_constraint` and `resolve_inline_max_height` are now `pub(crate)`: the constructors are their only callers.

No golden moved, in any backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamlined inline layout request construction for content-box and available-space scenarios.
  * Improved shape caching support during inline layout.

* **Improvements**
  * Standardized inline text layout behavior across PDF, raster, SVG, and interactive rendering.
  * Reduced duplicated layout configuration, helping maintain consistent sizing and constraint handling.

* **Documentation**
  * Added release notes describing the updated inline layout request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->