### PR TITLE
Raster: dedupe the gradient tile overlay dispatch

### DIFF
--- a/takumi-raster/src/background_drawing.rs
+++ b/takumi-raster/src/background_drawing.rs
@@ -17,11 +17,10 @@ use crate::{
   BorderProperties, DrawTarget, OverlayOptions, PaintSource, RenderContext, Result,
   SamplingFootprint, color_to_premultiplied, interpolate_with_footprint,
   layout::node::resolve_image,
-  overlay_gradient_tile, overlay_image, overlay_linear_gradient_tile, overlay_radial_gradient_tile,
-  pixmap_from_buffer, pixmap_ref_from_buffer,
+  overlay_image, pixmap_from_buffer, pixmap_ref_from_buffer,
   resources::{image::ImageSource, image_buffer::ImageBuffer},
   style::*,
-  uninit_buffer,
+  try_overlay_gradient_tile, uninit_buffer,
 };
 
 pub(crate) struct TileLayer {
@@ -93,44 +92,18 @@ pub(crate) fn rasterize_layers(
         if border.is_zero()
           && layer_transform.only_translation()
           && layer.blend_mode == BlendMode::Normal
+          && try_overlay_gradient_tile(
+            &mut pixmap,
+            &layer.tile,
+            Point {
+              x: layer_transform.x,
+              y: layer_transform.y,
+            },
+            layer.blend_mode,
+            None,
+          )
         {
-          let translation = Point {
-            x: layer_transform.x,
-            y: layer_transform.y,
-          };
-          match &layer.tile {
-            BackgroundTile::Linear(linear_gradient) => {
-              overlay_linear_gradient_tile(
-                &mut pixmap,
-                linear_gradient,
-                translation,
-                layer.blend_mode,
-                None,
-              );
-              continue;
-            }
-            BackgroundTile::Radial(radial_gradient) => {
-              overlay_radial_gradient_tile(
-                &mut pixmap,
-                radial_gradient,
-                translation,
-                layer.blend_mode,
-                None,
-              );
-              continue;
-            }
-            BackgroundTile::Conic(conic_gradient) => {
-              overlay_gradient_tile(
-                &mut pixmap,
-                conic_gradient,
-                translation,
-                layer.blend_mode,
-                None,
-              );
-              continue;
-            }
-            _ => {}
-          }
+          continue;
         }
 
         overlay_image(

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -16,9 +16,7 @@ use std::{borrow::Cow, mem::replace, sync::Arc};
 pub(crate) use blit::{
   composite_mask_source_to_pixmap, overlay_image, overlay_sampled_paint_source,
 };
-pub(crate) use gradient::{
-  overlay_gradient_tile, overlay_linear_gradient_tile, overlay_radial_gradient_tile,
-};
+pub(crate) use gradient::try_overlay_gradient_tile;
 use image::{
   ImageError, Rgba, RgbaImage,
   error::{ParameterError, ParameterErrorKind},
@@ -399,38 +397,14 @@ impl Canvas {
       y: translation.y - self.origin.y as f32,
     };
 
-    self.with_overlay_state(|target| match tile {
-      BackgroundTile::Linear(gradient) => {
-        overlay_linear_gradient_tile(
-          target.pixmap,
-          gradient,
-          localized_translation,
-          mode,
-          target.combined_mask,
-        );
-        true
-      }
-      BackgroundTile::Radial(gradient) => {
-        overlay_radial_gradient_tile(
-          target.pixmap,
-          gradient,
-          localized_translation,
-          mode,
-          target.combined_mask,
-        );
-        true
-      }
-      BackgroundTile::Conic(gradient) => {
-        overlay_gradient_tile(
-          target.pixmap,
-          gradient,
-          localized_translation,
-          mode,
-          target.combined_mask,
-        );
-        true
-      }
-      _ => false,
+    self.with_overlay_state(|target| {
+      try_overlay_gradient_tile(
+        target.pixmap,
+        tile,
+        localized_translation,
+        mode,
+        target.combined_mask,
+      )
     })
   }
 

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -152,7 +152,7 @@ fn blit_sampled_paint_source_translation(
 
 /// Walks the destination region row by row, pulling each pixel from `sample`
 /// in source-local coordinates.
-fn blit_rows_from_sampler(
+pub(super) fn blit_rows_from_sampler(
   pixels: &mut [[u8; 4]],
   canvas_width: u32,
   bounds: OverlayBounds,

--- a/takumi-raster/src/canvas/gradient.rs
+++ b/takumi-raster/src/canvas/gradient.rs
@@ -11,9 +11,35 @@ use tiny_skia::PixmapMut;
 
 use super::{
   MaskView,
-  blit::{apply_mask_row, compute_overlay_bounds_for_canvas},
+  blit::{blit_rows_from_sampler, compute_overlay_bounds_for_canvas},
 };
-use crate::{blend::*, style::BlendMode};
+use crate::{BackgroundTile, blend::*, style::BlendMode};
+
+/// Overlays a gradient-shaped [`BackgroundTile`] at a plain translation,
+/// reporting whether the tile was one. Non-gradient tiles are left for the
+/// caller's generic overlay path.
+pub(crate) fn try_overlay_gradient_tile(
+  pixmap: &mut PixmapMut<'_>,
+  tile: &BackgroundTile,
+  offset: Point<f32>,
+  mode: BlendMode,
+  combined_mask: Option<MaskView<'_>>,
+) -> bool {
+  match tile {
+    BackgroundTile::Linear(gradient) => {
+      overlay_linear_gradient_tile(pixmap, gradient, offset, mode, combined_mask)
+    }
+    BackgroundTile::Radial(gradient) => {
+      overlay_radial_gradient_tile(pixmap, gradient, offset, mode, combined_mask)
+    }
+    BackgroundTile::Conic(gradient) => {
+      overlay_gradient_tile(pixmap, gradient, offset, mode, combined_mask)
+    }
+    _ => return false,
+  }
+
+  true
+}
 
 pub(crate) fn overlay_gradient_tile<T>(
   pixmap: &mut PixmapMut<'_>,
@@ -54,28 +80,9 @@ pub(crate) fn overlay_gradient_tile<T>(
   };
 
   let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
-  for dest_y in bounds.y_min..bounds.y_max {
-    let mask_row = combined_mask.map(|view| view.row(dest_y, bounds.x_min));
-    if mask_row.is_some_and(|row| row.is_empty()) {
-      continue;
-    }
-
-    let src_y = (dest_y - bounds.offset_y) as u32;
-    let dst_row = dest_y as usize * bottom_width as usize;
-    for (i, dest_x) in (bounds.x_min..bounds.x_max).enumerate() {
-      let src_x = (dest_x - bounds.offset_x) as u32;
-      let src = premultiplied_from_pixel(gradient.sample_pixel(src_x, src_y));
-      if src[3] == 0 {
-        continue;
-      }
-
-      let Some(src) = apply_mask_row(src, mask_row, i) else {
-        continue;
-      };
-
-      blend_premultiplied_pixel(&mut pixels[dst_row + dest_x as usize], src, mode);
-    }
-  }
+  blit_rows_from_sampler(pixels, bottom_width, bounds, mode, combined_mask, |x, y| {
+    premultiplied_from_pixel(gradient.sample_pixel(x, y))
+  });
 }
 
 fn try_overlay_linear_gradient_tile_fast_normal_unconstrained(


### PR DESCRIPTION
## Why

The Linear/Radial/Conic overlay dispatch existed twice (`overlay_background_tile_direct` and `rasterize_layers`), and the conic slow path hand-rolled the same masked row walk `blit_rows_from_sampler` already implements.

## What

`try_overlay_gradient_tile` is now the one dispatcher both callers use, and the generic gradient overlay samples through `blit_rows_from_sampler`. The bench-validated linear/radial fast paths are untouched. Output is byte-identical: fixture suite passes with zero `.svg`/`.webp` churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of linear, radial, and conic gradients across backgrounds and layered content.
  * Fixed gradient compositing to better respect masks, boundaries, and blend modes.
  * Preserved reliable fallback rendering for content that cannot use optimized gradient handling.

* **Performance**
  * Streamlined gradient processing for smoother and more consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->