### PR TITLE
PDF: assert the size of every page preset

### DIFF
--- a/.tegami/pdf-page-size-keywords.md
+++ b/.tegami/pdf-page-size-keywords.md
@@ -4,6 +4,6 @@ packages:
     type: minor
 ---
 
-### Take every page keyword CSS defines
+### Take every page-size keyword CSS defines
 
-`size` knew `"a4"` and `"letter"`, so a receipt on A5 or a US legal contract meant working out the millimetres. It now takes the ten page keywords CSS Paged Media defines, from `"a3"` down to `"jis-b5"`.
+`size` knew `"a4"` and `"letter"`, so a receipt on A5 or a US legal contract meant working out the millimetres. It now takes all ten page-size keywords CSS Paged Media defines, ISO and JIS sheets alongside the US ones.

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -723,37 +723,31 @@ mod tests {
 
   #[test]
   fn presets_match_css_page_keywords() {
-    let a4 = PageOptions::A4;
-
-    assert!((a4.width - 793.7).abs() < 0.1);
-    assert!((a4.height - 1122.5).abs() < 0.1);
-
-    let letter = PageOptions::LETTER;
-
-    assert_eq!((letter.width, letter.height), (816.0, 1056.0));
-    assert_eq!(
-      (PageOptions::LEGAL.width, PageOptions::LEGAL.height),
-      (816.0, 1344.0)
-    );
-    assert_eq!(
-      (PageOptions::LEDGER.width, PageOptions::LEDGER.height),
-      (1056.0, 1632.0)
-    );
-
-    for page in [
-      PageOptions::A3,
-      PageOptions::A4,
-      PageOptions::A5,
-      PageOptions::B4,
-      PageOptions::B5,
-      PageOptions::JIS_B4,
-      PageOptions::JIS_B5,
-      PageOptions::LEDGER,
-      PageOptions::LEGAL,
-      PageOptions::LETTER,
+    // px at 96 dpi, from the millimetres and inches CSS Paged Media lists.
+    for (page, width, height) in [
+      (PageOptions::A3, 1122.52, 1587.40),
+      (PageOptions::A4, 793.70, 1122.52),
+      (PageOptions::A5, 559.37, 793.70),
+      (PageOptions::B4, 944.88, 1334.17),
+      (PageOptions::B5, 665.20, 944.88),
+      (PageOptions::JIS_B4, 971.34, 1375.75),
+      (PageOptions::JIS_B5, 687.87, 971.34),
+      (PageOptions::LEDGER, 1056.0, 1632.0),
+      (PageOptions::LEGAL, 816.0, 1344.0),
+      (PageOptions::LETTER, 816.0, 1056.0),
     ] {
+      assert!(
+        (page.width - width).abs() < 0.1,
+        "width of {width}x{height}"
+      );
+      assert!(
+        (page.height - height).abs() < 0.1,
+        "height of {width}x{height}"
+      );
       assert!(page.width < page.height, "presets are portrait");
     }
+
+    let a4 = PageOptions::A4;
 
     let landscape = PageOptions::A4.landscape();
 


### PR DESCRIPTION
## Why

The preset test that landed with #1268 checked `width < height` and nothing else for six of the ten sizes, so a mistyped millimetre in A3, A5, B4, B5 or either JIS sheet would ship as long as it stayed portrait.

The changeset heading also claimed every page keyword CSS defines. CSS defines other `@page` keywords; this is the page-size set.

## What

Every preset asserts the px it should be, from the millimetres and inches the spec lists. Swapping B5's 176mm for a wrong value now fails:

```
thread 'tests::presets_match_css_page_keywords' panicked
width of 665.2x944.88
```

The review that suggested this also suggested the numbers, and its B5 width was 664.6. The spec's 176mm is 665.2px at 96 dpi, so these are computed rather than pasted.