### PR TITLE
Docs: render the playground browser preview in an iframe

### DIFF
--- a/.tegami/emoji-presentation.md
+++ b/.tegami/emoji-presentation.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Follow Unicode emoji presentation in `extractEmojis`
+
+`extractEmojis` replaced every pictograph with a CDN image, so `‼` and `▶` came back as color emoji. Pictographs that default to text presentation now stay text, `U+FE0F` forces the emoji image, and `U+FE0E` forces the text glyph.

--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -37,9 +37,11 @@ function loadCompiler() {
 // Noto Sans superfamily across scripts. Set font-family on :host directly —
 // without Preflight nothing reads the font vars, so text would inherit the docs
 // page's font. Override every font var since the render has no serif/mono of
-// its own.
+// its own. `color` is pinned to the engine's initial value: inherited properties
+// cross the shadow boundary, so the docs theme would otherwise paint the pane's
+// text white in dark mode.
 const FONT_FAMILY = `${FONT_FAMILIES.map((name) => `"${name}"`).join(", ")}, ui-sans-serif, system-ui, sans-serif`;
-const HOST_CSS = `:host{font-family:${FONT_FAMILY};--font-sans:${FONT_FAMILY};--font-serif:${FONT_FAMILY};--font-mono:${FONT_FAMILY};--default-font-family:${FONT_FAMILY};--default-mono-font-family:${FONT_FAMILY}}`;
+const HOST_CSS = `:host{color:#000;font-family:${FONT_FAMILY};--font-sans:${FONT_FAMILY};--font-serif:${FONT_FAMILY};--font-mono:${FONT_FAMILY};--default-font-family:${FONT_FAMILY};--default-mono-font-family:${FONT_FAMILY}}`;
 
 // @font-face in a shadow root is ignored by Chrome, so load the same Google Font
 // subsets the worker uses at document level; the `css2` sheet subsets on demand.

--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -20,7 +20,7 @@ const INPUT = `@layer theme, base, utilities;
 @import "tailwindcss/utilities.css" layer(utilities);`;
 
 // Cache the resolved compiler so a remount (e.g. mobile tab switch) can paint
-// the shadow synchronously instead of flashing through an async load.
+// the frame synchronously instead of flashing through an async load.
 let compiler: { build(candidates: string[]): string } | undefined;
 let compilerPromise: Promise<void> | undefined;
 function loadCompiler() {
@@ -34,26 +34,12 @@ function loadCompiler() {
 }
 
 // Mirror the worker's font stack so the pane routes text to the same faces: one
-// Noto Sans superfamily across scripts. Set font-family on :host directly —
-// without Preflight nothing reads the font vars, so text would inherit the docs
-// page's font. Override every font var since the render has no serif/mono of
-// its own. `color` is pinned to the engine's initial value: inherited properties
-// cross the shadow boundary, so the docs theme would otherwise paint the pane's
-// text white in dark mode.
+// Noto Sans superfamily across scripts. Set font-family on the root directly —
+// without Preflight nothing reads the font vars, so text would inherit the UA
+// default. Override every font var since the render has no serif/mono of its
+// own, and pin `color` to the engine's initial value.
 const FONT_FAMILY = `${FONT_FAMILIES.map((name) => `"${name}"`).join(", ")}, ui-sans-serif, system-ui, sans-serif`;
-const HOST_CSS = `:host{color:#000;font-family:${FONT_FAMILY};--font-sans:${FONT_FAMILY};--font-serif:${FONT_FAMILY};--font-mono:${FONT_FAMILY};--default-font-family:${FONT_FAMILY};--default-mono-font-family:${FONT_FAMILY}}`;
-
-// @font-face in a shadow root is ignored by Chrome, so load the same Google Font
-// subsets the worker uses at document level; the `css2` sheet subsets on demand.
-let fontLoaded = false;
-function loadFont() {
-  if (fontLoaded || typeof document === "undefined") return;
-  fontLoaded = true;
-  const link = document.createElement("link");
-  link.rel = "stylesheet";
-  link.href = googleFontsCssUrl();
-  document.head.append(link);
-}
+const ROOT_CSS = `:root{color-scheme:light;color:#000;font-family:${FONT_FAMILY};--font-sans:${FONT_FAMILY};--font-serif:${FONT_FAMILY};--font-mono:${FONT_FAMILY};--default-font-family:${FONT_FAMILY};--default-mono-font-family:${FONT_FAMILY}}`;
 
 function extractClasses(html: string) {
   const classes = new Set<string>();
@@ -61,6 +47,31 @@ function extractClasses(html: string) {
     for (const token of match[1].split(/\s+/)) if (token) classes.add(token);
   }
   return [...classes];
+}
+
+// The engine treats the tree's outermost node as the document root, so `rem`
+// resolves against that node's own font size. Hoist it onto `<html>` and let
+// `<body>` drop out of the box tree, otherwise `rem` here would resolve against
+// the frame's untouched root instead.
+function paintRoot(doc: Document, html: string, height: number | undefined, padding?: string) {
+  const { documentElement, body } = doc;
+
+  body.innerHTML = html;
+  const root = body.firstElementChild;
+
+  documentElement.removeAttribute("class");
+  documentElement.removeAttribute("style");
+
+  if (root) {
+    for (const { name, value } of root.attributes) documentElement.setAttribute(name, value);
+    body.replaceChildren(...root.childNodes);
+  }
+
+  body.style.display = "contents";
+  // A fixed-size frame clips like the render does; the flowing one grows to fit
+  // instead, so it must keep whatever overflow the tree asked for.
+  if (height) documentElement.style.overflow = "hidden";
+  if (padding) documentElement.style.padding = padding;
 }
 
 function useFitScale(width: number, height: number | undefined) {
@@ -96,35 +107,39 @@ export default function BrowserPreview({
   cssContents?: string[];
 }) {
   const { ref, scale } = useFitScale(width, height);
-  const hostRef = useRef<HTMLDivElement>(null);
-  const shadowRef = useRef<{ host: HTMLElement; mount: HTMLElement; sheet: CSSStyleSheet }>(
-    undefined,
-  );
+  const frameRef = useRef<HTMLIFrameElement>(null);
+  const styleRef = useRef<{ frame: HTMLIFrameElement; style: HTMLStyleElement }>(undefined);
+  // An iframe never sizes itself to its content, so the flowing layout measures
+  // the painted document and grows the frame to match.
+  const [contentHeight, setContentHeight] = useState(0);
 
   useLayoutEffect(() => {
-    const host = hostRef.current;
-    if (!host || !html) return;
+    const frame = frameRef.current;
+    const doc = frame?.contentDocument;
+    if (!frame || !doc || !html) return;
 
-    loadFont();
-
-    // The host element is swapped when the pane switches between fixed-size and
-    // flowing layouts, which leaves the old shadow root behind.
-    if (shadowRef.current?.host !== host) {
-      const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
-      const sheet = new CSSStyleSheet();
-      root.adoptedStyleSheets = [sheet];
-      const mount = document.createElement("div");
-      root.replaceChildren(mount);
-      shadowRef.current = { host, mount, sheet };
+    if (styleRef.current?.frame !== frame) {
+      // @font-face has to reach the frame's own document; a sheet in the host
+      // page never applies inside it.
+      const link = doc.createElement("link");
+      link.rel = "stylesheet";
+      link.href = googleFontsCssUrl();
+      const style = doc.createElement("style");
+      doc.head.replaceChildren(link, style);
+      styleRef.current = { frame, style };
     }
 
     const paint = () => {
-      if (!compiler || !shadowRef.current) return;
-      shadowRef.current.sheet.replaceSync(
-        [HOST_CSS, compiler.build(extractClasses(html)), ...(cssContents ?? [])].join("\n\n"),
-      );
-      shadowRef.current.mount.style.cssText = `display:flex;width:100%;height:${height ? "100%" : "auto"};padding:${padding ?? "0"}`;
-      shadowRef.current.mount.innerHTML = html;
+      if (!compiler || styleRef.current?.frame !== frame) return;
+      styleRef.current.style.textContent = [
+        ROOT_CSS,
+        compiler.build(extractClasses(html)),
+        ...(cssContents ?? []),
+      ].join("\n\n");
+      paintRoot(doc, html, height, padding);
+      // Reading the layout here forces a reflow, not a repaint: the frame is
+      // painted once, after this effect returns.
+      if (!height) setContentHeight(doc.documentElement.scrollHeight);
     };
 
     if (compiler) {
@@ -148,7 +163,13 @@ export default function BrowserPreview({
     return (
       <div ref={ref} className="h-full min-w-0 overflow-auto bg-muted/20 py-4">
         {html && (
-          <div ref={hostRef} className="mx-auto border bg-white" style={{ width, zoom: scale }} />
+          <iframe
+            ref={frameRef}
+            title="Browser preview"
+            sandbox="allow-same-origin"
+            className="mx-auto block border bg-white"
+            style={{ width, height: contentHeight, zoom: scale }}
+          />
         )}
       </div>
     );
@@ -157,9 +178,11 @@ export default function BrowserPreview({
   return (
     <div ref={ref} className="relative h-full min-w-0 overflow-hidden bg-muted/20">
       {html && (
-        <div
-          ref={hostRef}
-          className="border"
+        <iframe
+          ref={frameRef}
+          title="Browser preview"
+          sandbox="allow-same-origin"
+          className="border bg-white"
           style={{
             position: "absolute",
             top: "50%",
@@ -167,7 +190,6 @@ export default function BrowserPreview({
             width,
             height,
             transform: `translate(-50%, -50%) scale(${scale})`,
-            overflow: "hidden",
           }}
         />
       )}

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -189,6 +189,8 @@ export function GET() {
 }
 ```
 
+`extractEmojis` follows the Unicode presentation rules. A pictograph that defaults to text presentation, such as `‼` or `▶`, stays text and renders with your fonts. Add `U+FE0F` after it to force the emoji image, or `U+FE0E` after an emoji to keep the text glyph.
+
 #### Manual extraction
 
 `ImageResponse` calls the `extractEmojis` helper for you. The helper splits emoji from text into image nodes pointing at a CDN. Run the steps yourself to fetch emoji bytes alongside other images.

--- a/takumi-helpers/src/emoji.ts
+++ b/takumi-helpers/src/emoji.ts
@@ -5,8 +5,12 @@ export type EmojiType = "twemoji" | "blobmoji" | "noto" | "openmoji" | "fluent" 
 
 const UFE0Fg = /\uFE0F/g;
 const U200D = String.fromCharCode(0x200d);
-const EXTENDED_PICTOGRAPHIC_REGEX = /\p{Extended_Pictographic}/u;
-const REGIONAL_INDICATOR_PAIR_REGEX = /^(?:\p{Regional_Indicator}){2}$/u;
+const TEXT_VARIATION_SELECTOR = "\uFE0E";
+const EMOJI_VARIATION_SELECTOR = "\uFE0F";
+const EXTENDED_PICTOGRAPHIC_REGEX = /^\p{Extended_Pictographic}/u;
+const EMOJI_PRESENTATION_REGEX = /^\p{Emoji_Presentation}/u;
+const EMOJI_MODIFIER_SEQUENCE_REGEX = /^\p{Emoji_Modifier_Base}\p{Emoji_Modifier}/u;
+const REGIONAL_INDICATOR_REGEX = /^(?:\p{Regional_Indicator}){1,2}$/u;
 const KEYCAP_EMOJI_REGEX = /^[#*0-9]\uFE0F?\u20E3$/u;
 
 function getIconCode(char: string) {
@@ -40,11 +44,22 @@ function getSegments(text: string) {
   return Array.from(segmenter.segment(text));
 }
 
+// https://github.com/google/emoji-segmenter/blob/master/emoji_presentation_scanner.rl
 function isEmojiSegment(segment: string): boolean {
+  if (segment.includes(TEXT_VARIATION_SELECTOR)) {
+    return false;
+  }
+
+  if (REGIONAL_INDICATOR_REGEX.test(segment) || KEYCAP_EMOJI_REGEX.test(segment)) {
+    return true;
+  }
+
   return (
-    EXTENDED_PICTOGRAPHIC_REGEX.test(segment) ||
-    REGIONAL_INDICATOR_PAIR_REGEX.test(segment) ||
-    KEYCAP_EMOJI_REGEX.test(segment)
+    EXTENDED_PICTOGRAPHIC_REGEX.test(segment) &&
+    (segment.includes(EMOJI_VARIATION_SELECTOR) ||
+      segment.includes(U200D) ||
+      EMOJI_PRESENTATION_REGEX.test(segment) ||
+      EMOJI_MODIFIER_SEQUENCE_REGEX.test(segment))
   );
 }
 

--- a/takumi-helpers/tests/emoji.test.ts
+++ b/takumi-helpers/tests/emoji.test.ts
@@ -195,6 +195,44 @@ describe("emoji", () => {
       }
     });
 
+    it("should keep text-presentation pictographs as text", () => {
+      for (const content of ["‼", "\u{1F17F}", "▶", "😀︎", "1︎⃣"]) {
+        const node = text(content);
+        expect(extractEmojis(node, "twemoji")).toEqual(node);
+      }
+    });
+
+    it("should extract pictographs forced to emoji presentation", () => {
+      const cases = [
+        { content: "‼️", code: "203c" },
+        { content: "\u{1F17F}️", code: "1f17f" },
+        { content: "☝\u{1F3FD}", code: "261d-1f3fd" },
+        { content: "❤‍🔥", code: "2764-200d-1f525" },
+        { content: "🇺", code: "1f1fa" },
+      ];
+
+      for (const { content, code } of cases) {
+        const result = extractEmojis(text(content), "twemoji");
+
+        expect(result).toEqual(
+          container({
+            children: [
+              image({
+                src: `https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/${code}.svg`,
+                style: {
+                  display: "inline-block",
+                  width: "1em",
+                  height: "1em",
+                  margin: "0 0.05em 0 0.1em",
+                  verticalAlign: "-0.1em",
+                },
+              }),
+            ],
+          }),
+        );
+      }
+    });
+
     it("should preserve metadata when wrapping in container", () => {
       const props = {
         text: "😀",

--- a/takumi-helpers/tests/emoji.test.ts
+++ b/takumi-helpers/tests/emoji.test.ts
@@ -206,6 +206,7 @@ describe("emoji", () => {
       const cases = [
         { content: "‼️", code: "203c" },
         { content: "\u{1F17F}️", code: "1f17f" },
+        { content: "▶️", code: "25b6" },
         { content: "☝\u{1F3FD}", code: "261d-1f3fd" },
         { content: "❤‍🔥", code: "2764-200d-1f525" },
         { content: "🇺", code: "1f1fa" },


### PR DESCRIPTION
## Why

The pane mounted the tree in a shadow root, where `rem` still resolves against the docs page's `<html>`. The engine resolves it against the tree's own outermost node, so any template that sets a font size on that node drew every `rem` length 1.5x off in one pane and not the other. Inherited properties crossed the shadow boundary too, so the docs dark theme painted the preview's text white.

## What

The pane renders into an iframe and hoists the outermost node's attributes onto that document's `<html>`, with `<body>` set to `display: contents`. `rem` now resolves against the same box the engine calls the root, and the frame's own document keeps the docs theme out.

An iframe never sizes itself to its content, so the flowing PDF layout measures `scrollHeight` and grows the frame. Both the measurement and the paint happen inside one `useLayoutEffect`, so the intermediate layout is never painted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser preview rendering for more accurate sizing and `rem` behavior.
  * Fixed style and font application within previews.
  * Improved support for both flowing and fixed-size preview layouts.
  * Set preview defaults to a light color scheme with consistent text and font styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->