### PR TITLE
Docs: read the PDF objects and their text in the playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,10 @@ jobs:
         working-directory: takumi-template
         run: bun test
 
+      # Runs from the root: the playground's PDF reader pulls in nothing else.
+      - name: Test docs playground
+        run: bun test docs/app/playground
+
       - name: Test cloudflare-workers example
         working-directory: example/cloudflare-workers
         run: bun run test

--- a/docs/app/components/playground/output-panel.tsx
+++ b/docs/app/components/playground/output-panel.tsx
@@ -2,15 +2,15 @@ import { Loader2Icon } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "~/lib/utils";
-import type { PdfInspection, PdfPageStream } from "~/playground/inspect-pdf";
+import type { PdfInspection, PdfObject } from "~/playground/inspect-pdf";
 import type { RenderError, RenderSuccess } from "./use-render-worker";
 
-export type PdfView = "preview" | "document" | "stream";
+export type PdfView = "preview" | "document" | "objects";
 
 export const PDF_VIEWS: { id: PdfView; label: string }[] = [
   { id: "preview", label: "Preview" },
   { id: "document", label: "Document" },
-  { id: "stream", label: "Stream" },
+  { id: "objects", label: "Objects" },
 ];
 
 export type Zoom = "fit" | "actual";
@@ -63,6 +63,7 @@ function DocumentPanel({ inspection }: { inspection: PdfInspection }) {
       </Field>
       <Field label="Tagged">{inspection.tagged ? "yes" : "no"}</Field>
       <Field label="Pages">{inspection.pages}</Field>
+      <Field label="Text objects">{inspection.textObjects.join(" · ")}</Field>
       {inspection.title && <Field label="Title">{inspection.title}</Field>}
       {inspection.authors && <Field label="Authors">{inspection.authors.join(", ")}</Field>}
       {inspection.created && <Field label="Created">{inspection.created}</Field>}
@@ -99,28 +100,21 @@ function DocumentPanel({ inspection }: { inspection: PdfInspection }) {
   );
 }
 
-/**
- * The decoded page content streams. One shaped run emits one `BT` block, so the
- * count beside each page is where a font switch splitting words shows up first.
- */
-function StreamPanel({ streams }: { streams: PdfPageStream[] }) {
-  if (streams.length === 0) {
-    return (
-      <div className="flex h-full items-center justify-center bg-muted/20 font-mono text-xs text-muted-foreground">
-        no readable content stream
-      </div>
-    );
-  }
-
+/** The file as written: every object's dictionary, and the streams that read as text. */
+function ObjectsPanel({ objects }: { objects: PdfObject[] }) {
   return (
     <div className="h-full overflow-auto bg-muted/20 px-4 py-3 font-mono text-xs">
-      {streams.map((stream) => (
-        <div key={stream.page} className="mb-4 last:mb-0">
-          <div className="mb-1 text-muted-foreground">
-            page {stream.page} · {stream.textObjects} text objects
-          </div>
-          <pre className="whitespace-pre-wrap break-all">{stream.operators}</pre>
-        </div>
+      {objects.map((object) => (
+        <details key={object.number} className="border-b py-1.5 last:border-b-0">
+          <summary className="cursor-pointer select-none">
+            {object.number} 0 obj
+            {object.label && <span className="text-muted-foreground"> · {object.label}</span>}
+          </summary>
+          <pre className="mt-1 whitespace-pre-wrap break-all text-muted-foreground">
+            {object.dict}
+          </pre>
+          {object.body && <pre className="mt-1 whitespace-pre-wrap break-all">{object.body}</pre>}
+        </details>
       ))}
     </div>
   );
@@ -173,7 +167,7 @@ export function OutputPanel({
   // is the point of the format.
   if (lastSuccess?.outputKind === "pdf" && lastSuccess.inspection) {
     if (pdfView === "document") return <DocumentPanel inspection={lastSuccess.inspection} />;
-    if (pdfView === "stream") return <StreamPanel streams={lastSuccess.inspection.streams} />;
+    if (pdfView === "objects") return <ObjectsPanel objects={lastSuccess.inspection.objects} />;
   }
 
   const output =

--- a/docs/app/components/playground/output-panel.tsx
+++ b/docs/app/components/playground/output-panel.tsx
@@ -1,6 +1,6 @@
 import { Loader2Icon } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { cn } from "~/lib/utils";
 import type { PdfInspection, PdfObject } from "~/playground/inspect-pdf";
 import type { RenderError, RenderSuccess } from "./use-render-worker";
@@ -100,22 +100,88 @@ function DocumentPanel({ inspection }: { inspection: PdfInspection }) {
   );
 }
 
+const objectId = (number: string) => `pdf-object-${number}`;
+
+/** Turns every `12 0 R` in a dictionary into a jump to that object. */
+function linkReferences(dict: string, onJump: (number: string) => void): ReactNode[] {
+  return dict.split(/(\d+ 0 R)/g).map((part, index) => {
+    const number = part.match(/^(\d+) 0 R$/)?.[1];
+
+    if (!number) return part;
+
+    return (
+      <button
+        key={`${index}-${part}`}
+        type="button"
+        onClick={() => onJump(number)}
+        className="text-primary underline underline-offset-2"
+      >
+        {part}
+      </button>
+    );
+  });
+}
+
 /** The file as written: every object's dictionary, and the streams that read as text. */
 function ObjectsPanel({ objects }: { objects: PdfObject[] }) {
+  const [query, setQuery] = useState("");
+  const [opened, setOpened] = useState<string[]>([]);
+
+  const needle = query.toLowerCase();
+  const matches = objects.filter((object) =>
+    `${object.number} ${object.label} ${object.dict} ${object.body ?? ""}`
+      .toLowerCase()
+      .includes(needle),
+  );
+
+  const toggle = (number: string, open: boolean) =>
+    setOpened((current) =>
+      open ? [...new Set([...current, number])] : current.filter((entry) => entry !== number),
+    );
+
+  // The target may be filtered out, so the scroll waits for the cleared list to paint.
+  const jump = (number: string) => {
+    setQuery("");
+    toggle(number, true);
+    requestAnimationFrame(() => document.getElementById(objectId(number))?.scrollIntoView());
+  };
+
   return (
-    <div className="h-full overflow-auto bg-muted/20 px-4 py-3 font-mono text-xs">
-      {objects.map((object) => (
-        <details key={object.number} className="border-b py-1.5 last:border-b-0">
-          <summary className="cursor-pointer select-none">
-            {object.number} 0 obj
-            {object.label && <span className="text-muted-foreground"> · {object.label}</span>}
-          </summary>
-          <pre className="mt-1 whitespace-pre-wrap break-all text-muted-foreground">
-            {object.dict}
-          </pre>
-          {object.body && <pre className="mt-1 whitespace-pre-wrap break-all">{object.body}</pre>}
-        </details>
-      ))}
+    <div className="flex h-full flex-col bg-muted/20 font-mono text-xs">
+      <div className="flex shrink-0 items-center gap-3 border-b px-4 py-2">
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Filter by number, type, dictionary or operator"
+          aria-label="Filter objects"
+          className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+        />
+        <span className="shrink-0 text-muted-foreground">
+          {matches.length === objects.length
+            ? `${objects.length} objects`
+            : `${matches.length} of ${objects.length}`}
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto px-4 py-1">
+        {matches.map((object) => (
+          <details
+            key={object.number}
+            id={objectId(object.number)}
+            open={opened.includes(object.number)}
+            onToggle={(event) => toggle(object.number, event.currentTarget.open)}
+            className="scroll-mt-1 border-b py-1.5 last:border-b-0"
+          >
+            <summary className="cursor-pointer select-none">
+              {object.number} 0 obj
+              {object.label && <span className="text-muted-foreground"> · {object.label}</span>}
+            </summary>
+            <pre className="mt-1 whitespace-pre-wrap break-all text-muted-foreground">
+              {linkReferences(object.dict, jump)}
+            </pre>
+            {object.body && <pre className="mt-1 whitespace-pre-wrap break-all">{object.body}</pre>}
+          </details>
+        ))}
+      </div>
     </div>
   );
 }

--- a/docs/app/components/playground/output-panel.tsx
+++ b/docs/app/components/playground/output-panel.tsx
@@ -63,7 +63,13 @@ function DocumentPanel({ inspection }: { inspection: PdfInspection }) {
       </Field>
       <Field label="Tagged">{inspection.tagged ? "yes" : "no"}</Field>
       <Field label="Pages">{inspection.pages}</Field>
-      <Field label="Text objects">{inspection.textObjects.join(" · ")}</Field>
+      <Field label="Text">
+        {inspection.pageText.map((page, index) => (
+          <div key={`page-${index + 1}`}>
+            page {index + 1}: {page.blocks} blocks / {page.words} words
+          </div>
+        ))}
+      </Field>
       {inspection.title && <Field label="Title">{inspection.title}</Field>}
       {inspection.authors && <Field label="Authors">{inspection.authors.join(", ")}</Field>}
       {inspection.created && <Field label="Created">{inspection.created}</Field>}
@@ -129,7 +135,7 @@ function ObjectsPanel({ objects }: { objects: PdfObject[] }) {
 
   const needle = query.toLowerCase();
   const matches = objects.filter((object) =>
-    `${object.number} ${object.label} ${object.dict} ${object.body ?? ""}`
+    `${object.number} ${object.label} ${object.dict} ${object.text ?? ""} ${object.body ?? ""}`
       .toLowerCase()
       .includes(needle),
   );
@@ -152,7 +158,7 @@ function ObjectsPanel({ objects }: { objects: PdfObject[] }) {
         <input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="Filter by number, type, dictionary or operator"
+          placeholder="Filter by number, type, dictionary, text or operator"
           aria-label="Filter objects"
           className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
         />
@@ -178,6 +184,11 @@ function ObjectsPanel({ objects }: { objects: PdfObject[] }) {
             <pre className="mt-1 whitespace-pre-wrap break-all text-muted-foreground">
               {linkReferences(object.dict, jump)}
             </pre>
+            {object.text !== undefined && (
+              <p className="mt-1 whitespace-pre-wrap break-words border-l-2 pl-2">
+                {object.text || <span className="text-muted-foreground">draws no text</span>}
+              </p>
+            )}
             {object.body && <pre className="mt-1 whitespace-pre-wrap break-all">{object.body}</pre>}
           </details>
         ))}

--- a/docs/app/components/playground/output-panel.tsx
+++ b/docs/app/components/playground/output-panel.tsx
@@ -2,14 +2,15 @@ import { Loader2Icon } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "~/lib/utils";
-import type { PdfInspection } from "~/playground/inspect-pdf";
+import type { PdfInspection, PdfPageStream } from "~/playground/inspect-pdf";
 import type { RenderError, RenderSuccess } from "./use-render-worker";
 
-export type PdfView = "preview" | "document";
+export type PdfView = "preview" | "document" | "stream";
 
 export const PDF_VIEWS: { id: PdfView; label: string }[] = [
   { id: "preview", label: "Preview" },
   { id: "document", label: "Document" },
+  { id: "stream", label: "Stream" },
 ];
 
 export type Zoom = "fit" | "actual";
@@ -98,6 +99,33 @@ function DocumentPanel({ inspection }: { inspection: PdfInspection }) {
   );
 }
 
+/**
+ * The decoded page content streams. One shaped run emits one `BT` block, so the
+ * count beside each page is where a font switch splitting words shows up first.
+ */
+function StreamPanel({ streams }: { streams: PdfPageStream[] }) {
+  if (streams.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center bg-muted/20 font-mono text-xs text-muted-foreground">
+        no readable content stream
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto bg-muted/20 px-4 py-3 font-mono text-xs">
+      {streams.map((stream) => (
+        <div key={stream.page} className="mb-4 last:mb-0">
+          <div className="mb-1 text-muted-foreground">
+            page {stream.page} · {stream.textObjects} text objects
+          </div>
+          <pre className="whitespace-pre-wrap break-all">{stream.operators}</pre>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function PdfPreview({ url, dimmed }: { url: string | undefined; dimmed: boolean }) {
   if (!url) return null;
 
@@ -143,8 +171,9 @@ export function OutputPanel({
 
   // The browser's own PDF viewer brings paging, zoom and text selection, which
   // is the point of the format.
-  if (lastSuccess?.outputKind === "pdf" && pdfView === "document" && lastSuccess.inspection) {
-    return <DocumentPanel inspection={lastSuccess.inspection} />;
+  if (lastSuccess?.outputKind === "pdf" && lastSuccess.inspection) {
+    if (pdfView === "document") return <DocumentPanel inspection={lastSuccess.inspection} />;
+    if (pdfView === "stream") return <StreamPanel streams={lastSuccess.inspection.streams} />;
   }
 
   const output =

--- a/docs/app/components/playground/toolbar.tsx
+++ b/docs/app/components/playground/toolbar.tsx
@@ -18,6 +18,7 @@ import { cn } from "~/lib/utils";
 import { type OutputKind, outputKinds } from "~/playground/schema";
 import { type Template, templates } from "~/playground/templates";
 import { Button } from "../ui/button";
+import { Kbd } from "../ui/kbd";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -174,6 +175,7 @@ export function Toolbar({
         >
           <PlayIcon className="size-3.5" />
           <span className="max-md:hidden">Run</span>
+          <Kbd className="ml-1 bg-current/15 px-1.5 text-[11px] text-current max-md:hidden">⌘↵</Kbd>
         </Button>
         {isStale && !hintDismissed && (
           <div className="absolute top-9 left-0 z-20 w-56 rounded-md border bg-popover p-3 text-xs shadow-md">

--- a/docs/app/components/ui/kbd.tsx
+++ b/docs/app/components/ui/kbd.tsx
@@ -1,0 +1,18 @@
+import { cn } from "~/lib/utils";
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none",
+        "[&_svg:not([class*='size-'])]:size-3",
+        "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Kbd };

--- a/docs/app/playground/inspect-pdf.test.ts
+++ b/docs/app/playground/inspect-pdf.test.ts
@@ -12,24 +12,37 @@ function streamObject(entries: string, data: string): string {
   return `<<${entries}/Length ${data.length}>>\nstream\n${data}\nendstream`;
 }
 
-const CONTENT = streamObject("", "BT /f0 12 Tf (hi) Tj ET");
+// The font and its CMap come first so both stay at the same object number
+// whatever else the fixture holds.
+const FONT = "<</Type/Font/Subtype/Type0/ToUnicode 2 0 R>>";
+const RESOURCES = "/Resources<</Font<</f0 1 0 R>>>>";
+
+function cmap(entries: string): string {
+  return streamObject("/Type/CMap", entries);
+}
+
+/** `<0001>` and `<0002>` spell "Hi", one word however many pages draw it. */
+const HI = cmap("beginbfchar\n<0001><0048>\n<0002><0069>\nendbfchar");
+const CONTENT = streamObject("", "BT /f0 12 Tf <00010002> Tj ET");
 
 test("counts a shared content stream against both pages", async () => {
   const inspection = await inspectPdf(
     pdf([
-      "<</Type/Catalog/Pages 2 0 R>>",
-      "<</Type/Pages/Count 2/Kids[3 0 R 4 0 R]>>",
-      "<</Type/Page/Parent 2 0 R/Contents 5 0 R>>",
-      "<</Type/Page/Parent 2 0 R/Contents 5 0 R>>",
+      FONT,
+      HI,
+      "<</Type/Catalog/Pages 4 0 R>>",
+      "<</Type/Pages/Count 2/Kids[5 0 R 6 0 R]>>",
+      `<</Type/Page/Parent 4 0 R${RESOURCES}/Contents 7 0 R>>`,
+      `<</Type/Page/Parent 4 0 R${RESOURCES}/Contents 7 0 R>>`,
       CONTENT,
     ]),
   );
 
   expect(inspection.pageText).toEqual([
-    { blocks: 1, words: 0 },
-    { blocks: 1, words: 0 },
+    { blocks: 1, words: 1 },
+    { blocks: 1, words: 1 },
   ]);
-  expect(inspection.objects.find((object) => object.number === "5")?.label).toBe(
+  expect(inspection.objects.find((object) => object.number === "7")?.label).toBe(
     "content stream, pages 1, 2",
   );
 });
@@ -37,15 +50,17 @@ test("counts a shared content stream against both pages", async () => {
 test("names the single page a content stream belongs to", async () => {
   const inspection = await inspectPdf(
     pdf([
-      "<</Type/Catalog/Pages 2 0 R>>",
-      "<</Type/Pages/Count 1/Kids[3 0 R]>>",
-      "<</Type/Page/Parent 2 0 R/Contents 4 0 R>>",
+      FONT,
+      HI,
+      "<</Type/Catalog/Pages 4 0 R>>",
+      "<</Type/Pages/Count 1/Kids[5 0 R]>>",
+      `<</Type/Page/Parent 4 0 R${RESOURCES}/Contents 6 0 R>>`,
       CONTENT,
     ]),
   );
 
-  expect(inspection.pageText).toEqual([{ blocks: 1, words: 0 }]);
-  expect(inspection.objects.find((object) => object.number === "4")?.label).toBe(
+  expect(inspection.pageText).toEqual([{ blocks: 1, words: 1 }]);
+  expect(inspection.objects.find((object) => object.number === "6")?.label).toBe(
     "content stream, page 1",
   );
 });
@@ -53,19 +68,33 @@ test("names the single page a content stream belongs to", async () => {
 test("reads a content stream back through its ToUnicode CMap", async () => {
   const inspection = await inspectPdf(
     pdf([
-      "<</Type/Catalog/Pages 2 0 R>>",
-      "<</Type/Pages/Count 1/Kids[3 0 R]>>",
-      "<</Type/Page/Parent 2 0 R/Resources<</Font<</f0 5 0 R>>>>/Contents 4 0 R>>",
-      streamObject("", "BT /f0 12 Tf [(\\000\\001\\000\\002)-20(\\000\\003)] TJ ET"),
-      "<</Type/Font/Subtype/Type0/ToUnicode 6 0 R>>",
-      streamObject(
-        "/Type/CMap",
+      FONT,
+      cmap(
         "beginbfchar\n<0001><0048>\n<0002><0069>\nendbfchar\nbeginbfrange\n<0003><0003><0021>\nendbfrange",
       ),
+      "<</Type/Catalog/Pages 4 0 R>>",
+      "<</Type/Pages/Count 1/Kids[5 0 R]>>",
+      `<</Type/Page/Parent 4 0 R${RESOURCES}/Contents 6 0 R>>`,
+      streamObject("", "BT /f0 12 Tf [(\\000\\001\\000\\002)-20(\\000\\003)] TJ ET"),
     ]),
   );
 
-  expect(inspection.objects.find((object) => object.number === "4")?.text).toBe("Hi!");
+  expect(inspection.objects.find((object) => object.number === "6")?.text).toBe("Hi!");
+});
+
+test("steps a bfrange without breaking a surrogate pair", async () => {
+  const inspection = await inspectPdf(
+    pdf([
+      FONT,
+      cmap("beginbfrange\n<0001><0002><D83DDE00>\nendbfrange"),
+      "<</Type/Catalog/Pages 4 0 R>>",
+      "<</Type/Pages/Count 1/Kids[5 0 R]>>",
+      `<</Type/Page/Parent 4 0 R${RESOURCES}/Contents 6 0 R>>`,
+      streamObject("", "BT /f0 12 Tf <00010002> Tj ET"),
+    ]),
+  );
+
+  expect(inspection.objects.find((object) => object.number === "6")?.text).toBe("😀😁");
 });
 
 test("keeps a stream byte that the endstream newline would have eaten", async () => {

--- a/docs/app/playground/inspect-pdf.test.ts
+++ b/docs/app/playground/inspect-pdf.test.ts
@@ -8,7 +8,11 @@ function pdf(objects: string[]): Uint8Array {
   );
 }
 
-const CONTENT = "<</Length 24>>\nstream\nBT /f0 12 Tf (hi) Tj ET\nendstream";
+function streamObject(entries: string, data: string): string {
+  return `<<${entries}/Length ${data.length}>>\nstream\n${data}\nendstream`;
+}
+
+const CONTENT = streamObject("", "BT /f0 12 Tf (hi) Tj ET");
 
 test("counts a shared content stream against both pages", async () => {
   const inspection = await inspectPdf(
@@ -21,7 +25,10 @@ test("counts a shared content stream against both pages", async () => {
     ]),
   );
 
-  expect(inspection.textObjects).toEqual([1, 1]);
+  expect(inspection.pageText).toEqual([
+    { blocks: 1, words: 0 },
+    { blocks: 1, words: 0 },
+  ]);
   expect(inspection.objects.find((object) => object.number === "5")?.label).toBe(
     "content stream, pages 1, 2",
   );
@@ -37,8 +44,39 @@ test("names the single page a content stream belongs to", async () => {
     ]),
   );
 
-  expect(inspection.textObjects).toEqual([1]);
+  expect(inspection.pageText).toEqual([{ blocks: 1, words: 0 }]);
   expect(inspection.objects.find((object) => object.number === "4")?.label).toBe(
     "content stream, page 1",
   );
+});
+
+test("reads a content stream back through its ToUnicode CMap", async () => {
+  const inspection = await inspectPdf(
+    pdf([
+      "<</Type/Catalog/Pages 2 0 R>>",
+      "<</Type/Pages/Count 1/Kids[3 0 R]>>",
+      "<</Type/Page/Parent 2 0 R/Resources<</Font<</f0 5 0 R>>>>/Contents 4 0 R>>",
+      streamObject("", "BT /f0 12 Tf [(\\000\\001\\000\\002)-20(\\000\\003)] TJ ET"),
+      "<</Type/Font/Subtype/Type0/ToUnicode 6 0 R>>",
+      streamObject(
+        "/Type/CMap",
+        "beginbfchar\n<0001><0048>\n<0002><0069>\nendbfchar\nbeginbfrange\n<0003><0003><0021>\nendbfrange",
+      ),
+    ]),
+  );
+
+  expect(inspection.objects.find((object) => object.number === "4")?.text).toBe("Hi!");
+});
+
+test("keeps a stream byte that the endstream newline would have eaten", async () => {
+  const inspection = await inspectPdf(
+    pdf([
+      "<</Type/Catalog/Pages 2 0 R>>",
+      "<</Type/Pages/Count 1/Kids[3 0 R]>>",
+      "<</Type/Page/Parent 2 0 R/Contents 4 0 R>>",
+      streamObject("", "BT ET\n"),
+    ]),
+  );
+
+  expect(inspection.objects.find((object) => object.number === "4")?.body).toBe("BT ET\n");
 });

--- a/docs/app/playground/inspect-pdf.test.ts
+++ b/docs/app/playground/inspect-pdf.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { inspectPdf } from "./inspect-pdf";
+
+/** Hand-written so the streams stay uncompressed and the offsets stay readable. */
+function pdf(objects: string[]): Uint8Array {
+  return new TextEncoder().encode(
+    `%PDF-1.7\n${objects.map((object, index) => `${index + 1} 0 obj\n${object}\nendobj\n`).join("")}`,
+  );
+}
+
+const CONTENT = "<</Length 24>>\nstream\nBT /f0 12 Tf (hi) Tj ET\nendstream";
+
+test("counts a shared content stream against both pages", async () => {
+  const inspection = await inspectPdf(
+    pdf([
+      "<</Type/Catalog/Pages 2 0 R>>",
+      "<</Type/Pages/Count 2/Kids[3 0 R 4 0 R]>>",
+      "<</Type/Page/Parent 2 0 R/Contents 5 0 R>>",
+      "<</Type/Page/Parent 2 0 R/Contents 5 0 R>>",
+      CONTENT,
+    ]),
+  );
+
+  expect(inspection.textObjects).toEqual([1, 1]);
+  expect(inspection.objects.find((object) => object.number === "5")?.label).toBe(
+    "content stream, pages 1, 2",
+  );
+});
+
+test("names the single page a content stream belongs to", async () => {
+  const inspection = await inspectPdf(
+    pdf([
+      "<</Type/Catalog/Pages 2 0 R>>",
+      "<</Type/Pages/Count 1/Kids[3 0 R]>>",
+      "<</Type/Page/Parent 2 0 R/Contents 4 0 R>>",
+      CONTENT,
+    ]),
+  );
+
+  expect(inspection.textObjects).toEqual([1]);
+  expect(inspection.objects.find((object) => object.number === "4")?.label).toBe(
+    "content stream, page 1",
+  );
+});

--- a/docs/app/playground/inspect-pdf.ts
+++ b/docs/app/playground/inspect-pdf.ts
@@ -347,6 +347,53 @@ function pageFonts(
   return cmaps;
 }
 
+type ObjectSource = {
+  number: string;
+  raw: string;
+  stream: Uint8Array | undefined;
+  body: string | undefined;
+  pages: number[] | undefined;
+  text: string | undefined;
+};
+
+/** The object itself, followed by whatever an `/ObjStm` was hiding inside it. */
+function describeObject({ number, raw, stream, body, pages, text }: ObjectSource): PdfObject[] {
+  const keyword = raw.indexOf("stream");
+  const dict = (keyword === -1 ? raw : raw.slice(0, keyword)).trim();
+  const packed = stream && /\/Type\s*\/ObjStm\b/.test(dict) ? expandObjectStream(dict, stream) : [];
+
+  return [
+    {
+      number,
+      label: pages
+        ? `content stream, page${pages.length > 1 ? "s" : ""} ${pages.join(", ")}`
+        : (raw.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? ""),
+      dict,
+      body:
+        packed.length > 0
+          ? undefined
+          : stream && (body === undefined ? `${stream.length} bytes, not text` : clamp(body)),
+      text,
+    },
+    ...packed,
+  ];
+}
+
+function countPageText(
+  pageText: { blocks: number; words: number }[],
+  pages: number[],
+  body: string,
+  text: string,
+) {
+  const blocks = body.match(/\bBT\b/g)?.length ?? 0;
+  const words = text.split(/\s+/).filter(Boolean).length;
+
+  for (const page of pages) {
+    pageText[page - 1].blocks += blocks;
+    pageText[page - 1].words += words;
+  }
+}
+
 /** Every object the file declares, in file order, with `/ObjStm` contents unpacked in place. */
 async function readObjects(text: string, bytes: Uint8Array) {
   const ranges = objectRanges(text);
@@ -386,10 +433,7 @@ async function readObjects(text: string, bytes: Uint8Array) {
   });
 
   const pageText = kids.map(() => ({ blocks: 0, words: 0 }));
-  const objects = [...ranges].map(([number, range]) => {
-    const raw = text.slice(...range);
-    const keyword = raw.indexOf("stream");
-    const dict = (keyword === -1 ? raw : raw.slice(0, keyword)).trim();
+  const objects = [...ranges].flatMap(([number, range]) => {
     const stream = streams.get(number);
     const body = stream && readable(stream);
     const pages = pageOf.get(number);
@@ -398,37 +442,12 @@ async function readObjects(text: string, bytes: Uint8Array) {
         ? clamp(extractText(bytesToChars(stream), fontsOf.get(number) ?? new Map()))
         : undefined;
 
-    if (pages && body) {
-      const blocks = body.match(/\bBT\b/g)?.length ?? 0;
-      const words = (drawn ?? "").split(/\s+/).filter(Boolean).length;
+    if (pages && body) countPageText(pageText, pages, body, drawn ?? "");
 
-      for (const page of pages) {
-        pageText[page - 1].blocks += blocks;
-        pageText[page - 1].words += words;
-      }
-    }
-
-    const packed =
-      stream && /\/Type\s*\/ObjStm\b/.test(dict) ? expandObjectStream(dict, stream) : [];
-
-    return [
-      {
-        number,
-        label: pages
-          ? `content stream, page${pages.length > 1 ? "s" : ""} ${pages.join(", ")}`
-          : (raw.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? ""),
-        dict,
-        body:
-          packed.length > 0
-            ? undefined
-            : stream && (body === undefined ? `${stream.length} bytes, not text` : clamp(body)),
-        text: drawn,
-      },
-      ...packed,
-    ];
+    return describeObject({ number, raw: text.slice(...range), stream, body, pages, text: drawn });
   });
 
-  return { objects: objects.flat(), pageText };
+  return { objects, pageText };
 }
 
 export async function inspectPdf(bytes: Uint8Array): Promise<PdfInspection> {

--- a/docs/app/playground/inspect-pdf.ts
+++ b/docs/app/playground/inspect-pdf.ts
@@ -1,8 +1,8 @@
 /**
  * Reads back what a rendered PDF actually contains, so the playground can show
- * the structure instead of asking you to trust the render options. Page objects,
- * the outline, file specs and the XMP packet all sit outside object streams, so
- * this needs no PDF parser.
+ * the structure instead of asking you to trust the render options. Objects are
+ * found by scanning for `N 0 obj` rather than through the cross-reference table,
+ * which keeps this to one file and no PDF parser.
  */
 export type PdfInspection = {
   pages: number;
@@ -14,18 +14,20 @@ export type PdfInspection = {
   created?: string;
   bookmarks: Bookmark[];
   attachments: { name: string; description?: string }[];
-  streams: PdfPageStream[];
+  /**
+   * `BT` blocks per page. One shaped run emits one block, so a count far above
+   * the word count means something is cutting runs apart.
+   */
+  textObjects: number[];
+  objects: PdfObject[];
 };
 
-/**
- * A page's decoded content stream. One shaped run emits one `BT` block, so
- * `textObjects` counts far above the word count mean something is cutting runs.
- */
-export type PdfPageStream = { page: number; textObjects: number; operators: string };
+/** One indirect object, with its stream decoded when the bytes read as text. */
+export type PdfObject = { number: string; label: string; dict: string; body?: string };
 
 type Bookmark = { title: string; depth: number };
 
-const STREAM_LIMIT = 64 * 1024;
+const BODY_LIMIT = 64 * 1024;
 
 /**
  * One char per byte. `TextDecoder("latin1")` is windows-1252 by spec, which
@@ -138,14 +140,14 @@ async function readStream(
   text: string,
   bytes: Uint8Array,
   [start, end]: [number, number],
-): Promise<string> {
-  const body = text.slice(start, end);
-  const keyword = body.indexOf("stream");
-  const close = body.lastIndexOf("endstream");
+): Promise<Uint8Array | undefined> {
+  const object = text.slice(start, end);
+  const keyword = object.indexOf("stream");
+  const close = object.lastIndexOf("endstream");
 
-  if (keyword === -1 || close === -1) return "";
+  if (keyword === -1 || close === -1) return undefined;
 
-  const from = start + keyword + (body.startsWith("\r\n", keyword + 6) ? 8 : 7);
+  const from = start + keyword + (object.startsWith("\r\n", keyword + 6) ? 8 : 7);
   let to = start + close;
 
   while (to > from && (bytes[to - 1] === 0x0a || bytes[to - 1] === 0x0d)) to -= 1;
@@ -153,48 +155,103 @@ async function readStream(
   const raw = bytes.subarray(from, to);
 
   try {
-    return printable(/\/FlateDecode/.test(body.slice(0, keyword)) ? await inflate(raw) : raw);
+    return /\/FlateDecode/.test(object.slice(0, keyword)) ? await inflate(raw) : raw;
   } catch {
-    return "";
+    return undefined;
   }
 }
 
-/** Walks `/Pages` → `/Kids` → `/Contents`. Object numbers do not carry page order; `/Kids` does. */
-async function readPageStreams(text: string, bytes: Uint8Array): Promise<PdfPageStream[]> {
+function clamp(value: string): string {
+  return value.length > BODY_LIMIT ? `${value.slice(0, BODY_LIMIT)}\n… truncated` : value;
+}
+
+/** Font programs and images escape into several chars per byte, which is not worth reading. */
+function readable(data: Uint8Array): string | undefined {
+  const escaped = printable(data);
+
+  return escaped.length > data.length * 2 ? undefined : escaped;
+}
+
+/** Objects packed into an `/ObjStm`, which the file never lists at the top level. */
+function expandObjectStream(dict: string, data: Uint8Array): PdfObject[] {
+  const first = Number(dict.match(/\/First\s+(\d+)/)?.[1]);
+  const count = Number(dict.match(/\/N\s+(\d+)/)?.[1]);
+
+  if (!Number.isInteger(first) || !Number.isInteger(count)) return [];
+
+  const text = bytesToChars(data);
+  const header = text.slice(0, first).trim().split(/\s+/).map(Number);
+
+  return Array.from({ length: count }, (_, index) => {
+    const start = first + header[index * 2 + 1];
+    const next = header[index * 2 + 3];
+    const source = text.slice(start, next === undefined ? text.length : first + next).trim();
+
+    return {
+      number: String(header[index * 2]),
+      label: source.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? "",
+      dict: source,
+    };
+  });
+}
+
+/** Every object the file declares, in file order, with `/ObjStm` contents unpacked in place. */
+async function readObjects(text: string, bytes: Uint8Array) {
   const ranges = objectRanges(text);
-  const body = (number: string) => {
+  const source = (number: string) => {
     const range = ranges.get(number);
     return range && text.slice(...range);
   };
 
-  const tree = [...ranges.keys()].find((number) => /\/Type\s*\/Pages\b/.test(body(number) ?? ""));
-  const kids = references(body(tree ?? "")?.match(/\/Kids\s*\[([^\]]*)\]/)?.[1]);
+  // Object numbers do not carry page order; `/Kids` does.
+  const tree = [...ranges.keys()].find((number) => /\/Type\s*\/Pages\b/.test(source(number) ?? ""));
+  const kids = references(source(tree ?? "")?.match(/\/Kids\s*\[([^\]]*)\]/)?.[1]);
+  const pageOf = new Map<string, number>();
 
-  return Promise.all(
-    kids.map(async (kid, index) => {
-      const contents = references(body(kid)?.match(/\/Contents\s*(\[[^\]]*\]|\d+\s+0\s+R)/)?.[1]);
-      const decoded = await Promise.all(
-        contents.map((number) => {
-          const range = ranges.get(number);
-          return range ? readStream(text, bytes, range) : "";
-        }),
-      );
-      const operators = decoded.join("\n");
+  kids.forEach((kid, index) => {
+    const contents = source(kid)?.match(/\/Contents\s*(\[[^\]]*\]|\d+\s+0\s+R)/)?.[1];
 
-      return {
-        page: index + 1,
-        textObjects: operators.match(/\bBT\b/g)?.length ?? 0,
-        operators:
-          operators.length > STREAM_LIMIT
-            ? `${operators.slice(0, STREAM_LIMIT)}\n… truncated`
-            : operators,
-      };
+    for (const number of references(contents)) pageOf.set(number, index + 1);
+  });
+
+  const textObjects = kids.map(() => 0);
+  const objects = await Promise.all(
+    [...ranges].map(async ([number, range]) => {
+      const raw = text.slice(...range);
+      const keyword = raw.indexOf("stream");
+      const dict = (keyword === -1 ? raw : raw.slice(0, keyword)).trim();
+      const stream = await readStream(text, bytes, range);
+      const body = stream && readable(stream);
+      const page = pageOf.get(number);
+
+      if (page && body) textObjects[page - 1] += body.match(/\bBT\b/g)?.length ?? 0;
+
+      const packed =
+        stream && /\/Type\s*\/ObjStm\b/.test(dict) ? expandObjectStream(dict, stream) : [];
+
+      return [
+        {
+          number,
+          label: page
+            ? `content stream, page ${page}`
+            : (raw.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? ""),
+          dict,
+          body:
+            packed.length > 0
+              ? undefined
+              : stream && (body === undefined ? `${stream.length} bytes, not text` : clamp(body)),
+        },
+        ...packed,
+      ];
     }),
   );
+
+  return { objects: objects.flat(), textObjects };
 }
 
 export async function inspectPdf(bytes: Uint8Array): Promise<PdfInspection> {
   const text = bytesToChars(bytes);
+  const { objects: indirect, textObjects } = await readObjects(text, bytes);
   const objects = text.split("endobj");
   const xmp = text.match(/<x:xmpmeta[\s\S]*?<\/x:xmpmeta>/)?.[0] ?? "";
   const xmpValue = (tag: string) => xmp.match(new RegExp(`<${tag}>([^<]*)<`))?.[1];
@@ -222,6 +279,7 @@ export async function inspectPdf(bytes: Uint8Array): Promise<PdfInspection> {
       .filter((object) => object.includes("/Filespec"))
       .map((object) => ({ name: entry(object, "F") ?? "", description: entry(object, "Desc") }))
       .filter((attachment) => attachment.name),
-    streams: await readPageStreams(text, bytes),
+    textObjects,
+    objects: indirect,
   };
 }

--- a/docs/app/playground/inspect-pdf.ts
+++ b/docs/app/playground/inspect-pdf.ts
@@ -14,9 +14,18 @@ export type PdfInspection = {
   created?: string;
   bookmarks: Bookmark[];
   attachments: { name: string; description?: string }[];
+  streams: PdfPageStream[];
 };
 
+/**
+ * A page's decoded content stream. One shaped run emits one `BT` block, so
+ * `textObjects` counts far above the word count mean something is cutting runs.
+ */
+export type PdfPageStream = { page: number; textObjects: number; operators: string };
+
 type Bookmark = { title: string; depth: number };
+
+const STREAM_LIMIT = 64 * 1024;
 
 /**
  * One char per byte. `TextDecoder("latin1")` is windows-1252 by spec, which
@@ -94,7 +103,97 @@ function readBookmarks(objects: string[]): Bookmark[] {
   return bookmarks.filter((bookmark) => bookmark.title);
 }
 
-export function inspectPdf(bytes: Uint8Array): PdfInspection {
+/** Every indirect object's body, keyed by number. One char per byte, so the offsets index both. */
+function objectRanges(text: string): Map<string, [number, number]> {
+  const ranges = new Map<string, [number, number]>();
+
+  for (const match of text.matchAll(/(\d+)\s+0\s+obj/g)) {
+    const start = match.index + match[0].length;
+    const end = text.indexOf("endobj", start);
+
+    ranges.set(match[1], [start, end === -1 ? text.length : end]);
+  }
+
+  return ranges;
+}
+
+function references(value: string | undefined): string[] {
+  return [...(value ?? "").matchAll(/(\d+)\s+0\s+R/g)].map((match) => match[1]);
+}
+
+function printable(data: Uint8Array): string {
+  return bytesToChars(data).replace(
+    /[^\n\x20-\x7e]/g,
+    (char) => `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
+  );
+}
+
+async function inflate(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([data.slice()]).stream().pipeThrough(new DecompressionStream("deflate"));
+
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function readStream(
+  text: string,
+  bytes: Uint8Array,
+  [start, end]: [number, number],
+): Promise<string> {
+  const body = text.slice(start, end);
+  const keyword = body.indexOf("stream");
+  const close = body.lastIndexOf("endstream");
+
+  if (keyword === -1 || close === -1) return "";
+
+  const from = start + keyword + (body.startsWith("\r\n", keyword + 6) ? 8 : 7);
+  let to = start + close;
+
+  while (to > from && (bytes[to - 1] === 0x0a || bytes[to - 1] === 0x0d)) to -= 1;
+
+  const raw = bytes.subarray(from, to);
+
+  try {
+    return printable(/\/FlateDecode/.test(body.slice(0, keyword)) ? await inflate(raw) : raw);
+  } catch {
+    return "";
+  }
+}
+
+/** Walks `/Pages` → `/Kids` → `/Contents`. Object numbers do not carry page order; `/Kids` does. */
+async function readPageStreams(text: string, bytes: Uint8Array): Promise<PdfPageStream[]> {
+  const ranges = objectRanges(text);
+  const body = (number: string) => {
+    const range = ranges.get(number);
+    return range && text.slice(...range);
+  };
+
+  const tree = [...ranges.keys()].find((number) => /\/Type\s*\/Pages\b/.test(body(number) ?? ""));
+  const kids = references(body(tree ?? "")?.match(/\/Kids\s*\[([^\]]*)\]/)?.[1]);
+
+  return Promise.all(
+    kids.map(async (kid, index) => {
+      const contents = references(body(kid)?.match(/\/Contents\s*(\[[^\]]*\]|\d+\s+0\s+R)/)?.[1]);
+      const decoded = await Promise.all(
+        contents.map((number) => {
+          const range = ranges.get(number);
+          return range ? readStream(text, bytes, range) : "";
+        }),
+      );
+      const operators = decoded.join("\n");
+
+      return {
+        page: index + 1,
+        textObjects: operators.match(/\bBT\b/g)?.length ?? 0,
+        operators:
+          operators.length > STREAM_LIMIT
+            ? `${operators.slice(0, STREAM_LIMIT)}\n… truncated`
+            : operators,
+      };
+    }),
+  );
+}
+
+export async function inspectPdf(bytes: Uint8Array): Promise<PdfInspection> {
   const text = bytesToChars(bytes);
   const objects = text.split("endobj");
   const xmp = text.match(/<x:xmpmeta[\s\S]*?<\/x:xmpmeta>/)?.[0] ?? "";
@@ -123,5 +222,6 @@ export function inspectPdf(bytes: Uint8Array): PdfInspection {
       .filter((object) => object.includes("/Filespec"))
       .map((object) => ({ name: entry(object, "F") ?? "", description: entry(object, "Desc") }))
       .filter((attachment) => attachment.name),
+    streams: await readPageStreams(text, bytes),
   };
 }

--- a/docs/app/playground/inspect-pdf.ts
+++ b/docs/app/playground/inspect-pdf.ts
@@ -211,18 +211,18 @@ function dictValue(dict: string, key: string): string | undefined {
   return undefined;
 }
 
+/** A CMap destination is UTF-16BE, so an emoji arrives as the two units of its surrogate pair. */
+function utf16Units(hex: string): number[] {
+  return (hex.match(/.{4}/g) ?? []).map((unit) => Number.parseInt(unit, 16));
+}
+
 /** Reads `beginbfchar` and `beginbfrange`, the two forms Takumi's CMaps use. */
 function parseCMap(cmap: string): Map<number, string> {
-  const utf16 = (hex: string) =>
-    (hex.match(/.{4}/g) ?? [])
-      .map((unit) => String.fromCharCode(Number.parseInt(unit, 16)))
-      .join("");
-
   const codes = new Map<number, string>();
 
   for (const block of cmap.matchAll(/beginbfchar([\s\S]*?)endbfchar/g)) {
     for (const [, code, value] of block[1].matchAll(/<([0-9A-Fa-f]+)>\s*<([0-9A-Fa-f]+)>/g)) {
-      codes.set(Number.parseInt(code, 16), utf16(value));
+      codes.set(Number.parseInt(code, 16), String.fromCharCode(...utf16Units(value)));
     }
   }
 
@@ -232,10 +232,15 @@ function parseCMap(cmap: string): Map<number, string> {
 
     for (const [, low, high, value] of entries) {
       const start = Number.parseInt(low, 16);
-      const first = Number.parseInt(value, 16);
+      const units = utf16Units(value);
 
+      if (units.length === 0) continue;
+
+      // A range steps the last unit, which is what keeps a surrogate pair intact.
       for (let code = start; code <= Number.parseInt(high, 16); code += 1) {
-        codes.set(code, String.fromCodePoint(first + code - start));
+        const stepped = units.with(-1, units[units.length - 1] + code - start);
+
+        codes.set(code, String.fromCharCode(...stepped));
       }
     }
   }
@@ -353,17 +358,6 @@ async function readObjects(text: string, bytes: Uint8Array) {
   // Object numbers do not carry page order; `/Kids` does.
   const tree = [...ranges.keys()].find((number) => /\/Type\s*\/Pages\b/.test(source(number) ?? ""));
   const kids = references(source(tree ?? "")?.match(/\/Kids\s*\[([^\]]*)\]/)?.[1]);
-  const pageOf = new Map<string, number[]>();
-
-  kids.forEach((kid, index) => {
-    const contents = source(kid)?.match(/\/Contents\s*(\[[^\]]*\]|\d+\s+0\s+R)/)?.[1];
-
-    // Two pages may share one stream, so a page number appends instead of replacing.
-    for (const number of references(contents)) {
-      pageOf.set(number, [...(pageOf.get(number) ?? []), index + 1]);
-    }
-  });
-
   // Streams are decoded up front because a content stream is only readable
   // through the `/ToUnicode` stream of a font two references away.
   const streams = new Map<string, Uint8Array>();
@@ -376,13 +370,18 @@ async function readObjects(text: string, bytes: Uint8Array) {
     }),
   );
 
+  const pageOf = new Map<string, number[]>();
   const fontsOf = new Map<string, Map<string, Map<number, string>>>();
 
   kids.forEach((kid, index) => {
-    const fonts = pageFonts(source(kid) ?? "", source, streams);
+    const page = source(kid) ?? "";
+    const contents = references(page.match(/\/Contents\s*(\[[^\]]*\]|\d+\s+0\s+R)/)?.[1]);
+    const fonts = pageFonts(page, source, streams);
 
-    for (const number of pageOf.keys()) {
-      if (pageOf.get(number)?.includes(index + 1)) fontsOf.set(number, fonts);
+    // Two pages may share one stream, so a page number appends instead of replacing.
+    for (const number of contents) {
+      pageOf.set(number, [...(pageOf.get(number) ?? []), index + 1]);
+      fontsOf.set(number, fonts);
     }
   });
 

--- a/docs/app/playground/inspect-pdf.ts
+++ b/docs/app/playground/inspect-pdf.ts
@@ -206,12 +206,15 @@ async function readObjects(text: string, bytes: Uint8Array) {
   // Object numbers do not carry page order; `/Kids` does.
   const tree = [...ranges.keys()].find((number) => /\/Type\s*\/Pages\b/.test(source(number) ?? ""));
   const kids = references(source(tree ?? "")?.match(/\/Kids\s*\[([^\]]*)\]/)?.[1]);
-  const pageOf = new Map<string, number>();
+  const pageOf = new Map<string, number[]>();
 
   kids.forEach((kid, index) => {
     const contents = source(kid)?.match(/\/Contents\s*(\[[^\]]*\]|\d+\s+0\s+R)/)?.[1];
 
-    for (const number of references(contents)) pageOf.set(number, index + 1);
+    // Two pages may share one stream, so a page number appends instead of replacing.
+    for (const number of references(contents)) {
+      pageOf.set(number, [...(pageOf.get(number) ?? []), index + 1]);
+    }
   });
 
   const textObjects = kids.map(() => 0);
@@ -222,9 +225,13 @@ async function readObjects(text: string, bytes: Uint8Array) {
       const dict = (keyword === -1 ? raw : raw.slice(0, keyword)).trim();
       const stream = await readStream(text, bytes, range);
       const body = stream && readable(stream);
-      const page = pageOf.get(number);
+      const pages = pageOf.get(number);
 
-      if (page && body) textObjects[page - 1] += body.match(/\bBT\b/g)?.length ?? 0;
+      if (pages && body) {
+        const count = body.match(/\bBT\b/g)?.length ?? 0;
+
+        for (const page of pages) textObjects[page - 1] += count;
+      }
 
       const packed =
         stream && /\/Type\s*\/ObjStm\b/.test(dict) ? expandObjectStream(dict, stream) : [];
@@ -232,8 +239,8 @@ async function readObjects(text: string, bytes: Uint8Array) {
       return [
         {
           number,
-          label: page
-            ? `content stream, page ${page}`
+          label: pages
+            ? `content stream, page${pages.length > 1 ? "s" : ""} ${pages.join(", ")}`
             : (raw.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? ""),
           dict,
           body:

--- a/docs/app/playground/inspect-pdf.ts
+++ b/docs/app/playground/inspect-pdf.ts
@@ -15,15 +15,24 @@ export type PdfInspection = {
   bookmarks: Bookmark[];
   attachments: { name: string; description?: string }[];
   /**
-   * `BT` blocks per page. One shaped run emits one block, so a count far above
-   * the word count means something is cutting runs apart.
+   * One shaped run emits one `BT` block, so a page with about as many blocks as
+   * words is drawing every word separately and extractors will lose the spaces.
    */
-  textObjects: number[];
+  pageText: { blocks: number; words: number }[];
   objects: PdfObject[];
 };
 
-/** One indirect object, with its stream decoded when the bytes read as text. */
-export type PdfObject = { number: string; label: string; dict: string; body?: string };
+/**
+ * One indirect object, with its stream decoded when the bytes read as text.
+ * `text` is a content stream's glyph codes read back through `/ToUnicode`.
+ */
+export type PdfObject = {
+  number: string;
+  label: string;
+  dict: string;
+  body?: string;
+  text?: string;
+};
 
 type Bookmark = { title: string; depth: number };
 
@@ -148,14 +157,19 @@ async function readStream(
   if (keyword === -1 || close === -1) return undefined;
 
   const from = start + keyword + (object.startsWith("\r\n", keyword + 6) ? 8 : 7);
+  const dict = object.slice(0, keyword);
+  const length = Number(dict.match(/\/Length\s+(\d+)/)?.[1]);
   let to = start + close;
 
-  while (to > from && (bytes[to - 1] === 0x0a || bytes[to - 1] === 0x0d)) to -= 1;
+  // Only trust the `endstream` offset when `/Length` is indirect: compressed
+  // data ending in 0x0a is real, and trimming it corrupts the stream.
+  if (Number.isInteger(length) && from + length <= to) to = from + length;
+  else while (to > from && (bytes[to - 1] === 0x0a || bytes[to - 1] === 0x0d)) to -= 1;
 
   const raw = bytes.subarray(from, to);
 
   try {
-    return /\/FlateDecode/.test(object.slice(0, keyword)) ? await inflate(raw) : raw;
+    return /\/FlateDecode/.test(dict) ? await inflate(raw) : raw;
   } catch {
     return undefined;
   }
@@ -170,6 +184,114 @@ function readable(data: Uint8Array): string | undefined {
   const escaped = printable(data);
 
   return escaped.length > data.length * 2 ? undefined : escaped;
+}
+
+/** A dictionary entry's raw value: a nested dictionary, or the reference standing in for one. */
+function dictValue(dict: string, key: string): string | undefined {
+  const at = dict.search(new RegExp(`/${key}\\b`));
+
+  if (at === -1) return undefined;
+
+  const rest = dict.slice(at + key.length + 1).trimStart();
+
+  if (!rest.startsWith("<<")) return rest.match(/^\d+\s+0\s+R/)?.[0];
+
+  let depth = 0;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest.startsWith("<<", index)) depth += 1;
+    else if (rest.startsWith(">>", index)) {
+      depth -= 1;
+      if (depth === 0) return rest.slice(0, index + 2);
+    } else continue;
+
+    index += 1;
+  }
+
+  return undefined;
+}
+
+/** Reads `beginbfchar` and `beginbfrange`, the two forms Takumi's CMaps use. */
+function parseCMap(cmap: string): Map<number, string> {
+  const utf16 = (hex: string) =>
+    (hex.match(/.{4}/g) ?? [])
+      .map((unit) => String.fromCharCode(Number.parseInt(unit, 16)))
+      .join("");
+
+  const codes = new Map<number, string>();
+
+  for (const block of cmap.matchAll(/beginbfchar([\s\S]*?)endbfchar/g)) {
+    for (const [, code, value] of block[1].matchAll(/<([0-9A-Fa-f]+)>\s*<([0-9A-Fa-f]+)>/g)) {
+      codes.set(Number.parseInt(code, 16), utf16(value));
+    }
+  }
+
+  // The `[ <a> <b> ]` destination form is skipped: Takumi never writes it.
+  for (const block of cmap.matchAll(/beginbfrange([\s\S]*?)endbfrange/g)) {
+    const entries = block[1].matchAll(/<([0-9A-Fa-f]+)>\s*<([0-9A-Fa-f]+)>\s*<([0-9A-Fa-f]+)>/g);
+
+    for (const [, low, high, value] of entries) {
+      const start = Number.parseInt(low, 16);
+      const first = Number.parseInt(value, 16);
+
+      for (let code = start; code <= Number.parseInt(high, 16); code += 1) {
+        codes.set(code, String.fromCodePoint(first + code - start));
+      }
+    }
+  }
+
+  return codes;
+}
+
+/** Undoes the `\ooo` and `\n` escapes a PDF literal string is written with. */
+function pdfLiteral(raw: string): string {
+  return raw.replace(/\\(\d{1,3}|[\s\S])/g, (_, escape: string) =>
+    /^\d/.test(escape)
+      ? String.fromCharCode(Number.parseInt(escape, 8))
+      : ({ n: "\n", r: "\r", t: "\t", b: "\b", f: "\f" }[escape] ?? escape),
+  );
+}
+
+/**
+ * The words a content stream draws. Codes are two bytes because every font
+ * Takumi embeds is Identity-encoded, and `Tf` says which CMap reads them.
+ */
+function extractText(content: string, fonts: Map<string, Map<number, string>>): string {
+  const tokens = content.matchAll(
+    /\/(\w+)\s+[\d.]+\s+Tf|\(((?:\\[\s\S]|[^\\()])*)\)|<([0-9A-Fa-f\s]+)>/g,
+  );
+
+  let cmap: Map<number, string> | undefined;
+  let out = "";
+
+  for (const [, font, literal, hex] of tokens) {
+    if (font !== undefined) {
+      cmap = fonts.get(font);
+      continue;
+    }
+
+    if (!cmap) continue;
+
+    for (const code of showCodes(literal, hex)) out += cmap.get(code) ?? "";
+  }
+
+  return out;
+}
+
+/** Both string forms carry the same two-byte codes, written differently. */
+function showCodes(literal: string | undefined, hex: string | undefined): number[] {
+  if (literal === undefined) {
+    return ((hex ?? "").replace(/\s/g, "").match(/.{4}/g) ?? []).map((unit) =>
+      Number.parseInt(unit, 16),
+    );
+  }
+
+  const bytes = pdfLiteral(literal);
+
+  return Array.from(
+    { length: bytes.length >> 1 },
+    (_, index) => (bytes.charCodeAt(index * 2) << 8) | bytes.charCodeAt(index * 2 + 1),
+  );
 }
 
 /** Objects packed into an `/ObjStm`, which the file never lists at the top level. */
@@ -195,6 +317,31 @@ function expandObjectStream(dict: string, data: Uint8Array): PdfObject[] {
   });
 }
 
+/** The `/Font` resources a page names, each paired with the CMap that reads its codes. */
+function pageFonts(
+  page: string,
+  source: (number: string) => string | undefined,
+  streams: Map<string, Uint8Array>,
+): Map<string, Map<number, string>> {
+  const resolve = (value: string | undefined) => {
+    const reference = value?.match(/^(\d+)\s+0\s+R/)?.[1];
+    return reference ? source(reference) : value;
+  };
+
+  const resources = resolve(dictValue(page, "Resources")) ?? "";
+  const fonts = resolve(dictValue(resources, "Font")) ?? "";
+  const cmaps = new Map<string, Map<number, string>>();
+
+  for (const [, name, reference] of fonts.matchAll(/\/(\w+)\s+(\d+)\s+0\s+R/g)) {
+    const toUnicode = dictValue(source(reference) ?? "", "ToUnicode")?.match(/^\d+/)?.[0];
+    const cmap = toUnicode && streams.get(toUnicode);
+
+    if (cmap) cmaps.set(name, parseCMap(bytesToChars(cmap)));
+  }
+
+  return cmaps;
+}
+
 /** Every object the file declares, in file order, with `/ObjStm` contents unpacked in place. */
 async function readObjects(text: string, bytes: Uint8Array) {
   const ranges = objectRanges(text);
@@ -217,48 +364,77 @@ async function readObjects(text: string, bytes: Uint8Array) {
     }
   });
 
-  const textObjects = kids.map(() => 0);
-  const objects = await Promise.all(
+  // Streams are decoded up front because a content stream is only readable
+  // through the `/ToUnicode` stream of a font two references away.
+  const streams = new Map<string, Uint8Array>();
+
+  await Promise.all(
     [...ranges].map(async ([number, range]) => {
-      const raw = text.slice(...range);
-      const keyword = raw.indexOf("stream");
-      const dict = (keyword === -1 ? raw : raw.slice(0, keyword)).trim();
       const stream = await readStream(text, bytes, range);
-      const body = stream && readable(stream);
-      const pages = pageOf.get(number);
 
-      if (pages && body) {
-        const count = body.match(/\bBT\b/g)?.length ?? 0;
-
-        for (const page of pages) textObjects[page - 1] += count;
-      }
-
-      const packed =
-        stream && /\/Type\s*\/ObjStm\b/.test(dict) ? expandObjectStream(dict, stream) : [];
-
-      return [
-        {
-          number,
-          label: pages
-            ? `content stream, page${pages.length > 1 ? "s" : ""} ${pages.join(", ")}`
-            : (raw.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? ""),
-          dict,
-          body:
-            packed.length > 0
-              ? undefined
-              : stream && (body === undefined ? `${stream.length} bytes, not text` : clamp(body)),
-        },
-        ...packed,
-      ];
+      if (stream) streams.set(number, stream);
     }),
   );
 
-  return { objects: objects.flat(), textObjects };
+  const fontsOf = new Map<string, Map<string, Map<number, string>>>();
+
+  kids.forEach((kid, index) => {
+    const fonts = pageFonts(source(kid) ?? "", source, streams);
+
+    for (const number of pageOf.keys()) {
+      if (pageOf.get(number)?.includes(index + 1)) fontsOf.set(number, fonts);
+    }
+  });
+
+  const pageText = kids.map(() => ({ blocks: 0, words: 0 }));
+  const objects = [...ranges].map(([number, range]) => {
+    const raw = text.slice(...range);
+    const keyword = raw.indexOf("stream");
+    const dict = (keyword === -1 ? raw : raw.slice(0, keyword)).trim();
+    const stream = streams.get(number);
+    const body = stream && readable(stream);
+    const pages = pageOf.get(number);
+    const drawn =
+      pages && stream
+        ? clamp(extractText(bytesToChars(stream), fontsOf.get(number) ?? new Map()))
+        : undefined;
+
+    if (pages && body) {
+      const blocks = body.match(/\bBT\b/g)?.length ?? 0;
+      const words = (drawn ?? "").split(/\s+/).filter(Boolean).length;
+
+      for (const page of pages) {
+        pageText[page - 1].blocks += blocks;
+        pageText[page - 1].words += words;
+      }
+    }
+
+    const packed =
+      stream && /\/Type\s*\/ObjStm\b/.test(dict) ? expandObjectStream(dict, stream) : [];
+
+    return [
+      {
+        number,
+        label: pages
+          ? `content stream, page${pages.length > 1 ? "s" : ""} ${pages.join(", ")}`
+          : (raw.match(/\/(?:Sub)?Type\s*\/(\w+)/)?.[1] ?? ""),
+        dict,
+        body:
+          packed.length > 0
+            ? undefined
+            : stream && (body === undefined ? `${stream.length} bytes, not text` : clamp(body)),
+        text: drawn,
+      },
+      ...packed,
+    ];
+  });
+
+  return { objects: objects.flat(), pageText };
 }
 
 export async function inspectPdf(bytes: Uint8Array): Promise<PdfInspection> {
   const text = bytesToChars(bytes);
-  const { objects: indirect, textObjects } = await readObjects(text, bytes);
+  const { objects: indirect, pageText } = await readObjects(text, bytes);
   const objects = text.split("endobj");
   const xmp = text.match(/<x:xmpmeta[\s\S]*?<\/x:xmpmeta>/)?.[0] ?? "";
   const xmpValue = (tag: string) => xmp.match(new RegExp(`<${tag}>([^<]*)<`))?.[1];
@@ -286,7 +462,7 @@ export async function inspectPdf(bytes: Uint8Array): Promise<PdfInspection> {
       .filter((object) => object.includes("/Filespec"))
       .map((object) => ({ name: entry(object, "F") ?? "", description: entry(object, "Desc") }))
       .filter((attachment) => attachment.name),
-    textObjects,
+    pageText,
     objects: indirect,
   };
 }

--- a/docs/app/playground/templates/gradient-poster.tsx
+++ b/docs/app/playground/templates/gradient-poster.tsx
@@ -5,7 +5,7 @@ export default function Poster() {
       style={{ backgroundImage: "conic-gradient(from 210deg, #ff6b6b, #556270, #ffd93d, #ff6b6b)" }}
     >
       <div
-        tw="flex h-[560px] w-[560px] flex-col items-center justify-center rounded-full border border-white/25 bg-white/10 text-white"
+        tw="flex h-[560px] w-[560px] flex-col items-center justify-center rounded-full bg-white/10 text-white"
         style={{ backdropFilter: "blur(12px)" }}
       >
         <span tw="text-[140px] leading-none">🌗</span>

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -153,6 +153,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
     ...resources,
   });
   const duration = performance.now() - start;
+  const inspection = output.kind === "pdf" ? await inspectPdf(output.buffer) : undefined;
 
   postMessage(
     {
@@ -165,7 +166,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
         outputKind: output.kind,
         outputFormat: output.format,
         label: geometry.label,
-        inspection: output.kind === "pdf" ? inspectPdf(output.buffer) : undefined,
+        inspection,
       },
     },
     [output.buffer.buffer],

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*", "**/.server/**/*", "**/.client/**/*", ".source/**/*"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["node", "vite/client"],
+    "types": ["node", "vite/client", "bun"],
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Why

The playground showed what a PDF claimed about itself, never what the file actually holds. A font switch that splits every word into its own text object renders identically, so #1176 was only visible by exporting the file and running `pdftotext` outside the browser.

## What

An Objects view lists every indirect object with its dictionary, inflates the streams that read as text, and unpacks `/ObjStm` contents in place. Content streams are read back through the font's `/ToUnicode` CMap, so the words a page draws show up next to the operators and the filter box searches them. Every `12 0 R` is a link to that object.

The Document view reports blocks and words per page. One shaped run emits one `BT` block, so a page with about as many blocks as words is drawing every word separately, which is the shape #1176 describes. The repro from that issue now renders as one block for eleven words.

Objects are found by scanning for `N 0 obj`, not through the cross-reference table. Stream extents come from `/Length` where it is a literal, because trimming the newline before `endstream` eats a real byte when the compressed data happens to end in `0x0a`.