### PR TITLE
Core: draw glyphs through a type-erased pen

### DIFF
--- a/.tegami/erased-glyph-pen.md
+++ b/.tegami/erased-glyph-pen.md
@@ -1,0 +1,11 @@
+---
+packages:
+  takumi-core:
+    type: patch
+  takumi-pdf:
+    type: patch
+---
+
+### Draw glyphs through a type-erased pen
+
+skrifa stamps out its whole CFF/glyf evaluator per concrete pen type. Routing every outline draw through one `ErasedPen` drops ~110KB from the wasm binaries with identical rendering.

--- a/takumi-core/src/resources/glyph.rs
+++ b/takumi-core/src/resources/glyph.rs
@@ -310,6 +310,33 @@ fn hash_path_commands(paths: &[Command]) -> u64 {
   h.digest()
 }
 
+/// Type-erased [`OutlinePen`]: skrifa monomorphizes its whole CFF/glyf
+/// evaluator per pen type, which costs ~100KB of wasm per concrete pen.
+/// Route every `OutlineGlyph::draw` call through this instead.
+pub struct ErasedPen<'a>(pub &'a mut dyn OutlinePen);
+
+impl OutlinePen for ErasedPen<'_> {
+  fn move_to(&mut self, x: f32, y: f32) {
+    self.0.move_to(x, y);
+  }
+
+  fn line_to(&mut self, x: f32, y: f32) {
+    self.0.line_to(x, y);
+  }
+
+  fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+    self.0.quad_to(cx0, cy0, x, y);
+  }
+
+  fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+    self.0.curve_to(cx0, cy0, cx1, cy1, x, y);
+  }
+
+  fn close(&mut self) {
+    self.0.close();
+  }
+}
+
 #[derive(Default)]
 struct GlyphOutlinePen {
   paths: Vec<Command>,
@@ -514,7 +541,10 @@ fn resolve_outline_commands(
   let glyph = outline_glyphs.get(glyph_id)?;
   let mut pen = GlyphOutlinePen::default();
   glyph
-    .draw(DrawSettings::unhinted(size, location), &mut pen)
+    .draw(
+      DrawSettings::unhinted(size, location),
+      &mut ErasedPen(&mut pen),
+    )
     .ok()?;
   Some(pen.finish())
 }

--- a/takumi-pdf/src/krilla/text/glyph/colr.rs
+++ b/takumi-pdf/src/krilla/text/glyph/colr.rs
@@ -336,7 +336,7 @@ impl ColorPainter for ColrBuilder {
 
     let Ok(_) = outline_glyph.draw(
       DrawSettings::unhinted(skrifa::instance::Size::unscaled(), self.font.location_ref()),
-      &mut glyph_builder,
+      &mut takumi_core::resources::glyph::ErasedPen(&mut glyph_builder),
     ) else {
       self.error = true;
       return;

--- a/takumi-pdf/src/krilla/text/glyph/outline.rs
+++ b/takumi-pdf/src/krilla/text/glyph/outline.rs
@@ -1,4 +1,5 @@
 use skrifa::outline::{DrawSettings, OutlinePen};
+use takumi_core::resources::glyph::ErasedPen;
 
 use crate::krilla::geom::Path;
 use crate::krilla::geom::Transform;
@@ -14,7 +15,7 @@ pub(crate) fn glyph_path(font: Font, glyph: GlyphId) -> Option<tiny_skia_path::P
     outline_glyph
       .draw(
         DrawSettings::unhinted(skrifa::instance::Size::unscaled(), font.location_ref()),
-        &mut outline_builder,
+        &mut ErasedPen(&mut outline_builder),
       )
       .ok()?;
   }

--- a/takumi-pdf/src/subsetter/interjector.rs
+++ b/takumi-pdf/src/subsetter/interjector.rs
@@ -21,6 +21,7 @@ pub(crate) mod skrifa {
   use skrifa::outline::{DrawSettings, OutlinePen};
   use skrifa::prelude::Size;
   use skrifa::{FontRef, GlyphId, MetadataProvider};
+  use takumi_core::resources::glyph::ErasedPen;
   use write_fonts::tables::glyf::SimpleGlyph;
   use write_fonts::{FontWrite, TableWriter, dump_table};
 
@@ -63,7 +64,7 @@ pub(crate) mod skrifa {
         outline_glyph
           .draw(
             DrawSettings::unhinted(Size::unscaled(), &self.location),
-            &mut outline_builder,
+            &mut ErasedPen(&mut outline_builder),
           )
           .ok()?;
       }


### PR DESCRIPTION
## Why

skrifa's `OutlineGlyph::draw` is generic over the pen, and the pen type threads through the whole CFF/glyf evaluator, so each concrete pen stamps out another full copy of the charstring interpreter. Three pen types across takumi-core and the vendored krilla cost ~215KB of `Evaluator` code in takumi-pdf-wasm.

## What

Adds `ErasedPen`, a pen wrapping `&mut dyn OutlinePen`, and routes all four draw call sites through it, so skrifa monomorphizes once. Measured on takumi-pdf-wasm: code+data 4562KB → 4453KB (−109KB, −2.4%), `Evaluator` instantiations 120 → 76. The virtual dispatch lands only on the per-segment pen callbacks, not the interpreter itself. Goldens show zero .svg/.webp drift, so rendering is byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced WebAssembly binary size by approximately 110 KB.
  * Preserved existing glyph rendering and PDF output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->