### PR TITLE
PDF: give a link target something to point at under PDF/UA-2

### DIFF
--- a/.tegami/pdf-ua2-link-destination.md
+++ b/.tegami/pdf-ua2-link-destination.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Give a link target something to point at under PDF/UA-2
+
+A link to `#some-id` names a structure element, and PDF/UA-2 requires every link inside a document to do so. Markup with nothing to say for itself, a plain `div` holding an id, left no element behind, so the link named one that was never written and the file failed validation while the render reported success.

--- a/takumi-pdf/src/tags.rs
+++ b/takumi-pdf/src/tags.rs
@@ -160,7 +160,16 @@ fn build_node(
   let identifiers = walk.collector.take(path);
   let mut annotations = walk.collector.take_annotations(path);
 
-  match role(node, walk, nesting) {
+  let mut role = role(node, walk, nesting);
+
+  if role.is_none() && walk.targets.contains(path.as_slice()) {
+    // A destination names a structure element, and PDF/UA-2 asks every link
+    // inside a document to be one. A target that carries no meaning of its own
+    // still has to exist for the link to land on.
+    role = Some(Tag::P.into());
+  }
+
+  match role {
     Some(kind) => {
       flush_paragraph(pending, parent);
       let is_link = matches!(kind, TagKind::Link(_));
@@ -169,7 +178,9 @@ fn build_node(
       let is_figure = matches!(kind, TagKind::Figure(_));
       let mut kind = kind;
 
-      if walk.targets.contains(path.as_slice()) {
+      let is_target = walk.targets.contains(path.as_slice());
+
+      if is_target {
         kind.set_id(Some(tag_id(path)));
       }
       let mut group = TagGroup::new(kind);
@@ -226,8 +237,10 @@ fn build_node(
         }
       }
       // Inline formatting inside a text run leaves its element without any
-      // content of its own; an empty structure element is pure noise.
-      if has_content {
+      // content of its own; an empty structure element is pure noise. An
+      // element a destination names is the exception: dropping it leaves the
+      // link pointing at nothing.
+      if has_content || is_target {
         // An `LI` outside a list is invalid on its own, so it brings a list
         // of its own along.
         if is_list_item && !nesting.in_list {

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -1069,6 +1069,54 @@ fn blend_opacity_isolation() {
   });
 }
 
+/// PDF/UA-2 asks every link inside a document to name a structure element. A
+/// link can point at anything with an id, including markup that carries no
+/// meaning of its own and would otherwise leave no element to name.
+#[test]
+fn a_link_target_without_meaning_still_gets_an_element() {
+  for target in [
+    r#"<div id="target">plain target div</div>"#,
+    r#"<div id="target"></div>"#,
+  ] {
+    let doc = format!(
+      r##"<div style="width:700px;font-size:20px">
+        <p><a href="#target">jump to target</a></p>
+        <h1>heading for the outline</h1>
+        {target}
+      </div>"##
+    );
+    let pdf = render(
+      PdfOptions::builder()
+        .node(from_html(&doc, FromHtmlOptions::default()).expect("parse anchor doc"))
+        .page(PageOptions::A4)
+        .tagged(Tagging::Ua2)
+        .standard(PdfStandard::A4)
+        .lang(Some(takumi_core::style::Lang::parse("en").expect("lang")))
+        .metadata(PdfMetadata {
+          title: Some("Anchors".into()),
+          creation_date: Some(PdfDate {
+            year: 2026,
+            month: 8,
+            day: 7,
+            hour: 0,
+            minute: 0,
+            second: 0,
+          }),
+          ..Default::default()
+        })
+        .fonts(&fonts())
+        .build(),
+    )
+    .expect("render anchor doc");
+
+    // The destination names this element, so the element has to be in the file.
+    assert!(
+      inflated_text(&pdf).contains("n.0.2"),
+      "the link target left no structure element to name: {target}"
+    );
+  }
+}
+
 /// A clip keeps content off the page, but a PDF clip does not keep it out of
 /// the text layer. Content an ancestor cuts away must never be emitted, or it
 /// stays extractable on whichever page its own geometry happens to land on.


### PR DESCRIPTION
## Why

A link to `#some-id` names a structure element rather than a place on a page, which is what ISO 14289-2 §8.8 asks of every link inside a document. Markup with nothing to say for itself, a plain `div` carrying only an id, produced no element, so the link named one that was never written. krilla falls back to a page destination without complaint, and neither its validator nor the `6.3.x` font sweep looks at this, so the render reported success and the file failed veraPDF at clause 8.8.

## What

A node a destination points at is tagged as a paragraph when it has no role of its own, and is kept even when it holds nothing: an element a link names is the one case where an empty structure element earns its place.

The test covers a target with text and an empty one, and every UA fixture still passes veraPDF, UA-2 included.