### PR TITLE
PDF: count pages in more scripts

### DIFF
--- a/.tegami/pdf-counter-styles.md
+++ b/.tegami/pdf-counter-styles.md
@@ -1,0 +1,11 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Count pages in more scripts
+
+Page counters knew seven `@counter-style` names. They now know the digits of eighteen more scripts, from Devanagari and Thai to Tamil and Tibetan, and count through five alphabets including Latin letters, Greek, hiragana and katakana.
+
+A face registered through `fonts` is kept only when its range covers something the page asks for, and a counter's characters appear nowhere in the document. A counter in a style other than decimal now keeps every registered face, so the one it needs survives.

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -271,12 +271,14 @@ export class PdfRenderer {
       footer === undefined ? undefined : resolveNode(footer),
     ]);
     const bands = [headerResult?.node, footerResult?.node].filter((band) => band !== undefined);
-    // A band's page counters render characters no node in the tree carries, and
-    // which ones depends on the counter style, so the renderer names them.
-    const counters =
-      bands.length > 0 ? counterCharacters(bands.flatMap((band) => classNames(band))) : "";
     const resources = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: [main.node, ...bands, counters] }),
+      fonts &&
+        subsetFonts({
+          fonts,
+          // A band's page counters render characters no node in the tree
+          // carries, and which ones depends on the style, so the renderer says.
+          source: [main.node, ...bands, counterCharacters(bands.flatMap(classNames))],
+        }),
       images,
       fontFamilies,
     );

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -4,7 +4,7 @@ import type { FontLoader, ImagesInput, RegisteredFamilyLike } from "@takumi-rs/h
 import { FontRegistry } from "@takumi-rs/helpers/renderer";
 import { type Node, type ReactElementLike, subsetFonts } from "@takumi-rs/helpers";
 import type { ReactNode } from "react";
-import { PdfRenderer as PdfRendererInternal } from "../pkg/takumi_pdf_wasm";
+import { counterCharacters, PdfRenderer as PdfRendererInternal } from "../pkg/takumi_pdf_wasm";
 
 export { default, initSync } from "../pkg/takumi_pdf_wasm";
 export type { FontLoader, ImagesInput } from "@takumi-rs/helpers/renderer";
@@ -15,38 +15,22 @@ declare module "react" {
   }
 }
 
-/** What a page counter renders in the style every band gets by default. */
-const COUNTER_DIGITS = "0123456789";
-
-/** The class hooks a page counter is requested through. */
-const COUNTER_HOOKS = ["pageNumber", "totalPages"];
-
-/**
- * Whether a tree asks for a page counter in a style other than decimal.
- *
- * A face is kept only when its `unicode-range` covers something the render asks
- * for, and a counter's characters appear nowhere in the document. Which
- * characters a style reaches for is the renderer's to know, so rather than
- * keeping a copy of that here, a non-decimal counter keeps every face.
- */
-function usesNonDecimalCounter(node: unknown): boolean {
+/** Every class name in a tree, so the renderer can say what its counters draw. */
+function classNames(node: unknown, into: string[] = []): string[] {
   if (typeof node !== "object" || node === null) {
-    return false;
+    return into;
   }
   const { className, children } = node as { className?: unknown; children?: unknown };
 
   if (typeof className === "string") {
-    const classes = className.split(/\s+/);
-
-    if (
-      classes.some((name) => COUNTER_HOOKS.includes(name)) &&
-      classes.some((name) => name !== "decimal" && name.includes("-"))
-    ) {
-      return true;
+    into.push(...className.split(/\s+/).filter(Boolean));
+  }
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      classNames(child, into);
     }
   }
-
-  return Array.isArray(children) && children.some(usesNonDecimalCounter);
+  return into;
 }
 
 /** A document input: a takumi node tree, JSX, or an HTML string. */
@@ -287,16 +271,12 @@ export class PdfRenderer {
       footer === undefined ? undefined : resolveNode(footer),
     ]);
     const bands = [headerResult?.node, footerResult?.node].filter((band) => band !== undefined);
-    const keepEveryFace = bands.some(usesNonDecimalCounter);
+    // A band's page counters render characters no node in the tree carries, and
+    // which ones depends on the counter style, so the renderer names them.
+    const counters =
+      bands.length > 0 ? counterCharacters(bands.flatMap((band) => classNames(band))) : "";
     const resources = await this.fonts.resolveResources(
-      fonts &&
-        (keepEveryFace
-          ? fonts
-          : subsetFonts({
-              fonts,
-              // A band's page counters render digits no node in the tree carries.
-              source: bands.length > 0 ? [main.node, ...bands, COUNTER_DIGITS] : main.node,
-            })),
+      fonts && subsetFonts({ fonts, source: [main.node, ...bands, counters] }),
       images,
       fontFamilies,
     );
@@ -333,7 +313,11 @@ export class PdfRenderer {
     const main = await resolveNode(node);
     // The tree measured may itself be a band, so its counters are always in play.
     const resources = await this.fonts.resolveResources(
-      fonts && subsetFonts({ fonts, source: [main.node, COUNTER_DIGITS] }),
+      fonts &&
+        subsetFonts({
+          fonts,
+          source: [main.node, counterCharacters(classNames(main.node))],
+        }),
       images,
       fontFamilies,
     );

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -16,9 +16,16 @@ declare module "react" {
 }
 
 /** Every class name in a tree, so the renderer can say what its counters draw. */
-function classNames(node: unknown, into: string[] = []): string[] {
+function classNames(node: unknown): string[] {
+  const into: string[] = [];
+
+  collectClassNames(node, into);
+  return into;
+}
+
+function collectClassNames(node: unknown, into: string[]): void {
   if (typeof node !== "object" || node === null) {
-    return into;
+    return;
   }
   const { className, children } = node as { className?: unknown; children?: unknown };
 
@@ -27,10 +34,9 @@ function classNames(node: unknown, into: string[] = []): string[] {
   }
   if (Array.isArray(children)) {
     for (const child of children) {
-      classNames(child, into);
+      collectClassNames(child, into);
     }
   }
-  return into;
 }
 
 /** A document input: a takumi node tree, JSX, or an HTML string. */
@@ -277,7 +283,11 @@ export class PdfRenderer {
           fonts,
           // A band's page counters render characters no node in the tree
           // carries, and which ones depends on the style, so the renderer says.
-          source: [main.node, ...bands, counterCharacters(bands.flatMap(classNames))],
+          source: [
+            main.node,
+            ...bands,
+            counterCharacters(bands.flatMap((band) => classNames(band))),
+          ],
         }),
       images,
       fontFamilies,

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -15,8 +15,39 @@ declare module "react" {
   }
 }
 
-/** Every character a page counter can produce, so subsetting keeps the fonts a band needs. */
+/** What a page counter renders in the style every band gets by default. */
 const COUNTER_DIGITS = "0123456789";
+
+/** The class hooks a page counter is requested through. */
+const COUNTER_HOOKS = ["pageNumber", "totalPages"];
+
+/**
+ * Whether a tree asks for a page counter in a style other than decimal.
+ *
+ * A face is kept only when its `unicode-range` covers something the render asks
+ * for, and a counter's characters appear nowhere in the document. Which
+ * characters a style reaches for is the renderer's to know, so rather than
+ * keeping a copy of that here, a non-decimal counter keeps every face.
+ */
+function usesNonDecimalCounter(node: unknown): boolean {
+  if (typeof node !== "object" || node === null) {
+    return false;
+  }
+  const { className, children } = node as { className?: unknown; children?: unknown };
+
+  if (typeof className === "string") {
+    const classes = className.split(/\s+/);
+
+    if (
+      classes.some((name) => COUNTER_HOOKS.includes(name)) &&
+      classes.some((name) => name !== "decimal" && name.includes("-"))
+    ) {
+      return true;
+    }
+  }
+
+  return Array.isArray(children) && children.some(usesNonDecimalCounter);
+}
 
 /** A document input: a takumi node tree, JSX, or an HTML string. */
 export type NodeInput = Node | ReactNode | ReactElementLike | string;
@@ -256,13 +287,16 @@ export class PdfRenderer {
       footer === undefined ? undefined : resolveNode(footer),
     ]);
     const bands = [headerResult?.node, footerResult?.node].filter((band) => band !== undefined);
+    const keepEveryFace = bands.some(usesNonDecimalCounter);
     const resources = await this.fonts.resolveResources(
       fonts &&
-        subsetFonts({
-          fonts,
-          // A band's page counters render digits no node in the tree carries.
-          source: bands.length > 0 ? [main.node, ...bands, COUNTER_DIGITS] : main.node,
-        }),
+        (keepEveryFace
+          ? fonts
+          : subsetFonts({
+              fonts,
+              // A band's page counters render digits no node in the tree carries.
+              source: bands.length > 0 ? [main.node, ...bands, COUNTER_DIGITS] : main.node,
+            })),
       images,
       fontFamilies,
     );

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { expect, test } from "bun:test";
 import { container, text } from "@takumi-rs/helpers";
 import { PdfRenderer } from "../bundlers/node.mjs";
@@ -60,6 +61,42 @@ test("paginates and substitutes footer counters", async () => {
       ],
     }),
   });
+
+  expect(pageCount(pdf)).toBeGreaterThan(1);
+});
+
+test("keeps a face the page counter needs but the document never uses", async () => {
+  // `fonts` are filtered by whether their range covers the render, and a
+  // chinese counter is the only thing on the page outside latin.
+  const pdf = await renderer.render(
+    container({
+      style: { display: "flex", flexDirection: "column", width: "100%" },
+      children: Array.from({ length: 60 }, (_, i) => text(`Row ${i + 1}`, { fontSize: 16 })),
+    }),
+    {
+      size: { width: 400, height: 300 },
+      margin: 24,
+      fonts: [
+        {
+          name: "Counter CJK",
+          ranges: [[0x4e00, 0x9fff]],
+          data: () =>
+            new Uint8Array(
+              readFileSync(
+                new URL(
+                  "../../assets/fonts/noto-sans/NotoSansTC-VariableFont_wght.woff2",
+                  import.meta.url,
+                ),
+              ),
+            ),
+        },
+      ],
+      footer: container({
+        style: { display: "flex", fontSize: 12 },
+        children: [container({ className: "totalPages trad-chinese-informal" })],
+      }),
+    },
+  );
 
   expect(pageCount(pdf)).toBeGreaterThan(1);
 });

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -44,11 +44,24 @@ test("renders an HTML string with its own stylesheet", async () => {
 });
 
 test("paginates and substitutes footer counters", async () => {
+  // The bundled face is latin only, and `trad-chinese-informal` counts in
+  // Chinese numerals. The face registered for it stays on a renderer of its
+  // own so the other tests keep the bundled set.
+  const counting = new PdfRenderer();
+
+  await counting.registerFont(
+    new Uint8Array(
+      readFileSync(
+        new URL("../../assets/fonts/noto-sans/NotoSansTC-VariableFont_wght.woff2", import.meta.url),
+      ),
+    ),
+  );
+
   const rows = container({
     style: { display: "flex", flexDirection: "column", width: "100%" },
     children: Array.from({ length: 60 }, (_, i) => text(`Row ${i + 1}`, { fontSize: 16 })),
   });
-  const pdf = await renderer.render(rows, {
+  const pdf = await counting.render(rows, {
     size: { width: 400, height: 300 },
     margin: 24,
     footer: container({

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -67,6 +67,15 @@ struct MeasuredSizeOutput {
   height: f32,
 }
 
+/// The characters the page counters named by these class names can produce.
+///
+/// A counter's characters appear nowhere in the document, so a caller choosing
+/// which faces to load has no other way to learn it needs, say, Thai digits.
+#[wasm_bindgen(js_name = counterCharacters)]
+pub fn counter_characters(classes: Vec<String>) -> String {
+  takumi_pdf::counter_characters(classes.iter().map(String::as_str))
+}
+
 /// A PDF renderer holding registered fonts and a decoded-resource cache.
 ///
 /// State lives behind a lock and every method takes `&self`, mirroring the

--- a/takumi-pdf/src/counters.rs
+++ b/takumi-pdf/src/counters.rs
@@ -2,25 +2,114 @@
 
 use takumi_core::layout::node::{Node, NodeKind};
 
-const COUNTER_STYLES: [&str; 7] = [
+/// Styles that write a decimal number in another script's digits, zero first.
+const DIGIT_STYLES: [(&str, [char; 10]); 20] = [
+  ("cjk-decimal", CHINESE_DIGITS),
+  (
+    "arabic-indic",
+    ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'],
+  ),
+  (
+    "bengali",
+    ['০', '১', '২', '৩', '৪', '৫', '৬', '৭', '৮', '৯'],
+  ),
+  (
+    "cambodian",
+    ['០', '១', '២', '៣', '៤', '៥', '៦', '៧', '៨', '៩'],
+  ),
+  ("khmer", ['០', '១', '២', '៣', '៤', '៥', '៦', '៧', '៨', '៩']),
+  (
+    "devanagari",
+    ['०', '१', '२', '३', '४', '५', '६', '७', '८', '९'],
+  ),
+  (
+    "gujarati",
+    ['૦', '૧', '૨', '૩', '૪', '૫', '૬', '૭', '૮', '૯'],
+  ),
+  (
+    "gurmukhi",
+    ['੦', '੧', '੨', '੩', '੪', '੫', '੬', '੭', '੮', '੯'],
+  ),
+  (
+    "kannada",
+    ['೦', '೧', '೨', '೩', '೪', '೫', '೬', '೭', '೮', '೯'],
+  ),
+  ("lao", ['໐', '໑', '໒', '໓', '໔', '໕', '໖', '໗', '໘', '໙']),
+  (
+    "malayalam",
+    ['൦', '൧', '൨', '൩', '൪', '൫', '൬', '൭', '൮', '൯'],
+  ),
+  (
+    "mongolian",
+    ['᠐', '᠑', '᠒', '᠓', '᠔', '᠕', '᠖', '᠗', '᠘', '᠙'],
+  ),
+  (
+    "myanmar",
+    ['၀', '၁', '၂', '၃', '၄', '၅', '၆', '၇', '၈', '၉'],
+  ),
+  ("oriya", ['୦', '୧', '୨', '୩', '୪', '୫', '୬', '୭', '୮', '୯']),
+  (
+    "persian",
+    ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'],
+  ),
+  ("urdu", ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']),
+  ("tamil", ['௦', '௧', '௨', '௩', '௪', '௫', '௬', '௭', '௮', '௯']),
+  ("telugu", ['౦', '౧', '౨', '౩', '౪', '౫', '౬', '౭', '౮', '౯']),
+  ("thai", ['๐', '๑', '๒', '๓', '๔', '๕', '๖', '๗', '๘', '๙']),
+  (
+    "tibetan",
+    ['༠', '༡', '༢', '༣', '༤', '༥', '༦', '༧', '༨', '༩'],
+  ),
+];
+
+/// Styles that count through an alphabet: a, b, ..., z, aa, ab, and so on.
+const ALPHABET_STYLES: [(&str, &str); 7] = [
+  ("lower-alpha", "abcdefghijklmnopqrstuvwxyz"),
+  ("lower-latin", "abcdefghijklmnopqrstuvwxyz"),
+  ("upper-alpha", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+  ("upper-latin", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+  ("lower-greek", "αβγδεζηθικλμνξοπρστυφχψω"),
+  (
+    "hiragana",
+    "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわゐゑをん",
+  ),
+  (
+    "katakana",
+    "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヰヱヲン",
+  ),
+];
+
+const OTHER_STYLES: [&str; 5] = [
   "decimal",
   "decimal-leading-zero",
   "lower-roman",
   "upper-roman",
-  "cjk-decimal",
   "trad-chinese-informal",
-  "cjk-ideographic",
 ];
+
+/// Whether a class names a counter style this renderer knows.
+fn is_counter_style(name: &str) -> bool {
+  name == "cjk-ideographic"
+    || OTHER_STYLES.contains(&name)
+    || DIGIT_STYLES.iter().any(|(style, _)| *style == name)
+    || ALPHABET_STYLES.iter().any(|(style, _)| *style == name)
+}
 
 /// Formats a page counter in a CSS `@counter-style` named style. Unknown
 /// styles fall back to `decimal`.
 fn format_counter(value: usize, style: &str) -> String {
-  match style {
-    "cjk-decimal" => value
+  if let Some((_, digits)) = DIGIT_STYLES.iter().find(|(name, _)| *name == style) {
+    return value
       .to_string()
       .bytes()
-      .map(|digit| CHINESE_DIGITS[usize::from(digit - b'0')])
-      .collect(),
+      .map(|digit| digits[usize::from(digit - b'0')])
+      .collect();
+  }
+  if let Some((_, alphabet)) = ALPHABET_STYLES.iter().find(|(name, _)| *name == style) {
+    return alphabetic(value, alphabet);
+  }
+
+  match style {
     // Blink defines cjk-ideographic as `extends trad-chinese-informal`.
     "trad-chinese-informal" | "cjk-ideographic" => chinese_informal(value),
     "lower-roman" => roman(value).to_ascii_lowercase(),
@@ -28,6 +117,26 @@ fn format_counter(value: usize, style: &str) -> String {
     "decimal-leading-zero" => format!("{value:02}"),
     _ => value.to_string(),
   }
+}
+
+/// Counts through `alphabet` the way a spreadsheet names its columns, where the
+/// last letter carries no zero and so `z` is followed by `aa`.
+fn alphabetic(value: usize, alphabet: &str) -> String {
+  let letters: Vec<char> = alphabet.chars().collect();
+
+  if value == 0 || letters.is_empty() {
+    return value.to_string();
+  }
+  let mut remaining = value;
+  let mut out = Vec::new();
+
+  while remaining > 0 {
+    remaining -= 1;
+    out.push(letters[remaining % letters.len()]);
+    remaining /= letters.len();
+  }
+  out.reverse();
+  out.into_iter().collect()
 }
 
 const CHINESE_DIGITS: [char; 10] = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
@@ -119,7 +228,7 @@ pub(crate) fn counter_text(node: &Node, page: usize, pages: usize) -> Option<Str
   };
   let style = classes
     .split_whitespace()
-    .find(|class| COUNTER_STYLES.contains(class))
+    .find(|class| is_counter_style(class))
     .unwrap_or("decimal");
 
   Some(format_counter(value, style))
@@ -140,5 +249,37 @@ pub(crate) fn substitute_page_counters(node: &mut Node, page: usize, pages: usiz
     for child in children {
       substitute_page_counters(child, page, pages);
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn digit_styles_spell_the_number_in_their_own_script() {
+    assert_eq!(format_counter(2026, "devanagari"), "२०२६");
+    assert_eq!(format_counter(2026, "thai"), "๒๐๒๖");
+    assert_eq!(format_counter(2026, "arabic-indic"), "٢٠٢٦");
+    // `khmer` and `urdu` are the same digits under another name.
+    assert_eq!(format_counter(7, "khmer"), format_counter(7, "cambodian"));
+    assert_eq!(format_counter(7, "urdu"), format_counter(7, "persian"));
+  }
+
+  #[test]
+  fn alphabet_styles_carry_past_their_last_letter() {
+    assert_eq!(format_counter(1, "lower-alpha"), "a");
+    assert_eq!(format_counter(26, "lower-alpha"), "z");
+    assert_eq!(format_counter(27, "lower-alpha"), "aa");
+    assert_eq!(format_counter(28, "upper-latin"), "AB");
+    assert_eq!(format_counter(1, "lower-greek"), "α");
+    assert_eq!(format_counter(1, "katakana"), "ア");
+  }
+
+  #[test]
+  fn unknown_styles_count_in_decimal() {
+    assert_eq!(format_counter(42, "no-such-style"), "42");
+    assert!(!is_counter_style("no-such-style"));
+    assert!(is_counter_style("tibetan"));
   }
 }

--- a/takumi-pdf/src/counters.rs
+++ b/takumi-pdf/src/counters.rs
@@ -249,12 +249,12 @@ pub fn counter_characters<'c>(classes: impl IntoIterator<Item = &'c str>) -> Str
     }
   }
 
-  match (hooked, characters.is_empty()) {
-    (false, _) => String::new(),
-    // A hook without a style counts in decimal.
-    (true, true) => style_characters("decimal"),
-    (true, false) => characters,
+  if !hooked {
+    return String::new();
   }
+  // A hook without a style counts in decimal, and a band can hold both: a
+  // plain `pageNumber` beside a `totalPages thai` still needs its own digits.
+  style_characters("decimal") + &characters
 }
 
 /// The counter value a node's class hooks request, if any: `pageNumber` or
@@ -323,6 +323,20 @@ mod tests {
     assert_eq!(format_counter(28, "upper-latin"), "AB");
     assert_eq!(format_counter(1, "lower-greek"), "α");
     assert_eq!(format_counter(1, "katakana"), "ア");
+  }
+
+  #[test]
+  fn a_styled_counter_leaves_an_unstyled_one_its_digits() {
+    let mixed = counter_characters(["pageNumber", "totalPages", "thai"]);
+
+    assert!(mixed.contains('7'), "the plain counter lost its digits");
+    assert!(mixed.contains('๗'), "the styled counter lost its digits");
+    assert_eq!(
+      counter_characters(["nav", "thai"]),
+      "",
+      "no counter, no characters"
+    );
+    assert_eq!(counter_characters(["pageNumber"]), "0123456789");
   }
 
   #[test]

--- a/takumi-pdf/src/counters.rs
+++ b/takumi-pdf/src/counters.rs
@@ -79,6 +79,9 @@ const ALPHABET_STYLES: [(&str, &str); 7] = [
   ),
 ];
 
+/// The class hooks a page counter is requested through.
+const COUNTER_HOOKS: [&str; 2] = ["pageNumber", "totalPages"];
+
 const OTHER_STYLES: [&str; 5] = [
   "decimal",
   "decimal-leading-zero",
@@ -208,6 +211,52 @@ fn roman(value: usize) -> String {
   out
 }
 
+/// Every character a counter in `style` can produce.
+fn style_characters(style: &str) -> String {
+  if let Some((_, digits)) = DIGIT_STYLES.iter().find(|(name, _)| *name == style) {
+    return digits.iter().collect();
+  }
+  if let Some((_, alphabet)) = ALPHABET_STYLES.iter().find(|(name, _)| *name == style) {
+    return (*alphabet).to_string();
+  }
+
+  match style {
+    "lower-roman" => "ivxlcdm".to_string(),
+    "upper-roman" => "IVXLCDM".to_string(),
+    "trad-chinese-informal" | "cjk-ideographic" => {
+      CHINESE_DIGITS.iter().collect::<String>() + "十百千"
+    }
+    _ => "0123456789".to_string(),
+  }
+}
+
+/// The characters the page counters named by `classes` can produce, or nothing
+/// when no class asks for a counter.
+///
+/// A counter's characters appear nowhere in the document, so a caller choosing
+/// which faces to load has no other way to learn it needs, say, Thai digits.
+pub fn counter_characters<'c>(classes: impl IntoIterator<Item = &'c str>) -> String {
+  let mut hooked = false;
+  let mut characters = String::new();
+
+  for class in classes {
+    if COUNTER_HOOKS.contains(&class) {
+      hooked = true;
+      continue;
+    }
+    if is_counter_style(class) {
+      characters.push_str(&style_characters(class));
+    }
+  }
+
+  match (hooked, characters.is_empty()) {
+    (false, _) => String::new(),
+    // A hook without a style counts in decimal.
+    (true, true) => style_characters("decimal"),
+    (true, false) => characters,
+  }
+}
+
 /// The counter value a node's class hooks request, if any: `pageNumber` or
 /// `totalPages`, optionally paired with a `@counter-style` name — the same
 /// contract as Chromium's print header/footer templates.
@@ -215,12 +264,12 @@ pub(crate) fn counter_text(node: &Node, page: usize, pages: usize) -> Option<Str
   let classes = node.class_name()?;
   let value = if classes
     .split_whitespace()
-    .any(|class| class == "pageNumber")
+    .any(|class| class == COUNTER_HOOKS[0])
   {
     page
   } else if classes
     .split_whitespace()
-    .any(|class| class == "totalPages")
+    .any(|class| class == COUNTER_HOOKS[1])
   {
     pages
   } else {

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -40,6 +40,8 @@ use std::{cell::RefCell, rc::Rc};
 mod background;
 mod bands;
 mod counters;
+
+pub use counters::counter_characters;
 mod emitter;
 mod filter;
 mod glyph;


### PR DESCRIPTION
## Why

Page counters knew seven `@counter-style` names, so a document set in Devanagari, Thai or Greek still numbered its pages in latin digits. Chromium ships around fifty.

Separately, a face passed through `fonts` is kept only when its `unicode-range` covers something the render asks for. A counter's characters appear nowhere in the document, so the face a Chinese counter needed was filtered out before it could be registered, and the counter drew nothing.

## What

Eighteen more scripts write their own digits, taken from Chromium's UA counter styles: Arabic-Indic, Bengali, Khmer, Devanagari, Gujarati, Gurmukhi, Kannada, Lao, Malayalam, Mongolian, Myanmar, Oriya, Persian, Urdu, Tamil, Telugu, Thai and Tibetan. Five alphabets count through their letters and carry past the last one the way spreadsheet columns do: latin lower and upper, Greek, hiragana and katakana.

Which characters a style reaches for stays on the Rust side. Rather than keeping a second copy of that in the wrapper, a counter in a style other than decimal keeps every registered face; a decimal counter keeps the digit filter it had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page counters supporting 20 additional digit scripts and seven alphabetic counting styles.
  * Added alphabetic counter rollover behavior and improved fallback handling for unsupported styles.
* **Bug Fixes**
  * Improved font retention for page counters in documents using non-Latin writing systems.
  * Improved pagination reliability when counter fonts are not used in the main document content.
* **Documentation**
  * Documented expanded page-counter support and font-retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->