### PR TITLE
PDF: reject a character no registered font covers

### DIFF
--- a/.tegami/pdf-uncovered-characters.md
+++ b/.tegami/pdf-uncovered-characters.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Reject a character no registered font covers
+
+A character outside every registered font shaped to `.notdef`. It painted nothing and left nothing in the text layer, so the page looked finished with the character quietly gone. Rendering now fails with `MissingGlyphs`, naming each character and its codepoint.

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -25,6 +25,8 @@ const pdf = await render(doc, {
 
 `fontFamilies` sets the fallback chain for each render. Registered fonts deduplicate across calls that use the same renderer.
 
+There is no system font to fall back on. A character that none of the registered fonts covers would draw nothing and leave nothing in the text layer, so `render` rejects it and names the character and its codepoint. Register a font covering every script the document uses. Watch the Google Fonts subsets in particular: `latin` and `latin-ext` split their coverage, so one file on its own can leave common accented characters out.
+
 ## Images
 
 The renderer never fetches over the network. Pass pre-fetched bytes for each image URL in the document:

--- a/takumi-pdf/src/bands.rs
+++ b/takumi-pdf/src/bands.rs
@@ -6,6 +6,8 @@ use takumi_core::{
   viewport::Viewport,
 };
 
+use std::cell::RefCell;
+
 use crate::{
   counters::{counter_text, substitute_page_counters},
   emitter::FontMap,
@@ -72,6 +74,7 @@ pub(crate) fn emit_band(
   fonts: &mut FontMap,
   bounds: (f32, f32, f32, f32),
   artifact: bool,
+  uncovered: &RefCell<String>,
   surface: &mut Surface,
 ) -> Result<(), PdfError> {
   let (x, y, width, height) = bounds;
@@ -89,7 +92,7 @@ pub(crate) fn emit_band(
   }
   surface.push_clip_path(&path, &FillRule::NonZero);
   surface.push_transform(&Transform::from_translate(x, y));
-  let mut emitter = band.emitter(fonts, None, None);
+  let mut emitter = band.emitter(fonts, None, None, uncovered);
 
   emitter.emit_context(0, Affine::IDENTITY, surface)?;
   surface.pop();

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -44,7 +44,7 @@ use crate::svg;
 use crate::{
   background::{Placement, cycled, place},
   filter::ColorFilter,
-  glyph::{PdfGlyph, glyph_text_spans},
+  glyph::run_glyphs,
   inline::{InlineMap, build_inline_runs, inline_key, node_inline_items, text_line_atoms},
   krilla::{
     Data,
@@ -57,7 +57,7 @@ use crate::{
     },
     surface::Surface,
     tagging::{Artifact, ArtifactType, ContentTag},
-    text::{Font, GlyphId, Tag},
+    text::{Font, Tag},
   },
   options::PdfError,
   pagination::Atom,
@@ -121,6 +121,10 @@ pub(crate) struct Emitter<'a> {
   /// Color transform from the `filter` properties of the enclosing stacking
   /// contexts, applied to every color this subtree paints.
   pub(crate) color_filter: Option<Rc<ColorFilter>>,
+  /// Characters no registered font covered. Collected rather than raised on the
+  /// spot: the surface has open transforms and clips mid-page, and unwinding
+  /// past them would leave it unbalanced.
+  pub(crate) uncovered: &'a RefCell<String>,
 }
 
 impl Emitter<'_> {
@@ -1208,19 +1212,7 @@ impl Emitter<'_> {
         .text
         .get(shaped.text_range.clone())
         .unwrap_or_default();
-      let spans = glyph_text_spans(shaped, run_text);
-
-      let glyphs: Vec<PdfGlyph> = shaped
-        .glyphs
-        .iter()
-        .zip(spans)
-        .map(|(glyph, range)| PdfGlyph {
-          id: GlyphId::new(glyph.id),
-          x_offset: glyph.x / shaped.font_size,
-          y_offset: -glyph.y / shaped.font_size,
-          range,
-        })
-        .collect();
+      let glyphs = run_glyphs(shaped, run_text, &mut self.uncovered.borrow_mut());
 
       let color = shaped.brush.color;
       let fill = fill_from_rgba(self.filtered(color), shaped.brush.opacity);
@@ -1414,6 +1406,7 @@ impl Emitter<'_> {
       line_window: None,
       tags: None,
       color_filter: self.color_filter.clone(),
+      uncovered: self.uncovered,
     };
     let x = origin.0 + subtree.margin_offset.x;
     let y = origin.1 + subtree.margin_offset.y;
@@ -1530,19 +1523,7 @@ impl Emitter<'_> {
         .text
         .get(shaped.text_range.clone())
         .unwrap_or_default();
-      let spans = glyph_text_spans(shaped, run_text);
-
-      let glyphs: Vec<PdfGlyph> = shaped
-        .glyphs
-        .iter()
-        .zip(spans)
-        .map(|(glyph, range)| PdfGlyph {
-          id: GlyphId::new(glyph.id),
-          x_offset: glyph.x / shaped.font_size,
-          y_offset: -glyph.y / shaped.font_size,
-          range,
-        })
-        .collect();
+      let glyphs = run_glyphs(shaped, run_text, &mut self.uncovered.borrow_mut());
 
       let color = color.unwrap_or(shaped.brush.color);
 

--- a/takumi-pdf/src/glyph.rs
+++ b/takumi-pdf/src/glyph.rs
@@ -4,14 +4,68 @@ use std::ops::Range;
 
 use takumi_core::layout::inline::ShapedRun;
 
-use crate::krilla::{
-  surface::Location,
-  text::{Glyph, GlyphId},
+use crate::{
+  krilla::{
+    surface::Location,
+    text::{Glyph, GlyphId},
+  },
+  options::PdfError,
 };
+
+/// The run's glyphs, each carrying the source text it maps to.
+///
+/// A character no registered font covers shapes to `.notdef`. It draws nothing
+/// and leaves nothing behind in the text layer, so the page would come out
+/// looking finished with the character quietly gone. Every such character lands
+/// in `uncovered` for the caller to report once the page is done.
+pub(crate) fn run_glyphs(
+  shaped: &ShapedRun,
+  run_text: &str,
+  uncovered: &mut String,
+) -> Vec<PdfGlyph> {
+  let spans = glyph_text_spans(shaped, run_text);
+
+  for (glyph, span) in shaped.glyphs.iter().zip(&spans) {
+    if glyph.id != 0 {
+      continue;
+    }
+    for character in run_text.get(span.clone()).unwrap_or_default().chars() {
+      if !uncovered.contains(character) {
+        uncovered.push(character);
+      }
+    }
+  }
+
+  shaped
+    .glyphs
+    .iter()
+    .zip(spans)
+    .map(|(glyph, range)| PdfGlyph {
+      id: GlyphId::new(glyph.id),
+      x_offset: glyph.x / shaped.font_size,
+      y_offset: -glyph.y / shaped.font_size,
+      range,
+    })
+    .collect()
+}
+
+/// The error naming what no font covered, or `None` when everything mapped.
+pub(crate) fn uncovered_error(uncovered: &str) -> Option<PdfError> {
+  if uncovered.is_empty() {
+    return None;
+  }
+  let named = uncovered
+    .chars()
+    .map(|character| format!("{character} (U+{:04X})", character as u32))
+    .collect::<Vec<_>>()
+    .join(", ");
+
+  Some(PdfError::MissingGlyphs(named))
+}
 
 /// Per-glyph byte ranges into `run_text` for ToUnicode, from the shaper's
 /// cluster segmentation (correct for ligatures and complex scripts).
-pub(crate) fn glyph_text_spans(shaped: &ShapedRun, run_text: &str) -> Vec<Range<usize>> {
+fn glyph_text_spans(shaped: &ShapedRun, run_text: &str) -> Vec<Range<usize>> {
   let base = shaped.text_range.start;
 
   if shaped.cluster_ranges.len() == shaped.glyphs.len() {

--- a/takumi-pdf/src/glyph.rs
+++ b/takumi-pdf/src/glyph.rs
@@ -23,19 +23,17 @@ pub(crate) fn run_glyphs(
   run_text: &str,
   uncovered: &mut String,
 ) -> Vec<PdfGlyph> {
-  let spans = glyph_text_spans(shaped, run_text);
+  let clusters = cluster_spans(shaped, run_text);
 
-  for (glyph, span) in shaped.glyphs.iter().zip(&spans) {
-    if glyph.id != 0 {
-      continue;
-    }
-    for character in run_text.get(span.clone()).unwrap_or_default().chars() {
-      if !uncovered.contains(character) {
-        uncovered.push(character);
-      }
-    }
+  if let Some(clusters) = &clusters {
+    collect_uncovered(shaped, run_text, clusters, uncovered);
   }
 
+  let mut spans = clusters
+    // Alignment unknown: map every glyph to the whole run.
+    .unwrap_or_else(|| vec![0..run_text.len(); shaped.glyphs.len()]);
+
+  merge_overlapping_spans(&mut spans);
   shaped
     .glyphs
     .iter()
@@ -47,6 +45,29 @@ pub(crate) fn run_glyphs(
       range,
     })
     .collect()
+}
+
+/// Adds the characters that came out as `.notdef`.
+///
+/// Reads the shaper's own cluster spans, before they are merged for ToUnicode:
+/// a merged span covers its neighbour's text too, and the fallback span covers
+/// the whole run, either of which would blame characters that shaped fine.
+fn collect_uncovered(
+  shaped: &ShapedRun,
+  run_text: &str,
+  clusters: &[Range<usize>],
+  uncovered: &mut String,
+) {
+  for (glyph, cluster) in shaped.glyphs.iter().zip(clusters) {
+    if glyph.id != 0 {
+      continue;
+    }
+    for character in run_text.get(cluster.clone()).unwrap_or_default().chars() {
+      if !uncovered.contains(character) {
+        uncovered.push(character);
+      }
+    }
+  }
 }
 
 /// The error naming what no font covered, or `None` when everything mapped.
@@ -63,13 +84,18 @@ pub(crate) fn uncovered_error(uncovered: &str) -> Option<PdfError> {
   Some(PdfError::MissingGlyphs(named))
 }
 
-/// Per-glyph byte ranges into `run_text` for ToUnicode, from the shaper's
-/// cluster segmentation (correct for ligatures and complex scripts).
-fn glyph_text_spans(shaped: &ShapedRun, run_text: &str) -> Vec<Range<usize>> {
+/// Per-glyph byte ranges into `run_text`, from the shaper's cluster
+/// segmentation (correct for ligatures and complex scripts). `None` when the
+/// shaper's ranges do not line up with the glyphs, which leaves every glyph's
+/// text unknown rather than wrong.
+fn cluster_spans(shaped: &ShapedRun, run_text: &str) -> Option<Vec<Range<usize>>> {
+  if shaped.cluster_ranges.len() != shaped.glyphs.len() {
+    return None;
+  }
   let base = shaped.text_range.start;
 
-  if shaped.cluster_ranges.len() == shaped.glyphs.len() {
-    let mut spans: Vec<Range<usize>> = shaped
+  Some(
+    shaped
       .cluster_ranges
       .iter()
       .map(|range| {
@@ -78,14 +104,8 @@ fn glyph_text_spans(shaped: &ShapedRun, run_text: &str) -> Vec<Range<usize>> {
 
         if start <= end { start..end } else { 0..0 }
       })
-      .collect();
-
-    merge_overlapping_spans(&mut spans);
-    return spans;
-  }
-
-  // Alignment unknown: map every glyph to the whole run.
-  vec![0..run_text.len(); shaped.glyphs.len()]
+      .collect(),
+  )
 }
 
 /// Gives every glyph whose text overlaps its neighbour's the union of the two.

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -87,6 +87,7 @@ pub use crate::options::{
 use crate::{
   bands::{emit_band, measure_band, prepare_band},
   emitter::FontMap,
+  glyph::uncovered_error,
   inline::{build_inline_map, collect_text_boxes},
   interactive::{add_link_annotations, build_outline, collect_interactive, destination_targets},
   krilla::{
@@ -154,6 +155,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
     lang: options.lang,
   };
   let mut fonts = FontMap::new();
+  let uncovered = RefCell::new(String::new());
   let mut document = {
     let mut builder = ConfigurationBuilder::new();
     let mut validated = false;
@@ -261,7 +263,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let mut forced = Vec::new();
 
       content
-        .emitter(&mut fonts, Some(&inline_map), None)
+        .emitter(&mut fonts, Some(&inline_map), None, &uncovered)
         .collect_atoms(0, Affine::IDENTITY, &mut atoms, &mut forced)?;
       let starts = page_starts(&mut atoms, &mut forced, content.height, window_height);
       let pages = starts.len();
@@ -302,6 +304,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
             &mut fonts,
             (0.0, BAND_EDGE_PADDING, page.width, header_height),
             tag_collector.is_some(),
+            &uncovered,
             &mut surface,
           )?;
         }
@@ -322,7 +325,12 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
             page.margin.left,
             content_top - y0,
           ));
-          let mut emitter = content.emitter(&mut fonts, Some(&inline_map), tag_collector.as_ref());
+          let mut emitter = content.emitter(
+            &mut fonts,
+            Some(&inline_map),
+            tag_collector.as_ref(),
+            &uncovered,
+          );
 
           emitter.window = Some((y0, y0 + paint_height));
           emitter.line_window = Some((if index == 0 { f32::NEG_INFINITY } else { y0 }, next_start));
@@ -350,6 +358,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
               footer_height,
             ),
             tag_collector.is_some(),
+            &uncovered,
             &mut surface,
           )?;
         }
@@ -398,7 +407,12 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let mut surface = page.surface();
 
       surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
-      let mut emitter = content.emitter(&mut fonts, Some(&inline_map), tag_collector.as_ref());
+      let mut emitter = content.emitter(
+        &mut fonts,
+        Some(&inline_map),
+        tag_collector.as_ref(),
+        &uncovered,
+      );
 
       emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
       surface.pop();
@@ -443,6 +457,10 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         ));
       }
     }
+  }
+
+  if let Some(error) = uncovered_error(&uncovered.borrow()) {
+    return Err(error);
   }
 
   document.finish().map_err(PdfError::Krilla)

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -42,6 +42,9 @@ pub enum PdfError {
   /// An XMP schema carries a prefix, property name or namespace URI that
   /// cannot be written into XML.
   InvalidXmpSchema(String),
+  /// No registered font covers these characters. They would draw nothing and
+  /// leave no trace in the text layer, so the render stops instead.
+  MissingGlyphs(String),
 }
 
 impl From<TakumiError> for PdfError {

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -70,9 +70,11 @@ impl PreparedTree {
     fonts: &'a mut FontMap,
     inline: Option<&'a InlineMap<'a>>,
     tags: Option<&'a RefCell<TagCollector>>,
+    uncovered: &'a RefCell<String>,
   ) -> Emitter<'a> {
     Emitter {
       color_filter: None,
+      uncovered,
       root: &self.root,
       contexts: &self.contexts,
       results: &self.results,

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -1313,6 +1313,40 @@ fn invalid_xmp_schema_rejects() {
   assert!(matches!(result, Err(PdfError::InvalidXmpSchema(prefix)) if prefix == "1fx bad"));
 }
 
+/// A character no registered font covers shapes to `.notdef`. It paints nothing
+/// and leaves nothing in the text layer, so the render stops and names it
+/// instead of handing back a page with the character quietly gone.
+#[test]
+fn uncovered_character_stops_the_render() {
+  let latin_only = {
+    let mut fonts = Fonts::default();
+    let data = fs::read(
+      Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../assets/fonts/archivo/Archivo-VariableFont_wdth,wght.ttf"),
+    )
+    .expect("read test font");
+
+    fonts
+      .register(FontResource::new(data))
+      .expect("load test font");
+    fonts
+  };
+  let render_with = |content: &str| {
+    render(
+      PdfOptions::builder()
+        .node(text(content, 16.0))
+        .viewport(Viewport::new((200, 100)))
+        .fonts(&latin_only)
+        .build(),
+    )
+  };
+
+  assert!(render_with("covered").is_ok());
+  assert!(
+    matches!(render_with("uncovered \u{76F4}"), Err(PdfError::MissingGlyphs(named)) if named == "直 (U+76F4)")
+  );
+}
+
 /// The invoice carries a machine-readable XML attachment under PDF/A-3b:
 /// the file spec, association kind, and name tree all serialize, the
 /// modification date falls back to the metadata creation date, and a custom


### PR DESCRIPTION
Closes #1181.

## Why

There is no system font to fall back on, so a character outside every registered font shapes to `.notdef`. It paints nothing and leaves nothing in the text layer. The render returned `Ok`, the page looked finished, and the character was gone with no signal at any stage. Anything downstream of the text layer, search indexing and accessibility tooling included, lost the content silently.

PDF/A and PDF/UA already caught this through krilla's `ContainsNotDefGlyph`, but a plain render dropped the same signal on the floor.

## What

`render` now fails with `MissingGlyphs`, naming each uncovered character and its codepoint. The characters are collected during emission rather than raised on the spot: the surface has open transforms and clips mid-page, and unwinding past them leaves it unbalanced.

Existing goldens are unchanged, so nothing in the suite was relying on a dropped character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PDF rendering now detects characters unsupported by all registered fonts.
  - Rendering reports each missing character and its Unicode code point through a dedicated error.

- **Documentation**
  - Added guidance on font fallback behavior, invisible characters, text-layer omissions, and Google Fonts subsets.
  - Added a changelog entry describing missing-glyph errors.

- **Tests**
  - Added coverage confirming supported text renders successfully and unsupported characters produce the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->