### PR TITLE
PDF: merge overlapping cluster spans where they are consumed

### DIFF
--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2209,40 +2209,10 @@ fn glyph_cluster_ranges(
   let Some(start) = (0..=full.len().saturating_sub(count)).find(|&s| matches_at(s)) else {
     return Vec::new();
   };
-  let mut ranges: Vec<Range<usize>> = full[start..start + count]
+  full[start..start + count]
     .iter()
     .map(|(_, range)| range.clone())
-    .collect();
-
-  merge_overlapping_spans(&mut ranges);
-  ranges
-}
-
-/// Gives every glyph whose text overlaps its neighbour's the union of the two.
-///
-/// A consonant and its matra come back as two clusters over the same source
-/// text rather than a partition of it, so each glyph would map to the base
-/// character again. Sharing one range instead marks them as a single cluster,
-/// which is what the PDF backend needs to emit them under one `ActualText`.
-fn merge_overlapping_spans(ranges: &mut [Range<usize>]) {
-  let mut group = 0;
-
-  for index in 1..ranges.len() {
-    if !spans_overlap(&ranges[group], &ranges[index]) {
-      group = index;
-      continue;
-    }
-    let union =
-      ranges[group].start.min(ranges[index].start)..ranges[group].end.max(ranges[index].end);
-
-    for range in &mut ranges[group..=index] {
-      *range = union.clone();
-    }
-  }
-}
-
-fn spans_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
-  left.start < right.end && right.start < left.end
+    .collect()
 }
 
 /// A shaped, positioned glyph run — the core-owned replacement for
@@ -3229,27 +3199,5 @@ mod tests {
       segments.iter().any(|(_, text, _)| text.contains("before")),
       "{segments:#?}"
     );
-  }
-
-  #[test]
-  fn overlapping_spans_share_one_range() {
-    // A consonant and its matra, twice, around a space.
-    let mut ranges = vec![0..3, 0..6, 6..9, 6..12, 12..13];
-
-    merge_overlapping_spans(&mut ranges);
-    assert_eq!(ranges, vec![0..6, 0..6, 6..12, 6..12, 12..13]);
-  }
-
-  #[test]
-  fn disjoint_spans_stay_apart() {
-    let ascending = vec![0..1, 1..2, 2..3];
-    let descending = vec![4..6, 2..4, 0..2];
-
-    for original in [ascending, descending] {
-      let mut ranges = original.clone();
-
-      merge_overlapping_spans(&mut ranges);
-      assert_eq!(ranges, original);
-    }
   }
 }

--- a/takumi-pdf/src/glyph.rs
+++ b/takumi-pdf/src/glyph.rs
@@ -15,7 +15,7 @@ pub(crate) fn glyph_text_spans(shaped: &ShapedRun, run_text: &str) -> Vec<Range<
   let base = shaped.text_range.start;
 
   if shaped.cluster_ranges.len() == shaped.glyphs.len() {
-    return shaped
+    let mut spans: Vec<Range<usize>> = shaped
       .cluster_ranges
       .iter()
       .map(|range| {
@@ -25,10 +25,39 @@ pub(crate) fn glyph_text_spans(shaped: &ShapedRun, run_text: &str) -> Vec<Range<
         if start <= end { start..end } else { 0..0 }
       })
       .collect();
+
+    merge_overlapping_spans(&mut spans);
+    return spans;
   }
 
   // Alignment unknown: map every glyph to the whole run.
   vec![0..run_text.len(); shaped.glyphs.len()]
+}
+
+/// Gives every glyph whose text overlaps its neighbour's the union of the two.
+///
+/// A consonant and its matra come back as two clusters over the same source
+/// text rather than a partition of it, so each glyph would map to the base
+/// character again. An identical range instead marks them as one cluster, which
+/// is what krilla needs to emit them under a single `/ActualText`.
+fn merge_overlapping_spans(spans: &mut [Range<usize>]) {
+  let mut group = 0;
+
+  for index in 1..spans.len() {
+    if !spans_overlap(&spans[group], &spans[index]) {
+      group = index;
+      continue;
+    }
+    let union = spans[group].start.min(spans[index].start)..spans[group].end.max(spans[index].end);
+
+    for span in &mut spans[group..=index] {
+      *span = union.clone();
+    }
+  }
+}
+
+fn spans_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
+  left.start < right.end && right.start < left.end
 }
 
 /// A positioned glyph adapter. Offsets are stored em-normalized (position ÷ font
@@ -69,5 +98,32 @@ impl Glyph for PdfGlyph {
 
   fn location(&self) -> Option<Location> {
     None
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn overlapping_spans_share_one_range() {
+    // A consonant and its matra, twice, around a space.
+    let mut spans = vec![0..3, 0..6, 6..9, 6..12, 12..13];
+
+    merge_overlapping_spans(&mut spans);
+    assert_eq!(spans, vec![0..6, 0..6, 6..12, 6..12, 12..13]);
+  }
+
+  #[test]
+  fn disjoint_spans_stay_apart() {
+    let ascending = vec![0..1, 1..2, 2..3];
+    let descending = vec![4..6, 2..4, 0..2];
+
+    for original in [ascending, descending] {
+      let mut spans = original.clone();
+
+      merge_overlapping_spans(&mut spans);
+      assert_eq!(spans, original);
+    }
   }
 }


### PR DESCRIPTION
## Why

`ShapedRun::cluster_ranges` carries the shaper's own cluster segmentation, and that is what its consumers expect to read. Folding the overlapping clusters together inside `takumi-core` changed the meaning of a public field for a need only the PDF backend has.

## What

`glyph_text_spans` in `takumi-pdf` does the merge, right before the ranges become `/ActualText`. `takumi-core` hands back the shaper's ranges untouched, ligature continuations included. Output is byte-identical, so no changeset and no golden moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text span generation in PDF output when glyph clusters overlap.
  * Preserved overlapping glyph ranges accurately before combining related spans.
  * Added support for consistently handling spans in both ascending and descending order.
  * Improved handling of disjoint text spans to produce more reliable mappings between rendered glyphs and source text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->