### PR TITLE
Raster, SVG: clip an inset box-shadow to the padding box

### DIFF
--- a/.tegami/inset-shadow-padding-box.md
+++ b/.tegami/inset-shadow-padding-box.md
@@ -1,0 +1,13 @@
+---
+packages:
+  takumi-raster:
+    type: patch
+  takumi-svg:
+    type: patch
+  takumi:
+    type: patch
+---
+
+### Place an inset `box-shadow` in the padding box
+
+An inset `box-shadow` was placed against the border box instead of the padding box. On a box with a border the shadow fell at the border's position, where the opaque border covered it. The shadow is now placed against the padding box and appears just inside the border.

--- a/takumi-raster/src/components/shadow.rs
+++ b/takumi-raster/src/components/shadow.rs
@@ -145,10 +145,27 @@ pub(crate) fn draw_inset_shadow(
   let height = border_box.height as u32;
   let [red, green, blue, alpha] = shadow.color.0;
   let mut shadow_alpha = vec![alpha; (width * height) as usize];
+  let shadow_placement = Placement {
+    left: 0,
+    top: 0,
+    width,
+    height,
+  };
+
+  let mut padding = border;
+  padding.inset_by_border_width();
+  let padding_offset = Point {
+    x: border.width.left,
+    y: border.width.top,
+  };
+  let padding_size = Size {
+    width: (border_box.width - border.width.left - border.width.right).max(0.0),
+    height: (border_box.height - border.width.top - border.width.bottom).max(0.0),
+  };
 
   let hole = ClipBox::inset_shadow_hole(
-    border,
-    border_box,
+    padding,
+    padding_size,
     shadow.spread_radius,
     Point {
       x: shadow.offset_x,
@@ -157,19 +174,18 @@ pub(crate) fn draw_inset_shadow(
   );
 
   let mut paths = Vec::new();
-  hole
-    .border
-    .append_mask_commands(&mut paths, hole.size, hole.offset);
+  hole.border.append_mask_commands(
+    &mut paths,
+    hole.size,
+    Point {
+      x: padding_offset.x + hole.offset.x,
+      y: padding_offset.y + hole.offset.y,
+    },
+  );
 
   let (mask, placement) = render_mask(&paths, None, Some(Fill::NonZero.into()));
 
   if !mask.is_empty() {
-    let shadow_placement = Placement {
-      left: 0,
-      top: 0,
-      width,
-      height,
-    };
     attenuate_alpha_by_mask(&mut shadow_alpha, shadow_placement, &mask, placement);
   }
 
@@ -182,6 +198,19 @@ pub(crate) fn draw_inset_shadow(
     shadow.blur_radius,
     BlurType::Shadow,
   )?;
+
+  let mut clip_paths = Vec::new();
+  border.append_mask_commands(&mut clip_paths, border_box, Point::ZERO);
+  padding.append_mask_commands(&mut clip_paths, padding_size, padding_offset);
+  let (clip_mask, clip_placement) = render_mask(&clip_paths, None, Some(Fill::EvenOdd.into()));
+  if !clip_mask.is_empty() {
+    attenuate_alpha_by_mask(
+      &mut shadow_alpha,
+      shadow_placement,
+      &clip_mask,
+      clip_placement,
+    );
+  }
 
   let mut data = uninit_buffer((width * height * 4) as usize);
   for (pixel, &alpha) in bytemuck::cast_slice_mut::<u8, [u8; 4]>(&mut data)

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -1036,10 +1036,11 @@ pub(crate) fn emit_box_shadows(
   Ok(())
 }
 
-/// Emits inset `box-shadow`s as a blurred ring inside the element's rounded border
-/// box. Mirrors the raster backend's `draw_inset_shadow`: the shadow color fills
-/// the border box minus an inner rounded-rect (shrunk by the spread, shifted by
-/// the offset), blurred and clipped to the rounded border box.
+/// Emits inset `box-shadow`s as a blurred ring inside the element's rounded
+/// padding box. Mirrors the PDF backend's `emit_inset_shadows`: the shadow
+/// color fills the padding box minus an inner rounded-rect (shrunk by the
+/// spread, shifted by the offset), blurred and clipped to the rounded padding
+/// box.
 pub(crate) fn emit_inset_box_shadows(
   node: &RenderNode,
   border: &BorderProperties,
@@ -1048,29 +1049,32 @@ pub(crate) fn emit_inset_box_shadows(
   y: f32,
   doc: &mut SvgDocument,
 ) -> io::Result<()> {
-  let size = layout.size;
-  if size.width <= 0.0 || size.height <= 0.0 {
+  if layout.size.width <= 0.0 || layout.size.height <= 0.0 {
     return Ok(());
   }
-  let outer = border_box_path_data(border, size, x, y);
+  let padding = ClipBox::padding_box(*border, layout);
+  let outer = clip_box_path_data(padding, x, y);
   for resolved in BoxPainter::new(&node.context, layout).shadows().inset {
     let fill = Rgba(resolved.color.0);
 
-    // The shadow fills the border box minus the hole it leaves uncovered (shared
-    // core geometry with the raster backend), drawn even-odd.
+    // The shadow fills the padding box minus the hole it leaves uncovered
+    // (shared core geometry with the raster backend), drawn even-odd.
     let hole = ClipBox::inset_shadow_hole(
-      *border,
-      size,
+      padding.border,
+      padding.size,
       resolved.spread_radius,
       Point {
         x: resolved.offset_x,
         y: resolved.offset_y,
       },
     );
-    let ring = format!("{outer}{}", clip_box_path_data(hole, x, y));
+    let ring = format!(
+      "{outer}{}",
+      clip_box_path_data(hole, x + padding.offset.x, y + padding.offset.y)
+    );
 
-    // Border box minus the hole, drawn even-odd, blurred, and clipped to the
-    // rounded border box so the blur stays inside the element.
+    // Padding box minus the hole, drawn even-odd, blurred, and clipped to the
+    // rounded padding box so the blur stays inside the element.
     let clip = doc.clip_path(&outer)?;
     let clip_group = doc.begin_group(IDENTITY, 1.0, Some(&clip), None)?;
     emit_with_blur(doc, resolved.blur_radius, |doc| doc.path(&ring, fill, true))?;


### PR DESCRIPTION
An inset box-shadow was computed against the border box instead of the padding box. On a box with a border the shadow landed under the border, where the opaque border covered it, so no shadow appeared inside the box unless it was large enough to reach past the border. The shadow is now computed against the padding box and appears just inside the border, matching the PDF backend.

# Before / After
<img width="752" height="160" alt="takumi-1786702168" src="https://github.com/user-attachments/assets/faa0cabe-7ec7-4b16-b53c-687b54c412e8" />

# Reproduction Code

```
<!doctype html><html><head><title>inset box-shadow with a border</title></head><body style="margin:0;background-color:rgb(230,230,230)"><div style="box-sizing:border-box;width:240px;height:160px;background-color:rgb(255,255,255);border:18px solid rgb(120,140,200);border-radius:16px;box-shadow:inset 0px 0px 0px 30px rgba(0,0,0,0.6);" ></div></body></html>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected inset box-shadow rendering so shadows appear inside the border, within the padding area.
  - Improved inset shadows for bordered and rounded elements, including more accurate clipping and positioning.
  - Prevented rendering issues for elements with non-positive dimensions.

- **Documentation**
  - Added release notes for the corrected inset shadow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->