### PR TITLE
PDF: decode JPEG, WebP and GIF image bytes

### DIFF
--- a/.tegami/pdf-core-image-decoders.md
+++ b/.tegami/pdf-core-image-decoders.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Decode JPEG, WebP and GIF images
+
+`raster-images` pulled in krilla's decoders but left takumi-core's compiled out, so an `<img>` carrying anything but PNG bytes failed the whole render with `Unsupported(Format(Unknown))`. The feature now forwards `takumi-core/image-decoding`, the way `svg` already forwards `takumi-core/svg`.

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -43,6 +43,33 @@ test("renders an HTML string with its own stylesheet", async () => {
   expect(pageCount(pdf)).toBe(1);
 });
 
+// One red pixel per raster format, inline so the suite carries no binary
+// fixtures. Each is `sharp({ create: { width: 1, height: 1, channels: 4,
+// background: "#dc3c3c" } }).toFormat(format)`.
+const pixels = {
+  png: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVQImWO4Y2PzHwAFoAJUkZ/O4AAAAABJRU5ErkJggg==",
+  jpeg: "/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAABQf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCIAAVt/9k=",
+  webp: "UklGRjoAAABXRUJQVlA4IC4AAACQAQCdASoBAAEAAUAmJaACdLoAA5gA/urUf/cdgbrxb/9zgf92T/+2T/1IAAAA",
+  gif: "R0lGODlhAQABAIAAAExpcdw8PCH5BAUAAAAALAAAAAABAAEAAAICTAEAOw==",
+};
+
+// The decoders are takumi-core features that `raster-images` forwards, and this
+// build compiles takumi-core's defaults out: a format missing from that forward
+// fails the whole render rather than dropping the image.
+test.each(Object.entries(pixels))("embeds pre-fetched %s bytes", async (format, base64) => {
+  const src = `https://example.test/pixel.${format}`;
+  const pdf = await renderer.render(`<img src="${src}" style="width: 64px">`, {
+    viewport: { width: 80, height: 80 },
+    images: [{ src, data: new Uint8Array(Buffer.from(base64, "base64")) }],
+  });
+  const bytes = decoder.decode(pdf);
+
+  expect(bytes).toContain("/Subtype/Image");
+  // The XObject carries the decoded pixel, not a placeholder.
+  expect(bytes).toContain("/Width 1");
+  expect(bytes).toContain("/Height 1");
+});
+
 test("paginates and substitutes footer counters", async () => {
   // The bundled face is latin only, and `trad-chinese-informal` counts in
   // Chinese numerals. The face registered for it stays on a renderer of its

--- a/takumi-pdf/Cargo.toml
+++ b/takumi-pdf/Cargo.toml
@@ -10,7 +10,14 @@ publish = false
 [features]
 default = ["images", "svg"]
 images = ["raster-images"]
-raster-images = ["dep:png", "dep:zune-jpeg", "dep:gif", "dep:image-webp", "dep:imagesize"]
+raster-images = [
+  "dep:png",
+  "dep:zune-jpeg",
+  "dep:gif",
+  "dep:image-webp",
+  "dep:imagesize",
+  "takumi-core/image-decoding",
+]
 svg = ["takumi-core/svg"]
 
 [dependencies]


### PR DESCRIPTION
**Background as to why I ended up here:** When migrating from Chromium to takumi I noticed that embedding JPEG, WebP images didn't work, resulting in DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) })).

I had Claude work on finding a minimal solution to the problem, let me know where I could improve.

---

`render` takes pre-fetched bytes through `images`, and the docs draw no distinction between raster formats. PNG embeds; the same picture as a JPEG or a WebP rejects the whole render:

```
DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) }))
```

## Cause

The decoding happens in takumi-core, whose `jpeg`/`webp`/`gif` features are compiled out for this build: `takumi-pdf` depends on takumi-core with `default-features = false, features = ["woff2"]`, and its own `raster-images` feature lists only krilla's decoders. The error is `format_compiled_out_error()` in `takumi-core/src/resources/image_decoder.rs`.

The takumi-pdf-side decoders don't cover for it — `paint.rs` always hands krilla `Image::from_rgba8`, so `Image::from_jpeg` is never reached.

This is the same gap #1205 closed for `takumi`, `takumi-napi` and `takumi-wasm`; `takumi-pdf` is the consumer it missed.

## Fix

`raster-images` forwards `takumi-core/image-decoding`, the way `svg` already forwards `takumi-core/svg`. One line; every consumer of takumi-pdf (the wasm binding included) picks it up through feature unification.

## Verifying

The test is in `takumi-pdf-js`, because that build is the one with `default-features = false` and it's what CI runs. A Rust test in `takumi-pdf` can't observe the bug at all: `takumi-html` is a dev-dependency and unifies takumi-core's defaults back in, so the fixture suite has the decoders either way.

It renders one 1x1 pixel per format — PNG, JPEG, WebP, GIF — through `images` and asserts the PDF carries an image XObject of the decoded size. The pixels are inline base64, so no binary fixtures join the repo. Against the release wasm build all four pass, and a document with no image contains neither `/Subtype/Image` nor `/Width 1`, so the assertions discriminate.

`takumi_pdf_wasm_bg.wasm` grows 4,395,847 → 4,687,974 B (+6.6%). If that's too much to spend by default, the alternative shapes are an opt-in feature per format, or forwarding `takumi-core/webp` and `takumi-core/jpeg` only and leaving GIF out (+6.0%) — happy to cut it either way. Worth noting the native side too: `takumi-core/webp` pulls `libwebp-sys` on non-wasm targets, so a Rust-only takumi-pdf consumer now builds libwebp.

`cargo fmt`, `oxlint`/`oxfmt`, `cargo machete`, `cargo test -p takumi-pdf -p takumi-pdf-wasm` and `bun test` in `takumi-pdf-js` (20 pass) are clean. I couldn't run the workspace-wide Rust gates locally — takumi-core's tests need the nightly `assert_matches`, and I only have stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding JPEG, WebP, and GIF images in generated PDFs, in addition to PNG images.

* **Bug Fixes**
  * Improved PDF rendering for pre-fetched non-PNG image data.

* **Tests**
  * Added regression coverage for embedding non-PNG images during PDF generation.

* **Documentation**
  * Documented the expanded image-decoding support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->