### PR TITLE
CI: build tests without debug info and with optimized deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   # Remove file paths to reduce binary size
   RUSTFLAGS: >-
@@ -76,7 +77,7 @@ jobs:
           exit $fail
 
       - name: Run tests
-        run: CARGO_PROFILE_TEST_STRIP="debuginfo" cargo test
+        run: cargo test
 
       # The fixtures claim PDF/A and PDF/UA conformance in their metadata. Only
       # the reference validator can tell whether the claim holds.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,9 @@ redundant_closure_for_method_calls = "deny"
 level = "deny"
 priority = -1
 
+[profile.dev.package."*"]
+opt-level = 2
+
 [profile.release]
 strip = true
 opt-level = 3


### PR DESCRIPTION
## Why

`cargo test` takes 382s of the Rust job's 8.3 minutes, and much of that pays for work nothing reads. The job generated full debug info and stripped it again in the same step, and dependencies built at `opt-level = 0`, which leaves resvg rasterizing the 248 SVG fixtures unoptimized.

## What

`CARGO_PROFILE_DEV_DEBUG=line-tables-only` replaces `CARGO_PROFILE_TEST_STRIP=debuginfo`, so the debug info is never generated and a failing test still names its file and line. Dependencies build at `opt-level = 2`; workspace crates stay unoptimized, so a local rebuild is as fast as before.

Locally the suite runs in 65s instead of 144s, with `svg_parity` at 11s instead of 79s. A cold build costs about 45s more, which the cache absorbs from the second run on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved development build performance by optimizing dependency compilation.
* **Testing**
  * Simplified test execution while retaining useful debugging information in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->