### PR TITLE
Revert "Version Packages"

### DIFF
--- a/.tegami/pdf-error-messages.md
+++ b/.tegami/pdf-error-messages.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Say what a failed render needs
+
+A failed render threw the error's Rust shape, such as `MissingGlyphs("क (U+0915)")` or `DecodeError(Unsupported(UnsupportedError { format: Unknown }))`. Every error now reads as a sentence that names the fix, and the ones wrapping another error carry its message instead of its debug form.

--- a/.tegami/pdf-next-entry.md
+++ b/.tegami/pdf-next-entry.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Render from a Next.js route without configuring the bundler
+
+Turbopack bundles a server route's imports, and it resolved `takumi-pdf` to the Vite entry, whose `?url` import only Vite reads. The build failed unless the package was listed in `serverExternalPackages`. `takumi-pdf/next` hands Turbopack the binary in the form it emits, on the Node runtime and the Edge runtime alike.

--- a/.tegami/publish-lock.yaml
+++ b/.tegami/publish-lock.yaml
@@ -1,104 +1,89 @@
 core:changelogs:
-  - content: "---\npackages:\n  \"@takumi-rs/wasm\":\n    type: minor\n  takumi-js:\n    type: minor\n  takumi-pdf:\n    type: minor\n---\n\n### Load the wasm binary in a browser bundle\n\nVite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`, the call Vite, webpack and Turbopack rewrite to the asset they emit. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.\n"
-    filename: wasm-url-export.md
-    v: 0.0.0
-  - content: "---\npackages:\n  takumi-pdf:\n    type: patch\n---\n\n### Say what a failed render needs\n\nA failed render threw the error's Rust shape, such as `MissingGlyphs(\"क (U+0915)\")` or `DecodeError(Unsupported(UnsupportedError { format: Unknown }))`. Every error now reads as a sentence that names the fix, and the ones wrapping another error carry its message instead of its debug form.\n"
-    filename: pdf-error-messages.md
-    v: 0.0.0
-  - content: "---\npackages:\n  \"@takumi-rs/wasm\":\n    type: patch\n  takumi-pdf:\n    type: patch\n---\n\n### Pick the Node entry when webpack targets Node\n\nA webpack build for Node resolved the Vite entry, because both environments set the `module` condition and it is listed first. The build then failed on that entry's `?url` import, which only Vite reads. A `webpack` condition now routes webpack's Node target to the Node entry, and every other bundler keeps the entry it already resolved.\n"
-    filename: webpack-node-condition.md
-    v: 0.0.0
-  - content: "---\npackages:\n  takumi-pdf:\n    type: minor\n---\n\n### Render from a Next.js route without configuring the bundler\n\nTurbopack bundles a server route's imports, and it resolved `takumi-pdf` to the Vite entry, whose `?url` import only Vite reads. The build failed unless the package was listed in `serverExternalPackages`. `takumi-pdf/next` hands Turbopack the binary in the form it emits, on the Node runtime and the Edge runtime alike.\n"
-    filename: pdf-next-entry.md
+  - content: "---\npackages:\n  \"@takumi-rs/wasm\":\n    type: patch\n  takumi-pdf:\n    type: patch\n---\n\n### Ship without skrifa's hinting interpreter\n\nEvery draw is unhinted, but skrifa's TrueType hinting interpreter and autohinter survived dead-code elimination through runtime branches. A patched skrifa gates them behind a `hinting` feature, cutting ~240KB from the wasm binaries with identical rendering.\n"
+    filename: skrifa-no-hinting.md
     v: 0.0.0
 core:packages:
   - id: npm:takumi
     updated: false
-  - id: npm:@takumi-rs/core
+  - changelogIds:
+      - skrifa-no-hinting.md
+    id: npm:@takumi-rs/wasm
     updated: true
-  - id: npm:docs
-    updated: false
   - id: npm:takumi-template
     updated: false
   - id: npm:@takumi-rs/helpers
     updated: true
-  - changelogIds:
-      - wasm-url-export.md
-    id: npm:takumi-js
-    updated: true
-  - changelogIds:
-      - pdf-error-messages.md
-      - wasm-url-export.md
-      - webpack-node-condition.md
-      - pdf-next-entry.md
-    id: npm:takumi-pdf
-    updated: true
-  - changelogIds:
-      - wasm-url-export.md
-      - webpack-node-condition.md
-    id: npm:@takumi-rs/wasm
+  - id: npm:docs
+    updated: false
+  - id: npm:@takumi-rs/core
     updated: true
   - id: npm:@takumi-rs/image-response
     updated: true
-  - id: npm:svelte
+  - id: npm:takumi-js
+    updated: true
+  - changelogIds:
+      - skrifa-no-hinting.md
+    id: npm:takumi-pdf
+    updated: true
+  - id: npm:waku-ssr
     updated: false
-  - id: npm:example-nextjs
-    updated: false
-  - id: npm:example-e-invoice
-    updated: false
-  - id: npm:example-generate-invoice
+  - id: npm:example-twitter-images
     updated: false
   - id: npm:ffmpeg-keyframe-animation
     updated: false
-  - id: npm:example-liquid-glass
+  - id: npm:example-tanstack-start
+    updated: false
+  - id: npm:example-e-invoice
+    updated: false
+  - id: npm:example-nextjs
+    updated: false
+  - id: npm:example-cloudflare-workers
+    updated: false
+  - id: npm:example-generate-invoice
     updated: false
   - id: npm:example-satori-html
     updated: false
-  - id: npm:example-cloudflare-workers
+  - id: npm:svelte
+    updated: false
+  - id: npm:ffplay
     updated: false
   - id: npm:example-css-library-integration
     updated: false
   - id: npm:pdf-bench
     updated: false
-  - id: npm:waku-ssr
+  - id: npm:example-liquid-glass
     updated: false
-  - id: npm:example-tanstack-start
-    updated: false
-  - id: npm:example-twitter-images
-    updated: false
-  - id: npm:ffplay
-    updated: false
-  - id: cargo:takumi-svg
+  - id: cargo:takumi-html
     updated: false
   - id: cargo:takumi-core
     updated: false
   - id: cargo:takumi-raster
     updated: false
-  - id: cargo:takumi-html
+  - id: cargo:takumi-svg
     updated: false
   - id: cargo:takumi
     updated: true
 npm:packages:
   - id: npm:takumi
-  - id: npm:@takumi-rs/core
-  - id: npm:docs
+  - id: npm:@takumi-rs/wasm
   - id: npm:takumi-template
   - id: npm:@takumi-rs/helpers
+  - id: npm:docs
+  - id: npm:@takumi-rs/core
+  - id: npm:@takumi-rs/image-response
   - id: npm:takumi-js
   - id: npm:takumi-pdf
-  - id: npm:@takumi-rs/wasm
-  - id: npm:@takumi-rs/image-response
-  - id: npm:svelte
-  - id: npm:example-nextjs
-  - id: npm:example-e-invoice
-  - id: npm:example-generate-invoice
+  - id: npm:waku-ssr
+  - id: npm:example-twitter-images
   - id: npm:ffmpeg-keyframe-animation
-  - id: npm:example-liquid-glass
-  - id: npm:example-satori-html
+  - id: npm:example-tanstack-start
+  - id: npm:example-e-invoice
+  - id: npm:example-nextjs
   - id: npm:example-cloudflare-workers
+  - id: npm:example-generate-invoice
+  - id: npm:example-satori-html
+  - id: npm:svelte
+  - id: npm:ffplay
   - id: npm:example-css-library-integration
   - id: npm:pdf-bench
-  - id: npm:waku-ssr
-  - id: npm:example-tanstack-start
-  - id: npm:example-twitter-images
-  - id: npm:ffplay
+  - id: npm:example-liquid-glass

--- a/.tegami/wasm-url-export.md
+++ b/.tegami/wasm-url-export.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/wasm":
+    type: minor
+  takumi-js:
+    type: minor
+  takumi-pdf:
+    type: minor
+---
+
+### Load the wasm binary in a browser bundle
+
+Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`, the call Vite, webpack and Turbopack rewrite to the asset they emit. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.

--- a/.tegami/webpack-node-condition.md
+++ b/.tegami/webpack-node-condition.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/wasm":
+    type: patch
+  takumi-pdf:
+    type: patch
+---
+
+### Pick the Node entry when webpack targets Node
+
+A webpack build for Node resolved the Vite entry, because both environments set the `module` condition and it is listed first. The build then failed on that entry's `?url` import, which only Vite reads. A `webpack` condition now routes webpack's Node target to the Node entry, and every other bundler keeps the entry it already resolved.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "takumi"
-version = "2.9.0"
+version = "2.8.1"
 dependencies = [
  "criterion",
  "image",

--- a/bun.lock
+++ b/bun.lock
@@ -271,7 +271,7 @@
     },
     "takumi-helpers": {
       "name": "@takumi-rs/helpers",
-      "version": "2.9.0",
+      "version": "2.8.1",
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/react": "catalog:",
@@ -295,7 +295,7 @@
     },
     "takumi-image-response": {
       "name": "@takumi-rs/image-response",
-      "version": "2.9.0",
+      "version": "2.8.1",
       "dependencies": {
         "takumi-js": "workspace:*",
       },
@@ -307,7 +307,7 @@
     },
     "takumi-js": {
       "name": "takumi-js",
-      "version": "2.9.0",
+      "version": "2.8.1",
       "dependencies": {
         "@takumi-rs/core": "workspace:*",
         "@takumi-rs/helpers": "workspace:*",
@@ -323,7 +323,7 @@
     },
     "takumi-napi": {
       "name": "@takumi-rs/core",
-      "version": "2.9.0",
+      "version": "2.8.1",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
       },
@@ -347,7 +347,7 @@
     },
     "takumi-pdf-js": {
       "name": "takumi-pdf",
-      "version": "0.9.0",
+      "version": "0.8.1",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
       },
@@ -376,7 +376,7 @@
     },
     "takumi-wasm": {
       "name": "@takumi-rs/wasm",
-      "version": "2.9.0",
+      "version": "2.8.1",
       "dependencies": {
         "@takumi-rs/helpers": "workspace:*",
       },

--- a/takumi-helpers/package.json
+++ b/takumi-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takumi-rs/helpers",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "Convert JSX and HTML to Takumi node trees. Load fonts and emoji.",
   "keywords": [
     "emoji",

--- a/takumi-image-response/package.json
+++ b/takumi-image-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takumi-rs/image-response",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "Moved into takumi-js. Import `ImageResponse` from `takumi-js/response`.",
   "license": "(MIT OR Apache-2.0)",
   "author": {

--- a/takumi-js/CHANGELOG.md
+++ b/takumi-js/CHANGELOG.md
@@ -1,9 +1,3 @@
-## takumi-js@2.9.0
-
-### Load the wasm binary in a browser bundle
-
-Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`, the call Vite, webpack and Turbopack rewrite to the asset they emit. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.
-
 ## takumi-js@2.5.0
 
 ### Add `setGlyphCacheMaxBytes`

--- a/takumi-js/package.json
+++ b/takumi-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takumi-js",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "Render OG images from JSX, HTML, and CSS. No headless browser.",
   "keywords": [
     "animated-webp",

--- a/takumi-napi/package.json
+++ b/takumi-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takumi-rs/core",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "Render OG images from Takumi node trees with native Node.js bindings. No headless browser.",
   "keywords": [
     "css",

--- a/takumi-pdf-js/CHANGELOG.md
+++ b/takumi-pdf-js/CHANGELOG.md
@@ -1,21 +1,3 @@
-## takumi-pdf@0.9.0
-
-### Say what a failed render needs
-
-A failed render threw the error's Rust shape, such as `MissingGlyphs("क (U+0915)")` or `DecodeError(Unsupported(UnsupportedError { format: Unknown }))`. Every error now reads as a sentence that names the fix, and the ones wrapping another error carry its message instead of its debug form.
-
-### Load the wasm binary in a browser bundle
-
-Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`, the call Vite, webpack and Turbopack rewrite to the asset they emit. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.
-
-### Pick the Node entry when webpack targets Node
-
-A webpack build for Node resolved the Vite entry, because both environments set the `module` condition and it is listed first. The build then failed on that entry's `?url` import, which only Vite reads. A `webpack` condition now routes webpack's Node target to the Node entry, and every other bundler keeps the entry it already resolved.
-
-### Render from a Next.js route without configuring the bundler
-
-Turbopack bundles a server route's imports, and it resolved `takumi-pdf` to the Vite entry, whose `?url` import only Vite reads. The build failed unless the package was listed in `serverExternalPackages`. `takumi-pdf/next` hands Turbopack the binary in the form it emits, on the Node runtime and the Edge runtime alike.
-
 ## takumi-pdf@0.8.1
 
 ### Ship without skrifa's hinting interpreter

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takumi-pdf",
-  "version": "0.9.0",
+  "version": "0.8.1",
   "description": "Render paged PDFs from JSX, HTML, and CSS. No headless browser.",
   "keywords": [
     "chromium-free",

--- a/takumi-wasm/CHANGELOG.md
+++ b/takumi-wasm/CHANGELOG.md
@@ -1,13 +1,3 @@
-## @takumi-rs/wasm@2.9.0
-
-### Load the wasm binary in a browser bundle
-
-Vite, webpack and Turbopack set the same export conditions for a browser build. All three resolved the Vite entry, whose `?url` import only works in Vite. Each package now exports `wasm-url`, which resolves the binary through `new URL(specifier, import.meta.url)`, the call Vite, webpack and Turbopack rewrite to the asset they emit. Pair it with `takumi-pdf/no-init`, or with the new `takumi-js/wasm/no-init`, which keeps the auto-init entry out of the bundle.
-
-### Pick the Node entry when webpack targets Node
-
-A webpack build for Node resolved the Vite entry, because both environments set the `module` condition and it is listed first. The build then failed on that entry's `?url` import, which only Vite reads. A `webpack` condition now routes webpack's Node target to the Node entry, and every other bundler keeps the entry it already resolved.
-
 ## @takumi-rs/wasm@2.8.1
 
 ### Ship without skrifa's hinting interpreter

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takumi-rs/wasm",
-  "version": "2.9.0",
+  "version": "2.8.1",
   "description": "Render OG images from Takumi node trees with WebAssembly. No headless browser.",
   "keywords": [
     "cloudflare-workers",

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "takumi"
-version = "2.9.0"
+version = "2.8.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Render OG images from HTML, CSS, or component trees. No headless browser."


### PR DESCRIPTION
## Why

`margin: "auto"` is going into `takumi-pdf` next, and it belongs in the same release as the entries and error messages already queued. Holding the version bump keeps them together instead of shipping two versions an hour apart.

## What

Reverts #1262. The four changesets come back to `.tegami/`, and the next Version PR picks them all up along with the new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved browser support for loading WebAssembly assets across common bundlers.
  - Added smoother Next.js route rendering for both Node and Edge runtimes.
  - Improved bundler behavior for Node-targeted builds.

- **Bug Fixes**
  - PDF rendering errors now provide clearer, actionable messages.

- **Documentation**
  - Updated release documentation to reflect the latest package changes and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->