### PR TITLE
fix(showcase): fix motion gpu og image url

### DIFF
--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -84,7 +84,7 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
-    image: "https://www.motion-gpu.dev/docs/og",
+    image: "https://www.motion-gpu.dev/docs/og/index",
     url: "https://www.motion-gpu.dev/",
     width: 1200,
     height: 630,


### PR DESCRIPTION
Motion GPU has changed a couple of things recently, including Open Graph Image url. This PR just fixes URL/broken image on https://takumi.kane.tw/showcase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Motion GPU showcase image URL to display the correct image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->