### PR TITLE
Docs: add corner-shape, count the JS wrapper in the Workers budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ Takumi is a Rust rendering engine for markup and CSS. It handles layout, text sh
 ### Images
 
 - **`text-fit`** grows or shrinks a headline to fill its line box, no measuring loop.
+- **`text-wrap: balance`** evens multi-line headlines. `pretty` spares the orphan word.
 - **Animations** sample the tree across time. `@keyframes` and `animate-spin` become WebP, APNG, GIF, or video frames.
 - **Stylesheets** apply as written, with complex selectors, `var()`, `calc()`, and media queries.
 - **CSS Grid**, block, inline, and float handle layout.
 - **`lang`** picks each language's own Han glyphs for the same code points.
 - **Text on a path** follows `offset-path`. `background-clip: text` and conic gradients paint it.
 - Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
+- **SVG filters** run through `filter: url(...)`, `feTurbulence` and `feDisplacementMap` included.
 - **`corner-shape`** curves corners as `squircle`, `bevel`, `scoop`, `notch`, or `superellipse(n)`.
 - **Tailwind v4** utilities apply directly, arbitrary values included.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Takumi is a Rust rendering engine for markup and CSS. It handles layout, text sh
 - **`lang`** picks each language's own Han glyphs for the same code points.
 - **Text on a path** follows `offset-path`. `background-clip: text` and conic gradients paint it.
 - Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
+- **`corner-shape`** curves corners as `squircle`, `bevel`, `scoop`, `notch`, or `superellipse(n)`.
 - **Tailwind v4** utilities apply directly, arbitrary values included.
 
 ### PDF

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Takumi is a Rust rendering engine for markup and CSS. It handles layout, text sh
 - **Text on a path** follows `offset-path`. `background-clip: text` and conic gradients paint it.
 - Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
 - **SVG filters** run through `filter: url(...)`, `feTurbulence` and `feDisplacementMap` included.
-- **`corner-shape`** curves corners as `squircle`, `bevel`, `scoop`, `notch`, or `superellipse(n)`.
+- **`corner-shape`** swaps round corners for `squircle`, `bevel`, `scoop`, `notch`, or `superellipse(n)`.
 - **Tailwind v4** utilities apply directly, arbitrary values included.
 
 ### PDF

--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -40,7 +40,7 @@ pdf-lib, pdfkit, and jspdf are drawing primitives. You position each text line y
 
 takumi-pdf's wasm binary is the largest single JS download. It is also the whole engine. `node_modules` has 45 files.
 
-Cloudflare Workers caps a free-plan bundle at 3 MB after compression. The 1.52 MB wasm leaves half of that for application code.
+Cloudflare Workers caps a free-plan bundle at 3 MB after compression. The 1.52 MB wasm and the 10 KB JS wrapper leave half of that for application code.
 
 Reading the numbers honestly:
 


### PR DESCRIPTION
## Why

The Images feature list skips `corner-shape`, and the Workers budget line counted only the wasm, implying the wrapper is free.

## What

Adds a `corner-shape` bullet with the supported keywords, and folds the measured 10 KB JS wrapper into the Workers budget sentence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded image feature documentation to include balanced text wrapping, SVG filters, and additional corner shapes such as squircle, bevel, scoop, notch, and superellipse.
  - Clarified Cloudflare Workers bundle-size guidance by accounting for both the WebAssembly binary and JavaScript wrapper within the free-plan limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->