### PR TITLE
Core: match Blink's color table pairing rule

### DIFF
--- a/takumi-core/src/resources/font.rs
+++ b/takumi-core/src/resources/font.rs
@@ -203,13 +203,17 @@ pub(crate) struct FontClasses {
   pub(crate) mono_order: Vec<String>,
 }
 
-/// Blink keys the same decision on COLR/CBDT/sbix via `ColorTableLookup`.
-const COLOR_TABLES: [Tag; 3] = [Tag::new(b"COLR"), Tag::new(b"CBDT"), Tag::new(b"sbix")];
+const SBIX: Tag = Tag::new(b"sbix");
+const COLR: Tag = Tag::new(b"COLR");
+const CPAL: Tag = Tag::new(b"CPAL");
+const CBDT: Tag = Tag::new(b"CBDT");
+const CBLC: Tag = Tag::new(b"CBLC");
 
+/// Color tables in the pairs Blink's `ColorTableLookup` accepts.
 fn has_color_table(font: &FontRef) -> bool {
-  COLOR_TABLES
-    .iter()
-    .any(|tag| font.table_data(*tag).is_some())
+  font.table_data(SBIX).is_some()
+    || (font.table_data(COLR).is_some() && font.table_data(CPAL).is_some())
+    || (font.table_data(CBDT).is_some() && font.table_data(CBLC).is_some())
 }
 
 /// The registry of fonts available to a renderer.


### PR DESCRIPTION
## Why

The color font check from #1227 counts a lone `COLR` or `CBDT` table. Blink's `ColorTableLookup` only accepts `sbix` alone, `COLR` with `CPAL`, and `CBDT` with `CBLC`, so a malformed font missing the paired table classifies differently.

## What

Requires the same pairs. No behavior change for well-formed fonts, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color-font detection by recognizing `sbix` fonts independently.
  * Added validation for required table pairs in `COLR`/`CPAL` and `CBDT`/`CBLC` fonts.
  * Prevented fonts with incomplete color-font data from being incorrectly identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->