### PR TITLE
Core, PDF: resolve absolute units through one set of constants

### DIFF
--- a/.tegami/core-units-module.md
+++ b/.tegami/core-units-module.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Add `units` for the absolute length constants
+
+`takumi_core::units` exports the CSS absolute units in 96 dpi pixels, so page geometry and CSS lengths resolve through one set of constants instead of each crate rederiving them.

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod resources;
 pub mod scene;
 /// CSS value types, parsing, and the cascade.
 pub mod style;
+pub mod units;
 /// Viewport dimensions and device-pixel-ratio resolution.
 pub mod viewport;
 

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -11,12 +11,10 @@ use crate::style::{
   unexpected_token,
 };
 
-pub(crate) const ONE_CM_IN_PX: f32 = 96.0 / 2.54;
-pub(crate) const ONE_MM_IN_PX: f32 = ONE_CM_IN_PX / 10.0;
-pub(crate) const ONE_Q_IN_PX: f32 = ONE_CM_IN_PX / 40.0;
-pub(crate) const ONE_IN_PX: f32 = 2.54 * ONE_CM_IN_PX;
-pub(crate) const ONE_PT_IN_PX: f32 = ONE_IN_PX / 72.0;
-pub(crate) const ONE_PC_IN_PX: f32 = ONE_IN_PX / 6.0;
+pub(crate) use crate::units::{
+  ONE_CM_IN_PX, ONE_IN_PX, ONE_MM_IN_PX, ONE_PC_IN_PX, ONE_PT_IN_PX, ONE_Q_IN_PX,
+};
+
 const CALC_ZERO_EPSILON: f32 = 1e-6;
 const SAFE_INT_MIN_PX: f32 = i32::MIN as f32;
 const SAFE_INT_MAX_PX: f32 = i32::MAX as f32;

--- a/takumi-core/src/units.rs
+++ b/takumi-core/src/units.rs
@@ -1,0 +1,17 @@
+//! CSS absolute length units, in the 96 dpi pixels layout runs in.
+//!
+//! Every crate resolves physical units through these, so a `297mm` length and an
+//! A4 page reach the same pixel value.
+
+/// One centimetre.
+pub const ONE_CM_IN_PX: f32 = 96.0 / 2.54;
+/// One millimetre.
+pub const ONE_MM_IN_PX: f32 = ONE_CM_IN_PX / 10.0;
+/// One quarter-millimetre.
+pub const ONE_Q_IN_PX: f32 = ONE_CM_IN_PX / 40.0;
+/// One inch.
+pub const ONE_IN_PX: f32 = 2.54 * ONE_CM_IN_PX;
+/// One point.
+pub const ONE_PT_IN_PX: f32 = ONE_IN_PX / 72.0;
+/// One pica.
+pub const ONE_PC_IN_PX: f32 = ONE_IN_PX / 6.0;

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -9,6 +9,7 @@ use takumi_core::{
   layout::node::Node,
   resources::{font::FontError, image::ImageSource},
   style::{FontFamily, Lang, StyleSheet},
+  units::{ONE_IN_PX, ONE_MM_IN_PX, ONE_PT_IN_PX},
   viewport::Viewport,
 };
 use typed_builder::TypedBuilder;
@@ -421,36 +422,25 @@ pub struct PageOptions {
 /// CSS px (96 dpi) to PDF pt (72 dpi). Layout runs in px; page geometry,
 /// annotations, and destinations are written in pt so pages print at their
 /// physical size.
-pub(crate) const PT_PER_PX: f32 = 72.0 / 96.0;
+pub(crate) const PT_PER_PX: f32 = 1.0 / ONE_PT_IN_PX;
 
-/// 20px, which is Chromium's 15pt inset at 96 dpi: its print template page
-/// insets bands 15pt from the paper edge
+/// Chromium's print template page insets bands 15pt from the paper edge
 /// (`#header { padding-top: 15pt }`, `#footer { padding-bottom: 15pt }` in
 /// components/printing/resources/print_header_footer_template_page.html).
-pub(crate) const BAND_EDGE_PADDING: f32 = 20.0;
-
-/// Millimeters to CSS px (96 dpi).
-const fn mm(value: f32) -> f32 {
-  value / 25.4 * 96.0
-}
-
-/// Inches to CSS px (96 dpi).
-const fn inches(value: f32) -> f32 {
-  value * 96.0
-}
+pub(crate) const BAND_EDGE_PADDING: f32 = 15.0 * ONE_PT_IN_PX;
 
 /// Presets are portrait with a half-inch margin; chain
 /// [`landscape`](Self::landscape) and [`with_margin`](Self::with_margin) to
 /// adjust, or fill the fields directly for any other size.
 // ponytail: A4 + LETTER only; add other @page keywords when someone asks.
 impl PageOptions {
-  const DEFAULT_MARGIN: f32 = 48.0;
+  const DEFAULT_MARGIN: f32 = 0.5 * ONE_IN_PX;
 
   /// ISO A4: 210 × 297 mm.
-  pub const A4: Self = Self::preset(mm(210.0), mm(297.0));
+  pub const A4: Self = Self::preset(210.0 * ONE_MM_IN_PX, 297.0 * ONE_MM_IN_PX);
 
   /// US Letter: 8.5 × 11 in.
-  pub const LETTER: Self = Self::preset(inches(8.5), inches(11.0));
+  pub const LETTER: Self = Self::preset(8.5 * ONE_IN_PX, 11.0 * ONE_IN_PX);
 
   const fn preset(width: f32, height: f32) -> Self {
     Self {


### PR DESCRIPTION
## Why

`takumi-core` already had the CSS absolute units as constants, but they were `pub(crate)`, so `takumi-pdf` rederived them from raw `96.0` / `25.4` / `72.0` literals. Page geometry and CSS lengths ran on separate arithmetic that nothing kept in agreement.

`BAND_EDGE_PADDING` was the worst of it: a bare `20.0` whose 15pt origin lived only in a comment, free to drift from it.

## What

The constants move to `takumi_core::units`, and both crates read them. `PageOptions`, `PT_PER_PX` and `BAND_EDGE_PADDING` are now written in the units they are specified in, so `BAND_EDGE_PADDING` reads `15.0 * ONE_PT_IN_PX`.

A named module rather than a `style` re-export keeps these out of the prelude glob.

Every fixture regenerates byte-identical, so the two derivations did agree; nothing about the output changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable CSS absolute-length conversion constants for centimetres, millimetres, quarter-millimetres, inches, points, and picas based on 96-DPI pixels.
  * Made these unit conversions available through the core library.

* **Improvements**
  * Updated PDF sizing, margins, and A4/Letter page presets to use standardized unit conversions for more consistent measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->