### PR TITLE
Raster: resolve paint sources once before pixel loops

### DIFF
--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -224,6 +224,11 @@ impl<'a> SampledBitmapView<'a> {
     })
   }
 
+  /// The size the tile is drawn at.
+  pub(crate) fn size(&self) -> Size<u32> {
+    self.logical_size
+  }
+
   /// The source pixmap when the tile is drawn at exactly the source's size, so
   /// destination pixel `(x, y)` is source pixel `(x, y)`.
   ///
@@ -243,7 +248,7 @@ impl<'a> SampledBitmapView<'a> {
   #[inline]
   pub(crate) fn sample(&self, x: u32, y: u32) -> PremultipliedColorU8 {
     interpolate_with_footprint(
-      PaintSource::from(self.source),
+      self.source.into(),
       self.algorithm,
       (x as f32 + 0.5) * self.source.width() as f32 / self.logical_size.width.max(1) as f32,
       (y as f32 + 0.5) * self.source.height() as f32 / self.logical_size.height.max(1) as f32,

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -6,11 +6,11 @@ use takumi_core::geometry::{Point, Size};
 use tiny_skia::{PixmapMut, PremultipliedColorU8};
 
 use super::{
-  DrawTarget, MaskSamplingOptions, MaskView, OverlayOptions, PaintSource, SamplingFootprint,
-  SamplingOptions, composite,
+  DrawTarget, MaskSamplingOptions, MaskView, OverlayOptions, PaintSource, SamplingOptions,
+  composite,
   composite::sampling_footprint,
   mask::MaskRow,
-  paint_source::{MaskCompositeColor, sample_paint_source},
+  paint_source::{MaskCompositeColor, ResolvedSource, sample_paint_source},
   skia::{
     FillColorOptions, ImagePathFillOptions, try_draw_image_with_tiny_skia,
     try_fill_color_with_tiny_skia, try_fill_image_path_with_tiny_skia,
@@ -121,6 +121,7 @@ fn blit_sampled_paint_source_translation(
 
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
   let footprint = sampling_footprint(sampling.logical_to_source);
+  let resolved = source.resolve();
   for dest_y in bounds.y_min..bounds.y_max {
     let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
     if mask_row.is_some_and(|row| row.is_empty()) {
@@ -133,7 +134,7 @@ fn blit_sampled_paint_source_translation(
       .transform_point((bounds.x_min - bounds.offset_x) as f32 + 0.5, src_y + 0.5);
     let dst_row = dest_y as usize * canvas_width as usize;
     for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
-      let src = sample_paint_source(source, sampling.algorithm, sample_x, sample_y, footprint)
+      let src = sample_paint_source(resolved, sampling.algorithm, sample_x, sample_y, footprint)
         .unwrap_or([0, 0, 0, 0]);
       sample_x += sampling.logical_to_source.a;
       sample_y += sampling.logical_to_source.b;
@@ -190,13 +191,6 @@ fn blit_paint_source_translation(
   mode: BlendMode,
   combined_mask: Option<MaskView<'_>>,
 ) {
-  // Sampling a bitmap background drawn at its own size returns the source pixel
-  // unchanged, so hand the pixmap straight to the copy path below.
-  let source = source
-    .sampled_bitmap_view()
-    .and_then(|view| view.identity_source())
-    .map_or(source, PaintSource::Pixmap);
-
   if let Some(color) = source.premultiplied_constant() {
     blit_solid_translation(
       pixmap,
@@ -223,8 +217,8 @@ fn blit_paint_source_translation(
   };
 
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
-  match source {
-    PaintSource::Pixmap(source) => {
+  match source.resolve() {
+    ResolvedSource::Direct(PaintSource::Pixmap(source)) => {
       let source_pixels = source.pixels();
       let source_width = source.width();
       if mode == BlendMode::Normal && combined_mask.is_none() {
@@ -266,27 +260,11 @@ fn blit_paint_source_translation(
         }
       }
     }
-    // A bitmap tile samples through a view resolved once here. The generic
-    // sampler below reads the same texels, but rebuilds that view per pixel.
-    _ => match source.sampled_bitmap_view() {
-      Some(view) => {
-        blit_rows_from_sampler(pixels, canvas_width, bounds, mode, combined_mask, |x, y| {
-          premultiplied_from_pixel(view.sample(x, y))
-        });
-      }
-      None => {
-        blit_rows_from_sampler(pixels, canvas_width, bounds, mode, combined_mask, |x, y| {
-          sample_paint_source(
-            source,
-            ImageScalingAlgorithm::Pixelated,
-            x as f32,
-            y as f32,
-            SamplingFootprint::PIXEL,
-          )
-          .unwrap_or([0; 4])
-        });
-      }
-    },
+    resolved => {
+      blit_rows_from_sampler(pixels, canvas_width, bounds, mode, combined_mask, |x, y| {
+        premultiplied_from_pixel(resolved.get_pixel(x, y))
+      });
+    }
   }
 }
 

--- a/takumi-raster/src/canvas/composite.rs
+++ b/takumi-raster/src/canvas/composite.rs
@@ -316,6 +316,7 @@ fn source_general(
   } = region;
   let footprint = sampling_footprint(options.sampling.canvas_to_source);
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
+  let resolved = source.resolve();
 
   for dest_y in bounds.y_min..bounds.y_max {
     let combined_row = options
@@ -338,7 +339,7 @@ fn source_general(
         None
       } else {
         sample_paint_source(
-          source,
+          resolved,
           options.sampling.algorithm,
           sample_x,
           sample_y,

--- a/takumi-raster/src/canvas/paint_source.rs
+++ b/takumi-raster/src/canvas/paint_source.rs
@@ -15,8 +15,6 @@ pub(crate) struct SamplingFootprint {
 }
 
 impl SamplingFootprint {
-  pub(crate) const PIXEL: Self = Self { x: 1.0, y: 1.0 };
-
   pub(crate) fn new(x: f32, y: f32) -> Self {
     Self {
       x: x.max(0.0),
@@ -77,20 +75,34 @@ impl<'a> PaintSource<'a> {
     }
   }
 
-  pub(crate) fn as_pixmap_ref(self) -> Option<PixmapRef<'a>> {
-    match self {
-      Self::Pixmap(source) => Some(source),
-      Self::BackgroundTile(BackgroundTile::Pixmap(source)) => Some(source.as_ref().as_ref()),
-      // A bitmap background drawn at its own size already is its source pixmap.
-      Self::BackgroundTile(tile) => tile.sampled_bitmap_view()?.identity_source(),
-      _ => None,
+  /// Normalizes this source into the form pixel loops sample from, resolving
+  /// everything that does not depend on the pixel exactly once. Tiles that
+  /// already are a pixmap (including a bitmap drawn at its own size) come back
+  /// as [`PaintSource::Pixmap`], and a scaled bitmap comes back as its hoisted
+  /// [`SampledBitmapView`]. Every loop that reads more than one pixel must
+  /// resolve first instead of sampling `self` directly.
+  pub(crate) fn resolve(self) -> ResolvedSource<'a> {
+    let Self::BackgroundTile(tile) = self else {
+      return ResolvedSource::Direct(self);
+    };
+
+    match tile {
+      BackgroundTile::Pixmap(source) => {
+        ResolvedSource::Direct(Self::Pixmap(source.as_ref().as_ref()))
+      }
+      _ => match tile.sampled_bitmap_view() {
+        Some(view) => match view.identity_source() {
+          Some(source) => ResolvedSource::Direct(Self::Pixmap(source)),
+          None => ResolvedSource::Bitmap(view),
+        },
+        None => ResolvedSource::Direct(self),
+      },
     }
   }
 
-  /// The hoisted sampling state when this source is a bitmap background tile.
-  pub(crate) fn sampled_bitmap_view(self) -> Option<SampledBitmapView<'a>> {
-    match self {
-      Self::BackgroundTile(tile) => tile.sampled_bitmap_view(),
+  pub(crate) fn as_pixmap_ref(self) -> Option<PixmapRef<'a>> {
+    match self.resolve() {
+      ResolvedSource::Direct(Self::Pixmap(source)) => Some(source),
       _ => None,
     }
   }
@@ -106,7 +118,8 @@ impl<'a> PaintSource<'a> {
   }
 
   fn write_premultiplied(self, dst: &mut [u8]) {
-    if let Some(source) = self.as_pixmap_ref() {
+    let resolved = self.resolve();
+    if let ResolvedSource::Direct(Self::Pixmap(source)) = resolved {
       dst.copy_from_slice(bytemuck::cast_slice(source.pixels()));
       return;
     }
@@ -114,14 +127,9 @@ impl<'a> PaintSource<'a> {
     let width = self.width();
     let height = self.height();
     let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(dst);
-    let sampled = self.sampled_bitmap_view();
     for y in 0..height {
       for x in 0..width {
-        let pixel = match sampled {
-          Some(view) => view.sample(x, y),
-          None => self.get_pixel(x, y),
-        };
-        pixels[(y * width + x) as usize] = premultiplied_from_pixel(pixel);
+        pixels[(y * width + x) as usize] = premultiplied_from_pixel(resolved.get_pixel(x, y));
       }
     }
   }
@@ -142,6 +150,44 @@ impl<'a> PaintSource<'a> {
 
   pub(crate) fn supports_rounded_fill_fast_path(self) -> bool {
     matches!(self, Self::Pixmap(_))
+  }
+}
+
+/// A [`PaintSource`] after [`PaintSource::resolve`]: the form the interpolators
+/// and pixel loops read from. Keeping them off the raw source is what
+/// guarantees per-pixel work never re-derives sampling state.
+#[derive(Clone, Copy)]
+pub(crate) enum ResolvedSource<'a> {
+  Direct(PaintSource<'a>),
+  Bitmap(SampledBitmapView<'a>),
+}
+
+impl ResolvedSource<'_> {
+  pub(crate) fn width(self) -> u32 {
+    match self {
+      Self::Direct(source) => source.width(),
+      Self::Bitmap(view) => view.size().width,
+    }
+  }
+
+  pub(crate) fn height(self) -> u32 {
+    match self {
+      Self::Direct(source) => source.height(),
+      Self::Bitmap(view) => view.size().height,
+    }
+  }
+
+  pub(crate) fn get_pixel(self, x: u32, y: u32) -> PremultipliedColorU8 {
+    match self {
+      Self::Direct(source) => source.get_pixel(x, y),
+      Self::Bitmap(view) => view.sample(x, y),
+    }
+  }
+}
+
+impl<'a> From<PixmapRef<'a>> for ResolvedSource<'a> {
+  fn from(value: PixmapRef<'a>) -> Self {
+    Self::Direct(PaintSource::Pixmap(value))
   }
 }
 
@@ -205,7 +251,7 @@ pub(super) fn apply_mask_color_mode(src: [u8; 4], color_mode: MaskCompositeColor
 
 #[inline(always)]
 pub(super) fn sample_paint_source(
-  source: PaintSource<'_>,
+  source: ResolvedSource<'_>,
   algorithm: ImageScalingAlgorithm,
   x: f32,
   y: f32,
@@ -215,7 +261,7 @@ pub(super) fn sample_paint_source(
 }
 
 pub(crate) fn interpolate_with_footprint(
-  image: PaintSource<'_>,
+  image: ResolvedSource<'_>,
   algorithm: ImageScalingAlgorithm,
   x: f32,
   y: f32,
@@ -233,11 +279,7 @@ pub(crate) fn interpolate_with_footprint(
 }
 
 #[inline(always)]
-pub(crate) fn interpolate_nearest(
-  image: PaintSource<'_>,
-  x: f32,
-  y: f32,
-) -> Option<PremultipliedColorU8> {
+fn interpolate_nearest(image: ResolvedSource<'_>, x: f32, y: f32) -> Option<PremultipliedColorU8> {
   let w = image.width();
   let h = image.height();
   if w == 0 || h == 0 {
@@ -253,11 +295,7 @@ pub(crate) fn interpolate_nearest(
 }
 
 #[inline(always)]
-pub(crate) fn interpolate_bilinear(
-  image: PaintSource<'_>,
-  x: f32,
-  y: f32,
-) -> Option<PremultipliedColorU8> {
+fn interpolate_bilinear(image: ResolvedSource<'_>, x: f32, y: f32) -> Option<PremultipliedColorU8> {
   let w = image.width();
   let h = image.height();
   if w == 0 || h == 0 {
@@ -320,7 +358,7 @@ pub(crate) fn interpolate_bilinear(
 }
 
 fn interpolate_box(
-  image: PaintSource<'_>,
+  image: ResolvedSource<'_>,
   x: f32,
   y: f32,
   footprint: SamplingFootprint,
@@ -402,7 +440,7 @@ fn interpolate_box(
 mod tests {
   use tiny_skia::{Pixmap, PremultipliedColorU8};
 
-  use super::{PaintSource, SamplingFootprint, interpolate_with_footprint};
+  use super::{SamplingFootprint, interpolate_with_footprint};
   use crate::style::ImageScalingAlgorithm;
 
   #[test]
@@ -415,7 +453,7 @@ mod tests {
     }
 
     let sample = interpolate_with_footprint(
-      PaintSource::from(pixmap.as_ref()),
+      pixmap.as_ref().into(),
       ImageScalingAlgorithm::Auto,
       4.0,
       0.5,


### PR DESCRIPTION
## Why

The interpolators took a raw `PaintSource`, so any pixel loop handed a scaled bitmap tile re-derived its sampling state per texel. #1220 hoisted the loops it touched, but the compositor's slow path (custom blend modes, `background-clip: text`, mask compositing) still rebuilt the view up to four times per destination pixel, and nothing stopped the next loop from repeating the mistake.

## What

`PaintSource::resolve` normalizes a source once per draw: pixmap-shaped tiles (including a bitmap drawn at its own size) become `PaintSource::Pixmap`, a scaled bitmap becomes its hoisted `SampledBitmapView`, and the interpolators now only accept the resolved form. The scattered identity checks collapse into `resolve`, and pixmap gradient tiles pick up the row-copy blit they previously missed. Output is byte-identical: the full fixture suite passes with zero `.svg`/`.webp` churn, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved canvas rendering efficiency by resolving paint sources once before sampling and compositing.
  * Preserved optimized direct-pixel copying where available.
  * Streamlined nearest, bilinear, and box-filter interpolation paths.
* **Rendering Improvements**
  * Improved bitmap sampling consistency across blitting and compositing operations.
  * Reduced repeated sampling-state calculations during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->