### PR TITLE
PDF: take every page keyword CSS defines

### DIFF
--- a/.tegami/pdf-page-size-keywords.md
+++ b/.tegami/pdf-page-size-keywords.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Take every page keyword CSS defines
+
+`size` knew `"a4"` and `"letter"`, so a receipt on A5 or a US legal contract meant working out the millimetres. It now takes the ten page keywords CSS Paged Media defines, from `"a3"` down to `"jis-b5"`.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -73,7 +73,7 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(report, {
   // [!code highlight:3]
-  size: "letter", // "a4", "letter", or { width, height } in CSS px at 96 dpi
+  size: "letter", // a page keyword, or { width, height } in CSS px at 96 dpi
   landscape: true,
   margin: { top: 48, right: 32, bottom: 48, left: 32 },
 });
@@ -81,10 +81,22 @@ const pdf = await render(report, {
 
 | Option            | Type                                                      | Default  | Description                                                        |
 | ----------------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| `size`            | `"a4"`, `"letter"`, or `{ width, height }`                | `"a4"`   | Page size in CSS px at 96 dpi. Presets ignore case.                |
+| `size`            | a page keyword or `{ width, height }`                     | `"a4"`   | Page size in CSS px at 96 dpi. Keywords ignore case.               |
 | `landscape`       | `boolean`                                                 | `false`  | Swaps page width and height, including explicit sizes.             |
 | `margin`          | `number`, `"auto"`, or `{ top?, right?, bottom?, left? }` | `"auto"` | `"auto"` fits the band on that side. Missing object sides are `0`. |
 | `backgroundColor` | CSS color                                                 | unset    | Fills the page box, margins included, under everything.            |
+
+`size` takes the page keywords CSS Paged Media defines, portrait as that module writes them:
+
+| Keyword | Size         | Keyword    | Size         |
+| ------- | ------------ | ---------- | ------------ |
+| `"a3"`  | 297 × 420 mm | `"jis-b4"` | 257 × 364 mm |
+| `"a4"`  | 210 × 297 mm | `"jis-b5"` | 182 × 257 mm |
+| `"a5"`  | 148 × 210 mm | `"ledger"` | 11 × 17 in   |
+| `"b4"`  | 250 × 353 mm | `"legal"`  | 8.5 × 14 in  |
+| `"b5"`  | 176 × 250 mm | `"letter"` | 8.5 × 11 in  |
+
+Set `landscape` to turn any of them, or pass `{ width, height }` for a size with no keyword.
 
 These options are the structured form of `@page`, which takumi does not parse as CSS.
 `size` and `margin` map to the descriptors of the same name, `header` and `footer` to its margin boxes.

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -48,8 +48,21 @@ export type Dimensions = { width: number; height: number };
 /** A single-page viewport. Omitting `height` sizes the page to the content. */
 export type ViewportInput = { width: number; height?: number };
 
-/** A page size: a preset name (case-insensitive) or explicit {@link Dimensions}. */
-export type PageSize = "a4" | "letter" | Dimensions;
+/** A page keyword CSS Paged Media defines, matched case-insensitively. Portrait. */
+export type PageSizeName =
+  | "a3"
+  | "a4"
+  | "a5"
+  | "b4"
+  | "b5"
+  | "jis-b4"
+  | "jis-b5"
+  | "ledger"
+  | "legal"
+  | "letter";
+
+/** A page size: a preset name or explicit {@link Dimensions}. */
+export type PageSize = PageSizeName | Dimensions;
 
 /**
  * One side of a page margin: a length in CSS px, or `"auto"` to fit the band

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -54,7 +54,20 @@ export type Dimensions = { width: number; height: number };
 export type ViewportInput = { width: number; height?: number };
 
 /** A page size: a preset name (case-insensitive) or explicit dimensions. */
-export type PageSize = "a4" | "letter" | Dimensions;
+export type PageSizeName =
+  | "a3"
+  | "a4"
+  | "a5"
+  | "b4"
+  | "b5"
+  | "jis-b4"
+  | "jis-b5"
+  | "ledger"
+  | "legal"
+  | "letter";
+
+/** A page size: a preset name or explicit {@link Dimensions}. */
+export type PageSize = PageSizeName | Dimensions;
 
 /**
  * One side of a page margin: a length in CSS px, or `"auto"` to fit the band

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -107,7 +107,15 @@ fn resolve_page(
       ..PageOptions::A4
     },
     Some(SizeInput::Named(name)) => match name.to_ascii_lowercase().as_str() {
+      "a3" => PageOptions::A3,
       "a4" => PageOptions::A4,
+      "a5" => PageOptions::A5,
+      "b4" => PageOptions::B4,
+      "b5" => PageOptions::B5,
+      "jis-b4" => PageOptions::JIS_B4,
+      "jis-b5" => PageOptions::JIS_B5,
+      "ledger" => PageOptions::LEDGER,
+      "legal" => PageOptions::LEGAL,
       "letter" => PageOptions::LETTER,
       other => {
         return Err(js_sys::Error::new(&format!("unknown page size: {other}")));

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -731,6 +731,29 @@ mod tests {
     let letter = PageOptions::LETTER;
 
     assert_eq!((letter.width, letter.height), (816.0, 1056.0));
+    assert_eq!(
+      (PageOptions::LEGAL.width, PageOptions::LEGAL.height),
+      (816.0, 1344.0)
+    );
+    assert_eq!(
+      (PageOptions::LEDGER.width, PageOptions::LEDGER.height),
+      (1056.0, 1632.0)
+    );
+
+    for page in [
+      PageOptions::A3,
+      PageOptions::A4,
+      PageOptions::A5,
+      PageOptions::B4,
+      PageOptions::B5,
+      PageOptions::JIS_B4,
+      PageOptions::JIS_B5,
+      PageOptions::LEDGER,
+      PageOptions::LEGAL,
+      PageOptions::LETTER,
+    ] {
+      assert!(page.width < page.height, "presets are portrait");
+    }
 
     let landscape = PageOptions::A4.landscape();
 

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -528,13 +528,38 @@ pub(crate) const BAND_EDGE_PADDING: f32 = 15.0 * ONE_PT_IN_PX;
 /// Presets are portrait with a half-inch margin; chain
 /// [`landscape`](Self::landscape) and [`with_margin`](Self::with_margin) to
 /// adjust, or fill the fields directly for any other size.
-// ponytail: A4 + LETTER only; add other @page keywords when someone asks.
+/// The sizes are the page keywords CSS Paged Media defines, portrait as that
+/// module writes them.
 impl PageOptions {
   /// Half an inch, the margin a page starts with.
   pub const DEFAULT_MARGIN: f32 = 0.5 * ONE_IN_PX;
 
+  /// ISO A3: 297 × 420 mm.
+  pub const A3: Self = Self::preset(297.0 * ONE_MM_IN_PX, 420.0 * ONE_MM_IN_PX);
+
   /// ISO A4: 210 × 297 mm.
   pub const A4: Self = Self::preset(210.0 * ONE_MM_IN_PX, 297.0 * ONE_MM_IN_PX);
+
+  /// ISO A5: 148 × 210 mm.
+  pub const A5: Self = Self::preset(148.0 * ONE_MM_IN_PX, 210.0 * ONE_MM_IN_PX);
+
+  /// ISO B4: 250 × 353 mm.
+  pub const B4: Self = Self::preset(250.0 * ONE_MM_IN_PX, 353.0 * ONE_MM_IN_PX);
+
+  /// ISO B5: 176 × 250 mm.
+  pub const B5: Self = Self::preset(176.0 * ONE_MM_IN_PX, 250.0 * ONE_MM_IN_PX);
+
+  /// JIS B4: 257 × 364 mm.
+  pub const JIS_B4: Self = Self::preset(257.0 * ONE_MM_IN_PX, 364.0 * ONE_MM_IN_PX);
+
+  /// JIS B5: 182 × 257 mm.
+  pub const JIS_B5: Self = Self::preset(182.0 * ONE_MM_IN_PX, 257.0 * ONE_MM_IN_PX);
+
+  /// US Ledger: 11 × 17 in.
+  pub const LEDGER: Self = Self::preset(11.0 * ONE_IN_PX, 17.0 * ONE_IN_PX);
+
+  /// US Legal: 8.5 × 14 in.
+  pub const LEGAL: Self = Self::preset(8.5 * ONE_IN_PX, 14.0 * ONE_IN_PX);
 
   /// US Letter: 8.5 × 11 in.
   pub const LETTER: Self = Self::preset(8.5 * ONE_IN_PX, 11.0 * ONE_IN_PX);


### PR DESCRIPTION
## Why

`size` knew `"a4"` and `"letter"`. A receipt on A5, a US legal contract, a JIS-B5 booklet all meant working the millimetres out by hand:

```ts
size: { width: 559, height: 794 }  // A5, if you did the arithmetic right
```

The code said as much: `// ponytail: A4 + LETTER only; add other @page keywords when someone asks`.

## What

The ten page keywords CSS Paged Media defines, portrait as that module writes them: `a3`, `a4`, `a5`, `b4`, `b5`, `jis-b4`, `jis-b5`, `ledger`, `legal`, `letter`. `landscape` turns any of them.

Following the CSS list rather than picking favourites decides the spelling questions for us, including `jis-b4` and ISO B versus JIS B. `tabloid` stays unknown, since CSS has no such keyword and `ledger` is that paper.

The TS side gets a `PageSizeName` union, so a typo is a compile error rather than a render-time one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CSS page-size keywords including A3, A5, B4, B5, JIS B4, JIS B5, Ledger, and Legal.
  * Added reusable page-size presets for the newly supported formats.
  * Existing A4, Letter, landscape, and explicit dimension options remain supported.

* **Documentation**
  * Expanded page-size guidance with supported keywords, dimensions, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->