### PR TITLE
Core, Helpers: treat the synthetic HTML root as a block container

### DIFF
--- a/.tegami/helpers-html-whitespace-roots.md
+++ b/.tegami/helpers-html-whitespace-roots.md
@@ -2,8 +2,10 @@
 packages:
   "@takumi-rs/helpers":
     type: patch
+  "@takumi-rs/core":
+    type: patch
 ---
 
-### Keep a newline-wrapped element a single root
+### Treat the synthetic HTML root as a block container
 
-`fromHtml` kept the whitespace a template literal leaves around the markup. Those text roots landed in an inline wrapper, where the first one held a line box and pushed the content down the page. They are dropped now, the way the Rust crate's `from_html` already did.
+Markup written in a template literal carries whitespace either side, which parsed into text roots. The synthetic root that holds them was inline, so the leading one kept a line box and pushed the content down the page. It is a block container now, the way `<body>` is, and `fromHtml` drops the whitespace roots the way the Rust crate already did.

--- a/.tegami/helpers-html-whitespace-roots.md
+++ b/.tegami/helpers-html-whitespace-roots.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Keep a newline-wrapped element a single root
+
+`fromHtml` kept the whitespace a template literal leaves around the markup. Those text roots landed in an inline wrapper, where the first one held a line box and pushed the content down the page. They are dropped now, the way the Rust crate's `from_html` already did.

--- a/takumi-helpers/src/html/index.ts
+++ b/takumi-helpers/src/html/index.ts
@@ -7,9 +7,6 @@ const isWhitespaceOnlyText = (node: Node): boolean =>
 
 export function fromHtml(html: string) {
   const { nodes: parsed, stylesheets } = fromStaticMarkup(html);
-  // A template literal leaves whitespace around the markup, which parses into
-  // text roots. Dropping them keeps a newline-wrapped element a single root,
-  // the way `from_html` does in the Rust crate (kane50613/takumi#1283).
   const nodes = [...parsed];
 
   while (nodes[0] && isWhitespaceOnlyText(nodes[0])) {
@@ -36,6 +33,7 @@ export function fromHtml(html: string) {
   return {
     node: container({
       style: {
+        display: "block",
         width: percentage(100),
         height: percentage(100),
       },

--- a/takumi-helpers/src/html/index.ts
+++ b/takumi-helpers/src/html/index.ts
@@ -6,8 +6,7 @@ const isWhitespaceOnlyText = (node: Node): boolean =>
   "text" in node && typeof node.text === "string" && node.text.trim() === "";
 
 export function fromHtml(html: string) {
-  const { nodes: parsed, stylesheets } = fromStaticMarkup(html);
-  const nodes = [...parsed];
+  const { nodes, stylesheets } = fromStaticMarkup(html);
 
   while (nodes[0] && isWhitespaceOnlyText(nodes[0])) {
     nodes.shift();

--- a/takumi-helpers/src/html/index.ts
+++ b/takumi-helpers/src/html/index.ts
@@ -1,8 +1,23 @@
 import { container, percentage } from "../helpers";
 import { fromStaticMarkup } from "./markup";
+import type { Node } from "../types";
+
+const isWhitespaceOnlyText = (node: Node): boolean =>
+  "text" in node && typeof node.text === "string" && node.text.trim() === "";
 
 export function fromHtml(html: string) {
-  const { nodes, stylesheets } = fromStaticMarkup(html);
+  const { nodes: parsed, stylesheets } = fromStaticMarkup(html);
+  // A template literal leaves whitespace around the markup, which parses into
+  // text roots. Dropping them keeps a newline-wrapped element a single root,
+  // the way `from_html` does in the Rust crate (kane50613/takumi#1283).
+  const nodes = [...parsed];
+
+  while (nodes[0] && isWhitespaceOnlyText(nodes[0])) {
+    nodes.shift();
+  }
+  while (nodes.at(-1) && isWhitespaceOnlyText(nodes.at(-1) as Node)) {
+    nodes.pop();
+  }
 
   if (nodes.length === 0) {
     return {

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -103,6 +103,7 @@ export async function fromJsx(
     node = container({
       children: nodes,
       style: {
+        display: "block",
         width: percentage(100),
         height: percentage(100),
       },

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -50,6 +50,15 @@ describe("fromHtml", () => {
     expect((node as TextNode).text).toBe("&constructor; &hasOwnProperty;");
   });
 
+  // A template literal leaves whitespace around the markup, which arrives as
+  // text siblings. An inline root keeps their line box and pushes the content
+  // down the page: kane50613/takumi#1283.
+  test("keeps a newline-wrapped element a single root", () => {
+    const markup = `<div style="width:100%;height:100%"></div>`;
+
+    expect(fromHtml(`\n  ${markup}\n`).node).toEqual(fromHtml(markup).node);
+  });
+
   test("leaves surrogate code point references untouched", () => {
     const { node } = fromHtml("<div>&#xd800;&#57343;</div>");
 

--- a/takumi-helpers/tests/jsx/jsx-processing.test.tsx
+++ b/takumi-helpers/tests/jsx/jsx-processing.test.tsx
@@ -291,6 +291,7 @@ describe("fromJsx", () => {
         },
       ],
       style: {
+        display: "block",
         width: "100%",
         height: "100%",
       },

--- a/takumi-html/src/lib.rs
+++ b/takumi-html/src/lib.rs
@@ -351,9 +351,9 @@ fn collapse(mut nodes: Vec<Node>) -> Node {
   match nodes.len() {
     0 => Node::container([]),
     1 => nodes.pop().unwrap_or_default(),
-    _ => {
-      Node::container(nodes).with_style(Style::from(parse_declarations("width:100%;height:100%")))
-    }
+    _ => Node::container(nodes).with_style(Style::from(parse_declarations(
+      "display:block;width:100%;height:100%",
+    ))),
   }
 }
 


### PR DESCRIPTION
## Why

Markup written in a template literal carries whitespace either side. `fromHtml` parsed it into text roots, and the synthetic root holding them was inline, so the leading whitespace kept its line box and pushed every page down by a line. Reported in #1283.

The engine was right to keep it: Blink's `Text::TextLayoutObjectIsNeeded` preserves leading whitespace under an inline parent. The root was what was wrong. `from_html` in the Rust crate trimmed the whitespace away, which hid the same inline root there, so the two sides disagreed on the same markup.

## What

The synthetic root is a block container now, in `from_html`, `fromHtml` and `fromJsx` alike, matching the `<body>` it stands in for.

`fromHtml` also drops whitespace-only roots, which is what fixes the reported case and what the Rust side already did. `fromJsx` does not: whitespace in JSX is written deliberately, as `{" "}`, so it is content rather than formatting.

Nothing else moves. Every fixture is a single root and never reaches the synthetic one, and two block-level roots already stacked, since they form anonymous block boxes under an inline parent either way. The block root is the correct one to start from rather than a behaviour change on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML and JSX rendering for content containing surrounding whitespace.
  * Multiple root elements now render inside a block-level container for more consistent layout behavior.

* **Tests**
  * Added regression coverage for whitespace-wrapped inline HTML.
  * Updated fragment rendering expectations to reflect block container styling.

* **Documentation**
  * Added release notes describing the HTML root and whitespace handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->