### PR TITLE
WASM, PDF: route webpack's Node target to the Node entry

### DIFF
--- a/.tegami/webpack-node-condition.md
+++ b/.tegami/webpack-node-condition.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/wasm":
+    type: patch
+  takumi-pdf:
+    type: patch
+---
+
+### Pick the Node entry when webpack targets Node
+
+A webpack build for Node resolved the Vite entry, because both environments set the `module` condition and it is listed first. The build then failed on that entry's `?url` import, which only Vite reads. A `webpack` condition now routes webpack's Node target to the Node entry, and every other bundler keeps the entry it already resolved.

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -59,6 +59,22 @@
         "types": "./bundlers/node.d.ts",
         "default": "./bundlers/next.mjs"
       },
+      "webpack": {
+        "node": {
+          "require": {
+            "types": "./bundlers/node.d.cts",
+            "default": "./bundlers/node.cjs"
+          },
+          "default": {
+            "types": "./bundlers/node.d.ts",
+            "default": "./bundlers/node.mjs"
+          }
+        },
+        "default": {
+          "types": "./bundlers/node.d.ts",
+          "default": "./bundlers/vite.mjs"
+        }
+      },
       "module": {
         "types": "./bundlers/node.d.ts",
         "default": "./bundlers/vite.mjs"

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -79,6 +79,22 @@
         "types": "./bundlers/wasm-module.d.ts",
         "default": "./bundlers/next.mjs"
       },
+      "webpack": {
+        "node": {
+          "require": {
+            "types": "./bundlers/node.d.cts",
+            "default": "./bundlers/node.cjs"
+          },
+          "default": {
+            "types": "./bundlers/node.d.ts",
+            "default": "./bundlers/node.mjs"
+          }
+        },
+        "default": {
+          "types": "./bundlers/vite.d.ts",
+          "default": "./bundlers/vite.mjs"
+        }
+      },
       "module": {
         "types": "./bundlers/vite.d.ts",
         "default": "./bundlers/vite.mjs"


### PR DESCRIPTION
## Why

A webpack build with `target: "node"` resolved `bundlers/vite.mjs`: webpack and Vite both set the `module` condition, and `module` is listed before `node`. The build then died on the Vite entry's `?url` import.

```
ERROR in …/takumi-pdf-js/bundlers/vite.mjs 9:36-47
Module not found: Error: Can't resolve './takumi_pdf_wasm_bg.js'
```

Reordering is not the fix. Moving `node` above `module` breaks a Vite SSR build that bundles the package, which is what the Vite entry's asset handling exists for:

```
VITE SSR BUNDLED FAIL: ENOENT … '<outdir>/pkg/takumi_pdf_wasm_bg.wasm'
```

## What

A `webpack` condition ahead of `module`, with `node` nested under it. Webpack's Node target takes the Node entry; its browser target and every other bundler fall through to exactly what they resolved before.

Measured before and after, one build each:

| Consumer | Before | After |
| --- | --- | --- |
| webpack `target: node` | `MODULE_NOT_FOUND` | renders |
| webpack `target: web` (via `wasm-url`) | asset emitted | asset emitted |
| Vite SSR, package bundled | renders | renders |
| Vite browser (docs playground) | asset emitted | asset emitted |
| Turbopack (Next client + server-external) | asset emitted | asset emitted |
| workerd, waku SSR, TanStack Start | pass | pass |

A Next app that bundles the package server-side (no `serverExternalPackages`) still fails: Turbopack does not set the `webpack` condition, so it stays on the Vite entry. That is unchanged by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved webpack compatibility for Node.js builds.
  * Added separate Node.js and browser/Vite entry points with matching module formats and type declarations.
  * Preserved existing entry resolution for other bundlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->