### PR TITLE
PDF: default an omitted margin side to auto

### DIFF
--- a/.tegami/pdf-margin-omitted-sides.md
+++ b/.tegami/pdf-margin-omitted-sides.md
@@ -1,7 +1,7 @@
 ---
 packages:
   takumi-pdf:
-    type: minor
+    type: patch
 ---
 
 ### Default an omitted margin side to `auto`

--- a/.tegami/pdf-margin-omitted-sides.md
+++ b/.tegami/pdf-margin-omitted-sides.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: minor
+---
+
+### Default an omitted margin side to `auto`
+
+A side left out of the `margin` object used to sit flush with the paper edge, which put a band on that side straight over the content. It now defaults to `"auto"`, the same as every other side. Pass `0` to get the old behaviour.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -48,9 +48,7 @@ looking as it did before. Set a side to a number to size it yourself, and leave
 out the sides you are happy with:
 
 ```ts
-margin: {
-  top: 96;
-}
+const margin = { top: 96 };
 ```
 
 Left and right hold no band. `"auto"` there is the default 48.

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -44,10 +44,13 @@ const pdf = await render(report, {
 
 An `"auto"` side comes out at the band height plus the 20px bands are inset from
 the paper edge, and never below the default 48. A short band leaves the page
-looking as it did before. Set a side to a number to size it yourself:
+looking as it did before. Set a side to a number to size it yourself, and leave
+out the sides you are happy with:
 
 ```ts
-margin: { top: 96, bottom: "auto" }
+margin: {
+  top: 96;
+}
 ```
 
 Left and right hold no band. `"auto"` there is the default 48.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -79,12 +79,12 @@ const pdf = await render(report, {
 });
 ```
 
-| Option            | Type                                                      | Default  | Description                                                        |
-| ----------------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| `size`            | a page keyword or `{ width, height }`                     | `"a4"`   | Page size in CSS px at 96 dpi. Keywords ignore case.               |
-| `landscape`       | `boolean`                                                 | `false`  | Swaps page width and height, including explicit sizes.             |
-| `margin`          | `number`, `"auto"`, or `{ top?, right?, bottom?, left? }` | `"auto"` | `"auto"` fits the band on that side. Missing object sides are `0`. |
-| `backgroundColor` | CSS color                                                 | unset    | Fills the page box, margins included, under everything.            |
+| Option            | Type                                                      | Default  | Description                                                                             |
+| ----------------- | --------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `size`            | a page keyword or `{ width, height }`                     | `"a4"`   | Page size in CSS px at 96 dpi. Keywords ignore case.                                    |
+| `landscape`       | `boolean`                                                 | `false`  | Swaps page width and height, including explicit sizes.                                  |
+| `margin`          | `number`, `"auto"`, or `{ top?, right?, bottom?, left? }` | `"auto"` | `"auto"` fits the band on that side, and a side left out of the object is `"auto"` too. |
+| `backgroundColor` | CSS color                                                 | unset    | Fills the page box, margins included, under everything.                                 |
 
 `size` takes the page keywords CSS Paged Media defines, portrait as that module writes them:
 

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -71,7 +71,7 @@ export type PageSize = PageSizeName | Dimensions;
  */
 export type PageMarginSide = number | "auto";
 
-/** A page margin: one value for all sides, or per-side values (missing sides are zero). */
+/** A page margin: one value for all sides, or per-side values (a side left out is `auto`). */
 export type PageMargin =
   | PageMarginSide
   | {

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -147,6 +147,21 @@ test("accepts case-insensitive presets and per-side margins", async () => {
   expect(pageCount(pdf)).toBe(1);
 });
 
+test("a side left out of the margin object is auto", async () => {
+  const rows = container({
+    style: { display: "flex", flexDirection: "column", width: "100%" },
+    children: Array.from({ length: 40 }, (_, i) => text(`Row ${i + 1}`, { fontSize: 16 })),
+  });
+  const size = { width: 400, height: 300 } as const;
+  const auto = await renderer.render(rows, { size, margin: { left: 0 } });
+  const zero = await renderer.render(rows, {
+    size,
+    margin: { top: 0, right: 0, bottom: 0, left: 0 },
+  });
+
+  expect(pageCount(auto)).toBeGreaterThan(pageCount(zero));
+});
+
 test("rejects an unknown size keyword", () => {
   expect(renderer.render(doc, { size: "tabloid" as "a4" })).rejects.toThrow("unknown page size");
 });

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -76,7 +76,7 @@ export type PageSize = PageSizeName | Dimensions;
  */
 export type PageMarginSide = number | "auto";
 
-/** A page margin: one value for all sides, or per-side values (missing sides are zero). */
+/** A page margin: one value for all sides, or per-side values (a side left out is `auto`). */
 export type PageMargin =
   | PageMarginSide
   | {

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -50,8 +50,8 @@ enum SizeInput {
   Dimensions(Dimensions),
 }
 
-/// A page margin: one value for all sides, or per-side values (missing sides
-/// are zero).
+/// A page margin: one value for all sides, or per-side values (a side left out
+/// is `auto`).
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum MarginInput {
@@ -89,9 +89,8 @@ impl SideInput {
   }
 }
 
-/// A side the caller left out sits flush with the paper edge.
 fn side_margin(side: &Option<SideInput>) -> PageMargin {
-  side.as_ref().map_or(PageMargin::Px(0.0), SideInput::margin)
+  side.as_ref().map_or(PageMargin::Auto, SideInput::margin)
 }
 
 fn resolve_page(


### PR DESCRIPTION
## Why

`margin: { left: 56, right: 56 }` left top and bottom at 0, so a header or footer drew straight over the content. Every other path to a margin starts at `"auto"`.

## What

A side left out of the `margin` object is `"auto"` now. Pass `0` for the old behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Omitted PDF margin sides now default to automatic spacing instead of sitting flush against the page edge.
  * Use `0` explicitly to preserve zero-margin behavior.

* **Documentation**
  * Updated PDF margin guidance and examples to reflect the new default behavior.
  * Added regression coverage for omitted margin sides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->