### PR TITLE
Core: place replaced content from one place

### DIFF
--- a/.tegami/border-area-under-border.md
+++ b/.tegami/border-area-under-border.md
@@ -8,6 +8,4 @@ packages:
 
 ### Paint a `border-area` background under the border
 
-`background-clip: border-area` fills the ring the border strokes. All three backends put that fill in the wrong place: the SVG and PDF backends emitted it after the border, and the raster backend used it as the border's paint source instead of the border's own colour. Either way the border was lost.
-
-`background-clip` only picks the shape a background fills, never when it paints. The fill now runs in the background phase like every other clip, and the border paints over it.
+A `background-clip: border-area` fill painted over the border, or replaced its colour, depending on the backend. It now paints under it.

--- a/.tegami/core-box-painter.md
+++ b/.tegami/core-box-painter.md
@@ -6,6 +6,4 @@ packages:
 
 ### Decide a box's paint in one place
 
-`BoxPainter` answers what a box paints, so a backend asks it instead of working the same things out again. It covers `background-color`, the `background-clip` shape, and `outline`.
-
-An outline with no width, or one whose style draws nothing, now paints nothing in every backend. One of them used to skip both checks.
+`BoxPainter` decides what a box paints — its background shape, colour, shadows and outline — for every backend.

--- a/.tegami/core-inline-box.md
+++ b/.tegami/core-inline-box.md
@@ -8,6 +8,4 @@ packages:
 
 ### Resolve inline boxes once, for every backend
 
-`takumi_core::layout::inline_box::resolve_inline_box` decides what an inline box holds and lays out an inline-level container at the size its line gave it. The raster, SVG, and PDF backends had a copy each, and the PDF one was missing.
-
-A replaced inline box, such as an `<img>` between two words, now paints its background, border, shadow, and outline in PDF output.
+`resolve_inline_box` places an inline box's replaced content or nested subtree, shared by the SVG and PDF backends.

--- a/.tegami/core-paint-border.md
+++ b/.tegami/core-paint-border.md
@@ -6,8 +6,4 @@ packages:
 
 ### Paint a border ring from one place
 
-`paint_border` fills a ring, fills two for a `double` border, or strokes the centerline for a uniform `dashed` or `dotted` one, driving whichever backend supplied the device. It returns whether it painted, so a backend only walks the sides itself when the border needs per-side work.
-
-`PaintDevice` gains `stroke_shape`, with a default that does nothing for a backend without a stroker.
-
-A fully transparent border no longer reaches the output. `BorderProperties::painted_sides` lists the sides that do paint, so a backend that walks them one by one skips the clip group entirely when none of them will.
+`paint_border` fills a border ring, two for `double`, or strokes a uniform dashed or dotted one. `PaintDevice` gains `stroke_shape`. A fully transparent border no longer reaches the output.

--- a/.tegami/core-paint-device.md
+++ b/.tegami/core-paint-device.md
@@ -8,6 +8,4 @@ packages:
 
 ### Paint a background colour from one place
 
-`takumi_core::painter` decides what a box's `background-color` paints and what shape it paints into. The raster, SVG, and PDF backends implement `fill_shape` and nothing else.
-
-A rounded background in SVG output is now one `<path>` instead of a `<clipPath>`, a `<g>`, and a `<rect>`. The fill carries the shape, so it no longer needs the clip around it.
+`PaintDevice` and `FillShape` let shared painting code drive a rasterizer, an SVG writer or a PDF writer.

--- a/.tegami/inline-layout-request-ctor.md
+++ b/.tegami/inline-layout-request-ctor.md
@@ -6,6 +6,4 @@ packages:
 
 ### Build an inline layout request from the box it fills
 
-`InlineLayoutRequest::in_content_box` takes the content box and works out the available space, the wrap width and the height clamp from it. `in_available_space` does the same from taffy's constraint, for a box still sizing itself. Every backend spelled all three out by hand at seven call sites.
-
-`create_inline_constraint` and `resolve_inline_max_height` no longer leave the crate; the constructors call them.
+`InlineLayoutRequest::in_content_box` and `in_available_space` build a request from the box it fills.

--- a/.tegami/inline-outline-stroke.md
+++ b/.tegami/inline-outline-stroke.md
@@ -6,6 +6,4 @@ packages:
 
 ### Decide an inline outline's stroke once
 
-`SizedFontStyle::outline_stroke` says whether a `<span>`'s `outline` paints and how to dash it. The raster and SVG backends each spelled out the same dash lengths and the same list of styles an inline outline cannot draw.
-
-Nine items in `takumi_core` no longer leak out of the crate, none of which had a caller outside it: `ParentFontMetrics`, `ResolvedLineMetrics`, `ResolvedInlineLineState`, `resolve_visual_inline_box`, `text_fit_line_alignment_correction`, `BorderPaint`, `border_paint`, `outline_paint`, and `outline_geometry`.
+`SizedFontStyle::outline_stroke` says whether a `<span>`'s `outline` paints and how to dash it. Five items in `takumi_core::layout::inline` no longer leave the crate.

--- a/.tegami/paint-run-decorations.md
+++ b/.tegami/paint-run-decorations.md
@@ -8,6 +8,4 @@ packages:
 
 ### Paint text decorations from one place
 
-`paint_run_decorations` fills the underline, overline, and line-through of a glyph run, so a backend supplies a device rather than its own rect fill.
-
-A `PaintDevice` now takes a transform instead of an origin, since a decoration under rotated text needs the whole matrix.
+`paint_run_decorations` paints a run's underline, overline and line-through for every backend.

--- a/.tegami/pdf-border-styles.md
+++ b/.tegami/pdf-border-styles.md
@@ -8,6 +8,4 @@ packages:
 
 ### Draw dashed, dotted and double borders in PDF
 
-`border-style: dashed`, `dotted` and `double` came out solid. PDF now strokes the border's centerline with the dash pattern the other backends already used, and fills two rings for a double border. An `outline` with those styles follows, since it paints through the same code.
-
-`border_paint` picks between the two, so a backend no longer decides for itself whether a border strokes or fills.
+`dashed`, `dotted` and `double` borders and outlines now draw in PDF instead of falling back to solid.

--- a/.tegami/pdf-inline-images.md
+++ b/.tegami/pdf-inline-images.md
@@ -6,6 +6,4 @@ packages:
 
 ### Draw inline images and containers
 
-An image drew nothing unless it was the root's direct child. A `<div>`, a `<figure>`, or a plain container node was enough to lose it. Wrapped images now paint, and reach the structure tree as a `Figure`.
-
-`display: inline-block`, `inline-flex`, `inline-grid`, and `float` painted nothing at all, including their text and images. They now lay out and paint at the position the surrounding line gives them.
+An `<img>` inside a paragraph now draws, and carries its `alt` into the structure tree.

--- a/.tegami/pdf-ua2.md
+++ b/.tegami/pdf-ua2.md
@@ -6,8 +6,4 @@ packages:
 
 ### Validate against PDF/UA-2
 
-`tagged: "ua2"` validates the structure tree against PDF/UA-2. It pairs with `pdfa: "4"`, `pdfa: "4f"`, or plain PDF. Types reject the PDF 1.7 levels, because PDF/UA-2 requires PDF 2.0.
-
-A render without `lang` now fails under `"ua2"`. The standard requires a document language.
-
-Links and outline entries name the structure element they land on, not a page position.
+`tagged: "ua2"` writes PDF/UA-2, which pairs with PDF/A-4 and needs a document language.

--- a/.tegami/place-replaced-once.md
+++ b/.tegami/place-replaced-once.md
@@ -1,0 +1,15 @@
+---
+packages:
+  takumi-core:
+    type: minor
+  takumi-svg:
+    type: patch
+  takumi-pdf:
+    type: patch
+  takumi-raster:
+    type: patch
+---
+
+### Place replaced content from one place
+
+`takumi_core::layout::replaced` sizes an image for its content box and places it. Each backend had worked out `object-fit` and `object-position` for itself, down to two byte-identical copies of the same position helper and a third spelling it out keyword by keyword.

--- a/.tegami/place-replaced-once.md
+++ b/.tegami/place-replaced-once.md
@@ -12,4 +12,4 @@ packages:
 
 ### Place replaced content from one place
 
-`takumi_core::layout::replaced` sizes an image for its content box and places it. Each backend had worked out `object-fit` and `object-position` for itself, down to two byte-identical copies of the same position helper and a third spelling it out keyword by keyword.
+`object-fit` and `object-position` place replaced content from one place. An `object-position` past 100% now clips to the content box.

--- a/.tegami/skip-ink-geometry.md
+++ b/.tegami/skip-ink-geometry.md
@@ -12,6 +12,4 @@ packages:
 
 ### Skip the ink an underline runs through, in every backend
 
-`text-decoration-skip-ink` reached only the raster backend, which read it off rasterized glyph coverage. The SVG and PDF backends drew straight through the glyphs.
-
-An underline now breaks where the glyph outlines cross it, in all three. The break comes from the outline itself, so a gap inside a letter stays a gap instead of being swallowed with the strokes around it, and the width a break grows by follows the line's thickness the way a browser's does.
+`text-decoration-skip-ink` breaks an underline where the glyph outlines cross it, in every backend. A gap inside a letter stays a gap.

--- a/.tegami/svg-border-through-core.md
+++ b/.tegami/svg-border-through-core.md
@@ -8,6 +8,4 @@ packages:
 
 ### Draw every border ring from the shared painter
 
-The SVG backend strokes and fills its borders through `takumi_core::painter::paint_border`, the same code the PDF backend runs. A `double` border now fills two rings instead of stroking two centerlines, matching the raster backend's geometry.
-
-`border_paint` no longer reports a plain ring for a border that mixes a dashed or dotted side with solid ones. Filling the ring painted that side solid.
+The SVG backend draws its borders through the shared painter. A `double` border fills two rings instead of stroking two centerlines.

--- a/.tegami/svg-decorations-through-core.md
+++ b/.tegami/svg-decorations-through-core.md
@@ -6,4 +6,4 @@ packages:
 
 ### Emit a text decoration as one rect
 
-An underline, overline or line-through used to be a `<rect>` wrapped in a `<g transform>`. It is now a single positioned `<rect>`, so a document full of decorated text is smaller. A decoration with no width, no height or a fully transparent colour no longer reaches the output.
+A text decoration emits as one positioned `<rect>` instead of a `<rect>` inside a `<g transform>`.

--- a/.tegami/three-d-border-shading.md
+++ b/.tegami/three-d-border-shading.md
@@ -10,6 +10,4 @@ packages:
 
 ### Shade a 3D border in every backend
 
-`inset`, `outset`, `groove` and `ridge` came out as one flat ring in the SVG and PDF backends. Only the raster backend lit the sides the way a browser does. All three now shade each side, and split `groove` and `ridge` into their two bands.
-
-`takumi_core::layout::border::side_bands` returns the strips a side fills and the colour each one takes, so the three backends stopped deciding that separately.
+`inset`, `outset`, `groove` and `ridge` borders now shade their sides in the SVG and PDF backends, as the raster backend already did.

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -935,7 +935,7 @@ pub fn inset_size(size: Size<f32>, inset: Rect<f32>) -> Size<f32> {
 }
 
 /// Per-side `lhs - rhs`, clamped to zero.
-pub fn subtract_rect(lhs: Rect<f32>, rhs: Rect<f32>) -> Rect<f32> {
+pub(crate) fn subtract_rect(lhs: Rect<f32>, rhs: Rect<f32>) -> Rect<f32> {
   Rect {
     top: (lhs.top - rhs.top).max(0.0),
     right: (lhs.right - rhs.right).max(0.0),
@@ -1101,7 +1101,7 @@ fn select_best_dash_gap(length: f32, dash: f32, gap: f32, closed: bool) -> f32 {
 }
 
 /// Lightens or darkens a side color for `inset`/`outset` 3D border shading.
-pub fn shade_3d_border_color(color: Color, side: BorderSide, style: BorderStyle) -> Color {
+pub(crate) fn shade_3d_border_color(color: Color, side: BorderSide, style: BorderStyle) -> Color {
   let lighten = match style {
     BorderStyle::Outset => matches!(side, BorderSide::Top | BorderSide::Left),
     BorderStyle::Inset => matches!(side, BorderSide::Right | BorderSide::Bottom),

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2148,9 +2148,9 @@ pub(crate) fn scale_text_fit_x(
 pub struct PositionedGlyph {
   /// Glyph id in the run's font.
   pub id: u32,
-  /// Run-local horizontal position.
+  /// Horizontal position from the line origin, the run's own offset included.
   pub x: f32,
-  /// Run-local vertical position.
+  /// Vertical position from the line origin, the run's baseline included.
   pub y: f32,
 }
 
@@ -2220,9 +2220,11 @@ fn glyph_cluster_ranges(
 /// `parley::GlyphRun`. Owns everything both backends need to paint a run; carries
 /// no borrow into the parley layout.
 pub struct ShapedRun {
-  /// The run's glyphs, in run-local coordinates.
+  /// The run's glyphs, positioned from the line origin.
   pub glyphs: Vec<PositionedGlyph>,
-  /// Horizontal offset of the run's start from the line origin.
+  /// Horizontal offset of the run's start from the line origin. A glyph's `x`
+  /// already carries it; this is for placing what the glyphs do not, such as a
+  /// decoration spanning the run.
   pub offset: f32,
   /// Baseline position within the line.
   pub baseline: f32,

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2637,12 +2637,17 @@ pub struct DecorationRect {
 /// raster geometry in `draw_decoration` (skip-ink is a raster-only refinement and
 /// omitted here). `transform` is the run's border-box transform
 /// ([`PositionedInlineRun::transform`] with an identity base).
-/// Each glyph's outline, placed where the run draws it.
-fn glyph_outlines(
+/// Each glyph's outline, placed at `origin` plus the glyph's own position.
+///
+/// `origin` is whatever puts the glyphs in the same space as the caller's band:
+/// the decoration's coordinates on one axis need not be the layout's on the
+/// other, and only the difference between the two matters.
+pub fn glyph_outlines<'g>(
   glyph_run: &ShapedRun,
-  resolved_glyphs: &HashMap<u32, Arc<ResolvedGlyph>>,
+  resolved_glyphs: &'g HashMap<u32, Arc<ResolvedGlyph>>,
+  origin: Point<f32>,
   baseline_shift: f32,
-) -> Vec<(Point<f32>, Vec<PathCommand>)> {
+) -> Vec<(Point<f32>, &'g [PathCommand])> {
   glyph_run
     .glyphs
     .iter()
@@ -2653,10 +2658,10 @@ fn glyph_outlines(
 
       Some((
         Point {
-          x: glyph.x,
-          y: glyph.y + baseline_shift,
+          x: origin.x + glyph.x,
+          y: origin.y + glyph.y + baseline_shift,
         },
-        outline.paths().to_vec(),
+        outline.paths(),
       ))
     })
     .collect()
@@ -2716,10 +2721,19 @@ pub fn run_decorations(
         .into_iter()
         .collect()
     } else {
-      let outlines = glyph_outlines(glyph_run, resolved_glyphs, baseline_shift);
+      // The band runs from the content box, so the glyphs have to as well.
+      let outlines = glyph_outlines(
+        glyph_run,
+        resolved_glyphs,
+        Point {
+          x: layout.border.left + layout.padding.left,
+          y: 0.0,
+        },
+        baseline_shift,
+      );
 
       skip_ink_spans(
-        outlines.iter().map(|(at, paths)| (*at, paths.as_slice())),
+        outlines.iter().copied(),
         snapped_start_x,
         snapped_start_x + width,
         y_offset,

--- a/takumi-core/src/layout/intercept.rs
+++ b/takumi-core/src/layout/intercept.rs
@@ -404,4 +404,44 @@ mod tests {
   fn a_skip_covering_the_line_leaves_nothing() {
     assert!(remaining_spans(2.0, 8.0, &[(0.0, 10.0)]).is_empty());
   }
+
+  #[test]
+  fn a_curve_is_flattened_before_it_is_measured() {
+    // A circle of radius 5 at the origin, drawn as four cubics. Across a band
+    // hugging its middle it is at its widest, so the span is the diameter.
+    const K: f32 = 5.0 * 0.552_284_7;
+    let paths = vec![
+      PathCommand::MoveTo(point(5.0, 0.0)),
+      PathCommand::CubicTo(point(5.0, K), point(K, 5.0), point(0.0, 5.0)),
+      PathCommand::CubicTo(point(-K, 5.0), point(-5.0, K), point(-5.0, 0.0)),
+      PathCommand::CubicTo(point(-5.0, -K), point(-K, -5.0), point(0.0, -5.0)),
+      PathCommand::CubicTo(point(K, -5.0), point(5.0, -K), point(5.0, 0.0)),
+      PathCommand::Close,
+    ];
+    let spans = text_intercepts(&paths, -0.5, 0.5);
+
+    assert_eq!(spans.len(), 1, "{spans:?}");
+    assert!((spans[0].0 + 5.0).abs() < 0.05, "{spans:?}");
+    assert!((spans[0].1 - 5.0).abs() < 0.05, "{spans:?}");
+  }
+
+  #[test]
+  fn a_counter_is_not_reported_as_ink() {
+    // An `o`: an outer contour with an inner one wound the other way. The band
+    // sees the two strokes, not the hole between them.
+    let mut paths = rect(0.0, -10.0, 10.0, 10.0);
+
+    paths.extend([
+      PathCommand::MoveTo(point(3.0, -10.0)),
+      PathCommand::LineTo(point(3.0, 10.0)),
+      PathCommand::LineTo(point(7.0, 10.0)),
+      PathCommand::LineTo(point(7.0, -10.0)),
+      PathCommand::Close,
+    ]);
+
+    assert_eq!(
+      text_intercepts(&paths, -1.0, 1.0).as_slice(),
+      [(0.0, 3.0), (7.0, 10.0)]
+    );
+  }
 }

--- a/takumi-core/src/layout/mod.rs
+++ b/takumi-core/src/layout/mod.rs
@@ -14,5 +14,7 @@ pub mod inline_box;
 pub mod intercept;
 /// Node Tree
 pub mod node;
+/// Where replaced content sits inside its content box.
+pub mod replaced;
 /// Layout tree: render nodes and their computed layout results.
 pub mod tree;

--- a/takumi-core/src/layout/replaced.rs
+++ b/takumi-core/src/layout/replaced.rs
@@ -1,0 +1,132 @@
+//! Where replaced content sits inside its content box.
+//!
+//! `object-fit` picks a size, `object-position` places it, and content larger
+//! than the box has to be clipped to it. That is the same arithmetic whether a
+//! backend then samples pixels, writes an `<image>`, or emits an XObject.
+
+use crate::{
+  context::RenderContext,
+  geometry::{Point, Size},
+  style::{Length, ObjectFit, PositionComponent},
+};
+
+/// Where and how large replaced content draws.
+#[derive(Debug, Clone, Copy)]
+pub struct ReplacedPlacement {
+  /// The drawn size.
+  pub size: Size<f32>,
+  /// The top-left, relative to the content box.
+  pub offset: Point<f32>,
+}
+
+impl ReplacedPlacement {
+  /// Whether the content reaches past its box and needs clipping to it. Half a
+  /// pixel of slack keeps a `cover` that lands on the box from opening a clip
+  /// nothing would show through.
+  pub fn overflows(&self, content: Size<f32>) -> bool {
+    self.size.width > content.width + 0.5 || self.size.height > content.height + 0.5
+  }
+}
+
+/// Sizes `intrinsic` content for a `content` box and places it.
+///
+/// `fill` and a missing intrinsic size both stretch to the box, which is what
+/// CSS asks for when there is no ratio to preserve.
+pub fn place_replaced(
+  context: &RenderContext,
+  content: Size<f32>,
+  intrinsic: Size<f32>,
+) -> ReplacedPlacement {
+  let scale = match context.style.object_fit {
+    _ if intrinsic.width <= 0.0 || intrinsic.height <= 0.0 => None,
+    ObjectFit::Fill => None,
+    ObjectFit::Contain => {
+      Some((content.width / intrinsic.width).min(content.height / intrinsic.height))
+    }
+    ObjectFit::Cover => {
+      Some((content.width / intrinsic.width).max(content.height / intrinsic.height))
+    }
+    ObjectFit::ScaleDown => Some(
+      (content.width / intrinsic.width)
+        .min(content.height / intrinsic.height)
+        .min(1.0),
+    ),
+    ObjectFit::None => Some(1.0),
+  };
+  let size = match scale {
+    Some(scale) => Size {
+      width: intrinsic.width * scale,
+      height: intrinsic.height * scale,
+    },
+    None => content,
+  };
+  let position = context.style.object_position.0;
+
+  ReplacedPlacement {
+    size,
+    offset: Point {
+      x: position_axis(position.x, context, content.width - size.width),
+      y: position_axis(position.y, context, content.height - size.height),
+    },
+  }
+}
+
+/// One axis of a `position` value against the space it has to move in. A
+/// keyword is a percentage of that space, so `center` lands halfway.
+pub fn position_axis(component: PositionComponent, context: &RenderContext, available: f32) -> f32 {
+  match Length::from(component) {
+    Length::Auto => available * 0.5,
+    length => length.to_px(&context.sizing, available),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::position_axis;
+  use crate::{
+    Fonts,
+    context::RenderContext,
+    style::{Length, PositionComponent, PositionKeywordX, SizingContext},
+    viewport::Viewport,
+  };
+
+  fn axis(component: PositionComponent, available: f32) -> f32 {
+    let fonts = Fonts::default();
+    let context = RenderContext::builder()
+      .fonts(fonts.snapshot_with_fallbacks(None))
+      .sizing(
+        SizingContext::builder()
+          .viewport(Viewport::new((1200, 630)))
+          .font_size(16.0)
+          .line_height(0.0)
+          .build(),
+      )
+      .build();
+
+    position_axis(component, &context, available)
+  }
+
+  #[test]
+  fn a_keyword_lands_at_its_share_of_the_free_space() {
+    assert_eq!(
+      axis(PositionComponent::KeywordX(PositionKeywordX::Center), 120.0),
+      60.0
+    );
+  }
+
+  #[test]
+  fn a_length_is_not_scaled_by_the_free_space() {
+    assert_eq!(
+      axis(PositionComponent::Length(Length::Px(12.0)), 120.0),
+      12.0
+    );
+  }
+
+  #[test]
+  fn a_percentage_may_reach_past_the_free_space() {
+    assert_eq!(
+      axis(PositionComponent::Length(Length::Percentage(150.0)), 120.0),
+      180.0
+    );
+  }
+}

--- a/takumi-core/src/layout/replaced.rs
+++ b/takumi-core/src/layout/replaced.rs
@@ -7,7 +7,7 @@
 use crate::{
   context::RenderContext,
   geometry::{Point, Size},
-  style::{Length, ObjectFit, PositionComponent},
+  style::ObjectFit,
 };
 
 /// Where and how large replaced content draws.
@@ -65,24 +65,14 @@ pub fn place_replaced(
   ReplacedPlacement {
     size,
     offset: Point {
-      x: position_axis(position.x, context, content.width - size.width),
-      y: position_axis(position.y, context, content.height - size.height),
+      x: position.x.resolve(context, content.width - size.width),
+      y: position.y.resolve(context, content.height - size.height),
     },
-  }
-}
-
-/// One axis of a `position` value against the space it has to move in. A
-/// keyword is a percentage of that space, so `center` lands halfway.
-pub fn position_axis(component: PositionComponent, context: &RenderContext, available: f32) -> f32 {
-  match Length::from(component) {
-    Length::Auto => available * 0.5,
-    length => length.to_px(&context.sizing, available),
   }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::position_axis;
   use crate::{
     Fonts,
     context::RenderContext,
@@ -103,7 +93,7 @@ mod tests {
       )
       .build();
 
-    position_axis(component, &context, available)
+    component.resolve(&context, available)
   }
 
   #[test]

--- a/takumi-core/src/layout/replaced.rs
+++ b/takumi-core/src/layout/replaced.rs
@@ -20,11 +20,15 @@ pub struct ReplacedPlacement {
 }
 
 impl ReplacedPlacement {
-  /// Whether the content reaches past its box and needs clipping to it. Half a
-  /// pixel of slack keeps a `cover` that lands on the box from opening a clip
-  /// nothing would show through.
+  /// Whether the content reaches past its box and needs clipping to it. A
+  /// percentage past 100% pushes content that fits out of the box, so the test
+  /// is on the placed edges, not the size alone. Half a pixel of slack keeps a
+  /// `cover` that lands on the box from opening a clip nothing shows through.
   pub fn overflows(&self, content: Size<f32>) -> bool {
-    self.size.width > content.width + 0.5 || self.size.height > content.height + 0.5
+    self.offset.x < -0.5
+      || self.offset.y < -0.5
+      || self.offset.x + self.size.width > content.width + 0.5
+      || self.offset.y + self.size.height > content.height + 0.5
   }
 }
 
@@ -73,9 +77,11 @@ pub fn place_replaced(
 
 #[cfg(test)]
 mod tests {
+  use super::ReplacedPlacement;
   use crate::{
     Fonts,
     context::RenderContext,
+    geometry::{Point, Size},
     style::{Length, PositionComponent, PositionKeywordX, SizingContext},
     viewport::Viewport,
   };
@@ -117,6 +123,30 @@ mod tests {
     assert_eq!(
       axis(PositionComponent::Length(Length::Percentage(150.0)), 120.0),
       180.0
+    );
+  }
+
+  #[test]
+  fn content_pushed_past_its_box_asks_to_be_clipped() {
+    let placement = ReplacedPlacement {
+      size: Size {
+        width: 40.0,
+        height: 40.0,
+      },
+      offset: Point { x: 90.0, y: 0.0 },
+    };
+    let content = Size {
+      width: 100.0,
+      height: 100.0,
+    };
+
+    assert!(placement.overflows(content));
+    assert!(
+      !ReplacedPlacement {
+        offset: Point { x: 30.0, y: 30.0 },
+        ..placement
+      }
+      .overflows(content)
     );
   }
 }

--- a/takumi-core/src/style/properties/background_position.rs
+++ b/takumi-core/src/style/properties/background_position.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use super::background_image::parse_comma_list;
+use crate::context::RenderContext;
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, ListInterpolationStrategy,
   MakeComputed, ParseResult, SizingContext, SpacePair, ToCss, tw::TailwindPropertyParser,
@@ -40,6 +41,18 @@ pub enum PositionComponent {
   KeywordY(PositionKeywordY),
   /// An absolute length value.
   Length(Length),
+}
+
+impl PositionComponent {
+  /// Where this component lands in `available` space. A keyword is a share of
+  /// that space, so `center` sits halfway; `auto` behaves the same, since a
+  /// position with nothing to say centres.
+  pub fn resolve(self, context: &RenderContext, available: f32) -> f32 {
+    match Length::from(self) {
+      Length::Auto => available * 0.5,
+      length => length.to_px(&context.sizing, available),
+    }
+  }
 }
 
 impl MakeComputed for PositionComponent {

--- a/takumi-pdf/src/background.rs
+++ b/takumi-pdf/src/background.rs
@@ -4,13 +4,12 @@
 use takumi_core::{
   context::RenderContext,
   geometry::Size,
+  layout::replaced::position_axis,
   style::{
     BackgroundRepeat, BackgroundRepeatStyle, BackgroundSize, IntrinsicSizing, Length,
     PositionComponent, PositionValue,
   },
 };
-
-use crate::paint::position_axis;
 
 /// The value for one layer: CSS cycles the shorter list over the layers.
 pub(crate) fn cycled<T: Copy + Default>(values: &[T], index: usize) -> T {

--- a/takumi-pdf/src/background.rs
+++ b/takumi-pdf/src/background.rs
@@ -4,7 +4,6 @@
 use takumi_core::{
   context::RenderContext,
   geometry::Size,
-  layout::replaced::position_axis,
   style::{
     BackgroundRepeat, BackgroundRepeatStyle, BackgroundSize, IntrinsicSizing, Length,
     PositionComponent, PositionValue,
@@ -122,7 +121,7 @@ fn axis(
       step: area.max(1.0),
     };
   }
-  let anchor = position_axis(position, context, area - tile);
+  let anchor = position.resolve(context, area - tile);
   let once = Axis {
     tile,
     origin: anchor,
@@ -140,7 +139,7 @@ fn axis(
       let count = (area / tile).round().max(1.0);
       let rounded = area / count;
       // The position still applies, against the rescaled tile.
-      let anchor = position_axis(position, context, area - rounded);
+      let anchor = position.resolve(context, area - rounded);
 
       Axis {
         tile: rounded,

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -7,7 +7,6 @@ use takumi_core::{
   context::RenderContext,
   layout::node::{ImageData, resolve_image},
   resources::image::ImageSource,
-  style::ObjectFit,
 };
 use takumi_core::{
   font_style::SizedFontStyle,
@@ -19,6 +18,7 @@ use takumi_core::{
     inline::{BuiltInlineLayout, InlineRunLayout, ProcessedInlineSpan, ShapedRun, run_decorations},
     inline_box::{InlineBoxPaint, InlineSubtree, resolve_inline_box},
     node::NodeKind,
+    replaced::place_replaced,
     tree::{LayoutResults, RenderNode},
   },
   paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile, resolve_stops_along_axis},
@@ -38,7 +38,7 @@ use takumi_core::{
 #[cfg(feature = "images")]
 use crate::krilla::geom::Size as KrillaSize;
 #[cfg(feature = "images")]
-use crate::paint::{position_axis, rasterized_image};
+use crate::paint::rasterized_image;
 #[cfg(all(feature = "svg", feature = "images"))]
 use crate::svg;
 use crate::{
@@ -1021,18 +1021,19 @@ impl Emitter<'_> {
       }
       (width, height)
     };
-    let scale = match context.style.object_fit {
-      ObjectFit::Contain => (w / iw).min(h / ih),
-      ObjectFit::Cover => (w / iw).max(h / ih),
-      ObjectFit::ScaleDown => (w / iw).min(h / ih).min(1.0),
-      ObjectFit::None => 1.0,
-      _ => 0.0,
+    let content = Size {
+      width: w,
+      height: h,
     };
-    let (dw, dh) = if scale == 0.0 {
-      (w, h)
-    } else {
-      (iw * scale, ih * scale)
-    };
+    let placement = place_replaced(
+      context,
+      content,
+      Size {
+        width: iw,
+        height: ih,
+      },
+    );
+    let (dw, dh) = (placement.size.width, placement.size.height);
     // SVG sources embed as vector ops; everything else rasterizes. A color
     // filter rasterizes them too, since the transform applies to pixels.
     #[cfg(feature = "svg")]
@@ -1059,14 +1060,13 @@ impl Emitter<'_> {
     } else {
       None
     };
-    let position = context.style.object_position.0;
-    let ix = bx + position_axis(position.x, context, w - dw);
-    let iy = by + position_axis(position.y, context, h - dh);
+    let ix = bx + placement.offset.x;
+    let iy = by + placement.offset.y;
 
     let Some(size) = KrillaSize::from_wh(dw, dh) else {
       return;
     };
-    let overflows = dw > w + 0.5 || dh > h + 0.5;
+    let overflows = placement.overflows(content);
 
     if overflows {
       let Some(path) = KrillaRect::from_xywh(bx, by, w, h).and_then(rect_path) else {

--- a/takumi-pdf/src/paint.rs
+++ b/takumi-pdf/src/paint.rs
@@ -5,7 +5,7 @@ use takumi_core::resources::image::{ImageSource, RenderedImage};
 use takumi_core::{
   context::RenderContext,
   geometry::{ComputedLayout as Layout, PathCommand},
-  style::{BlendMode, ComputedStyle, Length, Overflow, PositionComponent, ResolvedGradientStop},
+  style::{BlendMode, ComputedStyle, Overflow, ResolvedGradientStop},
 };
 
 #[cfg(feature = "images")]
@@ -86,18 +86,6 @@ pub(crate) fn overflow_clip_rect(
     (y - UNBOUNDED, y + layout.size.height + UNBOUNDED)
   };
   KrillaRect::from_ltrb(left, top, right, bottom).and_then(rect_path)
-}
-
-/// Resolves one `object-position` axis to an offset within `available` space.
-pub(crate) fn position_axis(
-  component: PositionComponent,
-  context: &RenderContext,
-  available: f32,
-) -> f32 {
-  match Length::from(component) {
-    Length::Auto => available * 0.5,
-    length => length.to_px(&context.sizing, available),
-  }
 }
 
 /// Rasterizes an image source into a krilla image. Bitmap sources rasterize at

--- a/takumi-raster/src/image_drawing.rs
+++ b/takumi-raster/src/image_drawing.rs
@@ -1,37 +1,17 @@
-use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
+use takumi_core::{
+  geometry::{ComputedLayout as Layout, Point, Size},
+  layout::replaced::position_axis,
+};
 
 use crate::{
   BorderProperties, Canvas, RenderContext, Result, SamplingOptions, pixmap_ref_from_buffer,
   resources::image::{ImageSource, RenderedImage},
-  style::{
-    Affine, BlendMode, ObjectFit, PositionComponent, PositionKeywordX, PositionKeywordY,
-    SizingContext,
-  },
+  style::{Affine, BlendMode, ObjectFit},
 };
 
 pub(crate) struct PreparedImage {
   image: RenderedImage,
   logical_to_source: Affine,
-}
-
-fn resolve_object_position_axis(
-  component: PositionComponent,
-  sizing: &SizingContext,
-  available_space: f32,
-) -> f32 {
-  match component {
-    PositionComponent::KeywordX(keyword) => match keyword {
-      PositionKeywordX::Left => 0.0,
-      PositionKeywordX::Center => available_space * 0.5,
-      PositionKeywordX::Right => available_space,
-    },
-    PositionComponent::KeywordY(keyword) => match keyword {
-      PositionKeywordY::Top => 0.0,
-      PositionKeywordY::Center => available_space * 0.5,
-      PositionKeywordY::Bottom => available_space,
-    },
-    PositionComponent::Length(length) => length.to_px(sizing, available_space),
-  }
 }
 
 /// Process an image according to the specified object-fit style.
@@ -97,8 +77,8 @@ pub(crate) fn process_image_for_object_fit(
       let available_x = content_box.width - new_width;
       let available_y = content_box.height - new_height;
 
-      let offset_x = resolve_object_position_axis(object_position.x, &context.sizing, available_x);
-      let offset_y = resolve_object_position_axis(object_position.y, &context.sizing, available_y);
+      let offset_x = position_axis(object_position.x, context, available_x);
+      let offset_y = position_axis(object_position.y, context, available_y);
 
       Ok((
         PreparedImage {
@@ -131,10 +111,8 @@ pub(crate) fn process_image_for_object_fit(
       let available_crop_x = new_width - content_box.width;
       let available_crop_y = new_height - content_box.height;
 
-      let crop_x =
-        resolve_object_position_axis(object_position.x, &context.sizing, available_crop_x);
-      let crop_y =
-        resolve_object_position_axis(object_position.y, &context.sizing, available_crop_y);
+      let crop_x = position_axis(object_position.x, context, available_crop_x);
+      let crop_y = position_axis(object_position.y, context, available_crop_y);
 
       Ok((
         PreparedImage {
@@ -181,8 +159,8 @@ pub(crate) fn process_image_for_object_fit(
       let available_x = content_box.width - new_width;
       let available_y = content_box.height - new_height;
 
-      let offset_x = resolve_object_position_axis(object_position.x, &context.sizing, available_x);
-      let offset_y = resolve_object_position_axis(object_position.y, &context.sizing, available_y);
+      let offset_x = position_axis(object_position.x, context, available_x);
+      let offset_y = position_axis(object_position.y, context, available_y);
 
       Ok((
         PreparedImage {
@@ -205,10 +183,8 @@ pub(crate) fn process_image_for_object_fit(
         let available_x = (content_box.width - image_width).max(0.0);
         let available_y = (content_box.height - image_height).max(0.0);
 
-        let offset_x =
-          resolve_object_position_axis(object_position.x, &context.sizing, available_x);
-        let offset_y =
-          resolve_object_position_axis(object_position.y, &context.sizing, available_y);
+        let offset_x = position_axis(object_position.x, context, available_x);
+        let offset_y = position_axis(object_position.y, context, available_y);
 
         return Ok((
           PreparedImage {
@@ -230,22 +206,20 @@ pub(crate) fn process_image_for_object_fit(
       let available_crop_x = (image_width - content_box.width).max(0.0);
       let available_crop_y = (image_height - content_box.height).max(0.0);
 
-      let crop_x =
-        resolve_object_position_axis(object_position.x, &context.sizing, available_crop_x);
-      let crop_y =
-        resolve_object_position_axis(object_position.y, &context.sizing, available_crop_y);
+      let crop_x = position_axis(object_position.x, context, available_crop_x);
+      let crop_y = position_axis(object_position.y, context, available_crop_y);
 
       let crop_width = content_box.width.min(image_width);
       let crop_height = content_box.height.min(image_height);
 
-      let offset_x = resolve_object_position_axis(
+      let offset_x = position_axis(
         object_position.x,
-        &context.sizing,
+        context,
         (content_box.width - crop_width).max(0.0),
       );
-      let offset_y = resolve_object_position_axis(
+      let offset_y = position_axis(
         object_position.y,
-        &context.sizing,
+        context,
         (content_box.height - crop_height).max(0.0),
       );
 
@@ -329,51 +303,4 @@ pub(crate) fn draw_image(
   }
 
   Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-  use super::resolve_object_position_axis;
-  use crate::{
-    style::{Length, PositionComponent, PositionKeywordX, SizingContext},
-    viewport::Viewport,
-  };
-
-  fn sizing() -> SizingContext {
-    SizingContext::builder()
-      .viewport(Viewport::new((1200, 630)))
-      .font_size(16.0)
-      .line_height(0.0)
-      .build()
-  }
-
-  #[test]
-  fn object_position_keyword_center_uses_half_free_space() {
-    let resolved = resolve_object_position_axis(
-      PositionComponent::KeywordX(PositionKeywordX::Center),
-      &sizing(),
-      120.0,
-    );
-    assert_eq!(resolved, 60.0);
-  }
-
-  #[test]
-  fn object_position_length_is_not_scaled_by_container_size() {
-    let resolved = resolve_object_position_axis(
-      PositionComponent::Length(Length::Px(12.0)),
-      &sizing(),
-      120.0,
-    );
-    assert_eq!(resolved, 12.0);
-  }
-
-  #[test]
-  fn object_position_percentage_supports_out_of_range_values() {
-    let resolved = resolve_object_position_axis(
-      PositionComponent::Length(Length::Percentage(150.0)),
-      &sizing(),
-      120.0,
-    );
-    assert_eq!(resolved, 180.0);
-  }
 }

--- a/takumi-raster/src/image_drawing.rs
+++ b/takumi-raster/src/image_drawing.rs
@@ -1,7 +1,4 @@
-use takumi_core::{
-  geometry::{ComputedLayout as Layout, Point, Size},
-  layout::replaced::position_axis,
-};
+use takumi_core::geometry::{ComputedLayout as Layout, Point, Size};
 
 use crate::{
   BorderProperties, Canvas, RenderContext, Result, SamplingOptions, pixmap_ref_from_buffer,
@@ -77,8 +74,8 @@ pub(crate) fn process_image_for_object_fit(
       let available_x = content_box.width - new_width;
       let available_y = content_box.height - new_height;
 
-      let offset_x = position_axis(object_position.x, context, available_x);
-      let offset_y = position_axis(object_position.y, context, available_y);
+      let offset_x = object_position.x.resolve(context, available_x);
+      let offset_y = object_position.y.resolve(context, available_y);
 
       Ok((
         PreparedImage {
@@ -111,8 +108,8 @@ pub(crate) fn process_image_for_object_fit(
       let available_crop_x = new_width - content_box.width;
       let available_crop_y = new_height - content_box.height;
 
-      let crop_x = position_axis(object_position.x, context, available_crop_x);
-      let crop_y = position_axis(object_position.y, context, available_crop_y);
+      let crop_x = object_position.x.resolve(context, available_crop_x);
+      let crop_y = object_position.y.resolve(context, available_crop_y);
 
       Ok((
         PreparedImage {
@@ -159,8 +156,8 @@ pub(crate) fn process_image_for_object_fit(
       let available_x = content_box.width - new_width;
       let available_y = content_box.height - new_height;
 
-      let offset_x = position_axis(object_position.x, context, available_x);
-      let offset_y = position_axis(object_position.y, context, available_y);
+      let offset_x = object_position.x.resolve(context, available_x);
+      let offset_y = object_position.y.resolve(context, available_y);
 
       Ok((
         PreparedImage {
@@ -183,8 +180,8 @@ pub(crate) fn process_image_for_object_fit(
         let available_x = (content_box.width - image_width).max(0.0);
         let available_y = (content_box.height - image_height).max(0.0);
 
-        let offset_x = position_axis(object_position.x, context, available_x);
-        let offset_y = position_axis(object_position.y, context, available_y);
+        let offset_x = object_position.x.resolve(context, available_x);
+        let offset_y = object_position.y.resolve(context, available_y);
 
         return Ok((
           PreparedImage {
@@ -206,22 +203,18 @@ pub(crate) fn process_image_for_object_fit(
       let available_crop_x = (image_width - content_box.width).max(0.0);
       let available_crop_y = (image_height - content_box.height).max(0.0);
 
-      let crop_x = position_axis(object_position.x, context, available_crop_x);
-      let crop_y = position_axis(object_position.y, context, available_crop_y);
+      let crop_x = object_position.x.resolve(context, available_crop_x);
+      let crop_y = object_position.y.resolve(context, available_crop_y);
 
       let crop_width = content_box.width.min(image_width);
       let crop_height = content_box.height.min(image_height);
 
-      let offset_x = position_axis(
-        object_position.x,
-        context,
-        (content_box.width - crop_width).max(0.0),
-      );
-      let offset_y = position_axis(
-        object_position.y,
-        context,
-        (content_box.height - crop_height).max(0.0),
-      );
+      let offset_x = object_position
+        .x
+        .resolve(context, (content_box.width - crop_width).max(0.0));
+      let offset_y = object_position
+        .y
+        .resolve(context, (content_box.height - crop_height).max(0.0));
 
       Ok((
         PreparedImage {

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use skrifa::{FontRef, MetadataProvider};
 use takumi_core::{
-  geometry::{ComputedLayout as Layout, NodeId, PathCommand as Command, Point, Size},
+  geometry::{ComputedLayout as Layout, NodeId, Point, Size},
   layout::{
     inline_box::{InlineBoxPaint, resolve_inline_box},
     intercept::skip_ink_spans,
@@ -17,8 +17,8 @@ use crate::{
   draw_outset_box_shadow,
   layout::inline::{
     BuiltInlineLayout, InlineBoxItem, InlineOutlineRect, InlineRunLayout, PositionedInlineRun,
-    ProcessedInlineSpan, ShapedRun, VisualInlineBox, outline_island_contour, outline_islands,
-    resolve_inline_runs,
+    ProcessedInlineSpan, ShapedRun, VisualInlineBox, glyph_outlines, outline_island_contour,
+    outline_islands, resolve_inline_runs,
   },
   painter::StrokeStyle,
   rasterize_layers,
@@ -91,26 +91,15 @@ fn draw_underline_with_skip_ink(
   let content_offset = options.layout.content_box_offset();
   let run_start_x = content_offset.x + glyph_run.offset;
   let line_top = content_offset.y + options.offset;
-  let outlines: Vec<(Point<f32>, Vec<Command>)> = glyph_run
-    .glyphs
-    .iter()
-    .filter_map(|glyph| {
-      let ResolvedGlyph::Outline(outline) = resolved_glyphs.get(&glyph.id)?.as_ref() else {
-        return None;
-      };
-
-      Some((
-        Point {
-          x: content_offset.x + glyph.x,
-          y: content_offset.y + glyph.y + options.baseline_shift,
-        },
-        outline.paths().to_vec(),
-      ))
-    })
-    .collect();
+  let outlines = glyph_outlines(
+    glyph_run,
+    resolved_glyphs,
+    content_offset,
+    options.baseline_shift,
+  );
 
   for (start_x, end_x) in skip_ink_spans(
-    outlines.iter().map(|(at, paths)| (*at, paths.as_slice())),
+    outlines.iter().copied(),
     run_start_x,
     run_start_x + glyph_run.advance,
     line_top,

--- a/takumi-svg/src/image.rs
+++ b/takumi-svg/src/image.rs
@@ -8,9 +8,13 @@ use std::io;
 
 use takumi_core::{
   context::RenderContext,
-  layout::node::{ImageData, ImageSourceInput, resolve_image},
+  geometry::Size,
+  layout::{
+    node::{ImageData, ImageSourceInput, resolve_image},
+    replaced::place_replaced,
+  },
   resources::image::{ImageSource, to_data_url},
-  style::{ImageScalingAlgorithm, Length, ObjectFit, PositionComponent},
+  style::{ImageScalingAlgorithm, ObjectFit},
 };
 
 use crate::{Frame, SvgDocument, box_model::rect_path_data};
@@ -23,15 +27,6 @@ pub(crate) fn data_url_for_url(url: &str, context: &RenderContext) -> Option<Str
   resolve_image(url, context)
     .ok()
     .and_then(|s| loaded_data_url(&s))
-}
-
-/// Resolves one `object-position` axis to a destination offset within
-/// `available` space, mirroring the raster backend's `resolve_object_position_axis`.
-fn position_axis(component: PositionComponent, context: &RenderContext, available: f32) -> f32 {
-  match Length::from(component) {
-    Length::Auto => available * 0.5,
-    length => length.to_px(&context.sizing, available),
-  }
 }
 
 /// Emits an image node's content into the given content-box rectangle.
@@ -48,8 +43,6 @@ pub(crate) fn emit_image(
   let Some(href) = data_url(&image.src, context) else {
     return Ok(());
   };
-  let position = context.style.object_position;
-
   if matches!(context.style.object_fit, ObjectFit::Fill) {
     return doc.image(x, y, w, h, &href, Some("none"));
   }
@@ -57,21 +50,22 @@ pub(crate) fn emit_image(
   let Some((iw, ih)) = intrinsic_size(&image.src, context) else {
     return doc.image(x, y, w, h, &href, Some("xMidYMid meet"));
   };
-
-  let scale = match context.style.object_fit {
-    ObjectFit::Fill => 1.0,
-    ObjectFit::Contain => (w / iw).min(h / ih),
-    ObjectFit::Cover => (w / iw).max(h / ih),
-    ObjectFit::ScaleDown => (w / iw).min(h / ih).min(1.0),
-    _ => 1.0,
+  let content = Size {
+    width: w,
+    height: h,
   };
-  let (dw, dh) = (iw * scale, ih * scale);
+  let placement = place_replaced(
+    context,
+    content,
+    Size {
+      width: iw,
+      height: ih,
+    },
+  );
+  let (dw, dh) = (placement.size.width, placement.size.height);
+  let (ix, iy) = (x + placement.offset.x, y + placement.offset.y);
 
-  let off_x = position_axis(position.0.x, context, w - dw);
-  let off_y = position_axis(position.0.y, context, h - dh);
-  let (ix, iy) = (x + off_x, y + off_y);
-
-  if dw > w + 0.5 || dh > h + 0.5 {
+  if placement.overflows(content) {
     let clip = doc.clip_path(&rect_path_data(x, y, w, h))?;
     let group = doc.begin_group(crate::IDENTITY, 1.0, Some(&clip), None)?;
     doc.image(ix, iy, dw, dh, &href, Some(PRESERVE_ASPECT_NONE))?;

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -14,9 +14,10 @@ use takumi_core::{
   geometry::{ComputedLayout as Layout, Point},
   layout::{
     inline::{
-      InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineOutlineRect, InlineRunLayout,
-      PositionedInlineRun, ProcessedInlineSpan, collect_inline_items, create_inline_layout,
-      outline_island_contour, outline_islands, resolve_inline_runs, run_decorations,
+      DecorationRect, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineOutlineRect,
+      InlineRunLayout, PositionedInlineRun, ProcessedInlineSpan, collect_inline_items,
+      create_inline_layout, outline_island_contour, outline_islands, resolve_inline_runs,
+      run_decorations,
     },
     node::TextData,
     tree::RenderNode,
@@ -182,8 +183,22 @@ fn emit_runs(
     doc.end_group(group)?;
   }
 
-  for run in &runs.runs {
-    emit_run_decorations(doc, run, frame, false)?;
+  let decorations: Vec<Vec<DecorationRect>> = runs
+    .runs
+    .iter()
+    .map(|run| {
+      run_decorations(
+        &run.glyph_run,
+        &run.resolved_glyphs,
+        frame.layout,
+        run.baseline_shift,
+        run.transform(IDENTITY),
+      )
+    })
+    .collect();
+
+  for (run, decorations) in runs.runs.iter().zip(&decorations) {
+    emit_run_decorations(doc, run, decorations, frame, false)?;
   }
 
   if context.style.background_clip == BackgroundClip::Text {
@@ -198,8 +213,8 @@ fn emit_runs(
   // raster backend's painting order.
   emit_inline_outlines(doc, runs, spans, frame.origin_x, frame.origin_y)?;
 
-  for run in &runs.runs {
-    emit_run_decorations(doc, run, frame, true)?;
+  for (run, decorations) in runs.runs.iter().zip(&decorations) {
+    emit_run_decorations(doc, run, decorations, frame, true)?;
   }
   Ok(())
 }
@@ -373,25 +388,18 @@ fn emit_clip_text_mask_glyphs(
 fn emit_run_decorations(
   doc: &mut SvgDocument,
   run: &PositionedInlineRun,
+  decorations: &[DecorationRect],
   frame: TextFrame,
   over: bool,
 ) -> io::Result<()> {
-  let transform = run.transform(IDENTITY);
   let opacity = run.glyph_run.brush.opacity;
   let opacity_group = (opacity < 1.0)
     .then(|| doc.begin_group(IDENTITY, opacity, None, None))
     .transpose()?;
-  let decorations = run_decorations(
-    &run.glyph_run,
-    &run.resolved_glyphs,
-    frame.layout,
-    run.baseline_shift,
-    transform,
-  );
   let mut device = DocumentDevice { doc, error: None };
 
   paint_run_decorations(
-    &decorations,
+    decorations,
     over,
     TextDecorationLines::empty(),
     Point {


### PR DESCRIPTION
Also carries the review follow-ups from #1170.

## Why

Every backend worked out `object-fit` and `object-position` for itself. The SVG and PDF backends held byte-identical copies of the same helper, and the raster backend spelled the same thing out keyword by keyword:

```rust
// svg/image.rs and pdf/paint.rs, character for character
match Length::from(component) {
  Length::Auto => available * 0.5,
  length => length.to_px(&context.sizing, available),
}
```

The SVG comment on it even said it mirrored the raster backend. The scale each backend derived was a third copy, and the PDF one used `0.0` as a sentinel for "stretch to the box".

## What

`takumi_core::layout::replaced::place_replaced` sizes the content and places it; `position_axis` resolves one axis of any position value. `ReplacedPlacement::overflows` answers whether a clip is needed, which SVG and PDF had each written as `dw > w + 0.5 || dh > h + 0.5`.

The raster backend keeps its own fit branches: it fuses placement with a resampling choice, rendering `cover` at the box's size with a crop transform rather than scaling a large bitmap. It takes `position_axis` from core, so the position decision is no longer duplicated anywhere.

## Review follow-ups from #1170

- The glyph outlines fed to skip-ink were in run-local x while the band was in border-box x, so a padded text box would have skipped the wrong places. `glyph_outlines` takes the origin that puts the two in the same space. No fixture had padding on the text, which is why nothing moved.
- `glyph_outlines` is exported, returns borrowed paths instead of cloning each outline, and the raster backend calls it instead of collecting its own.
- The SVG backend built `run_decorations` twice per run, once for the under pass and once for the over pass. Since skip-ink now runs inside it, that was the intercept work done twice. It builds them once.
- Two tests added for the intercepts: a circle drawn from cubics, and an `o` whose counter is wound the other way, which must not be reported as ink.

No golden moved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image sizing, positioning, and overflow clipping across SVG, PDF, and raster output.
  - Standardized `object-fit` and `object-position` handling, including percentage, length, and keyword values.
  - Improved behavior for invalid image dimensions and content extending beyond its container.
  - Corrected text decoration behavior around glyph counters, curved outlines, and underline skip-ink placement.
  - Improved PDF border styles, inline image rendering, and alternative-text support.
  - Harmonized border shading and background painting across output formats.

- **Refactor**
  - Unified replaced-content layout and text decoration calculations across rendering formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->