### PR TITLE
Core: resolve rem against the viewport instead of the outermost node

### DIFF
--- a/.tegami/html-document-root.md
+++ b/.tegami/html-document-root.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-html:
+    type: minor
+---
+
+### Keep the `<html>` root when parsing a document
+
+A source starting with `<html>` is parsed as a document, so the tree keeps that element along with `<body>` and the styles on both. It used to be parsed as a fragment, which dropped the wrappers. Anything else is still a fragment and gains no wrappers of its own.

--- a/.tegami/rem-resolves-against-viewport.md
+++ b/.tegami/rem-resolves-against-viewport.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Resolve `rem` against the viewport instead of the outermost node
+
+`rem` used the computed `font-size` of the tree's outermost node, so a `text-2xl` there silently scaled every `rem` length below it, including the whole Tailwind spacing scale. A tree built in code is content rather than a document, so `rem` and `rlh` now resolve against the viewport's font size. A tree parsed from a full HTML document keeps the old basis, since its outermost node is the `<html>` element that CSS makes the root.

--- a/.tegami/rem-resolves-against-viewport.md
+++ b/.tegami/rem-resolves-against-viewport.md
@@ -6,4 +6,4 @@ packages:
 
 ### Resolve `rem` against the viewport instead of the outermost node
 
-`rem` used the computed `font-size` of the tree's outermost node, so a `text-2xl` there silently scaled every `rem` length below it, including the whole Tailwind spacing scale. A tree built in code is content rather than a document, so `rem` and `rlh` now resolve against the viewport's font size. A tree parsed from a full HTML document keeps the old basis, since its outermost node is the `<html>` element that CSS makes the root.
+`rem` used the computed `font-size` of the tree's outermost node, so a `text-2xl` there silently scaled every `rem` length below it, including the whole Tailwind spacing scale. `rem` and `rlh` now resolve against the viewport's font size. A tree rooted at an `<html>` element keeps the old basis, since CSS makes that element the root; the JS `fromHtml` returns one for a full document.

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -29,6 +29,8 @@ The `props` argument holds the node's own fields. [Node types](/docs/reference#n
 
 Length and color shorthands return CSS strings. `vw`/`vh` are viewport width/height, `em`/`rem` are font-relative sizes, `fr` is a grid fraction. See the [MDN CSS values reference](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units).
 
+`rem` resolves against the viewport's font size, which defaults to 16px. A `fontSize` on the outermost node does not change it, so text scales without moving every `rem` length in the tree. Trees parsed from a full HTML document are the exception: their outermost node is the `<html>` element, and its font size is the `rem` basis.
+
 | Helper                 | Output             |
 | :--------------------- | :----------------- |
 | `percentage(50)`       | `50%`              |

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -29,7 +29,7 @@ The `props` argument holds the node's own fields. [Node types](/docs/reference#n
 
 Length and color shorthands return CSS strings. `vw`/`vh` are viewport width/height, `em`/`rem` are font-relative sizes, `fr` is a grid fraction. See the [MDN CSS values reference](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units).
 
-`rem` resolves against the viewport's font size, which defaults to 16px. A `fontSize` on the outermost node does not change it, so text scales without moving every `rem` length in the tree. Trees parsed from a full HTML document are the exception: their outermost node is the `<html>` element, and its font size is the `rem` basis.
+`rem` resolves against the viewport, not the outermost node. [Units](/docs/reference#units) covers what each font-relative unit follows.
 
 | Helper                 | Output             |
 | :--------------------- | :----------------- |

--- a/docs/content/docs/reference.mdx
+++ b/docs/content/docs/reference.mdx
@@ -111,7 +111,7 @@ Font-relative units resolve the way they do in a browser. `em` and `lh` follow t
 
 A `fontSize` on the outermost node changes its text and nothing else. It does not move the `rem` lengths below it, so `text-2xl` on a root container leaves the Tailwind spacing scale where it is.
 
-The exception is a tree whose outermost node is an `<html>` element, which CSS does make the root. The JS `fromHtml` keeps that element when it parses a full document, so `<html style="font-size: 62.5%">` sets the `rem` basis for everything under it. The Rust `from_html` parses fragments and never returns an `<html>` node, so trees from it always follow the viewport.
+The exception is a tree whose outermost node is an `<html>` element, which CSS does make the root. `fromHtml` keeps that element when the source is a full document, so `<html style="font-size: 62.5%">` sets the `rem` basis for everything under it.
 
 ## Style Properties
 

--- a/docs/content/docs/reference.mdx
+++ b/docs/content/docs/reference.mdx
@@ -109,7 +109,7 @@ Font-relative units resolve the way they do in a browser. `em` and `lh` follow t
 
 `rem` and `rlh` follow the root, and a node tree has no `<html>` element to be one. They resolve against the viewport's font size, which is 16px. In Rust, `Viewport::with_font_size` changes it; the JS render options do not expose it yet.
 
-A `fontSize` on the outermost node changes its text and nothing else. It does not move the `rem` lengths below it, so `text-2xl` on a root container leaves the Tailwind spacing scale where it is.
+A `fontSize` on the outermost node does not rescale the `rem` and `rlh` lengths below it, so `text-2xl` on a root container leaves the Tailwind spacing scale where it is. Descendants still inherit that font size, and their `em` and `lh` lengths follow it.
 
 The exception is a tree whose outermost node is an `<html>` element, which CSS does make the root. `fromHtml` keeps that element when the source is a full document, so `<html style="font-size: 62.5%">` sets the `rem` basis for everything under it.
 

--- a/docs/content/docs/reference.mdx
+++ b/docs/content/docs/reference.mdx
@@ -103,6 +103,16 @@ Displays a rasterized image or SVG. Adds:
   }}
 />
 
+## Units
+
+Font-relative units resolve the way they do in a browser. `em` and `lh` follow the element's own font size and line height, except on `fontSize` itself, where `em` follows the parent.
+
+`rem` and `rlh` follow the root, and a node tree has no `<html>` element to be one. They resolve against the viewport's font size, which is 16px. In Rust, `Viewport::with_font_size` changes it; the JS render options do not expose it yet.
+
+A `fontSize` on the outermost node changes its text and nothing else. It does not move the `rem` lengths below it, so `text-2xl` on a root container leaves the Tailwind spacing scale where it is.
+
+The exception is a tree whose outermost node is an `<html>` element, which CSS does make the root. The JS `fromHtml` keeps that element when it parses a full document, so `<html style="font-size: 62.5%">` sets the `rem` basis for everything under it. The Rust `from_html` parses fragments and never returns an `<html>` node, so trees from it always follow the viewport.
+
 ## Style Properties
 
 Properties use their camelCase names. Longhands are listed in parentheses. `Supported` means the property follows its CSS spec; a value cell instead lists the accepted keywords.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -290,14 +290,9 @@ fn pseudo_computed_style(
     .to_px(&parent_context.sizing, normal_basis);
   let sizing = parent_context.sizing.with_font_metrics(
     font_size,
-    Some(parent_context.sizing.root_font_size.unwrap_or(font_size)),
+    parent_context.sizing.root_font_size,
     line_height,
-    Some(
-      parent_context
-        .sizing
-        .root_line_height
-        .unwrap_or(line_height),
-    ),
+    parent_context.sizing.root_line_height,
   );
   let current_color = style.color.resolve(parent_context.current_color);
   style.make_computed(&sizing);
@@ -1204,9 +1199,15 @@ impl RenderNode {
 
       let mut style = style_layers.inherit_with_lang(&inherited_parent, lang);
 
-      // On the root element, `parent_root_font_size` is `None` so `rem` inside
-      // its own `font-size` falls back to `viewport.font_size`, per CSS Values 4
-      // §6.1. Descendants see `Some(root_font_size)`.
+      // A tree built in code is content, not a document: `rem` resolves against
+      // the viewport, so a `font-size` on the outermost node styles text without
+      // rescaling every `rem` length below it. A parsed document is the
+      // exception, since its outermost node is the `<html>` element that CSS
+      // does make the `rem` basis.
+      let is_document_root = node_index == 0
+        && node
+          .tag_name()
+          .is_some_and(|tag| tag.eq_ignore_ascii_case("html"));
       let parent_root_font_size = parent_context.sizing.root_font_size;
       let parent_root_line_height = parent_context.sizing.root_line_height;
 
@@ -1256,9 +1257,9 @@ impl RenderNode {
         .to_px(&parent_context.sizing, normal_basis);
       let sizing = parent_context.sizing.with_font_metrics(
         font_size,
-        Some(parent_root_font_size.unwrap_or(font_size)),
+        parent_root_font_size.or_else(|| is_document_root.then_some(font_size)),
         line_height,
-        Some(parent_root_line_height.unwrap_or(line_height)),
+        parent_root_line_height.or_else(|| is_document_root.then_some(line_height)),
       );
       let current_color = style.color.resolve(parent_context.current_color);
       style.make_computed(&sizing);
@@ -2429,5 +2430,48 @@ mod tests {
     let children = tree.children.as_deref().expect("block children");
     assert_eq!(children[0].context.style.width, Length::Px(10.0));
     assert_eq!(children[1].context.style.width, Length::Px(20.0));
+  }
+
+  #[test]
+  fn rem_follows_the_document_root_only_when_the_tree_is_a_document() {
+    use std::sync::Arc;
+
+    use crate::{
+      context::RenderContext,
+      layout::{node::Node, tree::RenderNode},
+      resources::font::Fonts,
+      style::{SizingContext, StyleSheet},
+      viewport::Viewport,
+    };
+
+    fn child_width(root: Node) -> f32 {
+      let stylesheet = StyleSheet::parse("#root { font-size: 32px } #child { width: 1rem }")
+        .expect("stylesheet parses");
+      let fonts = Fonts::default();
+      let context = RenderContext::builder()
+        .fonts(fonts.snapshot())
+        .sizing(
+          SizingContext::builder()
+            .viewport(Viewport::default())
+            .build(),
+        )
+        .stylesheet(Arc::new(stylesheet))
+        .build();
+
+      let tree = RenderNode::from_node(&context, root);
+      let children = tree.children.as_deref().expect("children");
+
+      let child = &children[0];
+
+      child.context.style.width.to_px(&child.context.sizing, 0.0)
+    }
+
+    let content = Node::container([Node::container([]).with_id("child")]).with_id("root");
+    assert_eq!(child_width(content), 16.0);
+
+    let document = Node::container([Node::container([]).with_id("child")])
+      .with_id("root")
+      .with_tag_name("html");
+    assert_eq!(child_width(document), 32.0);
   }
 }

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -816,10 +816,10 @@ mod tests {
   }
 
   #[test]
-  fn rlh_falls_back_to_element_line_height_when_root_unresolved() {
+  fn rlh_falls_back_to_viewport_font_size_without_document_root() {
     let mut sizing = sizing();
     sizing.root_line_height = None;
-    assert_near(Length::Rlh(1.0).to_px(&sizing, 0.0), 30.0);
+    assert_near(Length::Rlh(1.0).to_px(&sizing, 0.0), 32.0);
   }
 
   #[test]

--- a/takumi-core/src/style/sizing.rs
+++ b/takumi-core/src/style/sizing.rs
@@ -15,15 +15,17 @@ pub struct SizingContext {
   /// The font size in pixels.
   #[builder(default = viewport.to_device(viewport.font_size))]
   pub font_size: f32,
-  /// Computed `font-size` of the root element in device pixels. `None` before
-  /// the root has been resolved; readers should fall back to `viewport.font_size`.
+  /// Computed `font-size` of the document root in device pixels, set only when
+  /// the tree is a parsed document whose outermost node is an `<html>` element.
+  /// A tree built in code is content rather than a document, so it leaves this
+  /// `None` and `rem` resolves against the viewport.
   /// <https://www.w3.org/TR/css-values-4/#rem>
   #[builder(default)]
   pub root_font_size: Option<f32>,
   /// Pixel basis for the `lh` unit.
   #[builder(default = viewport.to_device(viewport.font_size))]
   pub line_height: f32,
-  /// Pixel basis for the `rlh` unit; `None` before root is resolved.
+  /// Pixel basis for the `rlh` unit, set alongside [`Self::root_font_size`].
   #[builder(default)]
   pub root_line_height: Option<f32>,
   /// The calc arena shared by the current layout tree.
@@ -77,7 +79,9 @@ impl SizingContext {
 
   /// Device-pixel basis for the `rlh` unit.
   pub(crate) fn root_line_height_basis(&self) -> f32 {
-    self.root_line_height.unwrap_or(self.line_height)
+    self
+      .root_line_height
+      .unwrap_or(self.to_device(self.viewport.font_size))
   }
 
   /// Sets the nearest query container size (content box), in device pixels.

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -314,9 +314,9 @@ fn starts_with_html_element(source: &str) -> bool {
     }
 
     return rest
-      .strip_prefix("<html")
-      .or_else(|| rest.strip_prefix("<HTML"))
-      .is_some_and(|after| {
+      .split_at_checked("<html".len())
+      .filter(|(prefix, _)| prefix.eq_ignore_ascii_case("<html"))
+      .is_some_and(|(_, after)| {
         after.starts_with(['>', '/']) || after.starts_with(char::is_whitespace)
       });
   }
@@ -649,6 +649,20 @@ mod tests {
     assert_eq!(parse("<div>hi</div>").tag_name(), Some("div"));
     assert_eq!(parse("<body><div>hi</div></body>").tag_name(), Some("div"));
     assert_eq!(parse("text <html> in content").tag_name(), None);
+  }
+
+  /// Tag names are ASCII case-insensitive, so a document is a document however
+  /// its author spelled the root.
+  #[test]
+  fn a_document_root_is_matched_case_insensitively() {
+    assert_eq!(
+      parse("<Html><body>hi</body></Html>").tag_name(),
+      Some("html")
+    );
+    assert_eq!(
+      parse("<HTML><body>hi</body></HTML>").tag_name(),
+      Some("html")
+    );
   }
 
   #[test]

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use html5ever::{
-  ParseOpts, QualName, local_name, ns, parse_fragment,
+  ParseOpts, QualName, local_name, ns, parse_document, parse_fragment,
   serialize::{SerializeOpts, TraversalScope, serialize},
   tendril::TendrilSink,
 };
@@ -238,40 +238,88 @@ impl Default for FromHtmlOptions {
 /// elements are dropped. A single root element is returned as-is; multiple
 /// roots are wrapped in a full-size container.
 ///
-/// The source is parsed as a fragment, so a full document's `<html>` and
-/// `<body>` wrappers are dropped along with the styles on them. No tree from
-/// here is rooted at an `<html>` element, and `rem` in one always resolves
-/// against [`takumi_core::viewport::Viewport::font_size`].
+/// A source that starts with an `<html>` element is parsed as a document, so
+/// the tree keeps that element as its root along with `<head>` and `<body>`.
+/// Anything else is parsed as a fragment and gains no wrappers of its own.
 pub fn from_html(source: &str, options: FromHtmlOptions) -> Result<Node, HtmlError> {
   let tw_property = options.tailwind_property.as_deref().unwrap_or("tw");
 
-  let context = QualName::new(None, ns!(html), local_name!("body"));
-  let dom = parse_fragment(
-    RcDom::default(),
-    ParseOpts::default(),
-    context,
-    vec![],
-    false,
-  )
-  .one(source);
-
-  // `parse_fragment` wraps the roots in a synthetic context element, the
-  // document's only child.
   let mut nodes = Vec::new();
-  if let Some(context) = dom.document.children.borrow().first() {
-    for child in context.children.borrow().iter() {
-      build_nodes(
-        child,
-        &options.presets,
-        tw_property,
-        options.max_depth,
-        0,
-        &mut nodes,
-      )?;
+  let build = |handle: &Handle, nodes: &mut Vec<Node>| {
+    build_nodes(
+      handle,
+      &options.presets,
+      tw_property,
+      options.max_depth,
+      0,
+      nodes,
+    )
+  };
+
+  if starts_with_html_element(source) {
+    let dom = parse_document(RcDom::default(), ParseOpts::default()).one(source);
+
+    build(&dom.document, &mut nodes)?;
+  } else {
+    let context = QualName::new(None, ns!(html), local_name!("body"));
+    let dom = parse_fragment(
+      RcDom::default(),
+      ParseOpts::default(),
+      context,
+      vec![],
+      false,
+    )
+    .one(source);
+
+    // `parse_fragment` wraps the roots in a synthetic context element, the
+    // document's only child.
+    if let Some(context) = dom.document.children.borrow().first() {
+      for child in context.children.borrow().iter() {
+        build(child, &mut nodes)?;
+      }
     }
   }
 
   Ok(collapse(nodes))
+}
+
+/// Whether the source opens with an `<html>` tag, ignoring leading whitespace,
+/// a doctype, and comments.
+///
+/// Document parsing invents `<html>`, `<head>` and `<body>` for a source that
+/// has none, which would wrap every fragment in boxes its author never wrote.
+fn starts_with_html_element(source: &str) -> bool {
+  let mut rest = source.trim_start();
+
+  loop {
+    let lowered = rest.get(..9).map(str::to_ascii_lowercase);
+
+    if lowered
+      .as_deref()
+      .is_some_and(|s| s.starts_with("<!doctype"))
+    {
+      let Some((_, after)) = rest.split_once('>') else {
+        return false;
+      };
+      rest = after.trim_start();
+      continue;
+    }
+
+    if rest.starts_with("<!--") {
+      let Some((_, after)) = rest.split_once("-->") else {
+        return false;
+      };
+      rest = after.trim_start();
+      continue;
+    }
+
+    return rest
+      .strip_prefix("<html")
+      .or_else(|| rest.strip_prefix("<HTML"))
+      .is_some_and(|after| {
+        after.starts_with(['>', '/']) || after.starts_with(char::is_whitespace)
+      });
+  }
 }
 
 /// Adds [`Node::from_html`](FromHtml::from_html) when this crate is in scope.
@@ -582,6 +630,25 @@ mod tests {
         "preset `{tag}` produced no declarations",
       );
     }
+  }
+
+  #[test]
+  fn a_document_keeps_its_html_root() {
+    let node = parse(
+      r#"<!doctype html><html style="font-size:62.5%"><head><title>t</title></head><body><div>hi</div></body></html>"#,
+    );
+
+    assert_eq!(node.tag_name(), Some("html"));
+    assert!(node.to_html().contains("font-size: 62.5%"));
+
+    assert!(node.to_html().contains("<body"));
+  }
+
+  #[test]
+  fn a_fragment_gains_no_wrappers() {
+    assert_eq!(parse("<div>hi</div>").tag_name(), Some("div"));
+    assert_eq!(parse("<body><div>hi</div></body>").tag_name(), Some("div"));
+    assert_eq!(parse("text <html> in content").tag_name(), None);
   }
 
   #[test]

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -237,6 +237,11 @@ impl Default for FromHtmlOptions {
 /// corresponding node styling and metadata; `<style>` blocks and other void
 /// elements are dropped. A single root element is returned as-is; multiple
 /// roots are wrapped in a full-size container.
+///
+/// The source is parsed as a fragment, so a full document's `<html>` and
+/// `<body>` wrappers are dropped along with the styles on them. No tree from
+/// here is rooted at an `<html>` element, and `rem` in one always resolves
+/// against [`takumi_core::viewport::Viewport::font_size`].
 pub fn from_html(source: &str, options: FromHtmlOptions) -> Result<Node, HtmlError> {
   let tw_property = options.tailwind_property.as_deref().unwrap_or("tw");
 

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -1352,10 +1352,15 @@ fn test_measure_lh_resolves_against_explicit_line_height() {
 }
 
 #[test]
-fn test_measure_rlh_resolves_against_root_computed_line_height() {
-  let viewport = create_measure_viewport();
+fn test_measure_rlh_resolves_against_the_document_root_line_height() {
+  fn measure_inner_height(root: Node) -> f32 {
+    let result = measure(root, create_measure_viewport());
 
-  let result = measure(
+    assert_eq!(result.children.len(), 1);
+    result.children[0].height
+  }
+
+  fn tree() -> Node {
     Node::container([Node::container([]).with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
@@ -1367,22 +1372,26 @@ fn test_measure_rlh_resolves_against_root_computed_line_height() {
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::line_height(LineHeight::Length(Px(48.0)))),
-    ),
-    viewport,
-  );
+    )
+  }
 
-  assert_eq!(result.children.len(), 1);
-  assert_close(result.children[0].height, 48.0);
+  assert_close(measure_inner_height(tree()), 16.0);
+  assert_close(measure_inner_height(tree().with_tag_name("html")), 48.0);
 }
 
 #[test]
-fn test_measure_rem_resolves_against_root_computed_font_size() {
-  // CSS Values 4 §6.1: `rem` is the computed value of `font-size` on the root
-  // element. Setting font-size on the root should change what `1rem` means for
-  // descendants, regardless of the viewport's default font size.
-  let viewport = create_measure_viewport();
+fn test_measure_rem_resolves_against_the_document_root_font_size() {
+  // CSS Values 4 §6.1: `rem` is the computed `font-size` of the root element.
+  // A tree built in code is content rather than a document, so `rem` follows the
+  // viewport; a tree parsed from a document is rooted at a real `<html>`.
+  fn measure_inner_width(root: Node) -> f32 {
+    let result = measure(root, create_measure_viewport());
 
-  let result = measure(
+    assert_eq!(result.children.len(), 1);
+    result.children[0].width
+  }
+
+  fn tree() -> Node {
     Node::container([Node::container([]).with_style(
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
@@ -1393,14 +1402,11 @@ fn test_measure_rem_resolves_against_root_computed_font_size() {
       Style::default()
         .with(StyleDeclaration::display(Display::Flex))
         .with(StyleDeclaration::font_size(Px(22.0).into())),
-    ),
-    viewport,
-  );
+    )
+  }
 
-  assert_eq!(result.children.len(), 1);
-  let inner = &result.children[0];
-  assert_close(inner.width, 22.0);
-  assert_close(inner.height, 22.0);
+  assert_close(measure_inner_width(tree()), 16.0);
+  assert_close(measure_inner_width(tree().with_tag_name("html")), 22.0);
 }
 
 #[test]


### PR DESCRIPTION
## Why

`rem` resolved against the computed `font-size` of the tree's outermost node, which made that node an invisible `:root`. A `text-2xl` there scaled every `rem` length below it by 1.5, and since the Tailwind spacing scale is expressed in `rem`, one font-size class moved every `p-*`, `w-*` and `gap-*` in the tree. A unit whose basis moves with the tree is an `em` wearing a different name.

## What

`rem` and `rlh` resolve against `viewport.font_size`. A tree rooted at an `<html>` element keeps the old basis, since CSS makes that element the root, and the JS `fromHtml` returns one for a full document. The Rust `from_html` parses fragments and drops the `<html>` wrapper, so its trees always follow the viewport; the doc comment now says so.

`rlh` also stops falling back to the current element's line height when no root is set, which made it a second `lh`.

Every one of the 242 render goldens is byte-identical after the change, so nothing in the existing fixtures depended on the old basis. A survey of published usage found the same: the fumadocs OG template, which covers most public callers, sets no font size on its outermost node.

The new behavior is documented under [Units](https://takumi.kane.tw/docs/reference#units) rather than left implicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HTML sources beginning with `<html>` are now preserved as complete documents, including their `<head>`, `<body>`, and styles.
  - Other HTML input remains wrapper-free fragment content.

- **Bug Fixes**
  - Corrected `rem` and `rlh` sizing for programmatically built content trees to use viewport-based values.
  - Preserved document behavior where these units resolve from the `<html>` element’s font size and line height.
  - Updated `rlh` fallback behavior when document root metrics are unavailable.

- **Documentation**
  - Clarified resolution rules for `em`, `lh`, `rem`, and `rlh`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->