### PR TITLE
PDF: place a transformed box whole instead of cutting inside it

### DIFF
--- a/.tegami/pdf-transform-page-window.md
+++ b/.tegami/pdf-transform-page-window.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Keep the lines inside a rotated or scaled box
+
+Positions inside a transformed box are in that box's own frame, and pagination read them as positions on the page. A `break-before: page` inside one cut the page where nothing asked for a cut, and a line could end up claimed by no page at all and vanish from the document. A transformed box is now placed whole, as CSS fragmentation already treats it.

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -125,6 +125,10 @@ pub(crate) struct Emitter<'a> {
   /// its content marked with that language, which is how a reader knows to
   /// switch voices mid-document.
   pub(crate) document_lang: Option<&'a str>,
+  /// Whether the walk sits inside a frame that is not a plain translation.
+  /// Below one, a position is in the frame's own coordinates and says nothing
+  /// about where the page cuts, so the subtree is placed by its bounds alone.
+  pub(crate) transformed: bool,
   /// Characters no registered font covered. Collected rather than raised on the
   /// spot: the surface has open transforms and clips mid-page, and unwinding
   /// past them would leave it unbalanced.
@@ -143,9 +147,10 @@ impl Emitter<'_> {
   /// ascent band, which can poke above the container a forced break cut at) and
   /// half-open, so each line is emitted exactly once.
   fn window_disowns_line(&self, baseline: f32) -> bool {
-    self
-      .line_window
-      .is_some_and(|(y0, y1)| baseline < y0 || baseline >= y1)
+    !self.transformed
+      && self
+        .line_window
+        .is_some_and(|(y0, y1)| baseline < y0 || baseline >= y1)
   }
 
   fn window_excludes_bounds(&self, bounds: Option<takumi_core::scene::SceneBounds>) -> bool {
@@ -189,6 +194,7 @@ impl Emitter<'_> {
     }
 
     let (outer_window, outer_line_window) = (self.window, self.line_window);
+    let outer_transformed = self.transformed;
     let (child_frame, root_state) = match context.root() {
       Some(paint) => self.emit_box(paint, parent, surface)?,
       None => (parent, BoxState::default()),
@@ -222,6 +228,7 @@ impl Emitter<'_> {
     }
     self.finish_box(root_state, surface);
     (self.window, self.line_window) = (outer_window, outer_line_window);
+    self.transformed = outer_transformed;
     self.color_filter = outer_filter;
     Ok(())
   }
@@ -261,6 +268,10 @@ impl Emitter<'_> {
     }
 
     let relative = parent.invert().unwrap_or(Affine::IDENTITY) * paint.transform;
+
+    if !relative.only_translation() {
+      self.transformed = true;
+    }
     let (x, y) = if relative.only_translation() {
       (relative.x, relative.y)
     } else {
@@ -353,7 +364,7 @@ impl Emitter<'_> {
       // A clip keeps content off the page but not out of the text layer, so
       // what it cuts away must never be emitted. Only a translated frame maps
       // the box onto the window's axis.
-      if relative.only_translation() {
+      if relative.only_translation() && !self.transformed {
         let (top, bottom) = (y, y + layout.size.height);
 
         self.window = Some(narrowed(self.window, top, bottom));
@@ -1445,6 +1456,7 @@ impl Emitter<'_> {
       color_filter: self.color_filter.clone(),
       uncovered: self.uncovered,
       document_lang: self.document_lang,
+      transformed: self.transformed,
     };
     let x = origin.0 + subtree.margin_offset.x;
     let y = origin.1 + subtree.margin_offset.y;
@@ -1648,6 +1660,7 @@ impl Emitter<'_> {
       return Ok(());
     };
 
+    let outer_transformed = self.transformed;
     let child_frame = match context.root() {
       Some(paint) => self.collect_box_atoms(paint, parent, atoms, forced)?,
       None => parent,
@@ -1665,6 +1678,7 @@ impl Emitter<'_> {
         }
       }
     }
+    self.transformed = outer_transformed;
     Ok(())
   }
 
@@ -1686,10 +1700,15 @@ impl Emitter<'_> {
     };
 
     let relative = parent.invert().unwrap_or(Affine::IDENTITY) * paint.transform;
+
+    if self.transformed {
+      return Ok(parent * relative);
+    }
     if !relative.only_translation() {
       if let Some(bounds) = paint.paint_bounds {
         atoms.push((bounds.top as f32, bounds.bottom as f32));
       }
+      self.transformed = true;
       return Ok(parent * relative);
     }
     let y = relative.y;

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -77,6 +77,7 @@ impl PreparedTree {
       color_filter: None,
       uncovered,
       document_lang,
+      transformed: false,
       root: &self.root,
       contexts: &self.contexts,
       results: &self.results,

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -1096,6 +1096,36 @@ fn a_clipped_away_line_reaches_no_page() {
   );
 }
 
+/// A transformed box is a single unbreakable piece, and positions inside it are
+/// in its own frame. Reading them as page coordinates cuts the page where
+/// nothing asked for a cut, and leaves a line that neither page will take.
+#[test]
+fn a_transformed_subtree_keeps_its_lines() {
+  let doc = r#"<div style="width:700px">
+    <div style="font-size:20px;height:600px">intro on the first page</div>
+    <div style="transform:rotate(3deg)">
+      <div style="height:120px;font-size:20px">first inside</div>
+      <div style="break-before:page;font-size:20px">second inside</div>
+    </div>
+    <div style="font-size:20px">tail after</div>
+  </div>"#;
+  let pdf = render(
+    PdfOptions::builder()
+      .node(from_html(doc, FromHtmlOptions::default()).expect("parse transform doc"))
+      .page(PageOptions::A4)
+      .fonts(&fonts())
+      .build(),
+  )
+  .expect("render transform doc");
+
+  // Four runs of text, and every one of them reaches a page.
+  assert_eq!(
+    inflated_text(&pdf).matches("Tf").count(),
+    4,
+    "a line inside the transform reached no page"
+  );
+}
+
 /// A single page and an inline subtree both render without a page window, and a
 /// clip inside one still decides what may be emitted. The cut-away line is the
 /// only Chinese on the page, so the face it would need says whether it reached


### PR DESCRIPTION
Stacked on #1193, which it shares the page-window logic with.

## Why

Below a rotation or a scale, a position is in that frame rather than on the page, and pagination read the two as the same thing.

A `break-before: page` inside a rotated wrapper pushed its local offset as a page cut, so the first page ended 120pt in. Worse, a line was then judged twice in two different coordinate systems: excluded from the first page by its bounds, which are in page coordinates, and disowned by the second page by its baseline, which is in the frame's. Neither page took it, and the line was gone from the document.

## What

The walk carries whether it sits below a transform. Under one, no position is read as a page coordinate: no cuts are collected, no line is disowned, and a clip narrows nothing. The box is placed by its bounds as a single piece, which is what CSS fragmentation already says about a transformed box.

The test holds a rotated wrapper with a forced break inside it and counts the runs that reach a page. No golden moves.