### PR TITLE
WASM, PDF: keep each entry's binary import bundler-visible

### DIFF
--- a/takumi-pdf-js/bundlers/bun.mjs
+++ b/takumi-pdf-js/bundlers/bun.mjs
@@ -1,7 +1,7 @@
 import * as wasm from "../dist/export.mjs";
-import wasmUrl from "./wasm-url.mjs";
+import wasmPath from "../pkg/takumi_pdf_wasm_bg.wasm";
 
-const wasmBytes = await Bun.file(wasmUrl).arrayBuffer();
+const wasmBytes = await Bun.file(new URL(wasmPath, import.meta.url)).arrayBuffer();
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-pdf-js/bundlers/node.cjs
+++ b/takumi-pdf-js/bundlers/node.cjs
@@ -1,8 +1,9 @@
 const wasm = require("../dist/export.cjs");
 const { readFileSync } = require("node:fs");
-const wasmUrl = require("./wasm-url.cjs");
+const { join } = require("node:path");
 
-const wasmBytes = readFileSync(wasmUrl);
+const wasmPath = join(__dirname, "../pkg/takumi_pdf_wasm_bg.wasm");
+const wasmBytes = readFileSync(wasmPath);
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-pdf-js/bundlers/node.mjs
+++ b/takumi-pdf-js/bundlers/node.mjs
@@ -1,8 +1,7 @@
 import { readFileSync } from "node:fs";
 import * as wasm from "../dist/export.mjs";
-import wasmUrl from "./wasm-url.mjs";
 
-const wasmBytes = readFileSync(wasmUrl);
+const wasmBytes = readFileSync(new URL("../pkg/takumi_pdf_wasm_bg.wasm", import.meta.url));
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/bundlers/bun.mjs
+++ b/takumi-wasm/bundlers/bun.mjs
@@ -1,7 +1,7 @@
 import * as wasm from "../dist/export.mjs";
-import wasmUrl from "./wasm-url.mjs";
+import wasmPath from "../pkg/takumi_wasm_bg.wasm";
 
-const wasmBytes = await Bun.file(wasmUrl).arrayBuffer();
+const wasmBytes = await Bun.file(new URL(wasmPath, import.meta.url)).arrayBuffer();
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/bundlers/node.cjs
+++ b/takumi-wasm/bundlers/node.cjs
@@ -1,8 +1,9 @@
 const wasm = require("../dist/export.cjs");
 const { readFileSync } = require("node:fs");
-const wasmUrl = require("./wasm-url.cjs");
+const { join } = require("node:path");
 
-const wasmBytes = readFileSync(wasmUrl);
+const wasmPath = join(__dirname, "../pkg/takumi_wasm_bg.wasm");
+const wasmBytes = readFileSync(wasmPath);
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/bundlers/node.mjs
+++ b/takumi-wasm/bundlers/node.mjs
@@ -1,8 +1,7 @@
 import { readFileSync } from "node:fs";
 import * as wasm from "../dist/export.mjs";
-import wasmUrl from "./wasm-url.mjs";
 
-const wasmBytes = readFileSync(wasmUrl);
+const wasmBytes = readFileSync(new URL("../pkg/takumi_wasm_bg.wasm", import.meta.url));
 
 wasm.initSync({ module: wasmBytes });
 

--- a/takumi-wasm/tests/bundlers.test.ts
+++ b/takumi-wasm/tests/bundlers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Importing the entry instantiates the module, so a binary the bundler failed to
+// carry over surfaces as a load-time ENOENT rather than a later render failure.
+const ENTRY = `import { Renderer } from "../../bundlers/bun.mjs";\n\nconsole.log(typeof Renderer);\n`;
+
+describe("bun entry", () => {
+  // `bun build` leaves `new URL(specifier, import.meta.url)` untouched, so the entry
+  // has to reach the binary through an import the bundler rewrites and emits.
+  test("survives bundling with its binary", () => {
+    const dir = mkdtempSync(join(import.meta.dir, "..", "node_modules", ".bundler-"));
+    const entry = join(dir, "entry.mjs");
+
+    writeFileSync(entry, ENTRY);
+
+    try {
+      const built = Bun.spawnSync([
+        "bun",
+        "build",
+        entry,
+        "--target=bun",
+        `--outdir=${join(dir, "out")}`,
+      ]);
+
+      expect(built.exitCode).toBe(0);
+
+      const ran = Bun.spawnSync(["bun", join(dir, "out", "entry.js")]);
+
+      expect(ran.stderr.toString()).toBe("");
+      expect(ran.exitCode).toBe(0);
+      expect(ran.stdout.toString().trim()).toBe("function");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Why

#1254 pointed the Bun and Node entries at the shared `wasm-url` module, which resolves the binary with `new URL(specifier, import.meta.url)`. Bun's bundler leaves that call untouched, so a bundled app resolved the path against its own output directory:

```
ENOENT: no such file or directory, open '<outdir>/pkg/takumi_pdf_wasm_bg.wasm'
```

Unbundled Bun was fine, which is why the smoke check passed. The change is unreleased, so no published version carries it.

## What

Every entry spells out its own path to the binary again, the way it did before #1254. The Bun entry's `import wasmPath from "../pkg/…wasm"` is the form Bun's bundler rewrites and emits the asset for; the Node entries were behaviour-neutral either way, and sharing one module across entries with different loading rules is what caused this.

A test bundles the Bun entry with `bun build --target=bun` and runs the output. It fails on the merged code and passes on this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly asset loading for Node.js and Bun environments.
  * Bundled applications can now locate required WebAssembly resources more reliably across package installations.

* **Tests**
  * Added integration coverage verifying successful Bun bundling and execution.
  * Confirmed bundled output runs without errors and exposes the expected renderer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->