### PR TITLE
Helpers: follow Unicode emoji presentation in extractEmojis

### DIFF
--- a/.tegami/emoji-presentation.md
+++ b/.tegami/emoji-presentation.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Follow Unicode emoji presentation in `extractEmojis`
+
+`extractEmojis` replaced every pictograph with a CDN image, so `‼` and `▶` came back as color emoji. Pictographs that default to text presentation now stay text, `U+FE0F` forces the emoji image, and `U+FE0E` forces the text glyph.

--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -37,9 +37,11 @@ function loadCompiler() {
 // Noto Sans superfamily across scripts. Set font-family on :host directly —
 // without Preflight nothing reads the font vars, so text would inherit the docs
 // page's font. Override every font var since the render has no serif/mono of
-// its own.
+// its own. `color` is pinned to the engine's initial value: inherited properties
+// cross the shadow boundary, so the docs theme would otherwise paint the pane's
+// text white in dark mode.
 const FONT_FAMILY = `${FONT_FAMILIES.map((name) => `"${name}"`).join(", ")}, ui-sans-serif, system-ui, sans-serif`;
-const HOST_CSS = `:host{font-family:${FONT_FAMILY};--font-sans:${FONT_FAMILY};--font-serif:${FONT_FAMILY};--font-mono:${FONT_FAMILY};--default-font-family:${FONT_FAMILY};--default-mono-font-family:${FONT_FAMILY}}`;
+const HOST_CSS = `:host{color:#000;font-family:${FONT_FAMILY};--font-sans:${FONT_FAMILY};--font-serif:${FONT_FAMILY};--font-mono:${FONT_FAMILY};--default-font-family:${FONT_FAMILY};--default-mono-font-family:${FONT_FAMILY}}`;
 
 // @font-face in a shadow root is ignored by Chrome, so load the same Google Font
 // subsets the worker uses at document level; the `css2` sheet subsets on demand.

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -189,6 +189,8 @@ export function GET() {
 }
 ```
 
+`extractEmojis` follows the Unicode presentation rules. A pictograph that defaults to text presentation, such as `‼` or `▶`, stays text and renders with your fonts. Add `U+FE0F` after it to force the emoji image, or `U+FE0E` after an emoji to keep the text glyph.
+
 #### Manual extraction
 
 `ImageResponse` calls the `extractEmojis` helper for you. The helper splits emoji from text into image nodes pointing at a CDN. Run the steps yourself to fetch emoji bytes alongside other images.

--- a/takumi-helpers/src/emoji.ts
+++ b/takumi-helpers/src/emoji.ts
@@ -5,8 +5,12 @@ export type EmojiType = "twemoji" | "blobmoji" | "noto" | "openmoji" | "fluent" 
 
 const UFE0Fg = /\uFE0F/g;
 const U200D = String.fromCharCode(0x200d);
-const EXTENDED_PICTOGRAPHIC_REGEX = /\p{Extended_Pictographic}/u;
-const REGIONAL_INDICATOR_PAIR_REGEX = /^(?:\p{Regional_Indicator}){2}$/u;
+const TEXT_VARIATION_SELECTOR = "\uFE0E";
+const EMOJI_VARIATION_SELECTOR = "\uFE0F";
+const EXTENDED_PICTOGRAPHIC_REGEX = /^\p{Extended_Pictographic}/u;
+const EMOJI_PRESENTATION_REGEX = /^\p{Emoji_Presentation}/u;
+const EMOJI_MODIFIER_SEQUENCE_REGEX = /^\p{Emoji_Modifier_Base}\p{Emoji_Modifier}/u;
+const REGIONAL_INDICATOR_REGEX = /^(?:\p{Regional_Indicator}){1,2}$/u;
 const KEYCAP_EMOJI_REGEX = /^[#*0-9]\uFE0F?\u20E3$/u;
 
 function getIconCode(char: string) {
@@ -40,11 +44,22 @@ function getSegments(text: string) {
   return Array.from(segmenter.segment(text));
 }
 
+// https://github.com/google/emoji-segmenter/blob/master/emoji_presentation_scanner.rl
 function isEmojiSegment(segment: string): boolean {
+  if (segment.includes(TEXT_VARIATION_SELECTOR)) {
+    return false;
+  }
+
+  if (REGIONAL_INDICATOR_REGEX.test(segment) || KEYCAP_EMOJI_REGEX.test(segment)) {
+    return true;
+  }
+
   return (
-    EXTENDED_PICTOGRAPHIC_REGEX.test(segment) ||
-    REGIONAL_INDICATOR_PAIR_REGEX.test(segment) ||
-    KEYCAP_EMOJI_REGEX.test(segment)
+    EXTENDED_PICTOGRAPHIC_REGEX.test(segment) &&
+    (segment.includes(EMOJI_VARIATION_SELECTOR) ||
+      segment.includes(U200D) ||
+      EMOJI_PRESENTATION_REGEX.test(segment) ||
+      EMOJI_MODIFIER_SEQUENCE_REGEX.test(segment))
   );
 }
 

--- a/takumi-helpers/tests/emoji.test.ts
+++ b/takumi-helpers/tests/emoji.test.ts
@@ -195,6 +195,44 @@ describe("emoji", () => {
       }
     });
 
+    it("should keep text-presentation pictographs as text", () => {
+      for (const content of ["‼", "\u{1F17F}", "▶", "😀︎", "1︎⃣"]) {
+        const node = text(content);
+        expect(extractEmojis(node, "twemoji")).toEqual(node);
+      }
+    });
+
+    it("should extract pictographs forced to emoji presentation", () => {
+      const cases = [
+        { content: "‼️", code: "203c" },
+        { content: "\u{1F17F}️", code: "1f17f" },
+        { content: "☝\u{1F3FD}", code: "261d-1f3fd" },
+        { content: "❤‍🔥", code: "2764-200d-1f525" },
+        { content: "🇺", code: "1f1fa" },
+      ];
+
+      for (const { content, code } of cases) {
+        const result = extractEmojis(text(content), "twemoji");
+
+        expect(result).toEqual(
+          container({
+            children: [
+              image({
+                src: `https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/${code}.svg`,
+                style: {
+                  display: "inline-block",
+                  width: "1em",
+                  height: "1em",
+                  margin: "0 0.05em 0 0.1em",
+                  verticalAlign: "-0.1em",
+                },
+              }),
+            ],
+          }),
+        );
+      }
+    });
+
     it("should preserve metadata when wrapping in container", () => {
       const props = {
         text: "😀",

--- a/takumi-helpers/tests/emoji.test.ts
+++ b/takumi-helpers/tests/emoji.test.ts
@@ -206,6 +206,7 @@ describe("emoji", () => {
       const cases = [
         { content: "‼️", code: "203c" },
         { content: "\u{1F17F}️", code: "1f17f" },
+        { content: "▶️", code: "25b6" },
         { content: "☝\u{1F3FD}", code: "261d-1f3fd" },
         { content: "❤‍🔥", code: "2764-200d-1f525" },
         { content: "🇺", code: "1f1fa" },


### PR DESCRIPTION
## Why

`extractEmojis` treated every `Extended_Pictographic` character as an emoji, so `‼`, `▶` and `U+1F17F` came back as color images and `U+FE0F` made no difference. Fixes #1213.

## What

Segment classification now follows the [emoji-segmenter](https://github.com/google/emoji-segmenter) grammar that Chromium uses. A bare pictograph is an emoji only when `Emoji_Presentation=Yes`; `U+FE0F`, ZWJ sequences, skin-tone sequences, keycaps and regional indicators still force emoji, and `U+FE0E` forces text.

A differential run against a port of that grammar leaves two deliberate gaps: a keycap base with `U+FE0F` but no `U+20E3`, and a regional indicator followed by a modifier. Chromium renders both as emoji, but the CDNs ship no asset for either sequence, so they stay text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji detection for text and emoji presentation variants.
  * Added support for flags, keycaps, skin-tone modifiers, and joined emoji sequences.
  * Ensured text-style pictographs remain text unless explicitly switched to emoji presentation.
  * Improved conversion of explicitly emoji-presented characters into the correct Twemoji assets and styling.
  * Fixed preview text color so it displays consistently regardless of the documentation theme.

* **Documentation**
  * Documented how variation selectors affect emoji rendering and extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->