### PR TITLE
Docs: highlight what each PDF example is showing

### DIFF
--- a/docs/content/docs/pdf/attachments.mdx
+++ b/docs/content/docs/pdf/attachments.mdx
@@ -14,6 +14,7 @@ declare const xml: string;
 import { render } from "takumi-pdf";
 
 const pdf = await render(invoice, {
+  // [!code highlight]
   attachments: [
     {
       name: "factur-x.xml",
@@ -50,6 +51,7 @@ declare const xml: string;
 import { render } from "takumi-pdf";
 
 const pdf = await render(invoice, {
+  // [!code highlight]
   pdfa: "3b",
   metadata: { title: "Invoice 1042", creationDate: "2026-08-06" },
   attachments: [

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -18,6 +18,7 @@ import { render } from "takumi-pdf";
 import { googleFonts } from "@takumi-rs/helpers";
 
 const pdf = await render(doc, {
+  // [!code highlight:2]
   fonts: [...(await googleFonts(["Inter"])), { name: "Brand Sans", weight: 700, data: fontBytes }],
   fontFamilies: ["Brand Sans", "Inter", "sans-serif"],
 });
@@ -41,6 +42,7 @@ import { render } from "takumi-pdf";
 const logoBytes = new Uint8Array(await (await fetch(logoUrl)).arrayBuffer());
 
 const pdf = await render(doc, {
+  // [!code highlight]
   images: [{ src: logoUrl, data: logoBytes }],
 });
 ```

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -37,6 +37,7 @@ import { googleFonts } from "@takumi-rs/helpers";
 import { fromHtml } from "@takumi-rs/helpers/html";
 import { render } from "takumi-pdf";
 
+// [!code highlight]
 const { node, stylesheets } = fromHtml(html);
 
 const pdf = await render(node, {
@@ -90,6 +91,7 @@ import { fromHtml } from "@takumi-rs/helpers/html";
 import { render } from "takumi-pdf";
 
 const { node, stylesheets } = fromHtml(html);
+// [!code highlight]
 const images = await prepareImages({ node });
 
 const pdf = await render(node, { images, stylesheets });

--- a/docs/content/docs/pdf/from-react-pdf.mdx
+++ b/docs/content/docs/pdf/from-react-pdf.mdx
@@ -40,6 +40,7 @@ const pdf = await render(
     <span>Invoice</span>
     <span>INV-0042</span>
   </div>,
+  // [!code highlight]
   { size: "a4", margin: 48, fonts: await googleFonts(["Inter"]) },
 );
 ```
@@ -88,6 +89,7 @@ declare const report: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
+  // [!code highlight]
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
       Page <span className="pageNumber" /> of <span className="totalPages" />

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -13,6 +13,7 @@ declare const report: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
+  // [!code highlight]
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
       Page <span className="pageNumber" /> of <span className="totalPages" />
@@ -36,9 +37,11 @@ const footer = (
     Page <span className="pageNumber" /> of <span className="totalPages" />
   </div>
 );
+// [!code highlight]
 const { height } = await measure(footer, { size: "a4" });
 const pdf = await render(report, {
   footer,
+  // [!code highlight]
   margin: { top: 48, bottom: Math.max(48, height + 20) },
 });
 ```
@@ -71,6 +74,7 @@ import { render } from "takumi-pdf";
 const pdf = await render(report, {
   footer: (
     <div style={{ fontSize: 12 }}>
+      {/* [!code highlight:2] */}
       第 <span className="pageNumber trad-chinese-informal" /> 頁,共{" "}
       <span className="totalPages trad-chinese-informal" /> 頁
     </div>

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -35,6 +35,7 @@ import { writeFile } from "node:fs/promises";
 const pdf = await render(<Invoice data={data} />, {
   // A4 portrait with a 48px margin is the default
   size: "a4",
+  // [!code highlight]
   fonts: await googleFonts(["Inter"]),
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
@@ -53,6 +54,7 @@ HTML strings use the same parser as `takumi-js`. A `<style>` tag in the string a
 ```ts twoslash
 import { render } from "takumi-pdf";
 
+// [!code highlight:4]
 const pdf = await render(`
   <style>.total { font-weight: 700 }</style>
   <div><span class="total">Total: $1,290</span></div>
@@ -70,6 +72,7 @@ declare const report: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
+  // [!code highlight:3]
   size: "letter", // "a4", "letter", or { width, height } in CSS px at 96 dpi
   landscape: true,
   margin: { top: 48, right: 32, bottom: 48, left: 32 },
@@ -94,6 +97,7 @@ declare const doc: ReactNode;
 // ---cut---
 import { PdfRenderer } from "takumi-pdf";
 
+// [!code highlight:2]
 const renderer = new PdfRenderer();
 await renderer.registerFont("https://example.com/Inter-Regular.woff2");
 

--- a/docs/content/docs/pdf/invoices.mdx
+++ b/docs/content/docs/pdf/invoices.mdx
@@ -28,10 +28,12 @@ const footer = (
 );
 
 const fonts = await googleFonts(["Inter"]);
+// [!code highlight]
 const { height } = await measure(footer, { size: "a4", fonts });
 
 const pdf = await render(<InvoiceDocument data={invoice} />, {
   size: "a4",
+  // [!code highlight]
   margin: { top: 48, bottom: height + 32, left: 48, right: 48 },
   footer,
   fonts,
@@ -45,6 +47,7 @@ declare const item: { description: string; amount: string };
 // ---cut---
 import "takumi-pdf";
 
+// [!code highlight]
 <div tw="flex break-inside-avoid gap-3 pt-3 text-xs">
   <span tw="flex-1">{item.description}</span>
   <span tw="w-[100px] text-right">{item.amount}</span>

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -13,6 +13,7 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(
   <p>
+    {/* [!code highlight] */}
     Pay online at <a href="https://example.com/pay/1042">example.com/pay/1042</a>.
   </p>,
 );
@@ -27,6 +28,7 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(
   <div>
+    {/* [!code highlight:2] */}
     <a href="#appendix">Jump to the appendix</a>
     <h1 id="appendix">Appendix</h1>
   </div>,
@@ -47,6 +49,7 @@ const pdf = await render(
     <a href="#results" tw="flex items-baseline gap-2">
       <span>Results</span>
       <span tw="flex-1 border-b border-dotted border-gray-400" />
+      {/* [!code highlight] */}
       <span className="targetPageNumber" tw="w-8 shrink-0 text-right" />
     </a>
     <h1 id="results" style={{ breakBefore: "page" }}>
@@ -78,6 +81,7 @@ declare const report: ReactNode;
 // ---cut---
 import { render } from "takumi-pdf";
 
+// [!code highlight]
 const pdf = await render(report, { outline: true });
 ```
 
@@ -95,6 +99,7 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
   lang: "en",
+  // [!code highlight]
   metadata: {
     title: "Annual report 2026",
     description: "Consolidated results for fiscal year 2026",

--- a/docs/content/docs/pdf/pagination.mdx
+++ b/docs/content/docs/pdf/pagination.mdx
@@ -13,6 +13,7 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(
   <article>
+    {/* [!code highlight:2] */}
     <h1 style={{ breakBefore: "page" }}>Chapter two</h1>
     <section style={{ breakInside: "avoid" }}>Keep this together.</section>
   </article>,
@@ -36,6 +37,7 @@ A cut through a paragraph keeps at least `orphans` lines at the bottom of the pa
 import { render } from "takumi-pdf";
 
 const pdf = await render(
+  // [!code highlight]
   <article style={{ widows: 3, orphans: 3 }}>
     A long report body wraps into many lines across the page boundary.
   </article>,

--- a/docs/content/docs/pdf/pdf-a.mdx
+++ b/docs/content/docs/pdf/pdf-a.mdx
@@ -13,6 +13,7 @@ declare const invoice: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(invoice, {
+  // [!code highlight]
   pdfa: "3b",
 });
 ```
@@ -55,6 +56,7 @@ declare const report: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
+  // [!code highlight:2]
   pdfa: "2a",
   tagged: "ua1",
   lang: "en",
@@ -96,6 +98,7 @@ declare const report: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
+  // [!code highlight:2]
   pdfa: "4",
   tagged: "ua2",
   lang: "en",

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -15,8 +15,10 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(
   <article>
+    {/* [!code highlight] */}
     <section style={{ breakBefore: "page" }}>
       <h1>Results</h1>
+      {/* [!code highlight] */}
       <figure style={{ breakInside: "avoid" }}>
         <img src="chart.svg" alt="Revenue by quarter" />
         <figcaption>Revenue by quarter</figcaption>
@@ -26,7 +28,7 @@ const pdf = await render(
 );
 ```
 
-Takumi has no `orphans` or `widows` control. A heading can land alone at the foot of a page. Wrapping the heading and its first paragraph in a `break-inside: avoid` box prevents that.
+`widows` and `orphans` keep a paragraph from splitting into lone lines, but they do not tie a heading to the text under it. Wrap the heading and its first paragraph in a `break-inside: avoid` box for that.
 
 See [Pagination](/docs/pdf/pagination) for the full set of break properties.
 
@@ -60,6 +62,7 @@ import "takumi-pdf";
     <a key={chapter.id} href={`#${chapter.id}`} tw="flex items-baseline gap-2">
       <span>{chapter.title}</span>
       <span tw="flex-1 border-b border-dotted border-gray-300" />
+      {/* [!code highlight] */}
       <span className="targetPageNumber" tw="w-8 shrink-0 text-right" />
     </a>
   ))}
@@ -79,12 +82,14 @@ declare const report: ReactNode;
 import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
+  // [!code highlight]
   header: (
     <div tw="flex w-full justify-between px-12 text-[10px] text-gray-500">
       <span>Annual report 2026</span>
       <span>Acme Inc.</span>
     </div>
   ),
+  // [!code highlight]
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
       <span className="pageNumber" /> / <span className="totalPages" />
@@ -111,6 +116,7 @@ declare function HeaderRow(): ReactNode;
 import "takumi-pdf";
 
 <div tw="flex flex-col">
+  {/* [!code highlight] */}
   {chunk(rows, 24).map((group, index) => (
     <div key={index} tw="flex break-inside-avoid flex-col">
       <HeaderRow />
@@ -140,6 +146,7 @@ declare function save(id: string, pdf: Uint8Array): Promise<void>;
 import { PdfRenderer } from "takumi-pdf";
 import { googleFonts } from "@takumi-rs/helpers";
 
+// [!code highlight]
 const renderer = new PdfRenderer();
 const fonts = await googleFonts(["Inter"]);
 

--- a/docs/content/docs/pdf/single-page.mdx
+++ b/docs/content/docs/pdf/single-page.mdx
@@ -10,6 +10,7 @@ icon: File
 import { render } from "takumi-pdf";
 
 const pdf = await render(<div style={{ width: "100%", height: "100%" }}>Certificate</div>, {
+  // [!code highlight]
   viewport: { width: 1123, height: 794 }, // A4 landscape in px
 });
 ```
@@ -24,6 +25,7 @@ declare const receipt: ReactNode;
 // ---cut---
 import { render } from "takumi-pdf";
 
+// [!code highlight]
 const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
 ```
 

--- a/docs/content/docs/pdf/tickets.mdx
+++ b/docs/content/docs/pdf/tickets.mdx
@@ -22,6 +22,7 @@ const pdf = await render(
     <img src="qr.svg" alt="Tracking code" tw="h-40 w-40 self-center" />
     <span tw="text-xs text-gray-500">1Z 999 AA1 0123 4567</span>
   </div>,
+  // [!code highlight]
   { viewport: { width: 384, height: 576 }, images: [{ src: "qr.svg", data: qrSvg }] },
 );
 ```
@@ -48,6 +49,7 @@ declare const receipt: ReactNode;
 // ---cut---
 import { render } from "takumi-pdf";
 
+// [!code highlight]
 const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
 ```
 
@@ -65,6 +67,7 @@ import { render } from "takumi-pdf";
 const pdf = await render(
   <div
     tw="flex h-full w-full flex-col items-center justify-center"
+    // [!code highlight]
     style={{ backgroundImage: "linear-gradient(135deg, #eef2ff, #ffffff)" }}
   >
     <span tw="text-sm tracking-[0.3em] text-indigo-500">CERTIFICATE OF COMPLETION</span>


### PR DESCRIPTION
## Why

The PDF section had 43 code blocks and 3 highlights. A reader landing mid-page had to diff the sample against the prose to find the line it was about.

## What

Every block now marks the line it exists to show: the option being introduced, the class hook, the property under discussion. Five blocks stay unmarked on purpose, because no single line is the point: the Puppeteer and react-pdf before-snippets, `npm i takumi-pdf`, and the two validator CLIs.

One stale sentence went with it. `reports.mdx` said takumi has no `widows` or `orphans` control, which stopped being true in #1226; the paragraph now says what those properties do and does not cover, since the advice around it (wrap a heading with its first paragraph) is still right.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved code highlighting across PDF documentation examples, making key configuration and rendering steps easier to identify.
  * Clarified pagination behavior: `widows` and `orphans` prevent isolated paragraph lines but do not keep headings with following content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->