### PR TITLE
Helpers: render fragment, memo and forwardRef children inside <svg>

### DIFF
--- a/.tegami/svg-fragment-children.md
+++ b/.tegami/svg-fragment-children.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Render fragment, memo and forwardRef children inside `<svg>`
+
+Inline SVG silently dropped any child it could not map to a tag name. Fragments, `memo` and `forwardRef` components now serialize the same way React does.

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -225,33 +225,19 @@ function tryHandleComponentWrapper(
   element: ReactElementLike,
   options: ResolvedFromJsxOptions,
 ): Promise<FromJsxTraversalResult> | undefined {
-  if (typeof element.type !== "object" || element.type === null) return;
-
-  if (isReactForwardRef(element.type) && "render" in element.type) {
-    const forwardRefType = element.type as {
-      render: (props: unknown, ref: unknown) => ReactNode;
-    };
-    return renderFunctionComponent(
-      (props) => forwardRefType.render(props, null),
-      element.props,
-      options,
-    );
+  if (isReactForwardRef(element.type)) {
+    const { render } = element.type;
+    return renderFunctionComponent((props) => render(props, null), element.props, options);
   }
 
-  if (isReactMemo(element.type) && "type" in element.type) {
-    const memoType = element.type as { type: unknown };
-    const innerType = memoType.type;
+  if (isReactMemo(element.type)) {
+    const innerType = element.type.type;
 
     if (isFunctionComponent(innerType)) {
       return renderFunctionComponent(innerType, element.props, options);
     }
 
-    const cloned: ReactElementLike = {
-      ...element,
-      type: innerType as ReactElementLike["type"],
-    } as ReactElementLike;
-
-    return processReactElement(cloned, options);
+    return processReactElement({ ...element, type: innerType }, options);
   }
 }
 

--- a/takumi-helpers/src/jsx/svg.ts
+++ b/takumi-helpers/src/jsx/svg.ts
@@ -1,5 +1,12 @@
 import type { ComponentProps, ReactElement } from "react";
-import { camelToKebab, isFunctionComponent, isValidElement, type ReactElementLike } from "./utils";
+import {
+  camelToKebab,
+  isFunctionComponent,
+  isReactForwardRef,
+  isReactMemo,
+  isValidElement,
+  type ReactElementLike,
+} from "./utils";
 
 function isTextNode(node: unknown): node is string | number {
   return typeof node === "string" || typeof node === "number";
@@ -166,8 +173,21 @@ const serializeElementNode = (
     return;
   }
 
-  // Handle symbols (like React fragments) - they can't be serialized as HTML/SVG tags
-  if (typeof obj.type === "symbol") return;
+  // Fragments and other symbol types have no tag of their own; emit their children in place.
+  if (typeof obj.type === "symbol") {
+    serializeNode(props.children, parts, false);
+    return;
+  }
+
+  if (isReactForwardRef(obj.type)) {
+    serializeNode(obj.type.render(obj.props, null), parts, false);
+    return;
+  }
+
+  if (isReactMemo(obj.type)) {
+    serializeElementNode({ ...obj, type: obj.type.type }, parts, injectSvgXmlns);
+    return;
+  }
 
   // Only string types can be used as HTML/SVG tag names
   if (typeof obj.type !== "string") return;

--- a/takumi-helpers/src/jsx/utils.ts
+++ b/takumi-helpers/src/jsx/utils.ts
@@ -31,12 +31,21 @@ const REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
 const REACT_MEMO_TYPE = Symbol.for("react.memo");
 const REACT_FRAGMENT_TYPE = Symbol.for("react.fragment");
 
-export function isReactForwardRef(element: ReactElementLike): boolean {
-  return element.$$typeof === REACT_FORWARD_REF_TYPE;
+type ForwardRefComponent = { render: (props: unknown, ref: unknown) => ReactNode };
+type MemoComponent = { type: ReactElementLike["type"] };
+
+function hasReactMarker(type: unknown, marker: symbol): type is { $$typeof: symbol } {
+  return (
+    typeof type === "object" && type !== null && "$$typeof" in type && type.$$typeof === marker
+  );
 }
 
-export function isReactMemo(element: ReactElementLike): boolean {
-  return element.$$typeof === REACT_MEMO_TYPE;
+export function isReactForwardRef(type: unknown): type is ForwardRefComponent {
+  return hasReactMarker(type, REACT_FORWARD_REF_TYPE) && "render" in type;
+}
+
+export function isReactMemo(type: unknown): type is MemoComponent {
+  return hasReactMarker(type, REACT_MEMO_TYPE) && "type" in type;
 }
 
 export function isReactFragment(element: ReactElementLike): boolean {

--- a/takumi-helpers/src/jsx/utils.ts
+++ b/takumi-helpers/src/jsx/utils.ts
@@ -41,7 +41,11 @@ function hasReactMarker(type: unknown, marker: symbol): type is { $$typeof: symb
 }
 
 export function isReactForwardRef(type: unknown): type is ForwardRefComponent {
-  return hasReactMarker(type, REACT_FORWARD_REF_TYPE) && "render" in type;
+  return (
+    hasReactMarker(type, REACT_FORWARD_REF_TYPE) &&
+    "render" in type &&
+    typeof type.render === "function"
+  );
 }
 
 export function isReactMemo(type: unknown): type is MemoComponent {

--- a/takumi-helpers/tests/jsx/svg-serialize.test.tsx
+++ b/takumi-helpers/tests/jsx/svg-serialize.test.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { forwardRef, memo, StrictMode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { serializeSvg } from "../../src/jsx/svg";
@@ -45,6 +46,51 @@ test("serializeSvg preserves style objects and converts camelCase style keys", (
   const component = (
     <svg xmlns="http://www.w3.org/2000/svg">
       <rect style={{ strokeWidth: 2, strokeDasharray: "4 2" }} />
+    </svg>
+  );
+
+  const expected = renderToStaticMarkup(component);
+  const actual = serializeSvg(component);
+
+  expect(actual).toBe(expected);
+});
+
+test("serializeSvg emits fragment children, including from components", () => {
+  const Bars = () => (
+    <>
+      <rect x="0" width="10" height="10" />
+      <rect x="20" width="10" height="10" />
+    </>
+  );
+
+  const component = (
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <>
+        <circle cx="5" cy="5" r="5" />
+      </>
+      <Bars />
+      <StrictMode>
+        <rect x="40" />
+      </StrictMode>
+    </svg>
+  );
+
+  const expected = renderToStaticMarkup(component);
+  const actual = serializeSvg(component);
+
+  expect(actual).toBe(expected);
+});
+
+test("serializeSvg renders memo and forwardRef children", () => {
+  const Memoized = memo(() => <rect x="0" width="10" height="10" />);
+  const Forwarded = forwardRef<SVGCircleElement>((_props, ref) => (
+    <circle ref={ref} cx="5" cy="5" r="5" />
+  ));
+
+  const component = (
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <Memoized />
+      <Forwarded />
     </svg>
   );
 


### PR DESCRIPTION
## Why

`serializeSvg` only emitted elements whose type is a tag name. Anything else was skipped along with its whole subtree, so a fragment, or a `memo` / `forwardRef` component, produced an empty `<svg>` and no error. Chart and icon components that return `<>...</>` rendered nothing at all.

## What

Fragment children now serialize in place, and the serializer renders through `memo` and `forwardRef` the way `renderToStaticMarkup` does. Tests assert against it as the oracle, as the rest of that file already does.

`isReactForwardRef` and `isReactMemo` now narrow to the shapes they detect instead of returning `boolean`, which drops three casts from `tryHandleComponentWrapper` in the main JSX path.

`Suspense` still emits its primary children rather than a fallback. Nothing in this synchronous path can suspend, so an allowlist of transparent symbols would not buy anything today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline SVG rendering to match React behavior.
  * Fragment children are now serialized correctly instead of being dropped.
  * Added consistent rendering for memoized, forward-ref, and Strict Mode components.
* **Tests**
  * Added coverage for SVG fragments and wrapped components to help prevent regressions.
* **Documentation**
  * Documented the patch release for the SVG serialization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->