### PR TITLE
PDF: pick the WASM entry from the bundler's export condition

### DIFF
--- a/.tegami/pdf-bundler-conditions.md
+++ b/.tegami/pdf-bundler-conditions.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Pick the WASM entry from the bundler's export condition
+
+Bundling `takumi-pdf` broke initialization, because every environment resolved to the Node entry and that entry locates the binary from `import.meta.url`. Vite, Next, workerd and Bun now each get an entry that finds the binary where that bundler puts it.

--- a/takumi-pdf-js/bundlers/bun.mjs
+++ b/takumi-pdf-js/bundlers/bun.mjs
@@ -1,0 +1,9 @@
+import * as wasm from "../dist/export.mjs";
+import wasmPath from "../pkg/takumi_pdf_wasm_bg.wasm";
+
+const wasmBytes = await Bun.file(new URL(wasmPath, import.meta.url)).arrayBuffer();
+
+wasm.initSync({ module: wasmBytes });
+
+export * from "../dist/export.mjs";
+export default wasm.default;

--- a/takumi-pdf-js/bundlers/next.mjs
+++ b/takumi-pdf-js/bundlers/next.mjs
@@ -1,0 +1,11 @@
+import module from "../pkg/takumi_pdf_wasm_bg.wasm?module";
+import * as wasm from "../dist/export.mjs";
+
+// typeof module says its Module { } but instanceof WebAssembly.Module is false
+// Have to force override the prototype to be WebAssembly.Module
+Object.setPrototypeOf(module, WebAssembly.Module.prototype);
+
+wasm.initSync({ module });
+
+export * from "../dist/export.mjs";
+export default wasm.default;

--- a/takumi-pdf-js/bundlers/vite.mjs
+++ b/takumi-pdf-js/bundlers/vite.mjs
@@ -1,0 +1,46 @@
+import url from "../pkg/takumi_pdf_wasm_bg.wasm?url";
+import * as wasm from "../dist/export.mjs";
+
+// `?url` is a browser path; map it to a file for server reads. Vite emits the asset next to the
+// importing server chunk, so resolve relative to import.meta.url, not the framework output dir.
+async function resolveWasm() {
+  if (typeof process !== "undefined" && process.versions?.node != null) {
+    const { readFile } = await import("node:fs/promises");
+    const path = decodeURIComponent(url.replace(/[?#].*$/, ""));
+
+    // Dev SSR serves an `/@fs/<abs-path>` URL.
+    if (path.startsWith("/@fs/")) {
+      return readFile(path.slice("/@fs".length));
+    }
+
+    if (!path.startsWith("/")) {
+      return readFile(new URL(path, import.meta.url));
+    }
+
+    const basename = path.slice(path.lastIndexOf("/") + 1);
+    const candidates = [`./${basename}`, `.${path}`, `../client${path}`, `../../client${path}`];
+
+    let lastError;
+    for (const candidate of candidates) {
+      try {
+        return await readFile(new URL(candidate, import.meta.url));
+      } catch (error) {
+        if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+          lastError = error;
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw new Error(`Unable to locate Takumi WASM asset for SSR: ${url}`, { cause: lastError });
+  }
+
+  return fetch(new URL(url, import.meta.url)).then((response) => response.arrayBuffer());
+}
+
+wasm.initSync({ module: await resolveWasm() });
+
+export * from "../dist/export.mjs";
+export default wasm.default;

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -45,11 +45,23 @@
     ".": {
       "bun": {
         "types": "./bundlers/node.d.ts",
-        "default": "./bundlers/node.mjs"
+        "default": "./bundlers/bun.mjs"
       },
       "workerd": {
         "types": "./bundlers/node.d.ts",
         "default": "./bundlers/workerd.mjs"
+      },
+      "edge-light": {
+        "types": "./bundlers/node.d.ts",
+        "default": "./bundlers/next.mjs"
+      },
+      "unwasm": {
+        "types": "./bundlers/node.d.ts",
+        "default": "./bundlers/next.mjs"
+      },
+      "module": {
+        "types": "./bundlers/node.d.ts",
+        "default": "./bundlers/vite.mjs"
       },
       "node": {
         "require": {
@@ -62,8 +74,8 @@
         }
       },
       "default": {
-        "types": "./dist/export.d.mts",
-        "default": "./dist/export.mjs"
+        "types": "./bundlers/node.d.ts",
+        "default": "./bundlers/vite.mjs"
       }
     },
     "./no-init": {


### PR DESCRIPTION
## Why

takumi-pdf shipped one runtime entry for every environment. `bundlers/node.mjs` locates the WASM binary with `readFileSync(new URL("../pkg/takumi_pdf_wasm_bg.wasm", import.meta.url))`, so bundling the package with Vite or Bun aims that lookup at the emitted chunk and initialization fails. `@takumi-rs/wasm` already solved this with per-bundler entries behind export conditions, but takumi-pdf never got them.

## What

Adds `bundlers/vite.mjs`, `bundlers/next.mjs` and `bundlers/bun.mjs`, and extends the `.` export map with the `module`, `edge-light` and `unwasm` conditions, ordered the way `@takumi-rs/wasm` orders its `./auto` map. No new subpaths: callers still write `import "takumi-pdf"` and the condition picks the entry. The Vite entry adds one candidate path `@takumi-rs/wasm` does not have, `.${path}`, so a plain `vite build --ssr` with `ssrEmitAssets` finds the asset in `outDir/assets`.

Verified by bundling the package through `vite build --ssr` and through `bun build --target=bun`, then rendering a PDF from each output. Both produce `%PDF-`. The same gap in `@takumi-rs/wasm/bundlers/vite.mjs` is untouched here, and none of the new entries have automated coverage, since the existing bundler tests import `bundlers/node.mjs` directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bundler-specific support for Vite, Next.js, Bun, and edge environments.
  * WASM modules now load through the appropriate runtime entry point for improved compatibility.
  * Updated package exports to automatically select the correct environment-specific implementation.

* **Bug Fixes**
  * Prevented supported bundlers from incorrectly resolving the Node.js entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->