### PR TITLE
WASM: find the SSR asset Vite emits beside the server bundle

### DIFF
--- a/.tegami/wasm-vite-ssr-asset-path.md
+++ b/.tegami/wasm-vite-ssr-asset-path.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/wasm":
+    type: patch
+---
+
+### Find the WASM asset when Vite emits it beside the server bundle
+
+A plain `vite build --ssr` with `ssrEmitAssets` writes the asset to `assets/` under the same `outDir` as the server chunk. The SSR read looked next to the chunk and in a framework's `client/` directory, missed both, and threw `Unable to locate Takumi WASM asset for SSR`.

--- a/takumi-wasm/bundlers/vite.mjs
+++ b/takumi-wasm/bundlers/vite.mjs
@@ -17,7 +17,7 @@ async function processUrl() {
     }
 
     const basename = path.slice(path.lastIndexOf("/") + 1);
-    const candidates = [`./${basename}`, `../client${path}`, `../../client${path}`];
+    const candidates = [`./${basename}`, `.${path}`, `../client${path}`, `../../client${path}`];
 
     let lastError;
     for (const candidate of candidates) {


### PR DESCRIPTION
## Why

`vite build --ssr` with `ssrEmitAssets` puts the asset in `assets/` under the same `outDir` as the server chunk. The SSR read looked beside the chunk and in a framework's `client/` directory, found neither, and threw `Unable to locate Takumi WASM asset for SSR: /assets/takumi_wasm_bg-<hash>.wasm`.

## What

One more candidate, `.${path}`, which resolves from the server chunk into its own `assets/`. Framework layouts still hit `../client/` as before: the new candidate misses there and falls through on ENOENT.

Found while porting this bundler to `takumi-pdf` in #1239, which carries the same fix for that package.

Verified both layouts against a Vite SSR build that reads the asset at runtime: same `outDir` fails before the change and passes after, and a `dist/server` + `dist/client` split passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed WASM asset resolution for Vite SSR builds.
  - Prevented asset-not-found errors when files are emitted in the server bundle’s `assets/` directory.

- **Documentation**
  - Added release documentation describing the WASM asset path correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->