### PR TITLE
Docs: list the fragmentation properties in the reference

### DIFF
--- a/docs/content/docs/reference.mdx
+++ b/docs/content/docs/reference.mdx
@@ -241,6 +241,17 @@ Properties use their camelCase names. Longhands are listed in parentheses. `Supp
 | `animationFillMode`       | Supported                                                                                                     |
 | `animationPlayState`      | Supported                                                                                                     |
 
+### Fragmentation
+
+Consumed by [paged PDF output](/docs/pdf/pagination). Other backends ignore them.
+
+| Property                    | Values           |
+| :-------------------------- | :--------------- |
+| `breakBefore`, `breakAfter` | `auto`, `page`   |
+| `breakInside`               | `auto`, `avoid`  |
+| `boxDecorationBreak`        | `slice`, `clone` |
+| `widows`, `orphans`         | `<integer>`      |
+
 ### Typography
 
 | Property                                                                                                                       | Values                                                                                       |


### PR DESCRIPTION
## Why

#1226 shipped `widows` and `orphans`, and the reference page never listed the fragmentation properties at all.

## What

Adds a Fragmentation section to the reference: `breakBefore`/`breakAfter`, `breakInside`, `boxDecorationBreak`, `widows`, `orphans`, with a pointer to the pagination page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added reference documentation for pagination-related style properties, including page breaks, box decoration, widows, and orphans.
  - Clarified that these properties affect paged PDF output and are ignored by other rendering backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->