### PR TITLE
Core: recover from one bad declaration in a style attribute

### DIFF
--- a/.tegami/inline-style-error-recovery.md
+++ b/.tegami/inline-style-error-recovery.md
@@ -1,0 +1,11 @@
+---
+packages:
+  takumi-core:
+    type: minor
+  takumi-html:
+    type: patch
+---
+
+### Keep the rest of a `style` attribute when one declaration fails
+
+A value this crate cannot read, such as `width: fit-content`, discarded every other declaration in the same `style` attribute. It now invalidates only itself, which is the recovery CSS asks for and what a `<style>` sheet already did.

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -1700,6 +1700,23 @@ impl StyleDeclarationBlock {
   pub(crate) fn parse<'i>(name: &str, input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     parse_style_declaration(name, input)
   }
+
+  /// Parses a declaration list, dropping the declarations that fail and keeping the rest.
+  ///
+  /// This is how CSS asks a `style` attribute to be read: an unsupported value invalidates
+  /// its own declaration and nothing else. [`FromStr`] stays strict for callers that want to
+  /// know the input was not fully understood.
+  pub fn parse_loosy(input: &str) -> Self {
+    let mut parser_input = ParserInput::new(input);
+    let mut parser = Parser::new(&mut parser_input);
+    let mut declaration_parser = StyleDeclarationParser;
+    let mut block = Self::default();
+
+    for declarations in RuleBodyParser::new(&mut parser, &mut declaration_parser).flatten() {
+      block.append(declarations);
+    }
+    block
+  }
 }
 
 impl FromStr for StyleDeclarationBlock {

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -546,7 +546,7 @@ fn serialize_outer_html(handle: &Handle) -> Vec<u8> {
 /// Parse a CSS declaration block, ignoring it if it fails to parse. Parses the
 /// whole block so values containing `;` (e.g. `data:` URIs) survive.
 fn parse_declarations(css: &str) -> StyleDeclarationBlock {
-  StyleDeclarationBlock::from_str(css).unwrap_or_default()
+  StyleDeclarationBlock::parse_loosy(css)
 }
 
 #[cfg(test)]
@@ -555,6 +555,16 @@ mod tests {
 
   fn parse(source: &str) -> Node {
     from_html(source, FromHtmlOptions::default()).unwrap()
+  }
+
+  /// A `style` attribute is a declaration list, and CSS drops only the declaration it
+  /// cannot read. `fit-content` is not a width this crate understands, and it used to take
+  /// the whole attribute down with it.
+  #[test]
+  fn an_unreadable_declaration_leaves_its_neighbours_alone() {
+    let block = parse_declarations("font-size:64px;width:fit-content;color:red");
+
+    assert_eq!(block.len(), 2);
   }
 
   #[test]


### PR DESCRIPTION
## Why

`style="font-size:64px;width:fit-content"` rendered at the inherited font size. The `style` attribute went through the strict `StyleDeclarationBlock::from_str`, which returns an error on the first declaration it cannot read, and the caller turned that error into an empty block. Every declaration in the attribute went with it, including the ones before the bad one. A `<style>` sheet already recovered per declaration, so the same CSS behaved differently depending on where it was written.

## What

`StyleDeclarationBlock::parse_loosy` keeps the declarations that parse and drops the ones that do not, matching `StyleSheet::parse_loosy` alongside it, and the HTML `style` attribute uses it. `FromStr` stays strict for callers that want to know the input was not fully understood.

Note that the value in the repro is still unsupported: nothing here adds `width: fit-content`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inline styles now preserve valid declarations when another declaration is unsupported or malformed.
  * Improved resilience when parsing CSS styles, preventing one invalid property from discarding the entire style attribute.
  * Added coverage for unsupported width values to ensure neighboring declarations remain effective.

* **Documentation**
  * Added release notes describing the inline-style error recovery improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->