### PR TITLE
Core: keep forced breaks off anonymous boxes

### DIFF
--- a/.tegami/pdf-anonymous-box-breaks.md
+++ b/.tegami/pdf-anonymous-box-breaks.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-pdf:
+    type: patch
+---
+
+### Cut once at a forced break
+
+The anonymous box a text child lays out in copied `break-before` and `break-after` from its parent. A padded box carrying `break-after: page` cut twice, once at its content edge and once at its border edge, and the padding between them landed on a blank page of its own.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -912,6 +912,9 @@ impl RenderNode {
     context.style.rotate = None;
     context.style.scale = Default::default();
     context.style.translate = Default::default();
+    context.style.break_before = Default::default();
+    context.style.break_after = Default::default();
+    context.style.break_inside = Default::default();
     context
   }
 

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -290,6 +290,32 @@ fn paged_breaks() {
   });
 }
 
+/// The anonymous box a text child lays out in used to copy `break-after` from
+/// its parent, cutting a second time at the parent's content edge and leaving
+/// the padding below it on a page of its own.
+#[test]
+fn break_after_a_padded_box_cuts_once() {
+  let fonts = fonts();
+  let source = r#"<div style="display: flex; flex-direction: column;">
+    <div style="display: flex; padding-bottom: 64px; break-after: page;">One</div>
+    <div style="display: flex;">Two</div>
+  </div>"#;
+  let pdf = render(
+    PdfOptions::builder()
+      .node(from_html(source, FromHtmlOptions::default()).expect("parse the doc"))
+      .page(PageOptions::A4)
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("render the doc");
+
+  assert_eq!(
+    String::from_utf8_lossy(&pdf).matches("/Count 2").count(),
+    1,
+    "expected the break to cut once"
+  );
+}
+
 /// A table of contents whose entries carry `targetPageNumber` hooks. Each
 /// section is forced onto its own page, so the entries have to read 2, 3 and 4.
 fn toc_document(cells: [&str; 3]) -> String {


### PR DESCRIPTION
## Why

A box with `padding-bottom` and `break-after: page` cut twice: once at its content edge, once at its border edge. The padding between the two cuts became a blank page. pdfcn's report blocks hit this on every page.

## What

The anonymous box a text child lays out in resets `break-before`, `break-after`, and `break-inside` to their initial values, the way Blink builds anonymous style from `InitialStyle()` and inherits only what is inheritable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page-break handling for anonymous layout boxes.
  * Prevented duplicate page breaks that could place padding on a blank page.
  * Ensured padded flex containers with page breaks produce the expected number of pages.

* **Tests**
  * Added regression coverage for forced page breaks and duplicated cuts at content and border edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->