### PR TITLE
PDF: write render failures as sentences

### DIFF
--- a/.tegami/pdf-error-messages.md
+++ b/.tegami/pdf-error-messages.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Say what a failed render needs
+
+A failed render threw the error's Rust shape, such as `MissingGlyphs("क (U+0915)")` or `DecodeError(Unsupported(UnsupportedError { format: Unknown }))`. Every error now reads as a sentence that names the fix, and the ones wrapping another error carry its message instead of its debug form.

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -162,7 +162,7 @@ If your framework has to bundle it,
 
 ## Render errors
 
-### MissingGlyphs("क (U+0915), ो (U+094B), र (U+0930)")
+### No registered font covers क (U+0915)
 
 Register a font covering the characters the error names:
 
@@ -175,21 +175,17 @@ const pdf = await render(document, {
 });
 ```
 
-No registered font covers them today. They would draw nothing and leave nothing
-in the text layer, so the render stops rather than shipping a page with holes.
+Those characters would draw nothing and leave nothing in the text layer, so the
+render stops rather than shipping a page with holes.
 
-### UnsupportedFilter("blur(2px)")
+### A PDF cannot draw filter: blur(2px)
 
 Drop the filter, or rasterize that subtree yourself and place it as an `<img>`.
 
 PDF has no blur operator, so `blur()` and `drop-shadow()` cannot be drawn.
 Dropping them quietly would ship a page that disagrees with the image output.
 
-### DecodeError(Unsupported(UnsupportedError ...))
-
-```text
-DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) }))
-```
+### An error occurred while decoding the image data
 
 Re-encode the image as PNG, JPEG, or WebP.
 
@@ -197,7 +193,7 @@ Those three embed directly. GIF has no decoder in this build. A CSS `filter`
 needs pixels to work on and only PNG decodes for that path, so an image under a
 filter raises this too when it arrived as JPEG or WebP.
 
-### TooManyPages(20000)
+### The content spans more than 20000 pages
 
 Give the tree a height that resolves. A percentage height inside a paged render
 has nothing to resolve against, so the content grows until the page cap stops it.

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -26,8 +26,8 @@ use crate::{
   options::{PdfRenderOptions, decode_images, page_background, resolve_geometry},
 };
 
-pub(crate) fn map_error(error: impl core::fmt::Debug) -> js_sys::Error {
-  js_sys::Error::new(&format!("{error:?}"))
+pub(crate) fn map_error(error: impl core::fmt::Display) -> js_sys::Error {
+  js_sys::Error::new(&error.to_string())
 }
 
 #[wasm_bindgen(typescript_custom_section)]

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -56,6 +56,49 @@ pub enum PdfError {
   MissingGlyphs(String),
 }
 
+impl std::fmt::Display for PdfError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::Render(error) => write!(f, "{error}"),
+      Self::Font(error) => write!(f, "Font error: {error}"),
+      Self::Krilla(error) => write!(f, "Writing the PDF failed: {error}"),
+      Self::InvalidPageSize => f.write_str("Page size must be finite and larger than zero"),
+      Self::MissingViewport => {
+        f.write_str("Single-page output needs a viewport. Pass `viewport` or `size`.")
+      }
+      Self::InvalidStandard => f.write_str("The requested archival standard is not available"),
+      Self::InvalidMimeType(mime) => {
+        write!(f, "Attachment mime type is not a type/subtype pair: {mime}")
+      }
+      Self::DuplicateAttachment(name) => write!(f, "Two attachments are named {name}"),
+      Self::InvalidXmpSchema(schema) => write!(f, "XMP schema cannot be written as XML: {schema}"),
+      Self::TooManyPages(pages) => write!(
+        f,
+        "The content spans more than {pages} pages. Give it a height that resolves."
+      ),
+      Self::UnsupportedFilter(filter) => {
+        write!(f, "A PDF cannot draw filter: {filter}")
+      }
+      Self::UndrawableImage(reason) => write!(f, "Image could not be decoded: {reason}"),
+      Self::MissingGlyphs(characters) => write!(
+        f,
+        "No registered font covers {characters}. Register one that does."
+      ),
+    }
+  }
+}
+
+impl std::error::Error for PdfError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      Self::Render(error) => Some(error),
+      Self::Font(error) => Some(error),
+      Self::Krilla(error) => Some(error),
+      _ => None,
+    }
+  }
+}
+
 impl From<TakumiError> for PdfError {
   fn from(error: TakumiError) -> Self {
     Self::Render(error)
@@ -522,4 +565,25 @@ pub struct MeasuredSize {
   pub width: f32,
   /// The laid-out content height.
   pub height: f32,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::PdfError;
+
+  #[test]
+  fn error_messages_read_as_sentences() {
+    assert_eq!(
+      PdfError::MissingGlyphs("क (U+0915)".into()).to_string(),
+      "No registered font covers क (U+0915). Register one that does."
+    );
+    assert_eq!(
+      PdfError::UnsupportedFilter("blur(2px)".into()).to_string(),
+      "A PDF cannot draw filter: blur(2px)"
+    );
+    assert_eq!(
+      PdfError::TooManyPages(20_000).to_string(),
+      "The content spans more than 20000 pages. Give it a height that resolves."
+    );
+  }
 }


### PR DESCRIPTION
## Why

A failed render threw the error's Rust shape at the caller:

```
MissingGlyphs("क (U+0915), ो (U+094B), र (U+0930)")
DecodeError(Unsupported(UnsupportedError { format: Unknown, kind: Format(Unknown) }))
```

`PdfError` had no `Display`, so the wasm boundary formatted it with `{:?}`. The second line is an internal type leaking, and neither says what to do.

## What

`PdfError` gets a hand-written `Display` and `Error`, and the wasm boundary formats with `Display` instead of `Debug`. Wrapped errors now carry their own message, so an undecodable image reads as the image error rather than its debug form.

```
No registered font covers क (U+0915), ो (U+094B), र (U+0930). Register one that does.
A PDF cannot draw filter: blur(2px)
An error occurred while decoding the image data: ...
```

No new dependency: `thiserror` would have done it, but 14 match arms cost less than a proc-macro edge on the wasm build. `@takumi-rs/wasm` and `@takumi-rs/core` already mapped errors through `Display`, so this was the last binding formatting with `Debug`.

Docs land the new strings in the same change. Replaces #1260, which GitHub closed when its base branch was deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF rendering errors now display clear, sentence-based guidance instead of technical debug output.
  * Wrapped error messages are preserved for more useful troubleshooting.
  * Missing-font errors identify the unsupported character.
  * Image and filter errors provide clearer descriptions.
  * Page-limit errors now show the applicable numeric limit.

* **Documentation**
  * Updated troubleshooting guidance with user-facing error headings and additional remediation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->