### PR TITLE
PDF: add a Next.js entry that needs no bundler config

### DIFF
--- a/.tegami/pdf-next-entry.md
+++ b/.tegami/pdf-next-entry.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Render from a Next.js route without configuring the bundler
+
+Turbopack bundles a server route's imports, and it resolved `takumi-pdf` to the Vite entry, whose `?url` import only Vite reads. The build failed unless the package was listed in `serverExternalPackages`. `takumi-pdf/next` hands Turbopack the binary in the form it emits, on the Node runtime and the Edge runtime alike.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -117,6 +117,16 @@ Registered fonts deduplicate across calls. Rendering many documents pays the fon
 The module fits the Workers free-tier size limit.
 Import `takumi-pdf/no-init` to instantiate the wasm yourself.
 
+### Next.js
+
+Import `takumi-pdf/next` from a route handler. It hands the binary to Turbopack in the form
+Turbopack emits, on the Node runtime and the Edge runtime alike, so the package needs no
+`serverExternalPackages` entry.
+
+```ts
+import { render } from "takumi-pdf/next";
+```
+
 ### In the browser
 
 The default entry picks its loader from the export conditions the bundler sets.

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -78,6 +78,10 @@
         "default": "./bundlers/vite.mjs"
       }
     },
+    "./next": {
+      "types": "./bundlers/node.d.ts",
+      "default": "./bundlers/next.mjs"
+    },
     "./no-init": {
       "import": {
         "types": "./dist/export.d.mts",


### PR DESCRIPTION
## Why

Turbopack bundles a server route's imports. It resolved `takumi-pdf` to the Vite entry, because Vite and Turbopack both set the `module` condition, and the build then failed on that entry's `?url` import. The only way through was listing the package in `serverExternalPackages`.

Nothing in the export conditions separates the two: Turbopack sets no `webpack` condition and no `turbopack` condition, which I checked by adding branches for both and watching the build behave identically.

## What

`takumi-pdf/next` points at the existing `bundlers/next.mjs`, which imports the binary with `?module` — what Turbopack and Vercel's edge bundler emit.

Verified against a Next 16 app with **no** takumi entry in `serverExternalPackages`, one build, both routes hit on a running server:

| Route | Result |
| --- | --- |
| Node runtime | `200`, 13791 bytes, `%PDF-1.7` |
| Edge runtime (`export const runtime = "edge"`) | `200`, 1618 bytes, `%PDF-1.7` |

Browser bundles keep the `no-init` + `wasm-url` pairing from #1254; this entry is for server code.

`@takumi-rs/core` still needs the config entry, since a native addon cannot be bundled at all. That is what vercel/next.js#91899 is waiting on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Next.js support for `takumi-pdf` route handlers.
  * Supports both Node.js and Edge runtimes without additional bundler configuration.
  * Added a direct `render` import for Next.js integrations.

* **Documentation**
  * Added usage guidance and release notes for the Next.js integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->