### PR TITLE
PDF: stop counting pages at twenty thousand

### DIFF
--- a/.tegami/pdf-page-count-limit.md
+++ b/.tegami/pdf-page-count-limit.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Stop counting pages at twenty thousand
+
+Content tall enough to cut into millions of pages walked the whole document once per page, with nothing to stop it. A render taking untrusted markup could be handed a document whose only purpose was to spend the renderer's memory. Rendering now fails with `TooManyPages` rather than trying.

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -102,7 +102,7 @@ use crate::{
     paint::FillRule,
   },
   options::{BAND_EDGE_PADDING, PT_PER_PX, build_metadata, krilla_datetime, validate_xmp_schemas},
-  pagination::page_starts,
+  pagination::{MAX_PAGES, page_starts},
   paint::rect_path,
   tags::{TagCollector, build_tag_tree, tag_id},
   tree::{TreeInputs, prepare_tree},
@@ -275,6 +275,10 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         )
         .collect_atoms(0, Affine::IDENTITY, &mut atoms, &mut forced)?;
       let starts = page_starts(&mut atoms, &mut forced, content.height, window_height);
+
+      if starts.len() >= MAX_PAGES {
+        return Err(PdfError::TooManyPages(starts.len()));
+      }
       let pages = starts.len();
       let interactive = collect_interactive(&content);
       let structural = options.tagged.names_structure_destinations();
@@ -482,6 +486,13 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn content_taller_than_a_render_allows_stops_counting() {
+    let starts = page_starts(&mut [], &mut Vec::new(), 2_000_000.0, 10.0);
+
+    assert_eq!(starts.len(), MAX_PAGES, "the page count runs unbounded");
+  }
 
   #[test]
   fn page_starts_without_atoms_cuts_at_window() {

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -42,6 +42,8 @@ pub enum PdfError {
   /// An XMP schema carries a prefix, property name or namespace URI that
   /// cannot be written into XML.
   InvalidXmpSchema(String),
+  /// The content would cut into more pages than one render may produce.
+  TooManyPages(usize),
   /// No registered font covers these characters. They would draw nothing and
   /// leave no trace in the text layer, so the render stops instead.
   MissingGlyphs(String),

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -13,6 +13,11 @@ pub(crate) type Atom = (f32, f32);
 /// atom taller than the window can never fit a page, so it does not push cuts
 /// at all — matching browsers, where `break-inside: avoid` is dropped for
 /// boxes taller than the fragmentainer.
+/// How many pages one render may cut its content into. A document tall enough
+/// to pass this is not a document anyone reads; it is a way to spend a
+/// renderer's memory.
+pub(crate) const MAX_PAGES: usize = 20_000;
+
 pub(crate) fn page_starts(
   atoms: &mut [Atom],
   forced: &mut Vec<f32>,
@@ -67,8 +72,17 @@ pub(crate) fn page_starts(
       cut = pushed_up;
     }
 
+    // The page cap is what bounds this loop; a cut that did not move would
+    // spin forever without it, so refuse that too rather than lean on the cap.
+    if cut <= y0 {
+      break;
+    }
     starts.push(cut);
     y0 = cut;
+
+    if starts.len() >= MAX_PAGES {
+      break;
+    }
   }
   starts
 }


### PR DESCRIPTION
## Why

Nothing bounded how many pages a render could cut its content into. Every page walks the whole scene, so a document a few million pages tall is a way to spend a renderer's memory rather than a document anyone reads. A service taking untrusted markup could be handed one.

The cut search could also stop advancing outright: past 2^23 a float cannot hold a half, so a small window leaves the cut where it started and the loop never reaches the end.

## What

The search refuses a cut that did not move, and stops at twenty thousand pages. Reaching that is a failed render with `TooManyPages` rather than a silently shortened document.

Only the cap is reachable, and the test covers it. The stalled-cut guard is there so the loop does not depend on the cap for its own termination.