### PR TITLE
PDF: keep clipped-away content off every page

### DIFF
--- a/.tegami/pdf-clipped-content-leak.md
+++ b/.tegami/pdf-clipped-content-leak.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Keep clipped-away content off every page
+
+Content an `overflow` clip cut away still reached the file when it sat far enough down the page to land on a later one. A clip keeps it off the page, but not out of the text layer, so a redacted or collapsed section came back out of any tool that reads text: search, copy, an accessibility reader.

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -188,6 +188,7 @@ impl Emitter<'_> {
         ColorFilter::compose(outer_filter.as_deref(), &node.context.style.filter).map(Rc::new);
     }
 
+    let (outer_window, outer_line_window) = (self.window, self.line_window);
     let (child_frame, root_state) = match context.root() {
       Some(paint) => self.emit_box(paint, parent, surface)?,
       None => (parent, BoxState::default()),
@@ -197,6 +198,13 @@ impl Emitter<'_> {
       for item in bucket {
         match &item.kind {
           PaintItemKind::Node(paint) => {
+            // Skipping a node that paints outside the window only saves work;
+            // the page's own clip would drop it anyway. A context's root is
+            // never skipped this way, because the clip it opens decides what
+            // its descendants are allowed to emit.
+            if self.window_excludes_bounds(paint.paint_bounds) {
+              continue;
+            }
             let (_, state) = self.emit_box(paint, child_frame, surface)?;
             self.finish_box(state, surface);
           }
@@ -213,6 +221,7 @@ impl Emitter<'_> {
       }
     }
     self.finish_box(root_state, surface);
+    (self.window, self.line_window) = (outer_window, outer_line_window);
     self.color_filter = outer_filter;
     Ok(())
   }
@@ -231,9 +240,6 @@ impl Emitter<'_> {
     let Ok(layout) = self.results.layout(paint.node_id) else {
       return Ok((parent, BoxState::default()));
     };
-    if self.window_excludes_bounds(paint.paint_bounds) {
-      return Ok((parent, BoxState::default()));
-    }
 
     let style = &node.context.style;
     let mut pushed = 0;
@@ -344,6 +350,20 @@ impl Emitter<'_> {
     let mut overflow_clip = 0;
 
     if style.clips_overflow() {
+      // A clip keeps content off the page but not out of the text layer, so
+      // what it cuts away must never be emitted. Only a translated frame maps
+      // the box onto the window's axis.
+      if relative.only_translation() {
+        let (top, bottom) = (y, y + layout.size.height);
+
+        if let Some((from, to)) = self.window {
+          self.window = Some((from.max(top), to.min(bottom)));
+        }
+        // A text line is owned by its baseline, against its own window.
+        if let Some((from, to)) = self.line_window {
+          self.line_window = Some((from.max(top), to.min(bottom)));
+        }
+      }
       let clip_border = BorderProperties::from_context(&node.context, layout.size, layout.border);
       let path = if clip_border.is_zero() {
         overflow_clip_rect(style, layout, x, y)

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -1059,6 +1059,43 @@ fn blend_opacity_isolation() {
   });
 }
 
+/// A clip keeps content off the page, but a PDF clip does not keep it out of
+/// the text layer. Content an ancestor cuts away must never be emitted, or it
+/// stays extractable on whichever page its own geometry happens to land on.
+///
+/// The cut-away line is the only Chinese on the page, so the face it would need
+/// says whether it reached the file.
+#[test]
+fn a_clipped_away_line_reaches_no_page() {
+  let doc = r#"<div style="width:700px">
+    <div style="overflow:hidden;height:40px;background:#eee">
+      <div style="height:2600px">
+        <div style="margin-top:1500px;font-size:24px">裁掉的秘密</div>
+      </div>
+    </div>
+    <div style="font-size:24px;height:2200px">visible after box</div>
+  </div>"#;
+  let pdf = render(
+    PdfOptions::builder()
+      .node(from_html(doc, FromHtmlOptions::default()).expect("parse clipped doc"))
+      .page(PageOptions::A4)
+      .fonts(&fonts())
+      .build(),
+  )
+  .expect("render clipped doc");
+  let haystack = inflated_text(&pdf);
+
+  assert!(
+    embedded_subsets(&haystack, "Archivo") > 0,
+    "the fixture stopped covering what it was meant to keep"
+  );
+  assert_eq!(
+    embedded_subsets(&haystack, "NotoSansTC"),
+    0,
+    "content an overflow clip cuts away still reached the file"
+  );
+}
+
 /// Overflow clipping: rounded clip on both axes, and a single-axis clip that
 /// leaves the other axis unbounded.
 #[test]


### PR DESCRIPTION
## Why

A PDF clip keeps content off the page, but not out of the text layer: extraction reads the text-showing operator, whatever was clipping it. So the emitter has to decide not to emit at all, which is what its page window is for.

Two things kept that from happening. A box whose own geometry fell outside the page window returned from `emit_box` before opening its clip, even when it was a context root whose descendants did reach the page. And a clip never narrowed the window it passes down, so a descendant was judged against the page alone.

A section collapsed to `overflow: hidden` therefore came back out of any tool that reads text, on whichever page its own geometry happened to land on. Search, copy, an accessibility reader.

## What

A context root is no longer skipped by its own bounds; only the leaf nodes in a bucket are, where it saves work the page's own clip would do anyway. A box that clips its overflow narrows both the paint window and the line window it hands to its descendants, and the pair is restored when the context ends.

Only a translated frame narrows the window, since a rotated box does not map onto its axis. The new test holds the case; veraPDF still passes at UA-1 and A-2b, and no golden moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where text hidden by overflow clipping could still be extracted from the generated PDF.
  * Preserved visible text while preventing clipped content from appearing in the PDF text layer.
* **Tests**
  * Added regression coverage for clipped and visible text behavior.
* **Documentation**
  * Documented the PDF text-layer clipping fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->