### PR TITLE
Raster: stop rebuilding the sampler for every background-image pixel

### DIFF
--- a/.tegami/background-image-sampling-hoist.md
+++ b/.tegami/background-image-sampling-hoist.md
@@ -6,4 +6,4 @@ packages:
 
 ### Stop rebuilding the sampler for every background-image pixel
 
-Sampling a `background-image` bitmap re-derived the source dimensions, the sampling footprint and a length-checked `PixmapRef` over the whole image once per pixel, none of which depend on the pixel. That state is resolved once per tile now. A background drawn at the bitmap's own size is also handed to the compositor as the source pixmap it already is, instead of being resampled, since at 1:1 every `image-rendering` mode returns the source pixel anyway. On a 397×2160 wallpaper behind a full-height panel: 18.7 ms to 1.5 ms plain, 22.6 ms to 4.8 ms under `border-radius`, 31.3 ms to 18.4 ms under a rotation, and roughly 22% off a downscaled background. Output is unchanged.
+Sampling a bitmap background rebuilt the source dimensions, the sampling footprint and a length-checked `PixmapRef` for every pixel. That state is resolved once per tile now. A background drawn at the bitmap's own size is composited as the source pixmap instead of being resampled. Output is unchanged.

--- a/.tegami/background-image-sampling-hoist.md
+++ b/.tegami/background-image-sampling-hoist.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-raster:
+    type: patch
+---
+
+### Stop rebuilding the sampler for every background-image pixel
+
+Sampling a `background-image` bitmap re-derived the source dimensions, the sampling footprint and a length-checked `PixmapRef` over the whole image once per pixel, none of which depend on the pixel. That state is resolved once per tile now. A background drawn at the bitmap's own size is also handed to the compositor as the source pixmap it already is, instead of being resampled, since at 1:1 every `image-rendering` mode returns the source pixel anyway. On a 397×2160 wallpaper behind a full-height panel: 18.7 ms to 1.5 ms plain, 22.6 ms to 4.8 ms under `border-radius`, 31.3 ms to 18.4 ms under a rotation, and roughly 22% off a downscaled background. Output is unchanged.

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -9,7 +9,7 @@ use takumi_core::{
   },
   paint::{ConicGradientTile, GradientOverlayTile, LinearGradientTile, RadialGradientTile},
 };
-use tiny_skia::{IntSize, Pixmap, PixmapMut, PremultipliedColorU8};
+use tiny_skia::{IntSize, Pixmap, PixmapMut, PixmapRef, PremultipliedColorU8};
 
 #[cfg(feature = "svg")]
 use crate::resources::image::RenderedImage;
@@ -190,6 +190,98 @@ impl ColorTile {
   }
 }
 
+/// Everything about sampling a [`BackgroundTile::SampledBitmap`] that does not
+/// depend on the pixel being sampled: the source view, the sizes the mapping
+/// divides by, and the footprint. Resolved once per tile, not per pixel.
+#[derive(Clone, Copy)]
+pub(crate) struct SampledBitmapView<'a> {
+  source: PixmapRef<'a>,
+  algorithm: ImageScalingAlgorithm,
+  /// The source's own size, and the size the tile is drawn at. Equal sizes are
+  /// the identity mapping.
+  source_size: Size<u32>,
+  logical_size: Size<u32>,
+  footprint: SamplingFootprint,
+}
+
+impl<'a> SampledBitmapView<'a> {
+  fn new(
+    source: &'a ImageBuffer,
+    width: u32,
+    height: u32,
+    algorithm: ImageScalingAlgorithm,
+  ) -> Option<Self> {
+    let source_size = Size {
+      width: source.width(),
+      height: source.height(),
+    };
+    let logical_size = Size { width, height };
+
+    Some(Self {
+      source: pixmap_ref_from_buffer(source)?,
+      algorithm,
+      source_size,
+      logical_size,
+      footprint: SamplingFootprint::new(
+        source_size.width.max(1) as f32 / logical_size.width.max(1) as f32,
+        source_size.height.max(1) as f32 / logical_size.height.max(1) as f32,
+      ),
+    })
+  }
+
+  /// The source pixmap when the tile is drawn at exactly the source's size, so
+  /// destination pixel `(x, y)` is source pixel `(x, y)`.
+  ///
+  /// Every sampler agrees there. The sample lands on `x + 0.5`, which nearest
+  /// floors back to `x` and bilinear resolves to the same texel at zero
+  /// interpolation weight, and a one-pixel footprint never minifies. So the
+  /// scaling algorithm can be ignored and the pixels copied as they are.
+  pub(crate) fn identity_source(&self) -> Option<PixmapRef<'a>> {
+    (self.source_size == self.logical_size).then_some(self.source)
+  }
+
+  /// Keep the `(x + 0.5) * source / logical` form, casts included. Folding the
+  /// division into a precomputed scale rounds differently and shifts which texel
+  /// a minified sample lands on.
+  #[inline]
+  pub(crate) fn sample(&self, x: u32, y: u32) -> PremultipliedColorU8 {
+    interpolate_with_footprint(
+      PaintSource::from(self.source),
+      self.algorithm,
+      (x as f32 + 0.5) * self.source_size.width.max(1) as f32
+        / self.logical_size.width.max(1) as f32,
+      (y as f32 + 0.5) * self.source_size.height.max(1) as f32
+        / self.logical_size.height.max(1) as f32,
+      self.footprint,
+    )
+    .unwrap_or(PremultipliedColorU8::TRANSPARENT)
+  }
+
+  /// Copies source row `y` into `dst` when the tile is drawn 1:1, reporting
+  /// whether it did. A mismatched width would misalign the row offsets, so it
+  /// falls back to sampling.
+  fn try_copy_row(&self, y: u32, dst: &mut [[u8; 4]]) -> bool {
+    let Some(source) = self.identity_source() else {
+      return false;
+    };
+    if source.width() as usize != dst.len() {
+      return false;
+    }
+
+    let stride = dst.len() * 4;
+    let Some(row) = source
+      .data()
+      .get(y as usize * stride..)
+      .and_then(|rest| rest.get(..stride))
+    else {
+      return false;
+    };
+
+    dst.copy_from_slice(bytemuck::cast_slice(row));
+    true
+  }
+}
+
 pub(crate) enum BackgroundTile {
   Linear(LinearGradientTile),
   Radial(RadialGradientTile),
@@ -237,33 +329,27 @@ impl BackgroundTile {
       Self::Radial(t) => t.sample_pixel(x, y),
       Self::Conic(t) => t.sample_pixel(x, y),
       Self::Pixmap(t) => PaintSource::from(t.as_ref()).get_pixel(x, y),
-      Self::SampledBitmap {
-        source,
-        width,
-        height,
-        algo,
-      } => {
-        let logical_width = (*width).max(1);
-        let logical_height = (*height).max(1);
-        let source_width = source.width().max(1);
-        let source_height = source.height().max(1);
-
-        let mapped_x = (x as f32 + 0.5) * source_width as f32 / logical_width as f32;
-        let mapped_y = (y as f32 + 0.5) * source_height as f32 / logical_height as f32;
-        let footprint = SamplingFootprint::new(
-          source_width as f32 / logical_width as f32,
-          source_height as f32 / logical_height as f32,
-        );
-
-        let Some(pixmap_ref) = pixmap_ref_from_buffer(source.as_ref()) else {
-          return PremultipliedColorU8::TRANSPARENT;
-        };
-        let source = PaintSource::from(pixmap_ref);
-        interpolate_with_footprint(source, *algo, mapped_x, mapped_y, footprint)
-          .unwrap_or(PremultipliedColorU8::TRANSPARENT)
-      }
+      Self::SampledBitmap { .. } => self
+        .sampled_bitmap_view()
+        .map_or(PremultipliedColorU8::TRANSPARENT, |view| view.sample(x, y)),
       Self::Color(t) => t.get_pixel(x, y),
     }
+  }
+
+  /// The hoisted sampling state for a [`Self::SampledBitmap`], so a caller that
+  /// walks many pixels resolves the source once instead of per pixel.
+  pub(crate) fn sampled_bitmap_view(&self) -> Option<SampledBitmapView<'_>> {
+    let Self::SampledBitmap {
+      source,
+      width,
+      height,
+      algo,
+    } = self
+    else {
+      return None;
+    };
+
+    SampledBitmapView::new(source.as_ref(), *width, *height, *algo)
   }
 
   pub(crate) fn rasterize_row(&self, y: u32, width: u32, dst: &mut [u8]) {
@@ -292,8 +378,17 @@ impl BackgroundTile {
         }
       }
       Self::SampledBitmap { .. } => {
+        let Some(view) = self.sampled_bitmap_view() else {
+          pixels.fill([0; 4]);
+          return;
+        };
+
+        if view.try_copy_row(y, pixels) {
+          return;
+        }
+
         for (x, chunk) in pixels.iter_mut().enumerate() {
-          let p = self.get_pixel(x as u32, y);
+          let p = view.sample(x as u32, y);
           *chunk = [p.red(), p.green(), p.blue(), p.alpha()];
         }
       }
@@ -568,4 +663,104 @@ pub(crate) fn collect_background_layers(
   }
 
   Ok(layers)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{collections::HashMap, sync::Arc};
+
+  use super::*;
+  use crate::{
+    Fonts, RenderOptions,
+    layout::node::Node,
+    render,
+    resources::image::ImageSource,
+    style::{
+      BackgroundImages, BackgroundRepeats, BackgroundSizes, FromCssStr, ImageScalingAlgorithm,
+      Length::Percentage, Style, StyleDeclaration,
+    },
+    viewport::Viewport,
+  };
+
+  const BITMAP_URL: &str = "test://bitmap";
+
+  /// Opaque so the premultiplied round-trip through the canvas is lossless and
+  /// the rendered bytes can be compared against the source directly.
+  fn opaque_source(width: u32, height: u32) -> (Vec<u8>, ImageSource) {
+    let mut data = Vec::with_capacity((width as usize) * (height as usize) * 4);
+    for y in 0..height {
+      for x in 0..width {
+        data.extend_from_slice(&[
+          (x * 7 % 256) as u8,
+          (y * 11 % 256) as u8,
+          ((x + y) * 13 % 256) as u8,
+          u8::MAX,
+        ]);
+      }
+    }
+
+    let source = ImageBuffer::from_rgba_bytes(data.clone(), width, height)
+      .map(ImageSource::from)
+      .expect("source buffer dimensions");
+    (data, source)
+  }
+
+  fn render_background(
+    source: ImageSource,
+    viewport: (u32, u32),
+    algorithm: ImageScalingAlgorithm,
+  ) -> Vec<u8> {
+    let fonts = Fonts::default();
+    let node = Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::width(Percentage(100.0)))
+        .with(StyleDeclaration::height(Percentage(100.0)))
+        .with(StyleDeclaration::background_image(Some(
+          BackgroundImages::from_css_str(&format!("url({BITMAP_URL})")).expect("background url"),
+        )))
+        .with(StyleDeclaration::background_size(
+          BackgroundSizes::from_css_str("100% 100%").expect("background size"),
+        ))
+        .with(StyleDeclaration::background_repeat(
+          BackgroundRepeats::from_css_str("no-repeat").expect("background repeat"),
+        ))
+        .with(StyleDeclaration::image_rendering(algorithm)),
+    );
+
+    let options = RenderOptions::builder()
+      .fonts(&fonts)
+      .viewport(Viewport::new(viewport))
+      .node(node)
+      .images(HashMap::from([(Arc::from(BITMAP_URL), source)]))
+      .build();
+
+    render(options).expect("render background").into_raw()
+  }
+
+  /// A background drawn at the source's own size is a copy of the source, so
+  /// every `image-rendering` value has to agree with it and with each other.
+  #[test]
+  fn one_to_one_background_copies_the_source_for_every_algorithm() {
+    let (expected, source) = opaque_source(64, 48);
+
+    let auto = render_background(source.clone(), (64, 48), ImageScalingAlgorithm::Auto);
+    let smooth = render_background(source.clone(), (64, 48), ImageScalingAlgorithm::Smooth);
+    let pixelated = render_background(source, (64, 48), ImageScalingAlgorithm::Pixelated);
+
+    assert_eq!(auto, expected);
+    assert_eq!(smooth, expected);
+    assert_eq!(pixelated, expected);
+  }
+
+  /// The fast path must not swallow `image-rendering` for a genuinely scaled
+  /// background: nearest and the smooth samplers disagree there.
+  #[test]
+  fn scaled_background_still_honours_image_rendering() {
+    let (_, source) = opaque_source(64, 48);
+
+    let auto = render_background(source.clone(), (32, 24), ImageScalingAlgorithm::Auto);
+    let pixelated = render_background(source, (32, 24), ImageScalingAlgorithm::Pixelated);
+
+    assert_ne!(auto, pixelated);
+  }
 }

--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -191,15 +191,14 @@ impl ColorTile {
 }
 
 /// Everything about sampling a [`BackgroundTile::SampledBitmap`] that does not
-/// depend on the pixel being sampled: the source view, the sizes the mapping
+/// depend on the pixel being sampled: the source view, the size the mapping
 /// divides by, and the footprint. Resolved once per tile, not per pixel.
 #[derive(Clone, Copy)]
 pub(crate) struct SampledBitmapView<'a> {
   source: PixmapRef<'a>,
   algorithm: ImageScalingAlgorithm,
-  /// The source's own size, and the size the tile is drawn at. Equal sizes are
-  /// the identity mapping.
-  source_size: Size<u32>,
+  /// The size the tile is drawn at. When it equals the source's own size the
+  /// mapping is the identity.
   logical_size: Size<u32>,
   footprint: SamplingFootprint,
 }
@@ -211,20 +210,16 @@ impl<'a> SampledBitmapView<'a> {
     height: u32,
     algorithm: ImageScalingAlgorithm,
   ) -> Option<Self> {
-    let source_size = Size {
-      width: source.width(),
-      height: source.height(),
-    };
+    let source = pixmap_ref_from_buffer(source)?;
     let logical_size = Size { width, height };
 
     Some(Self {
-      source: pixmap_ref_from_buffer(source)?,
+      source,
       algorithm,
-      source_size,
       logical_size,
       footprint: SamplingFootprint::new(
-        source_size.width.max(1) as f32 / logical_size.width.max(1) as f32,
-        source_size.height.max(1) as f32 / logical_size.height.max(1) as f32,
+        source.width() as f32 / logical_size.width.max(1) as f32,
+        source.height() as f32 / logical_size.height.max(1) as f32,
       ),
     })
   }
@@ -237,7 +232,9 @@ impl<'a> SampledBitmapView<'a> {
   /// interpolation weight, and a one-pixel footprint never minifies. So the
   /// scaling algorithm can be ignored and the pixels copied as they are.
   pub(crate) fn identity_source(&self) -> Option<PixmapRef<'a>> {
-    (self.source_size == self.logical_size).then_some(self.source)
+    (self.source.width() == self.logical_size.width
+      && self.source.height() == self.logical_size.height)
+      .then_some(self.source)
   }
 
   /// Keep the `(x + 0.5) * source / logical` form, casts included. Folding the
@@ -248,10 +245,8 @@ impl<'a> SampledBitmapView<'a> {
     interpolate_with_footprint(
       PaintSource::from(self.source),
       self.algorithm,
-      (x as f32 + 0.5) * self.source_size.width.max(1) as f32
-        / self.logical_size.width.max(1) as f32,
-      (y as f32 + 0.5) * self.source_size.height.max(1) as f32
-        / self.logical_size.height.max(1) as f32,
+      (x as f32 + 0.5) * self.source.width() as f32 / self.logical_size.width.max(1) as f32,
+      (y as f32 + 0.5) * self.source.height() as f32 / self.logical_size.height.max(1) as f32,
       self.footprint,
     )
     .unwrap_or(PremultipliedColorU8::TRANSPARENT)
@@ -269,11 +264,8 @@ impl<'a> SampledBitmapView<'a> {
     }
 
     let stride = dst.len() * 4;
-    let Some(row) = source
-      .data()
-      .get(y as usize * stride..)
-      .and_then(|rest| rest.get(..stride))
-    else {
+    let start = y as usize * stride;
+    let Some(row) = source.data().get(start..start + stride) else {
       return false;
     };
 

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -150,6 +150,39 @@ fn blit_sampled_paint_source_translation(
   }
 }
 
+/// Walks the destination region row by row, pulling each pixel from `sample`
+/// in source-local coordinates.
+fn blit_rows_from_sampler(
+  pixels: &mut [[u8; 4]],
+  canvas_width: u32,
+  bounds: OverlayBounds,
+  mode: BlendMode,
+  combined_mask: Option<MaskView<'_>>,
+  sample: impl Fn(u32, u32) -> [u8; 4],
+) {
+  for dest_y in bounds.y_min..bounds.y_max {
+    let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
+    if mask_row.is_some_and(|row| row.is_empty()) {
+      continue;
+    }
+
+    let src_y = (dest_y - bounds.offset_y) as u32;
+    let dst_row = dest_y as usize * canvas_width as usize;
+    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
+      let src = sample((dest_x - bounds.offset_x) as u32, src_y);
+      if src[3] == 0 {
+        continue;
+      }
+
+      let Some(src) = apply_mask_row(src, mask_row, i) else {
+        continue;
+      };
+
+      blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
+    }
+  }
+}
+
 fn blit_paint_source_translation(
   pixmap: &mut PixmapMut<'_>,
   source: PaintSource<'_>,
@@ -157,6 +190,13 @@ fn blit_paint_source_translation(
   mode: BlendMode,
   combined_mask: Option<MaskView<'_>>,
 ) {
+  // Sampling a bitmap background drawn at its own size returns the source pixel
+  // unchanged, so hand the pixmap straight to the copy path below.
+  let source = source
+    .sampled_bitmap_view()
+    .and_then(|view| view.identity_source())
+    .map_or(source, PaintSource::Pixmap);
+
   if let Some(color) = source.premultiplied_constant() {
     blit_solid_translation(
       pixmap,
@@ -226,37 +266,27 @@ fn blit_paint_source_translation(
         }
       }
     }
-    _ => {
-      for dest_y in bounds.y_min..bounds.y_max {
-        let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
-        if mask_row.is_some_and(|row| row.is_empty()) {
-          continue;
-        }
-
-        let src_y = (dest_y - bounds.offset_y) as f32;
-        let dst_row = dest_y as usize * canvas_width as usize;
-        for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
-          let src_x = (dest_x - bounds.offset_x) as f32;
-          let src = sample_paint_source(
+    // A bitmap tile samples through a view resolved once here. The generic
+    // sampler below reads the same texels, but rebuilds that view per pixel.
+    _ => match source.sampled_bitmap_view() {
+      Some(view) => {
+        blit_rows_from_sampler(pixels, canvas_width, bounds, mode, combined_mask, |x, y| {
+          premultiplied_from_pixel(view.sample(x, y))
+        });
+      }
+      None => {
+        blit_rows_from_sampler(pixels, canvas_width, bounds, mode, combined_mask, |x, y| {
+          sample_paint_source(
             source,
             ImageScalingAlgorithm::Pixelated,
-            src_x,
-            src_y,
+            x as f32,
+            y as f32,
             SamplingFootprint::PIXEL,
           )
-          .unwrap_or([0; 4]);
-          if src[3] == 0 {
-            continue;
-          }
-
-          let Some(src) = apply_mask_row(src, mask_row, i) else {
-            continue;
-          };
-
-          blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
-        }
+          .unwrap_or([0; 4])
+        });
       }
-    }
+    },
   }
 }
 

--- a/takumi-raster/src/canvas/paint_source.rs
+++ b/takumi-raster/src/canvas/paint_source.rs
@@ -2,7 +2,7 @@ use image::Rgba;
 use tiny_skia::{PixmapRef, PremultipliedColorU8};
 
 use crate::{
-  BackgroundTile, ColorTile,
+  BackgroundTile, ColorTile, SampledBitmapView,
   blend::{premultiplied_from_pixel, premultiply_rgba},
   canvas::{composite_premultiplied_over, scratch::uninit_buffer},
   style::{Color, ImageScalingAlgorithm},
@@ -81,6 +81,16 @@ impl<'a> PaintSource<'a> {
     match self {
       Self::Pixmap(source) => Some(source),
       Self::BackgroundTile(BackgroundTile::Pixmap(source)) => Some(source.as_ref().as_ref()),
+      // A bitmap background drawn at its own size already is its source pixmap.
+      Self::BackgroundTile(tile) => tile.sampled_bitmap_view()?.identity_source(),
+      _ => None,
+    }
+  }
+
+  /// The hoisted sampling state when this source is a bitmap background tile.
+  pub(crate) fn sampled_bitmap_view(self) -> Option<SampledBitmapView<'a>> {
+    match self {
+      Self::BackgroundTile(tile) => tile.sampled_bitmap_view(),
       _ => None,
     }
   }
@@ -104,9 +114,14 @@ impl<'a> PaintSource<'a> {
     let width = self.width();
     let height = self.height();
     let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(dst);
+    let sampled = self.sampled_bitmap_view();
     for y in 0..height {
       for x in 0..width {
-        pixels[(y * width + x) as usize] = premultiplied_from_pixel(self.get_pixel(x, y));
+        let pixel = match sampled {
+          Some(view) => view.sample(x, y),
+          None => self.get_pixel(x, y),
+        };
+        pixels[(y * width + x) as usize] = premultiplied_from_pixel(pixel);
       }
     }
   }

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -76,6 +76,10 @@ workspace = true
 all-features = true
 
 [[bench]]
+name = "background"
+harness = false
+
+[[bench]]
 name = "canvas"
 harness = false
 

--- a/takumi/benches/background.rs
+++ b/takumi/benches/background.rs
@@ -1,7 +1,7 @@
 //! Background-image rasterization at the size of a full-height sidebar panel.
 //!
 //! A bitmap drawn 1:1 as a background should cost about what the same bitmap
-//! costs as an `<image>` node, so both are measured against an empty panel.
+//! costs as an `<image>` node, so the latter is measured as the baseline.
 
 use std::{collections::HashMap, hint::black_box, sync::Arc};
 
@@ -104,9 +104,6 @@ fn bench_background(c: &mut Criterion) {
 
   let mut group = c.benchmark_group("background");
 
-  group.bench_function("no_image", |b| {
-    b.iter(|| render_node(&fonts, black_box(panel(base_style())), &no_images))
-  });
   group.bench_function("image_node", |b| {
     b.iter(|| render_node(&fonts, black_box(image_node(source.clone())), &no_images))
   });
@@ -115,15 +112,6 @@ fn bench_background(c: &mut Criterion) {
       render_node(
         &fonts,
         black_box(panel(background_style(ImageScalingAlgorithm::Auto))),
-        &images,
-      )
-    })
-  });
-  group.bench_function("one_to_one_pixelated", |b| {
-    b.iter(|| {
-      render_node(
-        &fonts,
-        black_box(panel(background_style(ImageScalingAlgorithm::Pixelated))),
         &images,
       )
     })

--- a/takumi/benches/background.rs
+++ b/takumi/benches/background.rs
@@ -1,0 +1,151 @@
+//! Background-image rasterization at the size of a full-height sidebar panel.
+//!
+//! A bitmap drawn 1:1 as a background should cost about what the same bitmap
+//! costs as an `<image>` node, so both are measured against an empty panel.
+
+use std::{collections::HashMap, hint::black_box, sync::Arc};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use takumi::{
+  prelude::{
+    BackgroundImages, BackgroundRepeats, BackgroundSizes, Color, ColorInput, Display, Fonts,
+    FromCssStr, ImageScalingAlgorithm, ImageSource,
+    Length::{Percentage, Px},
+    Node, ObjectFit, RenderOptions, Style, StyleDeclaration, Viewport,
+  },
+  render,
+};
+use takumi_core::resources::image_buffer::ImageBuffer;
+
+const PANEL_WIDTH: u32 = 397;
+const PANEL_HEIGHT: u32 = 2160;
+const WALLPAPER_URL: &str = "bench://wallpaper";
+
+/// A deterministic opaque bitmap. The content only has to vary from pixel to
+/// pixel so no sampler can short-circuit on it.
+fn wallpaper(width: u32, height: u32) -> ImageSource {
+  let mut data = Vec::with_capacity((width as usize) * (height as usize) * 4);
+  for y in 0..height {
+    for x in 0..width {
+      data.extend_from_slice(&[
+        (x % 251) as u8,
+        (y % 241) as u8,
+        ((x + y) % 233) as u8,
+        u8::MAX,
+      ]);
+    }
+  }
+
+  ImageSource::from(
+    ImageBuffer::from_rgba_bytes(data, width, height).expect("wallpaper buffer dimensions"),
+  )
+}
+
+fn render_node(fonts: &Fonts, node: Node, images: &HashMap<Arc<str>, ImageSource>) {
+  let options = RenderOptions::builder()
+    .viewport(Viewport::new((PANEL_WIDTH, PANEL_HEIGHT)))
+    .node(node)
+    .fonts(fonts)
+    .images(images.clone())
+    .build();
+  let image = render(options).expect("render panel");
+  black_box(image);
+}
+
+fn panel(style: Style) -> Node {
+  Node::container([]).with_style(style)
+}
+
+fn base_style() -> Style {
+  Style::default()
+    .with(StyleDeclaration::display(Display::Flex))
+    .with(StyleDeclaration::width(Percentage(100.0)))
+    .with(StyleDeclaration::height(Percentage(100.0)))
+    .with(StyleDeclaration::background_color(ColorInput::Value(
+      Color([18, 18, 22, 255]),
+    )))
+}
+
+fn background_style(algorithm: ImageScalingAlgorithm) -> Style {
+  base_style()
+    .with(StyleDeclaration::background_image(Some(
+      BackgroundImages::from_css_str(&format!("url({WALLPAPER_URL})")).expect("background url"),
+    )))
+    .with(StyleDeclaration::background_size(
+      BackgroundSizes::from_css_str("100% 100%").expect("background size"),
+    ))
+    .with(StyleDeclaration::background_repeat(
+      BackgroundRepeats::from_css_str("no-repeat").expect("background repeat"),
+    ))
+    .with(StyleDeclaration::image_rendering(algorithm))
+}
+
+fn image_node(source: ImageSource) -> Node {
+  Node::container([Node::image(source).with_style(
+    Style::default()
+      .with(StyleDeclaration::display(Display::Flex))
+      .with(StyleDeclaration::width(Px(PANEL_WIDTH as f32)))
+      .with(StyleDeclaration::height(Px(PANEL_HEIGHT as f32)))
+      .with(StyleDeclaration::object_fit(ObjectFit::Fill)),
+  )])
+  .with_style(base_style())
+}
+
+fn bench_background(c: &mut Criterion) {
+  let fonts = Fonts::default();
+  let source = wallpaper(PANEL_WIDTH, PANEL_HEIGHT);
+  let oversized = wallpaper(PANEL_WIDTH * 2, PANEL_HEIGHT);
+
+  let images: HashMap<Arc<str>, ImageSource> =
+    HashMap::from([(Arc::from(WALLPAPER_URL), source.clone())]);
+  let scaled_images: HashMap<Arc<str>, ImageSource> =
+    HashMap::from([(Arc::from(WALLPAPER_URL), oversized)]);
+  let no_images = HashMap::new();
+
+  let mut group = c.benchmark_group("background");
+
+  group.bench_function("no_image", |b| {
+    b.iter(|| render_node(&fonts, black_box(panel(base_style())), &no_images))
+  });
+  group.bench_function("image_node", |b| {
+    b.iter(|| render_node(&fonts, black_box(image_node(source.clone())), &no_images))
+  });
+  group.bench_function("one_to_one_auto", |b| {
+    b.iter(|| {
+      render_node(
+        &fonts,
+        black_box(panel(background_style(ImageScalingAlgorithm::Auto))),
+        &images,
+      )
+    })
+  });
+  group.bench_function("one_to_one_pixelated", |b| {
+    b.iter(|| {
+      render_node(
+        &fonts,
+        black_box(panel(background_style(ImageScalingAlgorithm::Pixelated))),
+        &images,
+      )
+    })
+  });
+  group.bench_function("downscaled_auto", |b| {
+    b.iter(|| {
+      render_node(
+        &fonts,
+        black_box(panel(background_style(ImageScalingAlgorithm::Auto))),
+        &scaled_images,
+      )
+    })
+  });
+
+  group.finish();
+}
+
+mod common;
+
+criterion_group! {
+  name = benches;
+  config = common::criterion();
+  targets = bench_background
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Why

`BackgroundTile::SampledBitmap` re-derived the dimensions, the `SamplingFootprint` and a `PixmapRef` over the whole source for every pixel. The sibling `Pixmap` arm already hoists its `PaintSource`, so the same bitmap was cheap as an `<image>` node and expensive as a background.

## What

`SampledBitmapView` resolves that state once per tile. At the bitmap's own size the tile is handed over as its source pixmap instead of resampled: the sample lands on `x + 0.5`, so nearest floors back to `x`, bilinear picks the same texel at zero weight, and a one-pixel footprint never minifies.

397×2160, release build, criterion:

| | before | after |
| --- | --- | --- |
| 1:1, `image-rendering: auto` | 18.7 ms | 1.5 ms |
| 1:1, `pixelated` | 14.9 ms | 1.6 ms |
| 1:1 under `border-radius` | 22.6 ms | 4.8 ms |
| 1:1 under `rotate(7deg)` | 31.3 ms | 18.4 ms |
| downscaled 2:1 | 40.8 ms | 31.4 ms |
| same bitmap as an `<image>` node | 3.7 ms | 3.7 ms |
| empty panel (floor) | 0.6 ms | 0.6 ms |

Output is unchanged: fixture goldens regenerate byte-identical, and a 60-scenario differential run against `master` matches byte for byte (offsets, clipping, `border-radius`, rotation, tiling, blend modes, `mask-image`, each under `auto`/`smooth`/`pixelated`).

Worth a look: the mapping keeps its `(x + 0.5) * source / logical` form rather than a precomputed scale. Folding the division shifts minified samples, and only the differential run caught it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved background-image rendering efficiency, especially for images displayed at their native size.
  - Reduced unnecessary per-pixel processing while preserving visual output.
  - Optimized compositing and bitmap copying for faster rasterization.

- **Testing**
  - Added coverage for native-size background rendering and scaled-image behavior.

- **Benchmarks**
  - Added background-image rendering benchmarks to track performance across common scaling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->