### PR TITLE
PDF: size the page margin to its band

### DIFF
--- a/.tegami/pdf-auto-margin.md
+++ b/.tegami/pdf-auto-margin.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Size the page margin to the header and footer
+
+A band draws inside the page margin, so a margin shorter than the band let content run underneath it. Sizing it meant measuring the band first and passing the height back, a second call for something the renderer already knew. `margin` now takes `"auto"` on any side and defaults to it: the side grows to the space its band needs, and never drops below the 48 a page starts with. Left and right hold no band, so they stay at 48.

--- a/.tegami/pdf-auto-margin.md
+++ b/.tegami/pdf-auto-margin.md
@@ -4,6 +4,6 @@ packages:
     type: minor
 ---
 
-### Size the page margin to the header and footer
+### Size the page margin to its band
 
-A band draws inside the page margin, so a margin shorter than the band let content run underneath it. Sizing it meant measuring the band first and passing the height back, a second call for something the renderer already knew. `margin` now takes `"auto"` on any side and defaults to it: the side grows to the space its band needs, and never drops below the 48 a page starts with. Left and right hold no band, so they stay at 48.
+A band draws inside the page margin, and a margin shorter than the band left content running underneath it. `margin` now takes `"auto"` on any side and starts there, growing to the space that side's band needs and never dropping below the 48 it began at.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -24,29 +24,44 @@ const pdf = await render(report, {
 
 ## Sizing the margin
 
-Band height depends on layout, so it is hard to guess ahead of time. `measure` lays out a tree the same way `render` measures a band: full page width, counter hooks filled with three-digit numbers. Use the height to pick a margin:
+A band draws in the page margin, so the margin has to be tall enough to hold it.
+`margin` defaults to `"auto"`, which measures the band and takes the space it needs.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { measure, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
 
-const footer = (
-  <div tw="flex w-full justify-center text-[10px] text-gray-500">
-    Page <span className="pageNumber" /> of <span className="totalPages" />
-  </div>
-);
-// [!code highlight]
-const { height } = await measure(footer, { size: "a4" });
 const pdf = await render(report, {
-  footer,
-  // [!code highlight]
-  margin: { top: 48, bottom: Math.max(48, height + 20) },
+  footer: (
+    <div tw="flex w-full justify-center text-[10px] text-gray-500">
+      Page <span className="pageNumber" /> of <span className="totalPages" />
+    </div>
+  ),
 });
 ```
 
-Bands sit 20px in from the paper edge, so leave that on top of the measured height.
+`"auto"` never drops below the default 48, so a short band leaves the page looking
+as it did before. Set a side to a number to size it yourself:
+
+```ts
+margin: { top: 96, bottom: "auto" }
+```
+
+Left and right hold no band. `"auto"` there is the default 48.
+
+To place content against the band yourself, `measure` lays out a tree the way
+`render` measures a band: full page width, counter hooks filled with three-digit
+numbers.
+
+```tsx twoslash
+declare const footer: import("react").ReactNode;
+// ---cut---
+import { measure } from "takumi-pdf";
+
+const { height } = await measure(footer, { size: "a4" });
+```
 
 Passing `viewport` instead of a page size measures the tree as-is. Counter hooks stay empty.
 

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -42,8 +42,9 @@ const pdf = await render(report, {
 });
 ```
 
-`"auto"` never drops below the default 48, so a short band leaves the page looking
-as it did before. Set a side to a number to size it yourself:
+An `"auto"` side comes out at the band height plus the 20px bands are inset from
+the paper edge, and never below the default 48. A short band leaves the page
+looking as it did before. Set a side to a number to size it yourself:
 
 ```ts
 margin: { top: 96, bottom: "auto" }
@@ -51,9 +52,9 @@ margin: { top: 96, bottom: "auto" }
 
 Left and right hold no band. `"auto"` there is the default 48.
 
-To place content against the band yourself, `measure` lays out a tree the way
-`render` measures a band: full page width, counter hooks filled with three-digit
-numbers.
+To size a margin yourself, `measure` lays out a tree the way `render` measures a
+band: full page width, counter hooks filled with three-digit numbers. Leave the
+20px inset on top of the height it returns.
 
 ```tsx twoslash
 declare const footer: import("react").ReactNode;

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -89,8 +89,9 @@ const pdf = await render(report, {
 These options are the structured form of `@page`, which takumi does not parse as CSS.
 `size` and `margin` map to the descriptors of the same name, `header` and `footer` to its margin boxes.
 
-A margin left at `"auto"` takes the space its band needs, and never less than 48.
-Without a band on that side it is 48, which is where a page starts.
+A margin left at `"auto"` takes the space its band needs: the band's measured
+height plus the 20px it is inset from the paper edge, and never less than 48.
+Without a band on that side it stays at 48, which is where a page starts.
 
 Leave `backgroundColor` unset for white paper.
 A viewer draws white by default, and the file stays free of a full-page rectangle.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -79,15 +79,18 @@ const pdf = await render(report, {
 });
 ```
 
-| Option            | Type                                           | Default | Description                                                  |
-| ----------------- | ---------------------------------------------- | ------- | ------------------------------------------------------------ |
-| `size`            | `"a4"`, `"letter"`, or `{ width, height }`     | `"a4"`  | Page size in CSS px at 96 dpi. Presets ignore case.          |
-| `landscape`       | `boolean`                                      | `false` | Swaps page width and height, including explicit sizes.       |
-| `margin`          | `number` or `{ top?, right?, bottom?, left? }` | `48`    | A number applies to all sides. Missing object sides are `0`. |
-| `backgroundColor` | CSS color                                      | unset   | Fills the page box, margins included, under everything.      |
+| Option            | Type                                                      | Default  | Description                                                        |
+| ----------------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
+| `size`            | `"a4"`, `"letter"`, or `{ width, height }`                | `"a4"`   | Page size in CSS px at 96 dpi. Presets ignore case.                |
+| `landscape`       | `boolean`                                                 | `false`  | Swaps page width and height, including explicit sizes.             |
+| `margin`          | `number`, `"auto"`, or `{ top?, right?, bottom?, left? }` | `"auto"` | `"auto"` fits the band on that side. Missing object sides are `0`. |
+| `backgroundColor` | CSS color                                                 | unset    | Fills the page box, margins included, under everything.            |
 
 These options are the structured form of `@page`, which takumi does not parse as CSS.
 `size` and `margin` map to the descriptors of the same name, `header` and `footer` to its margin boxes.
+
+A margin left at `"auto"` takes the space its band needs, and never less than 48.
+Without a band on that side it is 48, which is where a page starts.
 
 Leave `backgroundColor` unset for white paper.
 A viewer draws white by default, and the file stays free of a full-page rectangle.

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -51,8 +51,22 @@ export type ViewportInput = { width: number; height?: number };
 /** A page size: a preset name (case-insensitive) or explicit {@link Dimensions}. */
 export type PageSize = "a4" | "letter" | Dimensions;
 
-/** A page margin in CSS px: one number for all sides, or per-side values (missing sides are zero). */
-export type PageMargin = number | { top?: number; right?: number; bottom?: number; left?: number };
+/**
+ * One side of a page margin: a length in CSS px, or `"auto"` to fit the band
+ * that draws on that side. `"auto"` never goes below the default 48, and the
+ * left and right sides hold no band, so they land on it.
+ */
+export type PageMarginSide = number | "auto";
+
+/** A page margin: one value for all sides, or per-side values (missing sides are zero). */
+export type PageMargin =
+  | PageMarginSide
+  | {
+      top?: PageMarginSide;
+      right?: PageMarginSide;
+      bottom?: PageMarginSide;
+      left?: PageMarginSide;
+    };
 
 /**
  * Paged output (the default): content flows across pages of `size`, like
@@ -66,7 +80,7 @@ type PagedOptions = {
   size?: PageSize;
   /** Swaps the page's width and height, including explicit sizes. */
   landscape?: boolean;
-  /** Page margin. Defaults to a uniform 48 (half an inch). */
+  /** Page margin. Defaults to `"auto"` on every side. */
   margin?: PageMargin;
   /**
    * Band repeated at the top of every page. Nodes with the `pageNumber` or

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -56,8 +56,22 @@ export type ViewportInput = { width: number; height?: number };
 /** A page size: a preset name (case-insensitive) or explicit dimensions. */
 export type PageSize = "a4" | "letter" | Dimensions;
 
-/** A page margin in CSS px: one number for all sides, or per-side values (missing sides are zero). */
-export type PageMargin = number | { top?: number; right?: number; bottom?: number; left?: number };
+/**
+ * One side of a page margin: a length in CSS px, or `"auto"` to fit the band
+ * that draws on that side. `"auto"` never goes below the default 48, and the
+ * left and right sides hold no band, so they land on it.
+ */
+export type PageMarginSide = number | "auto";
+
+/** A page margin: one value for all sides, or per-side values (missing sides are zero). */
+export type PageMargin =
+  | PageMarginSide
+  | {
+      top?: PageMarginSide;
+      right?: PageMarginSide;
+      bottom?: PageMarginSide;
+      left?: PageMarginSide;
+    };
 
 export type PdfMetadata = {
   title?: string;
@@ -107,7 +121,7 @@ export type PdfRenderOptions = {
   size?: PageSize;
   /** Swaps the page's width and height, including explicit sizes. */
   landscape?: boolean;
-  /** Page margin in CSS px. Defaults to a uniform 48 (half an inch). */
+  /** Page margin. Defaults to `"auto"` on every side. */
   margin?: PageMargin;
   /**
    * Band repeated at the top of every page. Nodes classed `pageNumber` /

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -65,28 +65,27 @@ enum MarginInput {
 }
 
 /// One side: a length in px, or `"auto"` for the space that side's band takes.
+/// serde requires every untagged variant to come last, so the keyword leads.
 #[derive(Deserialize)]
-#[serde(untagged)]
 enum SideInput {
+  #[serde(rename = "auto")]
+  Auto,
+  #[serde(untagged)]
   Px(f32),
-  Named(String),
 }
 
 impl SideInput {
-  fn margin(&self) -> Result<PageMargin, js_sys::Error> {
+  fn margin(&self) -> PageMargin {
     match self {
-      Self::Px(value) => Ok(PageMargin::Px(*value)),
-      Self::Named(name) if name.eq_ignore_ascii_case("auto") => Ok(PageMargin::Auto),
-      Self::Named(other) => Err(js_sys::Error::new(&format!("unknown margin: {other}"))),
+      Self::Auto => PageMargin::Auto,
+      Self::Px(value) => PageMargin::Px(*value),
     }
   }
 }
 
 /// A side the caller left out sits flush with the paper edge.
-fn side_margin(side: &Option<SideInput>) -> Result<PageMargin, js_sys::Error> {
-  side
-    .as_ref()
-    .map_or(Ok(PageMargin::Px(0.0)), SideInput::margin)
+fn side_margin(side: &Option<SideInput>) -> PageMargin {
+  side.as_ref().map_or(PageMargin::Px(0.0), SideInput::margin)
 }
 
 fn resolve_page(
@@ -116,7 +115,7 @@ fn resolve_page(
   match margin {
     None => {}
     Some(MarginInput::Uniform(value)) => {
-      let side = value.margin()?;
+      let side = value.margin();
 
       page.margin = PageMargins {
         top: side,
@@ -132,10 +131,10 @@ fn resolve_page(
       left,
     }) => {
       page.margin = PageMargins {
-        top: side_margin(top)?,
-        right: side_margin(right)?,
-        bottom: side_margin(bottom)?,
-        left: side_margin(left)?,
+        top: side_margin(top),
+        right: side_margin(right),
+        bottom: side_margin(bottom),
+        left: side_margin(left),
       };
     }
   }

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -11,7 +11,7 @@ use takumi_core::{
   style::{Color, ColorInput, FromCssStr},
   viewport::Viewport,
 };
-use takumi_pdf::{PageMargins, PageOptions};
+use takumi_pdf::{PageMargin, PageMargins, PageOptions};
 
 use crate::{
   map_error,
@@ -50,18 +50,46 @@ enum SizeInput {
   Dimensions(Dimensions),
 }
 
-/// A page margin: one number for all sides, or per-side values (missing
-/// sides are zero).
+/// A page margin: one value for all sides, or per-side values (missing sides
+/// are zero).
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum MarginInput {
-  Uniform(f32),
+  Uniform(SideInput),
   Sides {
-    top: Option<f32>,
-    right: Option<f32>,
-    bottom: Option<f32>,
-    left: Option<f32>,
+    top: Option<SideInput>,
+    right: Option<SideInput>,
+    bottom: Option<SideInput>,
+    left: Option<SideInput>,
   },
+}
+
+/// One side: a length in px, or `"auto"` for the space that side's band takes.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SideInput {
+  Px(f32),
+  Auto(AutoKeyword),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum AutoKeyword {
+  Auto,
+}
+
+impl SideInput {
+  fn margin(&self) -> PageMargin {
+    match self {
+      Self::Px(value) => PageMargin::Px(*value),
+      Self::Auto(AutoKeyword::Auto) => PageMargin::Auto,
+    }
+  }
+}
+
+/// A side the caller left out sits flush with the paper edge.
+fn side_margin(side: &Option<SideInput>) -> PageMargin {
+  side.as_ref().map_or(PageMargin::Px(0.0), SideInput::margin)
 }
 
 fn resolve_page(
@@ -90,7 +118,16 @@ fn resolve_page(
   }
   match margin {
     None => {}
-    Some(MarginInput::Uniform(value)) => page.margin = PageMargins::uniform(*value),
+    Some(MarginInput::Uniform(value)) => {
+      let side = value.margin();
+
+      page.margin = PageMargins {
+        top: side,
+        right: side,
+        bottom: side,
+        left: side,
+      };
+    }
     Some(MarginInput::Sides {
       top,
       right,
@@ -98,10 +135,10 @@ fn resolve_page(
       left,
     }) => {
       page.margin = PageMargins {
-        top: top.unwrap_or(0.0),
-        right: right.unwrap_or(0.0),
-        bottom: bottom.unwrap_or(0.0),
-        left: left.unwrap_or(0.0),
+        top: side_margin(top),
+        right: side_margin(right),
+        bottom: side_margin(bottom),
+        left: side_margin(left),
       };
     }
   }

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -69,27 +69,24 @@ enum MarginInput {
 #[serde(untagged)]
 enum SideInput {
   Px(f32),
-  Auto(AutoKeyword),
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum AutoKeyword {
-  Auto,
+  Named(String),
 }
 
 impl SideInput {
-  fn margin(&self) -> PageMargin {
+  fn margin(&self) -> Result<PageMargin, js_sys::Error> {
     match self {
-      Self::Px(value) => PageMargin::Px(*value),
-      Self::Auto(AutoKeyword::Auto) => PageMargin::Auto,
+      Self::Px(value) => Ok(PageMargin::Px(*value)),
+      Self::Named(name) if name.eq_ignore_ascii_case("auto") => Ok(PageMargin::Auto),
+      Self::Named(other) => Err(js_sys::Error::new(&format!("unknown margin: {other}"))),
     }
   }
 }
 
 /// A side the caller left out sits flush with the paper edge.
-fn side_margin(side: &Option<SideInput>) -> PageMargin {
-  side.as_ref().map_or(PageMargin::Px(0.0), SideInput::margin)
+fn side_margin(side: &Option<SideInput>) -> Result<PageMargin, js_sys::Error> {
+  side
+    .as_ref()
+    .map_or(Ok(PageMargin::Px(0.0)), SideInput::margin)
 }
 
 fn resolve_page(
@@ -119,7 +116,7 @@ fn resolve_page(
   match margin {
     None => {}
     Some(MarginInput::Uniform(value)) => {
-      let side = value.margin();
+      let side = value.margin()?;
 
       page.margin = PageMargins {
         top: side,
@@ -135,10 +132,10 @@ fn resolve_page(
       left,
     }) => {
       page.margin = PageMargins {
-        top: side_margin(top),
-        right: side_margin(right),
-        bottom: side_margin(bottom),
-        left: side_margin(left),
+        top: side_margin(top)?,
+        right: side_margin(right)?,
+        bottom: side_margin(bottom)?,
+        left: side_margin(left)?,
       };
     }
   }

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -64,21 +64,27 @@ enum MarginInput {
   },
 }
 
-/// One side: a length in px, or `"auto"` for the space that side's band takes.
-/// serde requires every untagged variant to come last, so the keyword leads.
+/// One side: a length in px, or a keyword for a size the renderer works out.
 #[derive(Deserialize)]
+#[serde(untagged)]
 enum SideInput {
-  #[serde(rename = "auto")]
-  Auto,
-  #[serde(untagged)]
   Px(f32),
+  Keyword(MarginKeyword),
+}
+
+/// A margin the renderer sizes itself.
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum MarginKeyword {
+  /// The space the band on that side takes.
+  Auto,
 }
 
 impl SideInput {
   fn margin(&self) -> PageMargin {
     match self {
-      Self::Auto => PageMargin::Auto,
       Self::Px(value) => PageMargin::Px(*value),
+      Self::Keyword(MarginKeyword::Auto) => PageMargin::Auto,
     }
   }
 }

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -87,11 +87,12 @@ use takumi_core::{
 };
 
 pub use crate::options::{
-  Attachment, AttachmentRelationship, MeasureOptions, MeasuredSize, PageMargins, PageOptions,
-  PdfDate, PdfError, PdfMetadata, PdfOptions, PdfStandard, Tagging, XmpProperty, XmpSchema,
+  Attachment, AttachmentRelationship, MeasureOptions, MeasuredSize, PageMargin, PageMargins,
+  PageOptions, PdfDate, PdfError, PdfMetadata, PdfOptions, PdfStandard, Tagging, XmpProperty,
+  XmpSchema,
 };
 use crate::{
-  bands::{emit_band, measure_band, prepare_band},
+  bands::{MeasuredBand, emit_band, measure_band, prepare_band},
   emitter::{FontMap, RenderIssues},
   glyph::uncovered_error,
   inline::{build_inline_map, collect_text_boxes},
@@ -112,6 +113,11 @@ use crate::{
   tags::{TagCollector, build_tag_tree, tag_id},
   tree::{TreeInputs, prepare_paged_tree, prepare_tree},
 };
+
+/// The height a measured band came out at, or nothing when the side has none.
+fn band_height(band: Option<&MeasuredBand>) -> Option<f32> {
+  band.map(|band| band.measured.height)
+}
 
 /// Lays out a node tree without rendering and returns its size.
 ///
@@ -242,20 +248,12 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
     Some(page) => {
       let page_size = KrillaSize::from_wh(page.width * PT_PER_PX, page.height * PT_PER_PX)
         .ok_or(PdfError::InvalidPageSize)?;
-      let (content_width, content_height) = page.content_size();
-      if !(content_width.is_finite()
-        && content_height.is_finite()
-        && content_width > 0.0
-        && content_height > 0.0)
-      {
-        return Err(PdfError::InvalidPageSize);
-      }
       // Bands lay out at full page width and draw inside the margin areas,
       // like Chromium's print header and footer templates. The content window
       // is always the full margin box; a band taller than its margin overlaps
-      // content, exactly as in Chromium.
+      // content, exactly as in Chromium. They are measured first so an `auto`
+      // margin can take the height they came out at.
       let band_viewport = Viewport::new((page.width as u32, None));
-      let content_viewport = Viewport::new((content_width as u32, None));
 
       // Band heights are measured once with three-digit counters; per-page
       // emission clips to the measured band, so a wrap caused by a wider real
@@ -271,12 +269,21 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         .as_ref()
         .map(|template| measure_band(&inputs, template, band_viewport))
         .transpose()?;
-      let header_height = header_band
-        .as_ref()
-        .map_or(0.0, |band| band.measured.height);
-      let footer_height = footer_band
-        .as_ref()
-        .map_or(0.0, |band| band.measured.height);
+      let margin = page.margin.resolve(
+        band_height(header_band.as_ref()),
+        band_height(footer_band.as_ref()),
+      );
+      let (content_width, content_height) = page.content_size(margin);
+      if !(content_width.is_finite()
+        && content_height.is_finite()
+        && content_width > 0.0
+        && content_height > 0.0)
+      {
+        return Err(PdfError::InvalidPageSize);
+      }
+      let content_viewport = Viewport::new((content_width as u32, None));
+      let header_height = band_height(header_band.as_ref()).unwrap_or(0.0);
+      let footer_height = band_height(footer_band.as_ref()).unwrap_or(0.0);
       let window_height = content_height;
 
       let mut node = options.node;
@@ -330,10 +337,10 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         let index = starts
           .partition_point(|start| *start <= top)
           .saturating_sub(1);
-        let y = page.margin.top + (top - starts[index]).max(0.0);
+        let y = margin.top + (top - starts[index]).max(0.0);
         let dest = XyzDestination::new(
           index,
-          Point::from_xy(page.margin.left * PT_PER_PX, y * PT_PER_PX),
+          Point::from_xy(margin.left * PT_PER_PX, y * PT_PER_PX),
         );
 
         match structural {
@@ -372,13 +379,13 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
           )?;
         }
 
-        let content_top = page.margin.top;
+        let content_top = margin.top;
 
         for fixed in repeated.iter().filter(|tree| tree.paints_below()) {
           emit_band(
             fixed,
             &mut fonts,
-            (page.margin.left, content_top, content_width, window_height),
+            (margin.left, content_top, content_width, window_height),
             tag_collector.is_some(),
             &issues,
             document_lang,
@@ -392,14 +399,11 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         let paint_height = (next_start - y0).min(window_height);
 
         if let Some(path) =
-          KrillaRect::from_xywh(page.margin.left, content_top, content_width, paint_height)
+          KrillaRect::from_xywh(margin.left, content_top, content_width, paint_height)
             .and_then(rect_path)
         {
           surface.push_clip_path(&path, &FillRule::NonZero);
-          surface.push_transform(&Transform::from_translate(
-            page.margin.left,
-            content_top - y0,
-          ));
+          surface.push_transform(&Transform::from_translate(margin.left, content_top - y0));
           let mut emitter = content.emitter(
             &mut fonts,
             Some(&inline_map),
@@ -419,7 +423,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
           emit_band(
             fixed,
             &mut fonts,
-            (page.margin.left, content_top, content_width, window_height),
+            (margin.left, content_top, content_width, window_height),
             tag_collector.is_some(),
             &issues,
             document_lang,
@@ -458,7 +462,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
           &mut pdf_page,
           &interactive.links,
           (y0, y0 + paint_height),
-          (page.margin.left, content_top),
+          (margin.left, content_top),
           tag_collector.as_ref(),
           |id| {
             interactive
@@ -475,7 +479,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
           &mut pdf_page,
           &repeated_links,
           (0.0, window_height),
-          (page.margin.left, content_top),
+          (margin.left, content_top),
           None,
           |id| {
             interactive
@@ -732,6 +736,43 @@ mod tests {
 
     assert_eq!(landscape.width, a4.height);
     assert_eq!(landscape.height, a4.width);
-    assert_eq!(PageOptions::A4.with_margin(0.0).margin.top, 0.0);
+    assert_eq!(
+      PageOptions::A4
+        .with_margin(0.0)
+        .margin
+        .resolve(None, None)
+        .top,
+      0.0
+    );
+  }
+
+  #[test]
+  fn auto_margin_takes_the_band_it_holds() {
+    let margins = PageOptions::A4.margin;
+
+    assert_eq!(
+      margins.resolve(None, None).top,
+      PageOptions::DEFAULT_MARGIN,
+      "a side with no band sits at the default"
+    );
+    assert_eq!(
+      margins.resolve(Some(4.0), None).top,
+      PageOptions::DEFAULT_MARGIN,
+      "a band that fits inside the default does not shrink the page"
+    );
+    assert_eq!(
+      margins.resolve(Some(80.0), None).top,
+      80.0 + BAND_EDGE_PADDING,
+      "a taller band takes its height plus the inset it draws at"
+    );
+    assert_eq!(
+      margins.resolve(None, Some(80.0)).bottom,
+      80.0 + BAND_EDGE_PADDING
+    );
+    assert_eq!(
+      margins.resolve(None, Some(80.0)).left,
+      PageOptions::DEFAULT_MARGIN,
+      "the sides hold no band"
+    );
   }
 }

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 use takumi_core::{
   Fonts,
   error::Error as TakumiError,
+  geometry::Rect,
   layout::node::Node,
   resources::{font::FontError, image::ImageSource},
   style::{Color, FontFamily, Lang, StyleSheet},
@@ -492,23 +493,14 @@ impl PageMargins {
   }
 
   /// Margins with every [`PageMargin::Auto`] replaced by the band it sits under.
-  pub(crate) fn resolve(self, header: Option<f32>, footer: Option<f32>) -> ResolvedMargins {
-    ResolvedMargins {
+  pub(crate) fn resolve(self, header: Option<f32>, footer: Option<f32>) -> Rect<f32> {
+    Rect {
       top: self.top.resolve(header),
       right: self.right.resolve(None),
       bottom: self.bottom.resolve(footer),
       left: self.left.resolve(None),
     }
   }
-}
-
-/// Page margins in px, with no side left to resolve.
-#[derive(Clone, Copy)]
-pub(crate) struct ResolvedMargins {
-  pub(crate) top: f32,
-  pub(crate) right: f32,
-  pub(crate) bottom: f32,
-  pub(crate) left: f32,
 }
 
 /// Paged output geometry: fixed page size with margins. Content lays out at
@@ -572,10 +564,10 @@ impl PageOptions {
     }
   }
 
-  pub(crate) const fn content_size(&self, margin: ResolvedMargins) -> (f32, f32) {
+  pub(crate) fn content_size(&self, margin: Rect<f32>) -> (f32, f32) {
     (
-      self.width - margin.left - margin.right,
-      self.height - margin.top - margin.bottom,
+      self.width - margin.horizontal(),
+      self.height - margin.vertical(),
     )
   }
 }

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -436,29 +436,79 @@ pub(crate) fn krilla_datetime(date: PdfDate) -> DateTime {
     .utc_offset_hour(0)
 }
 
-/// Per-side page margins in px.
+/// A page margin.
+#[derive(Clone, Copy)]
+pub enum PageMargin {
+  /// A length in px.
+  Px(f32),
+  /// The space the band on that side takes: its measured height plus the inset
+  /// it draws at, never below [`PageOptions::DEFAULT_MARGIN`]. Left and right
+  /// hold no band, so they take the default. Every side starts here.
+  Auto,
+}
+
+impl PageMargin {
+  fn resolve(self, band_height: Option<f32>) -> f32 {
+    match self {
+      Self::Px(value) => value,
+      Self::Auto => band_height.map_or(PageOptions::DEFAULT_MARGIN, |height| {
+        (height + BAND_EDGE_PADDING).max(PageOptions::DEFAULT_MARGIN)
+      }),
+    }
+  }
+}
+
+/// Per-side page margins. The header band draws in the top margin and the
+/// footer band in the bottom.
 #[derive(Clone, Copy)]
 pub struct PageMargins {
-  /// Top margin.
-  pub top: f32,
+  /// Top margin, where the header band draws.
+  pub top: PageMargin,
   /// Right margin.
-  pub right: f32,
-  /// Bottom margin.
-  pub bottom: f32,
+  pub right: PageMargin,
+  /// Bottom margin, where the footer band draws.
+  pub bottom: PageMargin,
   /// Left margin.
-  pub left: f32,
+  pub left: PageMargin,
 }
 
 impl PageMargins {
+  /// Every side sized to the band that draws in it.
+  pub const AUTO: Self = Self {
+    top: PageMargin::Auto,
+    right: PageMargin::Auto,
+    bottom: PageMargin::Auto,
+    left: PageMargin::Auto,
+  };
+
   /// The same margin on all four sides.
   pub const fn uniform(value: f32) -> Self {
     Self {
-      top: value,
-      right: value,
-      bottom: value,
-      left: value,
+      top: PageMargin::Px(value),
+      right: PageMargin::Px(value),
+      bottom: PageMargin::Px(value),
+      left: PageMargin::Px(value),
     }
   }
+
+  /// Margins with every [`PageMargin::Auto`] replaced by the band it sits under.
+  pub(crate) fn resolve(self, header: Option<f32>, footer: Option<f32>) -> ResolvedMargins {
+    ResolvedMargins {
+      top: self.top.resolve(header),
+      right: self.right.resolve(None),
+      bottom: self.bottom.resolve(footer),
+      left: self.left.resolve(None),
+    }
+  }
+}
+
+/// Page margins in px, with no side left to resolve.
+#[derive(Clone, Copy)]
+pub(crate) struct ResolvedMargins {
+  pub(crate) top: f32,
+  pub(crate) right: f32,
+  pub(crate) bottom: f32,
+  pub(crate) left: f32,
 }
 
 /// Paged output geometry: fixed page size with margins. Content lays out at
@@ -488,7 +538,8 @@ pub(crate) const BAND_EDGE_PADDING: f32 = 15.0 * ONE_PT_IN_PX;
 /// adjust, or fill the fields directly for any other size.
 // ponytail: A4 + LETTER only; add other @page keywords when someone asks.
 impl PageOptions {
-  const DEFAULT_MARGIN: f32 = 0.5 * ONE_IN_PX;
+  /// Half an inch, the margin a page starts with.
+  pub const DEFAULT_MARGIN: f32 = 0.5 * ONE_IN_PX;
 
   /// ISO A4: 210 × 297 mm.
   pub const A4: Self = Self::preset(210.0 * ONE_MM_IN_PX, 297.0 * ONE_MM_IN_PX);
@@ -500,7 +551,7 @@ impl PageOptions {
     Self {
       width,
       height,
-      margin: PageMargins::uniform(Self::DEFAULT_MARGIN),
+      margin: PageMargins::AUTO,
     }
   }
 
@@ -521,10 +572,10 @@ impl PageOptions {
     }
   }
 
-  pub(crate) const fn content_size(&self) -> (f32, f32) {
+  pub(crate) const fn content_size(&self, margin: ResolvedMargins) -> (f32, f32) {
     (
-      self.width - self.margin.left - self.margin.right,
-      self.height - self.margin.top - self.margin.bottom,
+      self.width - margin.left - margin.right,
+      self.height - margin.top - margin.bottom,
     )
   }
 }


### PR DESCRIPTION
## Why

A header or footer band draws inside the page margin, so a margin shorter than the band leaves content running underneath it. Getting it right meant a round trip:

```ts
const { height } = await measure(footer, { size: "a4" });
await render(report, { footer, margin: { bottom: Math.max(48, height + 20) } });
```

Two calls, and the band lays out twice, for a number `render` already had: it measures both bands before it decides the page geometry.

## What

`margin` takes `"auto"` on any side and starts there. An `auto` side becomes the space its band needs, its measured height plus the 20px inset bands draw at, and never less than the 48 a page starts with. Left and right hold no band, so `auto` leaves them at 48.

Nothing moves for a document without bands, and a short band no longer shrinks the page, so the default change is invisible unless a band was already overflowing its margin.

`render` now measures the bands before resolving margins, which is the only reordering. `PageMargins` fields become `PageMargin`, an enum of `Px(f32)` and `Auto`.

The existing band tests pass an explicit margin, so they exercise the same geometry as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF page margins now support automatic sizing based on header and footer band heights.
  * Configure margins uniformly or independently per side using fixed values or `"auto"`.
  * Automatic margins include a 48-pixel minimum and expand to fit oversized bands.
  * Default PDF margins now use automatic sizing.
  * Zero-margin configurations are supported.

* **Documentation**
  * Updated PDF setup and headers/footers guidance with automatic margin behavior and positioning recommendations.
  * Added a changelog entry describing automatic margin sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->