### PR TITLE
PDF: write render failures as sentences

### DIFF
--- a/.tegami/pdf-error-messages.md
+++ b/.tegami/pdf-error-messages.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Say what a failed render needs
+
+A failed render threw the error's Rust shape, such as `MissingGlyphs("क (U+0915)")` or `DecodeError(Unsupported(UnsupportedError { format: Unknown }))`. Every error now reads as a sentence that names the fix, and the ones wrapping another error carry its message instead of its debug form.

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -1,91 +1,95 @@
 ---
 title: Troubleshooting
-description: Common issues and solutions when using Takumi.
+description: Every error Takumi prints, what to do about it, and why it happens.
 icon: Bug
 ---
 
-## General Issues
+Each heading below is the text an error prints.
+Search this page for the line your build or your server printed.
 
-### Layout is not correct
+## Pick the right entry
 
-Set the `drawDebugBorder` option to outline every node.
+Most build failures are a target reading the wrong entry. Start here.
 
-```tsx
-import { ImageResponse } from "takumi-js/response";
+| Target                                 | Import                                             |
+| -------------------------------------- | -------------------------------------------------- |
+| Node.js, Bun, Deno, Cloudflare Workers | `takumi-pdf` / `takumi-js`                         |
+| A Next.js route, either runtime        | `takumi-pdf/next`                                  |
+| A browser or web worker bundle         | `takumi-pdf/no-init` plus `takumi-pdf/wasm-url`    |
+| A browser bundle, image output         | `takumi-js/wasm/no-init` plus `takumi-js/wasm-url` |
 
-export function GET() {
-  return new ImageResponse(<></>, {
-    width: 100,
-    height: 100,
-    drawDebugBorder: true,
-    // ...
-  });
-}
-```
+The default entry reads the export conditions your bundler sets.
+It covers every server runtime with no configuration.
 
-If the issue persists, file an issue on [our GitHub repository](https://github.com/kane50613/takumi/issues).
-
-## Browser Issues
+## Bundler errors
 
 ### Export default doesn't exist in target module
 
-`takumi-js/wasm` picks its wasm loader from the export conditions the bundler sets.
-Vite, webpack, and Turbopack set the same conditions for a browser build.
-All three land on the Vite entry, and its `?url` import only works in Vite.
-
-Load the binary yourself instead:
+Load the binary yourself:
 
 ```ts
-import wasmUrl from "takumi-js/wasm-url";
-import { init, Renderer } from "takumi-js/wasm/no-init";
+import init, { render } from "takumi-pdf/no-init";
+import wasmUrl from "takumi-pdf/wasm-url";
 
 await init({ module_or_path: wasmUrl });
 ```
 
-`takumi-js/wasm-url` resolves the binary with `new URL(specifier, import.meta.url)`.
-Vite, webpack, and Turbopack rewrite that call to the asset they emit.
-Server code should keep `takumi-js/wasm`, which locates the binary for the runtime it lands on.
+`takumi-js` takes the same pair: `takumi-js/wasm/no-init` and `takumi-js/wasm-url`.
 
-On Turbopack, drop any `turbopack.rules` entry mapping `*.wasm` to `type: "wasm"`.
-That rule makes Turbopack instantiate the binary and look for wasm-bindgen glue the
-package does not ship.
+Your browser bundle resolved the Vite entry. Vite, webpack, and Turbopack set the
+same conditions for a browser build, and that entry loads the binary through a
+`?url` import only Vite reads.
 
-`@takumi-rs/wasm` and `takumi-pdf` export `wasm-url` too.
+### non-ecmascript placeable asset
 
-## Node.js Issues
+Keep `@takumi-rs/core` out of the bundle:
+
+```ts title="next.config.ts"
+const config: NextConfig = {
+  serverExternalPackages: ["@takumi-rs/core"], // [!code ++]
+};
+```
+
+The package holds a native `.node` addon, which no bundler can inline.
+`takumi-pdf` needs no entry here, because it is WebAssembly only.
+
+### Cannot find module '@takumi-rs/core-42dc295dcb05a7ef'
+
+Add the `serverExternalPackages` entry above, then delete `.next` and start again.
+
+This is the same native addon in dev mode. Turbopack rewrote the specifier to an
+internal id, which Node cannot resolve at runtime.
 
 ### Cannot find native binding
 
-`@takumi-rs/core` loads a platform-specific native package. This error means the package for the current platform is missing.
+`@takumi-rs/core` loads a platform-specific native package, and the one for the
+current platform is missing. Two things cause that.
 
 #### Hoist the native package
 
-If you are using a package manager with virtual store such as `pnpm` or `yarn`, allow it to hoist the native binary. The following examples are for pnpm; after updating the configuration, re-run `pnpm i`.
+A package manager with a virtual store, such as pnpm or Yarn, has to be told to
+hoist the native binary. Re-run `pnpm i` after the change.
 
 ```yaml title="pnpm-workspace.yaml"
 publicHoistPattern:
   - "@takumi-rs/core-*"
 ```
 
-With pnpm versions earlier than 10.5.0, add the equivalent setting to `.npmrc` instead:
+With pnpm older than 10.5.0, put the equivalent setting in `.npmrc` instead:
 
 ```text title=".npmrc"
 public-hoist-pattern[]=@takumi-rs/core-*
 ```
 
-For other package managers, refer to their docs for hoist config instructions.
+#### Install the package for your deploy target
 
-#### Install the native package for your deploy target
-
-Package managers only install the native package matching the machine that runs the install. Installing on one platform and deploying to another (for example installing on macOS and deploying to a Linux server) leaves the target's native package missing.
-
-Install the package for the deploy target explicitly:
+Package managers install the native package for the machine running the install,
+so installing on macOS and deploying to Linux leaves the target's package missing.
+Install it explicitly:
 
 ```npm
 npm install @takumi-rs/core-linux-x64-gnu
 ```
-
-Pick the package matching the target platform:
 
 | Target                   | Package                            |
 | ------------------------ | ---------------------------------- |
@@ -98,6 +102,133 @@ Pick the package matching the target platform:
 | Windows x64              | `@takumi-rs/core-win32-x64-msvc`   |
 | Windows arm64            | `@takumi-rs/core-win32-arm64-msvc` |
 
+### Module not found: Can't resolve './takumi_pdf_wasm_bg.js'
+
+On Turbopack, drop the rule that asks for this:
+
+```ts title="next.config.ts"
+const config: NextConfig = {
+  turbopack: {
+    rules: { "*.wasm": { type: "wasm" } }, // [!code --]
+  },
+};
+```
+
+On webpack or Rspack with `target: "node"`, upgrade instead:
+
+```npm
+npm install takumi-pdf@latest @takumi-rs/wasm@latest
+```
+
+The rule asks the bundler to instantiate the binary, which sends it looking for
+wasm-bindgen glue the package does not ship: the glue is compiled into `dist`,
+and `pkg` holds the binary alone.
+
+### Module parse failed: Unexpected character '\0'
+
+Upgrade, then build again:
+
+```npm
+npm install takumi-pdf@latest @takumi-rs/wasm@latest
+```
+
+Rspack parsed the binary as JavaScript, for the same reason as above.
+
+### ENOENT: no such file or directory, open '.../pkg/takumi_pdf_wasm_bg.wasm'
+
+Mark the package external for that build:
+
+```js title="esbuild"
+esbuild.build({ external: ["takumi-pdf"] });
+```
+
+esbuild, Rollup, and Bun's bundler flatten the Node entry into one file and leave
+its `new URL(specifier, import.meta.url)` call alone, so the path lands next to
+the output instead of inside `node_modules`. Vite, webpack, and Turbopack rewrite
+that call and copy the binary, so they need nothing.
+
+### Unable to locate Takumi WASM asset for SSR
+
+Keep the package external for SSR:
+
+```ts title="vite.config.ts"
+export default { ssr: { external: ["takumi-pdf"] } };
+```
+
+Vite writes the client asset and the server chunk to different directories, and
+the entry searches the usual layouts for it. External skips the search entirely.
+If your framework has to bundle it,
+[open an issue](https://github.com/kane50613/takumi/issues) with the output layout.
+
+## Render errors
+
+### MissingGlyphs("क (U+0915), ो (U+094B), र (U+0930)")
+
+Register a font covering the characters the error names:
+
+```ts
+import { googleFonts } from "@takumi-rs/helpers";
+import { render } from "takumi-pdf";
+
+const pdf = await render(document, {
+  fonts: await googleFonts(["Noto Sans Devanagari"]),
+});
+```
+
+No registered font covers them today. They would draw nothing and leave nothing
+in the text layer, so the render stops rather than shipping a page with holes.
+
+### UnsupportedFilter("blur(2px)")
+
+Drop the filter, or rasterize that subtree yourself and place it as an `<img>`.
+
+PDF has no blur operator, so `blur()` and `drop-shadow()` cannot be drawn.
+Dropping them quietly would ship a page that disagrees with the image output.
+
+### DecodeError(Unsupported(UnsupportedError ...))
+
+```text
+DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) }))
+```
+
+Re-encode the image as PNG, JPEG, or WebP.
+
+Those three embed directly. GIF has no decoder in this build. A CSS `filter`
+needs pixels to work on and only PNG decodes for that path, so an image under a
+filter raises this too when it arrived as JPEG or WebP.
+
+### TooManyPages(20000)
+
+Give the tree a height that resolves. A percentage height inside a paged render
+has nothing to resolve against, so the content grows until the page cap stops it.
+
+## Node.js
+
 ### TypeError: fetch failed
 
-Node.js fetch (via [undici](https://github.com/nodejs/undici)) can drop the socket while loading a remote `img` URL ([#349](https://github.com/kane50613/takumi/issues/349)). Pass the image as a base64 data URL so Takumi skips the fetch.
+Pass the image as a base64 data URL, which skips the fetch.
+
+Node's fetch, through [undici](https://github.com/nodejs/undici), can drop the
+socket while loading a remote `img` URL
+([#349](https://github.com/kane50613/takumi/issues/349)).
+
+## Layout
+
+### The layout is not what I expected
+
+Set `drawDebugBorder` to outline every node:
+
+```tsx
+import { ImageResponse } from "takumi-js/response";
+
+export function GET() {
+  return new ImageResponse(<></>, {
+    width: 100,
+    height: 100,
+    drawDebugBorder: true,
+  });
+}
+```
+
+If the outlines look right and the render still does not,
+[file an issue](https://github.com/kane50613/takumi/issues).

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -162,7 +162,7 @@ If your framework has to bundle it,
 
 ## Render errors
 
-### MissingGlyphs("क (U+0915), ो (U+094B), र (U+0930)")
+### No registered font covers क (U+0915)
 
 Register a font covering the characters the error names:
 
@@ -175,21 +175,17 @@ const pdf = await render(document, {
 });
 ```
 
-No registered font covers them today. They would draw nothing and leave nothing
-in the text layer, so the render stops rather than shipping a page with holes.
+Those characters would draw nothing and leave nothing in the text layer, so the
+render stops rather than shipping a page with holes.
 
-### UnsupportedFilter("blur(2px)")
+### A PDF cannot draw filter: blur(2px)
 
 Drop the filter, or rasterize that subtree yourself and place it as an `<img>`.
 
 PDF has no blur operator, so `blur()` and `drop-shadow()` cannot be drawn.
 Dropping them quietly would ship a page that disagrees with the image output.
 
-### DecodeError(Unsupported(UnsupportedError ...))
-
-```text
-DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) }))
-```
+### An error occurred while decoding the image data
 
 Re-encode the image as PNG, JPEG, or WebP.
 
@@ -197,7 +193,7 @@ Those three embed directly. GIF has no decoder in this build. A CSS `filter`
 needs pixels to work on and only PNG decodes for that path, so an image under a
 filter raises this too when it arrived as JPEG or WebP.
 
-### TooManyPages(20000)
+### The content spans more than 20000 pages
 
 Give the tree a height that resolves. A percentage height inside a paged render
 has nothing to resolve against, so the content grows until the page cap stops it.

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -26,8 +26,8 @@ use crate::{
   options::{PdfRenderOptions, decode_images, page_background, resolve_geometry},
 };
 
-pub(crate) fn map_error(error: impl core::fmt::Debug) -> js_sys::Error {
-  js_sys::Error::new(&format!("{error:?}"))
+pub(crate) fn map_error(error: impl core::fmt::Display) -> js_sys::Error {
+  js_sys::Error::new(&error.to_string())
 }
 
 #[wasm_bindgen(typescript_custom_section)]

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -56,6 +56,49 @@ pub enum PdfError {
   MissingGlyphs(String),
 }
 
+impl std::fmt::Display for PdfError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::Render(error) => write!(f, "{error}"),
+      Self::Font(error) => write!(f, "Font error: {error}"),
+      Self::Krilla(error) => write!(f, "Writing the PDF failed: {error}"),
+      Self::InvalidPageSize => f.write_str("Page size must be finite and larger than zero"),
+      Self::MissingViewport => {
+        f.write_str("Single-page output needs a viewport. Pass `viewport` or `size`.")
+      }
+      Self::InvalidStandard => f.write_str("The requested archival standard is not available"),
+      Self::InvalidMimeType(mime) => {
+        write!(f, "Attachment mime type is not a type/subtype pair: {mime}")
+      }
+      Self::DuplicateAttachment(name) => write!(f, "Two attachments are named {name}"),
+      Self::InvalidXmpSchema(schema) => write!(f, "XMP schema cannot be written as XML: {schema}"),
+      Self::TooManyPages(pages) => write!(
+        f,
+        "The content spans more than {pages} pages. Give it a height that resolves."
+      ),
+      Self::UnsupportedFilter(filter) => {
+        write!(f, "A PDF cannot draw filter: {filter}")
+      }
+      Self::UndrawableImage(reason) => write!(f, "Image could not be decoded: {reason}"),
+      Self::MissingGlyphs(characters) => write!(
+        f,
+        "No registered font covers {characters}. Register one that does."
+      ),
+    }
+  }
+}
+
+impl std::error::Error for PdfError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      Self::Render(error) => Some(error),
+      Self::Font(error) => Some(error),
+      Self::Krilla(error) => Some(error),
+      _ => None,
+    }
+  }
+}
+
 impl From<TakumiError> for PdfError {
   fn from(error: TakumiError) -> Self {
     Self::Render(error)
@@ -522,4 +565,25 @@ pub struct MeasuredSize {
   pub width: f32,
   /// The laid-out content height.
   pub height: f32,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::PdfError;
+
+  #[test]
+  fn error_messages_read_as_sentences() {
+    assert_eq!(
+      PdfError::MissingGlyphs("क (U+0915)".into()).to_string(),
+      "No registered font covers क (U+0915). Register one that does."
+    );
+    assert_eq!(
+      PdfError::UnsupportedFilter("blur(2px)".into()).to_string(),
+      "A PDF cannot draw filter: blur(2px)"
+    );
+    assert_eq!(
+      PdfError::TooManyPages(20_000).to_string(),
+      "The content spans more than 20000 pages. Give it a height that resolves."
+    );
+  }
 }


### PR DESCRIPTION
## Why

A failed render threw the error's Rust shape at the caller:

```
MissingGlyphs("क (U+0915), ो (U+094B), र (U+0930)")
DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) }))
```

`PdfError` had no `Display`, so the wasm boundary formatted it with `{:?}`. The second line is an internal type leaking, and neither says what to do.

## What

`PdfError` gets a hand-written `Display` and `Error`, and the wasm boundary formats with `Display` instead of `Debug`. Wrapped errors now carry their own message, so an undecodable image reads as the image error rather than its debug form.

```
No registered font covers क (U+0915), ो (U+094B), र (U+0930). Register one that does.
A PDF cannot draw filter: blur(2px)
An error occurred while decoding the image data: ...
```

No new dependency: `thiserror` would have done it, but 14 match arms cost less than a proc-macro edge on the wasm build. `@takumi-rs/wasm` and `@takumi-rs/core` already mapped errors through `Display`, so this was the last binding formatting with `Debug`.

Stacked on #1259, which documents these strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF rendering error messages with clearer, actionable explanations.
  - Wrapped errors now include their underlying message for easier diagnosis.

- **Documentation**
  - Expanded troubleshooting guidance for bundler, native binding, WASM asset, rendering, fetch, and layout errors.
  - Added a target/import selection table with deployment-specific package recommendations.
  - Reorganized troubleshooting content around specific errors instead of broad issue categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->