### PR TITLE
Core: patch skrifa to drop the unused hinting interpreter

### DIFF
--- a/.tegami/skrifa-no-hinting.md
+++ b/.tegami/skrifa-no-hinting.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/wasm":
+    type: patch
+  takumi-pdf:
+    type: patch
+---
+
+### Ship without skrifa's hinting interpreter
+
+Every draw is unhinted, but skrifa's TrueType hinting interpreter and autohinter survived dead-code elimination through runtime branches. A patched skrifa gates them behind a `hinting` feature, cutting ~240KB from the wasm binaries with identical rendering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,8 +468,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "font-types"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
+source = "git+https://github.com/kane50613/fontations?rev=3a3cc7904d9b8207939b089e63ea7fba88663b22#3a3cc7904d9b8207939b089e63ea7fba88663b22"
 dependencies = [
  "bytemuck",
 ]
@@ -1418,8 +1417,7 @@ dependencies = [
 [[package]]
 name = "read-fonts"
 version = "0.40.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+source = "git+https://github.com/kane50613/fontations?rev=3a3cc7904d9b8207939b089e63ea7fba88663b22#3a3cc7904d9b8207939b089e63ea7fba88663b22"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -1687,8 +1685,7 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 [[package]]
 name = "skrifa"
 version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+source = "git+https://github.com/kane50613/fontations?rev=3a3cc7904d9b8207939b089e63ea7fba88663b22#3a3cc7904d9b8207939b089e63ea7fba88663b22"
 dependencies = [
  "bytemuck",
  "read-fonts 0.40.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,3 +238,12 @@ opt-level = "z"
 opt-level = "z"
 
 
+# skrifa's TrueType hinting interpreter and autohinter are dead code for us
+# (every draw is unhinted) but survive dead-code elimination through runtime
+# branches, costing ~240KB of wasm. The fork gates them behind an upstreamable
+# `hinting` cargo feature; drop the patch once it lands in a skrifa release.
+# https://github.com/googlefonts/fontations/issues/892
+[patch.crates-io]
+skrifa = { git = "https://github.com/kane50613/fontations", rev = "3a3cc7904d9b8207939b089e63ea7fba88663b22" }
+read-fonts = { git = "https://github.com/kane50613/fontations", rev = "3a3cc7904d9b8207939b089e63ea7fba88663b22" }
+font-types = { git = "https://github.com/kane50613/fontations", rev = "3a3cc7904d9b8207939b089e63ea7fba88663b22" }


### PR DESCRIPTION
## Why

Every takumi draw is unhinted, but skrifa's TrueType hinting interpreter, autohinter, and their CFF evaluator instantiations survive dead-code elimination: `FreeTypeScaler::load` and `OutlineGlyph::draw` reach them through runtime branches that LTO cannot prove dead. They cost ~240KB in takumi-pdf-wasm and most of that in @takumi-rs/wasm too (upstream: googlefonts/fontations#892).

## What

Adds a `[patch.crates-io]` pointing skrifa, read-fonts, and font-types at [kane50613/fontations `takumi/nohint`](https://github.com/kane50613/fontations/tree/takumi/nohint), a fork of skrifa 0.43.2 that gates the interpreter and autohinter behind a default-on `hinting` cargo feature (no `allow` attributes, both feature states compile warning-free, upstream tests pass). Our graph disables it via the existing `default-features = false`. Measured on takumi-pdf-wasm: code+data 4453KB → 4213KB, Evaluator instantiations 76 → 22, TT engine and autohint gone. All tests pass with zero golden drift. The patch only affects our built artifacts; crates.io consumers keep stock skrifa. Stacked on #1251 for the Cargo.lock; drop the patch once the feature lands upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced WebAssembly binary size by removing unused font hinting and autohinting code.
  - Rendering remains unhinted and unchanged.

- **Release Notes**
  - Added patch release documentation for the WASM and PDF packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->