### PR TITLE
Docs: front-load the feature lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,36 @@ Takumi renders images in Node.js, Cloudflare Workers, browsers, and Rust applica
 
 </div>
 
+## Features
+
+Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser.
+
+### Images
+
+- **CSS Grid**, block, inline, and float handle layout.
+- Complex selectors work, including `::before`, `::after`, `:is()`, and `:where()`.
+- Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
+- `background-clip: text` and conic gradients work.
+- **RTL**, CJK, and emoji shape correctly.
+- **Tailwind v4** utilities apply directly, arbitrary values included.
+
+### PDF
+
+- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
+- **Headers and footers** repeat on every page, with page counters.
+- **Text** stays selectable and searchable. Fonts embed as subsets.
+- **Links** and metadata carry into the output. `outline: true` builds bookmarks from headings.
+- **Attachments** embed files, including Factur-X e-invoice XML.
+- **Tagged PDF** is on by default. PDF/A-2, A-3, A-4, and PDF/UA-1 pass veraPDF.
+- **Arabic**, bidi text, CJK, and emoji shape correctly.
+- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
+
+### Runtimes
+
+- **Node.js and Bun** load a native binding, prebuilt for macOS, Linux (glibc and musl), and Windows on x64 and ARM64.
+- **Cloudflare Workers** and browsers load the WebAssembly build.
+- **Rust** applications embed the `takumi` crate.
+
 ## Quick Start
 
 ```bash
@@ -42,15 +72,6 @@ await writeFile("./output.png", image);
 
 ### PDF
 
-- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
-- **Headers and footers** repeat on every page, with page counters.
-- **Text** stays selectable and searchable. Fonts embed as subsets.
-- **Links** and metadata carry into the output. `outline: true` builds bookmarks from headings.
-- **Attachments** embed files, including Factur-X e-invoice XML.
-- **Tagged PDF** is on by default. PDF/A-2, A-3, A-4, and PDF/UA-1 pass veraPDF.
-- **Arabic**, bidi text, CJK, and emoji shape correctly.
-- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
-
 ```tsx
 import { render } from "takumi-pdf";
 import { writeFile } from "node:fs/promises";
@@ -66,23 +87,6 @@ const pdf = await render(<Invoice data={data} />, {
 
 await writeFile("invoice.pdf", pdf);
 ```
-
-## Features
-
-Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser.
-
-- **CSS Grid**, block, inline, and float handle layout.
-- Complex selectors work, including `::before`, `::after`, `:is()`, and `:where()`.
-- Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
-- `background-clip: text` and conic gradients work.
-- **RTL**, CJK, and emoji shape correctly.
-- **Tailwind v4** utilities apply directly, arbitrary values included.
-
-Each runtime gets its own backend:
-
-- **Node.js and Bun** load a native binding, prebuilt for macOS, Linux (glibc and musl), and Windows on x64 and ARM64.
-- **Cloudflare Workers** and browsers load the WebAssembly build.
-- **Rust** applications embed the `takumi` crate.
 
 ## Coming From Something Else
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,14 @@ await writeFile("./output.png", image);
 
 ### PDF
 
-The PDF package writes multiple pages with selectable text and embedded subset fonts. It supports page breaks plus repeating headers and footers.
+- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
+- **Headers and footers** repeat on every page, with page counters.
+- **Text** stays selectable and searchable. Fonts embed as subsets.
+- **Links** and metadata carry into the output. `outline: true` builds bookmarks from headings.
+- **Attachments** embed files, including Factur-X e-invoice XML.
+- **Tagged PDF** is on by default. PDF/A-2, A-3, A-4, and PDF/UA-1 pass veraPDF.
+- **Arabic**, bidi text, CJK, and emoji shape correctly.
+- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
 
 ```tsx
 import { render } from "takumi-pdf";
@@ -60,6 +67,23 @@ const pdf = await render(<Invoice data={data} />, {
 await writeFile("invoice.pdf", pdf);
 ```
 
+## Features
+
+Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser.
+
+- **CSS Grid**, block, inline, and float handle layout.
+- Complex selectors work, including `::before`, `::after`, `:is()`, and `:where()`.
+- Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
+- `background-clip: text` and conic gradients work.
+- **RTL**, CJK, and emoji shape correctly.
+- **Tailwind v4** utilities apply directly, arbitrary values included.
+
+Each runtime gets its own backend:
+
+- **Node.js and Bun** load a native binding, prebuilt for macOS, Linux (glibc and musl), and Windows on x64 and ARM64.
+- **Cloudflare Workers** and browsers load the WebAssembly build.
+- **Rust** applications embed the `takumi` crate.
+
 ## Coming From Something Else
 
 | You are using                    | What changes                                                                                                                                                                                                |
@@ -69,27 +93,6 @@ await writeFile("invoice.pdf", pdf);
 | Puppeteer or Playwright for PDFs | Replace `page.pdf()` with `render()`. You must preload remote assets, and Takumi supports less CSS than Chrome. [Read the migration guide](https://takumi.kane.tw/docs/pdf/from-puppeteer).                 |
 | `@react-pdf/renderer`            | Replace `Document`, `View`, and `Text` with HTML elements and CSS. Browser viewers and some text controls have no equivalent. [Read the migration guide](https://takumi.kane.tw/docs/pdf/from-react-pdf).   |
 | `pdfkit`                         | Use JSX or HTML instead of positioning each line. Keep `pdfkit` when you need low-level drawing control.                                                                                                    |
-
-## Why Takumi
-
-Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser.
-
-The image packages select a backend for each runtime:
-
-- Node.js and Bun load the native binding.
-- Cloudflare Workers and browsers load the WebAssembly build.
-- Rust applications embed the `takumi` crate.
-
-Prebuilt binaries ship for macOS, Linux (glibc and musl), and Windows, on x64 and ARM64.
-
-The image renderer supports these CSS features:
-
-- CSS Grid, block, inline, float
-- `::before`, `::after`, `:is()`, `:where()`
-- masks, `clip-path`, `backdrop-filter`, blend modes
-- `background-clip: text`, conic gradients
-- RTL text, CJK, and emoji
-- Tailwind v4 utilities, including arbitrary values
 
 ## More Output
 
@@ -217,6 +220,7 @@ The benchmark uses an 80-line invoice with two pages and a page-number footer. W
 | Deploy needs                  | 1.5 MB gzip wasm                            | pure JS                                               | Chrome install (hundreds of MB) |
 | Template language             | JSX, HTML, node trees with CSS and Tailwind | its own primitives (`<View>`, `<Text>`, `StyleSheet`) | HTML with full CSS              |
 | Selectable text, subset fonts | yes                                         | yes                                                   | yes                             |
+| Arabic and bidi text          | yes                                         | shaping only, manual direction                        | yes                             |
 | Runs on edge runtimes         | yes (Cloudflare Workers)                    | no (Node)                                             | no                              |
 
 Chrome has the most complete CSS support of the three. Takumi's PDF output does not support `filter: blur()`, `drop-shadow()`, or `backdrop-filter`. Use Puppeteer when you need to reproduce a complex web page pixel for pixel. See the [PDF comparison](https://takumi.kane.tw/docs/pdf/comparison) for install sizes and more caveats.
@@ -241,11 +245,9 @@ Takumi converts any template into a **node tree** with three node kinds: `contai
 3. **Compositing**: stacking contexts, blend modes, filters, transforms, SVG via [resvg](https://github.com/linebender/resvg)
 4. **Output**: PNG, JPEG, WebP, ICO for statics; GIF, APNG, WebP for animations; paged PDF; raw RGBA frames for video pipelines
 
-The input contract is a node tree, so any template system that serializes to HTML or JSON can feed it: React, Svelte, Vue, plain strings, or your own serializer in any language.
-
-A **time axis** threads through the pipeline: the renderer takes a timestamp, so a PNG is the tree at `t=0` and a GIF is the same tree sampled across `t`. CSS `@keyframes`, the `animation` shorthand, and Tailwind animation utilities (`animate-spin`, `animate-bounce`, arbitrary values) all resolve at render time.
-
-Takumi uses the same layout for two vector backends. `renderSvg()` (Rust `render_svg`, behind the `svg-backend` feature) writes an `<svg>` document from shapes and glyph outlines. `takumi-pdf` writes paged PDF from the same primitives. Use `renderSvg()` when you need Satori-style SVG output.
+- Any template system that serializes to HTML or JSON can feed the node tree: React, Svelte, Vue, plain strings, or your own serializer in any language.
+- A time axis threads through the pipeline. A PNG is the tree at `t=0`. A GIF samples the same tree across `t`. CSS `@keyframes`, the `animation` shorthand, and Tailwind animation utilities resolve at render time.
+- The same layout drives two vector backends: `renderSvg()` for Satori-style SVG, `takumi-pdf` for paged PDF.
 
 ```mermaid
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -19,21 +19,23 @@ Takumi renders images in Node.js, Cloudflare Workers, browsers, and Rust applica
 
 ## Features
 
-Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser.
+Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser. One component tree renders as an image, an animation, or a paged PDF.
 
 ### Images
 
+- **`text-fit`** grows or shrinks a headline to fill its line box, no measuring loop.
+- **Animations** sample the tree across time. `@keyframes` and `animate-spin` become WebP, APNG, GIF, or video frames.
+- **Stylesheets** apply as written, with complex selectors, `var()`, `calc()`, and media queries.
 - **CSS Grid**, block, inline, and float handle layout.
-- Complex selectors work, including `::before`, `::after`, `:is()`, and `:where()`.
+- **`lang`** picks each language's own Han glyphs for the same code points.
+- **Text on a path** follows `offset-path`. `background-clip: text` and conic gradients paint it.
 - Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
-- `background-clip: text` and conic gradients work.
-- **RTL**, CJK, and emoji shape correctly.
 - **Tailwind v4** utilities apply directly, arbitrary values included.
 
 ### PDF
 
 - **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
-- **Headers and footers** repeat on every page, with page counters.
+- **Headers and footers** repeat on every page. Counters speak CSS counter styles, `trad-chinese-informal` included.
 - **Text** stays selectable and searchable. Fonts embed as subsets.
 - **Links** and metadata carry into the output. `outline: true` builds bookmarks from headings.
 - **Attachments** embed files, including Factur-X e-invoice XML.

--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -20,6 +20,7 @@ Environment: Apple M1 Pro, macOS 15.7.4, Bun 1.3.14, Chrome 151.
 | Deploy needs                  | 1.5 MB gzip wasm                            | pure JS                                               | Chrome install (hundreds of MB) |
 | Template language             | JSX, HTML, node trees with CSS and Tailwind | its own primitives (`<View>`, `<Text>`, `StyleSheet`) | HTML with full CSS              |
 | Selectable text, subset fonts | yes                                         | yes                                                   | yes                             |
+| Arabic and bidi text          | yes                                         | shaping only, manual direction                        | yes                             |
 | Runs on edge runtimes         | yes (Cloudflare Workers)                    | no (Node)                                             | no                              |
 
 ## Bundle and install size
@@ -39,10 +40,12 @@ pdf-lib, pdfkit, and jspdf are drawing primitives. You position each text line y
 
 takumi-pdf's wasm binary is the largest single JS download. It is also the whole engine. `node_modules` has 45 files.
 
+Cloudflare Workers caps a free-plan bundle at 3 MB after compression. The 1.52 MB wasm leaves half of that for application code.
+
 Reading the numbers honestly:
 
 - Chrome's cold start includes launching a browser process. It varies with machine state. Its memory spans several processes. A single-process measurement misses this. Chrome performs well after warming. It has the most complete CSS support of the three.
-- react-pdf embeds the same Inter subsets as the other two. Subsetting on every render is most of its warm cost; the standard 14 PDF fonts avoid it. Documents use react-pdf's component set. Existing HTML, JSX, and Tailwind markup cannot be reused.
+- react-pdf embeds the same Inter subsets as the other two. Subsetting on every render is most of its warm cost; the standard 14 PDF fonts avoid it. Documents use react-pdf's component set. Existing HTML, JSX, and Tailwind markup cannot be reused. It shapes Arabic, but paragraph direction is manual, and our Arabic sample dropped its first letter.
 - takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `filter: blur()`, `drop-shadow()`, or `backdrop-filter`. A blurred `box-shadow` is approximated with bands, and a blurred `text-shadow` draws sharp. Tagged output is on by default and adds about 4 KB to this invoice, down from 10 KB before the structure tree moved into an object stream. `tagged: false` removes it.
 
 Rule of thumb: use Puppeteer to reproduce a complex web page pixel-perfectly. Any renderer suits documents written from scratch for PDF work. Use takumi-pdf to reuse Takumi image components. It suits edge runtimes. It also offers lower per-document latency.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -5,7 +5,17 @@ index: true
 icon: BookOpen
 ---
 
-`takumi-pdf` renders the same JSX, Tailwind classes, and node trees as image output. It writes a paged vector PDF instead: selectable text, embedded subset fonts, page breaks, and repeating headers and footers. It ships as a WebAssembly module. It runs on Node.js, Bun, and Cloudflare Workers without Chromium.
+`takumi-pdf` renders the same JSX, Tailwind classes, and node trees as image output. It writes a paged vector PDF instead. It ships as a WebAssembly module. It runs on Node.js, Bun, and Cloudflare Workers without Chromium.
+
+- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
+- **[Headers and footers](/docs/pdf/headers-and-footers)** repeat on every page, with page counters.
+- **Text** stays selectable and searchable. Fonts embed as subsets.
+- **[Links](/docs/pdf/links-and-outline)** and metadata carry into the output. `outline: true` builds bookmarks from headings.
+- **[Attachments](/docs/pdf/attachments)** embed files, including Factur-X e-invoice XML.
+- **Tagged PDF** is on by default. [PDF/A-2, A-3, A-4, and PDF/UA-1](/docs/pdf/pdf-a) pass veraPDF.
+- **Arabic**, bidi text, CJK, Devanagari, and emoji shape correctly.
+- **Gradients**, `box-shadow`, transforms, and color filters stay vector, conic gradients included.
+- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
 
 ```npm
 npm i takumi-pdf


### PR DESCRIPTION
## Why

The README and the PDF intro explain the engine before they list what it does. Readers scanning for a capability, like RTL text or PDF/A, had to dig for it. Bidi support was tested but never stated anywhere.

## What

Feature lists open the PDF intro, the PDF section of the README, and the renamed Features section. The comparison table gains an Arabic and bidi row, backed by a measured react-pdf sample, and the bundle-size section notes the wasm fits half of the Workers free-plan cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded PDF documentation to highlight pagination, headers and footers, selectable text, links, attachments, tagged PDFs, international text shaping, vector effects, and WebAssembly size.
  * Added Arabic and bidirectional-text support details to the PDF comparison.
  * Documented Cloudflare Workers’ bundle-size considerations and clarified Arabic text handling in competing tools.
  * Reorganized the README with a comprehensive Features section and a simplified architecture overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->