### PR TITLE
PDF: make Auto the Default page margin

### DIFF
--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -90,7 +90,7 @@ impl SideInput {
 }
 
 fn side_margin(side: &Option<SideInput>) -> PageMargin {
-  side.as_ref().map_or(PageMargin::Auto, SideInput::margin)
+  side.as_ref().map(SideInput::margin).unwrap_or_default()
 }
 
 fn resolve_page(

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -438,13 +438,14 @@ pub(crate) fn krilla_datetime(date: PdfDate) -> DateTime {
 }
 
 /// A page margin.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub enum PageMargin {
   /// A length in px.
   Px(f32),
   /// The space the band on that side takes: its measured height plus the inset
   /// it draws at, never below [`PageOptions::DEFAULT_MARGIN`]. Left and right
   /// hold no band, so they take the default. Every side starts here.
+  #[default]
   Auto,
 }
 
@@ -461,7 +462,7 @@ impl PageMargin {
 
 /// Per-side page margins. The header band draws in the top margin and the
 /// footer band in the bottom.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct PageMargins {
   /// Top margin, where the header band draws.
   pub top: PageMargin,
@@ -474,7 +475,7 @@ pub struct PageMargins {
 }
 
 impl PageMargins {
-  /// Every side sized to the band that draws in it.
+  /// [`Default`] in a const context.
   pub const AUTO: Self = Self {
     top: PageMargin::Auto,
     right: PageMargin::Auto,


### PR DESCRIPTION
## Why

`Auto` is where every margin side starts, but each caller had to name it.

## What

`PageMargin` and `PageMargins` derive `Default`. `PageMargins::AUTO` stays for the const contexts the page presets need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved default handling for page side margins when no value is provided.
  - Preserved custom margin values when specified.

- **Improvements**
  - Added default behavior for page margin settings.
  - Clarified that automatic page margins can be used in constant configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->