### PR TITLE
Docs: load the PDF renderer through the no-init entry

### DIFF
--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -3,8 +3,11 @@ import { extractEmojis } from "takumi-js/helpers/emoji";
 import { fromJsx } from "takumi-js/helpers/jsx";
 import type { FetchedImage, Node } from "takumi-js/helpers";
 import wasm, { init, Renderer } from "takumi-js/wasm";
-import type { PdfRenderer } from "takumi-pdf";
 import pdfWasm from "takumi-pdf/takumi_pdf_wasm_bg.wasm?url";
+// `no-init` over the entry that instantiates the module: the worker has the
+// asset URL already, and that entry needs top-level await, which an iife worker
+// bundle cannot have.
+import initPdf, { PdfRenderer } from "takumi-pdf/no-init";
 import type * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { evaluateCodeExports, renderReact } from "./evaluate";
@@ -35,18 +38,11 @@ let renderer: Renderer | undefined;
   postMessage({ type: "ready" });
 })();
 
-// The PDF engine is a second wasm module, so it only loads once a template asks
-// for one.
+// The wasm module is fetched the first time a template asks for a PDF.
 let pdfRenderer: Promise<PdfRenderer> | undefined;
 
 function loadPdfRenderer() {
-  // `no-init` skips the bundler entry that instantiates the module for you: the
-  // worker already has the asset URL, and that entry needs top-level await,
-  // which an iife worker bundle cannot have.
-  pdfRenderer ??= import("takumi-pdf/no-init").then(async ({ default: initPdf, PdfRenderer }) => {
-    await initPdf({ module_or_path: pdfWasm });
-    return new PdfRenderer();
-  });
+  pdfRenderer ??= initPdf({ module_or_path: pdfWasm }).then(() => new PdfRenderer());
 
   return pdfRenderer;
 }

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -40,7 +40,10 @@ let renderer: Renderer | undefined;
 let pdfRenderer: Promise<PdfRenderer> | undefined;
 
 function loadPdfRenderer() {
-  pdfRenderer ??= import("takumi-pdf").then(async ({ default: initPdf, PdfRenderer }) => {
+  // `no-init` skips the bundler entry that instantiates the module for you: the
+  // worker already has the asset URL, and that entry needs top-level await,
+  // which an iife worker bundle cannot have.
+  pdfRenderer ??= import("takumi-pdf/no-init").then(async ({ default: initPdf, PdfRenderer }) => {
     await initPdf({ module_or_path: pdfWasm });
     return new PdfRenderer();
   });


### PR DESCRIPTION
## Why

The docs build fails on master:

```
[UNSUPPORTED_FEATURE] Top-level await is currently not supported with the 'iife' output format
  ╭─[ ../takumi-pdf-js/bundlers/vite.mjs:43:25 ]
```

The playground worker imports `takumi-pdf`, which resolves to the bundler entry that instantiates the wasm module for the caller. That entry awaits the asset at the top level, and the worker bundle is iife.

## What

The worker imports `takumi-pdf/no-init`, statically. It fetches the asset with `?url` and calls `init` itself, so the entry that instantiates the module was doing the work twice.

The import was dynamic to defer the second wasm engine. An iife bundle has no code splitting, so rolldown inlined it anyway: the built worker contains no `import(` at all, and dropping the wrapper took it from 487,286 to 486,327 bytes.

`bun run build` and `bun run typecheck` in `docs` both pass.

Note for later: no export condition can fix this at the source. Conditions resolve before the output format exists, and Vite has no `worker.resolve.conditions` to aim at a worker build. Making `bundlers/vite.mjs` safe for iife means dropping its top-level await, which makes the synchronous `registerFont` async.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF rendering in the playground by ensuring WebAssembly initializes explicitly and only when the first PDF is requested.
  * Prevented automatic initialization conflicts that could affect PDF generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->