### PR TITLE
WASM, PDF: export the wasm URL for browser bundlers

### DIFF
--- a/.tegami/wasm-url-export.md
+++ b/.tegami/wasm-url-export.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/wasm":
+    type: minor
+  takumi-js:
+    type: minor
+  takumi-pdf:
+    type: minor
+---
+
+### Load the wasm binary in a browser bundle
+
+Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.

--- a/.tegami/wasm-url-export.md
+++ b/.tegami/wasm-url-export.md
@@ -10,4 +10,4 @@ packages:
 
 ### Load the wasm binary in a browser bundle
 
-Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.
+Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`, the call Vite, webpack and Turbopack rewrite to the asset they emit. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -3,7 +3,7 @@ import { extractEmojis } from "takumi-js/helpers/emoji";
 import { fromJsx } from "takumi-js/helpers/jsx";
 import type { FetchedImage, Node } from "takumi-js/helpers";
 import wasm, { init, Renderer } from "takumi-js/wasm";
-import pdfWasm from "takumi-pdf/takumi_pdf_wasm_bg.wasm?url";
+import pdfWasm from "takumi-pdf/wasm-url";
 // `no-init` over the entry that instantiates the module: the worker has the
 // asset URL already, and that entry needs top-level await, which an iife worker
 // bundle cannot have.

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -52,7 +52,3 @@ SVG image sources embed as vector paths and gradients, so logos stay sharp at an
 PNG, JPEG and WebP bytes all embed. A JPEG goes in as the JPEG you passed, so the PDF carries the compression the file already had. GIF bytes are rejected: no decoder for them ships in this build.
 
 A CSS `filter` needs pixels to work on, and this build decodes only PNG. An image under a filter that arrived as JPEG or WebP has none, so `render` rejects the document and names the image rather than leaving a hole in the page. The same goes for `filter: blur()` and `drop-shadow()`, which a PDF cannot express at all.
-
-## Runtimes
-
-`takumi-pdf` is wasm-only. It runs on Node.js, Bun, and Cloudflare Workers. The module fits within the Workers free-tier size limit. Import `takumi-pdf/no-init` to control wasm instantiation.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -110,3 +110,28 @@ const pdf = await renderer.render(doc);
 ```
 
 Registered fonts deduplicate across calls. Rendering many documents pays the font cost once.
+
+## Runtimes
+
+`takumi-pdf` ships as WebAssembly. It runs on Node.js, Bun, and Cloudflare Workers.
+The module fits the Workers free-tier size limit.
+Import `takumi-pdf/no-init` to instantiate the wasm yourself.
+
+### In the browser
+
+The default entry picks its loader from the export conditions the bundler sets.
+Vite, webpack, and Turbopack set the same conditions for a browser build.
+All three land on the Vite entry, and its `?url` import only works in Vite.
+
+Load the binary yourself instead:
+
+```ts
+import init, { render } from "takumi-pdf/no-init";
+import wasmUrl from "takumi-pdf/wasm-url";
+
+await init({ module_or_path: wasmUrl });
+```
+
+`takumi-pdf/wasm-url` resolves the binary with `new URL(specifier, import.meta.url)`.
+Vite, webpack, Turbopack, and Rollup all understand that syntax.
+The module has no top-level `await`, so it also works in a worker bundled as an IIFE.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -133,5 +133,8 @@ await init({ module_or_path: wasmUrl });
 ```
 
 `takumi-pdf/wasm-url` resolves the binary with `new URL(specifier, import.meta.url)`.
-Vite, webpack, Turbopack, and Rollup all understand that syntax.
+Vite, webpack, and Turbopack rewrite that call to the asset they emit.
 The module has no top-level `await`, so it also works in a worker bundled as an IIFE.
+
+Server code should keep the default entry. A Vite SSR build leaves the URL pointing at the
+server chunk, where the asset never lands.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -138,3 +138,7 @@ The module has no top-level `await`, so it also works in a worker bundled as an 
 
 Server code should keep the default entry. A Vite SSR build leaves the URL pointing at the
 server chunk, where the asset never lands.
+
+On Turbopack, drop any `turbopack.rules` entry mapping `*.wasm` to `type: "wasm"`.
+That rule makes Turbopack instantiate the binary and look for wasm-bindgen glue the
+package does not ship.

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -46,6 +46,10 @@ await init({ module_or_path: wasmUrl });
 Vite, webpack, and Turbopack rewrite that call to the asset they emit.
 Server code should keep `takumi-js/wasm`, which locates the binary for the runtime it lands on.
 
+On Turbopack, drop any `turbopack.rules` entry mapping `*.wasm` to `type: "wasm"`.
+That rule makes Turbopack instantiate the binary and look for wasm-bindgen glue the
+package does not ship.
+
 `@takumi-rs/wasm` and `takumi-pdf` export `wasm-url` too.
 
 ## Node.js Issues

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -25,6 +25,28 @@ export function GET() {
 
 If the issue persists, file an issue on [our GitHub repository](https://github.com/kane50613/takumi/issues).
 
+## Browser Issues
+
+### Export default doesn't exist in target module
+
+`takumi-js/wasm` picks its wasm loader from the export conditions the bundler sets.
+Vite, webpack, and Turbopack set the same conditions for a browser build.
+All three land on the Vite entry, and its `?url` import only works in Vite.
+
+Load the binary yourself instead:
+
+```ts
+import wasmUrl from "takumi-js/wasm-url";
+import { init, Renderer } from "takumi-js/wasm/no-init";
+
+await init({ module_or_path: wasmUrl });
+```
+
+`takumi-js/wasm-url` resolves the binary with `new URL(specifier, import.meta.url)`.
+Vite, webpack, Turbopack, and Rollup all understand that syntax.
+
+`@takumi-rs/wasm` and `takumi-pdf` export `wasm-url` too.
+
 ## Node.js Issues
 
 ### Cannot find native binding

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -43,7 +43,8 @@ await init({ module_or_path: wasmUrl });
 ```
 
 `takumi-js/wasm-url` resolves the binary with `new URL(specifier, import.meta.url)`.
-Vite, webpack, Turbopack, and Rollup all understand that syntax.
+Vite, webpack, and Turbopack rewrite that call to the asset they emit.
+Server code should keep `takumi-js/wasm`, which locates the binary for the runtime it lands on.
 
 `@takumi-rs/wasm` and `takumi-pdf` export `wasm-url` too.
 

--- a/takumi-js/bundlers/wasm-url.cjs
+++ b/takumi-js/bundlers/wasm-url.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@takumi-rs/wasm/wasm-url");

--- a/takumi-js/bundlers/wasm-url.d.cts
+++ b/takumi-js/bundlers/wasm-url.d.cts
@@ -1,0 +1,3 @@
+declare const url: URL;
+
+export = url;

--- a/takumi-js/bundlers/wasm-url.d.ts
+++ b/takumi-js/bundlers/wasm-url.d.ts
@@ -1,0 +1,3 @@
+declare const url: URL;
+
+export default url;

--- a/takumi-js/bundlers/wasm-url.mjs
+++ b/takumi-js/bundlers/wasm-url.mjs
@@ -1,0 +1,1 @@
+export { default } from "@takumi-rs/wasm/wasm-url";

--- a/takumi-js/package.json
+++ b/takumi-js/package.json
@@ -33,7 +33,8 @@
     "directory": "takumi-js"
   },
   "files": [
-    "dist"
+    "dist",
+    "bundlers"
   ],
   "type": "module",
   "sideEffects": false,
@@ -163,6 +164,26 @@
       "require": {
         "types": "./dist/wasm.d.cts",
         "default": "./dist/wasm.cjs"
+      }
+    },
+    "./wasm/no-init": {
+      "import": {
+        "types": "./dist/wasm/no-init.d.mts",
+        "default": "./dist/wasm/no-init.mjs"
+      },
+      "require": {
+        "types": "./dist/wasm/no-init.d.cts",
+        "default": "./dist/wasm/no-init.cjs"
+      }
+    },
+    "./wasm-url": {
+      "import": {
+        "types": "./bundlers/wasm-url.d.ts",
+        "default": "./bundlers/wasm-url.mjs"
+      },
+      "require": {
+        "types": "./bundlers/wasm-url.d.cts",
+        "default": "./bundlers/wasm-url.cjs"
       }
     },
     "./helpers": {

--- a/takumi-js/src/wasm/no-init.ts
+++ b/takumi-js/src/wasm/no-init.ts
@@ -1,0 +1,2 @@
+export { default as init } from "@takumi-rs/wasm";
+export * from "@takumi-rs/wasm";

--- a/takumi-js/tsdown.config.ts
+++ b/takumi-js/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     response: "src/response/index.ts",
     node: "src/node/index.ts",
     wasm: "src/wasm/index.ts",
+    "wasm/no-init": "src/wasm/no-init.ts",
     "backend/node": "src/backend/node.ts",
     "backend/wasm": "src/backend/wasm.ts",
     "helpers/index": "src/helpers/index.ts",

--- a/takumi-pdf-js/bundlers/bun.mjs
+++ b/takumi-pdf-js/bundlers/bun.mjs
@@ -1,7 +1,7 @@
 import * as wasm from "../dist/export.mjs";
-import wasmPath from "../pkg/takumi_pdf_wasm_bg.wasm";
+import wasmUrl from "./wasm-url.mjs";
 
-const wasmBytes = await Bun.file(new URL(wasmPath, import.meta.url)).arrayBuffer();
+const wasmBytes = await Bun.file(wasmUrl).arrayBuffer();
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-pdf-js/bundlers/node.cjs
+++ b/takumi-pdf-js/bundlers/node.cjs
@@ -1,9 +1,8 @@
 const wasm = require("../dist/export.cjs");
 const { readFileSync } = require("node:fs");
-const { join } = require("node:path");
+const wasmUrl = require("./wasm-url.cjs");
 
-const wasmPath = join(__dirname, "../pkg/takumi_pdf_wasm_bg.wasm");
-const wasmBytes = readFileSync(wasmPath);
+const wasmBytes = readFileSync(wasmUrl);
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-pdf-js/bundlers/node.mjs
+++ b/takumi-pdf-js/bundlers/node.mjs
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import * as wasm from "../dist/export.mjs";
+import wasmUrl from "./wasm-url.mjs";
 
-const wasmBytes = readFileSync(new URL("../pkg/takumi_pdf_wasm_bg.wasm", import.meta.url));
+const wasmBytes = readFileSync(wasmUrl);
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-pdf-js/bundlers/wasm-url.cjs
+++ b/takumi-pdf-js/bundlers/wasm-url.cjs
@@ -1,0 +1,4 @@
+const { join } = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+module.exports = pathToFileURL(join(__dirname, "../pkg/takumi_pdf_wasm_bg.wasm"));

--- a/takumi-pdf-js/bundlers/wasm-url.d.cts
+++ b/takumi-pdf-js/bundlers/wasm-url.d.cts
@@ -1,0 +1,3 @@
+declare const url: URL;
+
+export = url;

--- a/takumi-pdf-js/bundlers/wasm-url.d.ts
+++ b/takumi-pdf-js/bundlers/wasm-url.d.ts
@@ -1,0 +1,3 @@
+declare const url: URL;
+
+export default url;

--- a/takumi-pdf-js/bundlers/wasm-url.mjs
+++ b/takumi-pdf-js/bundlers/wasm-url.mjs
@@ -1,0 +1,1 @@
+export default new URL("../pkg/takumi_pdf_wasm_bg.wasm", import.meta.url);

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -91,6 +91,16 @@
     "./takumi_pdf_wasm_bg.wasm": {
       "types": "./pkg/takumi_pdf_wasm_bg.wasm.d.ts",
       "default": "./pkg/takumi_pdf_wasm_bg.wasm"
+    },
+    "./wasm-url": {
+      "import": {
+        "types": "./bundlers/wasm-url.d.ts",
+        "default": "./bundlers/wasm-url.mjs"
+      },
+      "require": {
+        "types": "./bundlers/wasm-url.d.cts",
+        "default": "./bundlers/wasm-url.cjs"
+      }
     }
   },
   "scripts": {

--- a/takumi-wasm/bundlers/bun.mjs
+++ b/takumi-wasm/bundlers/bun.mjs
@@ -1,7 +1,7 @@
 import * as wasm from "../dist/export.mjs";
-import wasmPath from "../pkg/takumi_wasm_bg.wasm";
+import wasmUrl from "./wasm-url.mjs";
 
-const wasmBytes = await Bun.file(new URL(wasmPath, import.meta.url)).arrayBuffer();
+const wasmBytes = await Bun.file(wasmUrl).arrayBuffer();
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/bundlers/node.cjs
+++ b/takumi-wasm/bundlers/node.cjs
@@ -1,9 +1,8 @@
 const wasm = require("../dist/export.cjs");
 const { readFileSync } = require("node:fs");
-const { join } = require("node:path");
+const wasmUrl = require("./wasm-url.cjs");
 
-const wasmPath = join(__dirname, "../pkg/takumi_wasm_bg.wasm");
-const wasmBytes = readFileSync(wasmPath);
+const wasmBytes = readFileSync(wasmUrl);
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/bundlers/node.mjs
+++ b/takumi-wasm/bundlers/node.mjs
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import * as wasm from "../dist/export.mjs";
+import wasmUrl from "./wasm-url.mjs";
 
-const wasmBytes = readFileSync(new URL("../pkg/takumi_wasm_bg.wasm", import.meta.url));
+const wasmBytes = readFileSync(wasmUrl);
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/bundlers/wasm-url.cjs
+++ b/takumi-wasm/bundlers/wasm-url.cjs
@@ -1,0 +1,4 @@
+const { join } = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+module.exports = pathToFileURL(join(__dirname, "../pkg/takumi_wasm_bg.wasm"));

--- a/takumi-wasm/bundlers/wasm-url.d.cts
+++ b/takumi-wasm/bundlers/wasm-url.d.cts
@@ -1,0 +1,3 @@
+declare const url: URL;
+
+export = url;

--- a/takumi-wasm/bundlers/wasm-url.d.ts
+++ b/takumi-wasm/bundlers/wasm-url.d.ts
@@ -1,0 +1,3 @@
+declare const url: URL;
+
+export default url;

--- a/takumi-wasm/bundlers/wasm-url.mjs
+++ b/takumi-wasm/bundlers/wasm-url.mjs
@@ -1,0 +1,1 @@
+export default new URL("../pkg/takumi_wasm_bg.wasm", import.meta.url);

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -102,6 +102,16 @@
       "types": "./pkg/takumi_wasm_bg.wasm.d.ts",
       "default": "./pkg/takumi_wasm_bg.wasm"
     },
+    "./wasm-url": {
+      "import": {
+        "types": "./bundlers/wasm-url.d.ts",
+        "default": "./bundlers/wasm-url.mjs"
+      },
+      "require": {
+        "types": "./bundlers/wasm-url.d.cts",
+        "default": "./bundlers/wasm-url.cjs"
+      }
+    },
     "./next": {
       "types": "./bundlers/wasm-module.d.ts",
       "default": "./bundlers/next.mjs"


### PR DESCRIPTION
## Why

Vite, webpack and Turbopack set the same export conditions for a browser build, so all three resolve `bundlers/vite.mjs` and its `?url` import, which only Vite understands. A Next.js client bundle fails with `Export default doesn't exist in target module`. Bundler resolution runs before dead-code elimination, so no runtime branch can hide the wrong specifier.

## What

Each package exports `wasm-url`, a module resolving the binary through `new URL(specifier, import.meta.url)`. It carries no top-level `await`, so an IIFE worker bundle takes it too. The Node and Bun entries now read the binary through that same module instead of spelling the path out again.

`takumi-js/wasm/no-init` is new: `takumi-js/wasm` statically re-exports `@takumi-rs/wasm/auto`, so the broken entry reaches the bundle even when the caller only wants `init`.

Measured, one build per bundler:

| Bundler | `new URL(…, import.meta.url)` |
| --- | --- |
| Vite (browser, our playground worker) | rewritten, asset emitted |
| webpack 5 (web) | rewritten, asset emitted |
| Turbopack (Next client) | rewritten, asset emitted |
| Vite (SSR) | left verbatim |
| Bun, esbuild, Rollup | left verbatim |

So `vite.mjs` keeps its `?url` import and its SSR fallback: the docs say to reach for `wasm-url` in a browser bundle and leave server code on the default entry. A Turbopack consumer also has to drop any `turbopack.rules` entry mapping `*.wasm` to `type: "wasm"`, since `pkg/` ships no wasm-bindgen glue to instantiate against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wasm-url` exports for reliable WebAssembly asset loading across Node.js, Bun, browsers, and bundlers.
  * Added a `wasm/no-init` entry point for manual WebAssembly initialization.
  * Improved compatibility with Vite, webpack, Turbopack, SSR, and Cloudflare Workers.
  * Updated PDF and WebAssembly integrations to use the new loading options.

* **Documentation**
  * Expanded runtime, browser bundling, initialization, and troubleshooting guidance.
  * Removed obsolete runtime guidance from the fonts and images documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->