### PR TITLE
PDF: compose each page from one frame and repeatable set

### DIFF
--- a/takumi-pdf/src/bands.rs
+++ b/takumi-pdf/src/bands.rs
@@ -1,41 +1,222 @@
-//! Measurement, per-page preparation and emission of the repeated header/footer bands.
-
-use takumi_core::{layout::node::Node, style::Affine, viewport::Viewport};
+//! Trees drawn once per page: header and footer bands, and repeated `fixed`
+//! boxes.
 
 use std::cell::RefCell;
+
+use takumi_core::{context::RenderContext, layout::node::Node, style::Affine, viewport::Viewport};
 
 use crate::{
   counters::{has_page_counters, substitute_page_counters, substitute_target_counters},
   emitter::{FontMap, RenderIssues},
+  interactive::{LinkTarget, collect_interactive},
   krilla::{
     geom::{Rect as KrillaRect, Transform},
     paint::FillRule,
     surface::Surface,
     tagging::{Artifact, ArtifactType, ContentTag},
   },
-  options::PdfError,
+  options::{BAND_EDGE_PADDING, PdfError},
+  page::PageFrame,
   paint::rect_path,
-  tree::{PreparedTree, TreeInputs, prepare_tree},
+  tree::{PreparedTree, RepeatedBox, RepeatedTemplate, TreeInputs, prepare_repeated, prepare_tree},
 };
 
-/// A band measured before pagination: the laid-out tree plus whether it must
-/// re-prepare per page (it contains counter hooks).
-pub(crate) struct MeasuredBand {
-  pub(crate) measured: PreparedTree,
-  pub(crate) dynamic: bool,
+/// Where a repeatable draws on the page.
+pub(crate) enum RepeatBounds {
+  /// The strip above the content, inside the top margin.
+  Header,
+  /// The strip below the content, inside the bottom margin.
+  Footer,
+  /// The content area, under the content when `below` is set.
+  Content {
+    /// A negative `z-index` on the box puts it under the content.
+    below: bool,
+  },
 }
 
-/// Measures a band with three-digit counters and records whether it must
-/// re-prepare per page.
-pub(crate) fn measure_band(
-  inputs: &TreeInputs<'_>,
-  template: &Node,
-  viewport: Viewport,
-) -> Result<MeasuredBand, PdfError> {
-  Ok(MeasuredBand {
-    measured: prepare_band(inputs, template, 999, 999, viewport)?,
-    dynamic: has_page_counters(template),
-  })
+impl RepeatBounds {
+  /// The clip rect a repeatable draws inside. A band clips to its measured
+  /// height, so a wrap caused by a wider real counter cannot move the band box
+  /// between pages.
+  fn rect(&self, frame: &PageFrame, height: f32) -> (f32, f32, f32, f32) {
+    match self {
+      Self::Header => (0.0, BAND_EDGE_PADDING, frame.size.0, height),
+      Self::Footer => (
+        0.0,
+        frame.size.1 - BAND_EDGE_PADDING - height,
+        frame.size.0,
+        height,
+      ),
+      Self::Content { .. } => (
+        frame.margin.left,
+        frame.margin.top,
+        frame.content_width,
+        frame.window_height,
+      ),
+    }
+  }
+}
+
+/// A tree drawn once per page. One holding a page counter lays out again for
+/// every page with that page's numbers; the rest reuse the measured layout.
+pub(crate) struct Repeatable {
+  prepared: PreparedTree,
+  template: Option<RepeatTemplate>,
+  bounds: RepeatBounds,
+  /// Links collected once from the measured layout. Bands never annotate
+  /// links, and a renumbered page collects its own.
+  links: Vec<LinkTarget>,
+}
+
+/// What a per-page layout starts from.
+enum RepeatTemplate {
+  /// A band re-lays out its option node with the page's counters.
+  Band(Node),
+  /// A repeated box re-lays out the subtree it was taken from.
+  Fixed(RepeatedTemplate),
+}
+
+impl Repeatable {
+  /// Measures a band with three-digit counters, recording the template when it
+  /// must re-prepare per page.
+  pub(crate) fn band(
+    inputs: &TreeInputs<'_>,
+    template: &Node,
+    viewport: Viewport,
+    bounds: RepeatBounds,
+  ) -> Result<Self, PdfError> {
+    Ok(Self {
+      prepared: prepare_band(inputs, template, 999, 999, viewport)?,
+      template: has_page_counters(template).then(|| RepeatTemplate::Band(template.clone())),
+      bounds,
+      links: Vec::new(),
+    })
+  }
+
+  /// Wraps a repeated `fixed` box, caching its links when it never re-lays out.
+  pub(crate) fn fixed(repeat: RepeatedBox) -> Self {
+    let links = match repeat.template {
+      Some(_) => Vec::new(),
+      None => collect_interactive(&repeat.prepared).links,
+    };
+    let below = repeat.prepared.paints_below();
+
+    Self {
+      prepared: repeat.prepared,
+      template: repeat.template.map(RepeatTemplate::Fixed),
+      bounds: RepeatBounds::Content { below },
+      links,
+    }
+  }
+
+  /// The height the measured layout came out at.
+  pub(crate) fn height(&self) -> f32 {
+    self.prepared.height
+  }
+
+  /// Resolves the tree this page draws: a fresh layout with the page's
+  /// counters, or the measured one.
+  pub(crate) fn for_page(
+    &self,
+    inputs: &TreeInputs<'_>,
+    page_context: &RenderContext,
+    frame: &PageFrame,
+    page: usize,
+    pages: usize,
+  ) -> Result<RepeatablePage<'_>, PdfError> {
+    let fresh = match &self.template {
+      None => None,
+      Some(RepeatTemplate::Band(node)) => Some(prepare_band(
+        inputs,
+        node,
+        page,
+        pages,
+        frame.band_viewport,
+      )?),
+      Some(RepeatTemplate::Fixed(template)) => Some(prepare_repeated(
+        page_context,
+        template,
+        page,
+        pages,
+        frame.page_area,
+      )?),
+    };
+    let fresh_links = match (&fresh, &self.bounds) {
+      (Some(tree), RepeatBounds::Content { .. }) => collect_interactive(tree).links,
+      _ => Vec::new(),
+    };
+
+    Ok(RepeatablePage {
+      repeatable: self,
+      fresh,
+      fresh_links,
+    })
+  }
+}
+
+/// One repeatable resolved for one page.
+pub(crate) struct RepeatablePage<'r> {
+  repeatable: &'r Repeatable,
+  fresh: Option<PreparedTree>,
+  fresh_links: Vec<LinkTarget>,
+}
+
+impl RepeatablePage<'_> {
+  fn tree(&self) -> &PreparedTree {
+    self.fresh.as_ref().unwrap_or(&self.repeatable.prepared)
+  }
+
+  /// Whether this draws under the content: the header band, or a repeated box
+  /// with a negative `z-index`.
+  pub(crate) fn draws_before_content(&self) -> bool {
+    matches!(
+      self.repeatable.bounds,
+      RepeatBounds::Header | RepeatBounds::Content { below: true }
+    )
+  }
+
+  /// The links this page annotates.
+  pub(crate) fn links(&self) -> impl Iterator<Item = &LinkTarget> {
+    self.repeatable.links.iter().chain(&self.fresh_links)
+  }
+
+  /// Emits the tree clipped to its bounds on the page.
+  pub(crate) fn emit(
+    &self,
+    frame: &PageFrame,
+    fonts: &mut FontMap,
+    artifact: bool,
+    issues: &RefCell<RenderIssues>,
+    document_lang: Option<&str>,
+    surface: &mut Surface,
+  ) -> Result<(), PdfError> {
+    let (x, y, width, height) = self.repeatable.bounds.rect(frame, self.repeatable.height());
+    let Some(path) = KrillaRect::from_xywh(x, y, width, height).and_then(rect_path) else {
+      return Ok(());
+    };
+
+    if artifact {
+      // `Other` stays valid below PDF 2.0, where the header/footer artifact
+      // subtypes do not exist yet.
+      surface.start_tagged(ContentTag::Artifact(Artifact::new(
+        ArtifactType::Other,
+        None,
+      )));
+    }
+    surface.push_clip_path(&path, &FillRule::NonZero);
+    surface.push_transform(&Transform::from_translate(x, y));
+    let mut emitter = self
+      .tree()
+      .emitter(fonts, None, None, issues, document_lang);
+
+    emitter.emit_context(0, Affine::IDENTITY, surface)?;
+    surface.pop();
+    surface.pop();
+    if artifact {
+      surface.end_tagged();
+    }
+    Ok(())
+  }
 }
 
 /// Lays out a band template with the given counter values.
@@ -54,40 +235,4 @@ pub(crate) fn prepare_band(
   // of leaving the placeholder the template put there.
   substitute_target_counters(&mut node, None, &|_: &str| None, &mut Vec::new());
   prepare_tree(inputs, node, viewport)
-}
-
-/// Emits a band clipped to `(x, y, width, height)` on the page.
-pub(crate) fn emit_band(
-  band: &PreparedTree,
-  fonts: &mut FontMap,
-  bounds: (f32, f32, f32, f32),
-  artifact: bool,
-  issues: &RefCell<RenderIssues>,
-  document_lang: Option<&str>,
-  surface: &mut Surface,
-) -> Result<(), PdfError> {
-  let (x, y, width, height) = bounds;
-  let Some(path) = KrillaRect::from_xywh(x, y, width, height).and_then(rect_path) else {
-    return Ok(());
-  };
-
-  if artifact {
-    // `Other` stays valid below PDF 2.0, where the header/footer artifact
-    // subtypes do not exist yet.
-    surface.start_tagged(ContentTag::Artifact(Artifact::new(
-      ArtifactType::Other,
-      None,
-    )));
-  }
-  surface.push_clip_path(&path, &FillRule::NonZero);
-  surface.push_transform(&Transform::from_translate(x, y));
-  let mut emitter = band.emitter(fonts, None, None, issues, document_lang);
-
-  emitter.emit_context(0, Affine::IDENTITY, surface)?;
-  surface.pop();
-  surface.pop();
-  if artifact {
-    surface.end_tagged();
-  }
-  Ok(())
 }

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -290,12 +290,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let node = options.node;
 
       let page_area = Viewport::new((content_width as u32, content_height as u32));
-      let Paginated {
-        content,
-        repeated,
-        starts,
-        interactive,
-      } = paginate(
+      let paginated = paginate(
         node,
         &inputs,
         &mut fonts,
@@ -307,6 +302,14 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
           window_height,
         },
       )?;
+
+      let Paginated {
+        content,
+        repeated,
+        starts,
+        interactive,
+        ..
+      } = &paginated;
 
       if starts.len() >= MAX_PAGES {
         return Err(PdfError::TooManyPages(starts.len()));
@@ -327,9 +330,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let pages = starts.len();
       let structural = options.tagged.names_structure_destinations();
       let destination = |top: f32, path: &[usize]| {
-        let index = starts
-          .partition_point(|start| *start <= top)
-          .saturating_sub(1);
+        let index = paginated.page_index(top);
         let y = margin.top + (top - starts[index]).max(0.0);
         let dest = XyzDestination::new(
           index,
@@ -342,7 +343,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         }
       };
 
-      for (index, &y0) in starts.iter().enumerate() {
+      for slice in paginated.pages() {
         // A repeated box holding a counter lays out again with this page's
         // numbers; the rest keep the layout they were prepared with.
         let renumbered = repeated
@@ -352,7 +353,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
               .template
               .as_ref()
               .map(|template| {
-                prepare_repeated(&page_context, template, index + 1, pages, page_area)
+                prepare_repeated(&page_context, template, slice.index + 1, pages, page_area)
               })
               .transpose()
           })
@@ -382,7 +383,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         if let (Some(band), Some(template)) = (&header_band, &options.header) {
           let prepared;
           let tree = if band.dynamic {
-            prepared = prepare_band(&inputs, template, index + 1, pages, band_viewport)?;
+            prepared = prepare_band(&inputs, template, slice.index + 1, pages, band_viewport)?;
             &prepared
           } else {
             &band.measured
@@ -419,15 +420,15 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         // Paint stops at the next cut: the region between a raised cut and the
         // page's full height belongs to the next page and stays blank, exactly
         // like browser print fragmentation.
-        let next_start = starts.get(index + 1).copied().unwrap_or(f32::INFINITY);
-        let paint_height = (next_start - y0).min(window_height);
-
         if let Some(path) =
-          KrillaRect::from_xywh(margin.left, content_top, content_width, paint_height)
+          KrillaRect::from_xywh(margin.left, content_top, content_width, slice.paint_height)
             .and_then(rect_path)
         {
           surface.push_clip_path(&path, &FillRule::NonZero);
-          surface.push_transform(&Transform::from_translate(margin.left, content_top - y0));
+          surface.push_transform(&Transform::from_translate(
+            margin.left,
+            content_top - slice.start,
+          ));
           let mut emitter = content.emitter(
             &mut fonts,
             Some(&inline_map),
@@ -436,8 +437,15 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
             document_lang,
           );
 
-          emitter.window = Some((y0, y0 + paint_height));
-          emitter.line_window = Some((if index == 0 { f32::NEG_INFINITY } else { y0 }, next_start));
+          emitter.window = Some((slice.start, slice.start + slice.paint_height));
+          emitter.line_window = Some((
+            if slice.index == 0 {
+              f32::NEG_INFINITY
+            } else {
+              slice.start
+            },
+            slice.end,
+          ));
           emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
           surface.pop();
           surface.pop();
@@ -462,7 +470,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         if let (Some(band), Some(template)) = (&footer_band, &options.footer) {
           let prepared;
           let tree = if band.dynamic {
-            prepared = prepare_band(&inputs, template, index + 1, pages, band_viewport)?;
+            prepared = prepare_band(&inputs, template, slice.index + 1, pages, band_viewport)?;
             &prepared
           } else {
             &band.measured
@@ -489,7 +497,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         add_link_annotations(
           &mut pdf_page,
           &interactive.links,
-          (y0, y0 + paint_height),
+          (slice.start, slice.start + slice.paint_height),
           (margin.left, content_top),
           tag_collector.as_ref(),
           |id| {

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -37,7 +37,7 @@
 //! `filter: blur()` and `drop-shadow()` have no PDF equivalent. [`render`]
 //! stops and names the function.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, mem::take, rc::Rc};
 
 mod background;
 mod bands;
@@ -50,6 +50,7 @@ mod glyph;
 mod inline;
 mod interactive;
 mod options;
+mod page;
 mod pagination;
 mod paint;
 #[cfg(feature = "images")]
@@ -92,7 +93,7 @@ pub use crate::options::{
   XmpSchema,
 };
 use crate::{
-  bands::{MeasuredBand, emit_band, measure_band, prepare_band},
+  bands::{RepeatBounds, Repeatable, prepare_band},
   emitter::{FontMap, RenderIssues},
   glyph::uncovered_error,
   inline::{build_inline_map, collect_text_boxes},
@@ -104,20 +105,15 @@ use crate::{
     embed::{EmbeddedFile, MimeType},
     geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
     page::PageSettings,
-    paint::FillRule,
     surface::Surface,
   },
-  options::{BAND_EDGE_PADDING, PT_PER_PX, build_metadata, krilla_datetime, validate_xmp_schemas},
-  pagination::{MAX_PAGES, PageGeometry, Paginated, paginate},
+  options::{PT_PER_PX, build_metadata, krilla_datetime, validate_xmp_schemas},
+  page::{PageComposer, PageFrame},
+  pagination::{MAX_PAGES, paginate},
   paint::{fill_from_rgba, rect_path},
   tags::{TagCollector, build_tag_tree, tag_id},
-  tree::{TreeInputs, prepare_repeated, prepare_tree, tree_context},
+  tree::{TreeInputs, prepare_tree, tree_context},
 };
-
-/// The height a measured band came out at, or nothing when the side has none.
-fn band_height(band: Option<&MeasuredBand>) -> Option<f32> {
-  band.map(|band| band.measured.height)
-}
 
 /// Lays out a node tree without rendering and returns its size.
 ///
@@ -246,302 +242,80 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
   }
   match options.page {
     Some(page) => {
-      let page_size = KrillaSize::from_wh(page.width * PT_PER_PX, page.height * PT_PER_PX)
-        .ok_or(PdfError::InvalidPageSize)?;
       // Bands lay out at full page width and draw inside the margin areas,
-      // like Chromium's print header and footer templates. The content window
-      // is always the full margin box; a band taller than its margin overlaps
-      // content, exactly as in Chromium. They are measured first so an `auto`
-      // margin can take the height they came out at.
+      // like Chromium's print header and footer templates.
       let band_viewport = Viewport::new((page.width as u32, None));
-
-      // Band heights are measured once with three-digit counters; per-page
-      // emission clips to the measured band, so a wrap caused by a wider real
-      // counter cannot move the band box between pages. A band without counter
-      // hooks reuses the measured layout on every page.
-      let header_band = options
+      let header = options
         .header
         .as_ref()
-        .map(|template| measure_band(&inputs, template, band_viewport))
+        .map(|template| Repeatable::band(&inputs, template, band_viewport, RepeatBounds::Header))
         .transpose()?;
-      let footer_band = options
+      let footer = options
         .footer
         .as_ref()
-        .map(|template| measure_band(&inputs, template, band_viewport))
+        .map(|template| Repeatable::band(&inputs, template, band_viewport, RepeatBounds::Footer))
         .transpose()?;
-      let margin = page.margin.resolve(
-        (page.width, page.height),
-        band_height(header_band.as_ref()),
-        band_height(footer_band.as_ref()),
-      );
-      let (content_width, content_height) = page.content_size(margin);
-      if !(content_width.is_finite()
-        && content_height.is_finite()
-        && content_width > 0.0
-        && content_height > 0.0)
-      {
-        return Err(PdfError::InvalidPageSize);
-      }
-      let content_viewport = Viewport::new((content_width as u32, None));
-      let header_height = band_height(header_band.as_ref()).unwrap_or(0.0);
-      let footer_height = band_height(footer_band.as_ref()).unwrap_or(0.0);
-      let window_height = content_height;
-
-      let node = options.node;
-
-      let page_area = Viewport::new((content_width as u32, content_height as u32));
-      let paginated = paginate(
-        node,
+      let frame = PageFrame::resolve(
+        &page,
+        band_viewport,
+        header.as_ref().map(Repeatable::height),
+        footer.as_ref().map(Repeatable::height),
+      )?;
+      let mut paginated = paginate(
+        options.node,
         &inputs,
         &mut fonts,
         &issues,
         document_lang,
-        &PageGeometry {
-          viewport: content_viewport,
-          page_area,
-          window_height,
-        },
+        &frame.geometry(),
       )?;
 
-      let Paginated {
-        content,
-        repeated,
-        starts,
-        interactive,
-        ..
-      } = &paginated;
-
-      if starts.len() >= MAX_PAGES {
-        return Err(PdfError::TooManyPages(starts.len()));
+      if paginated.starts.len() >= MAX_PAGES {
+        return Err(PdfError::TooManyPages(paginated.starts.len()));
       }
-      let page_context = tree_context(&inputs, page_area);
-      // A repeated box without a counter keeps the one layout, so its links are
-      // collected once rather than per page. They stay grouped by box, which is
-      // the order the annotations are added in.
-      let kept_links: Vec<_> = repeated
-        .iter()
-        .map(|repeat| match repeat.template {
-          Some(_) => Vec::new(),
-          None => collect_interactive(&repeat.prepared).links,
-        })
+      let repeatables: Vec<Repeatable> = header
+        .into_iter()
+        .chain(
+          take(&mut paginated.repeated)
+            .into_iter()
+            .map(Repeatable::fixed),
+        )
+        .chain(footer)
         .collect();
-      let text_boxes = collect_text_boxes(&content);
+      let text_boxes = collect_text_boxes(&paginated.content);
       let inline_map = build_inline_map(&text_boxes)?;
-      let pages = starts.len();
-      let structural = options.tagged.names_structure_destinations();
-      let destination = |top: f32, path: &[usize]| {
-        let index = paginated.page_index(top);
-        let y = margin.top + (top - starts[index]).max(0.0);
-        let dest = XyzDestination::new(
-          index,
-          Point::from_xy(margin.left * PT_PER_PX, y * PT_PER_PX),
-        );
-
-        match structural {
-          true => dest.with_structure(tag_id(path)),
-          false => dest,
-        }
+      let mut composer = PageComposer {
+        frame: &frame,
+        paginated: &paginated,
+        inputs: &inputs,
+        page_context: tree_context(&inputs, frame.page_area),
+        inline_map: &inline_map,
+        fonts: &mut fonts,
+        issues: &issues,
+        tag_collector: tag_collector.as_ref(),
+        document_lang,
+        background: options.background_color,
+        structural: options.tagged.names_structure_destinations(),
       };
 
       for slice in paginated.pages() {
-        // A repeated box holding a counter lays out again with this page's
-        // numbers; the rest keep the layout they were prepared with.
-        let renumbered = repeated
-          .iter()
-          .map(|repeat| {
-            repeat
-              .template
-              .as_ref()
-              .map(|template| {
-                prepare_repeated(&page_context, template, slice.index + 1, pages, page_area)
-              })
-              .transpose()
-          })
-          .collect::<Result<Vec<_>, PdfError>>()?;
-        let page_boxes: Vec<_> = repeated
-          .iter()
-          .zip(&renumbered)
-          .map(|(repeat, fresh)| fresh.as_ref().unwrap_or(&repeat.prepared))
-          .collect();
-        let renumbered_links: Vec<_> = renumbered
-          .iter()
-          .map(|fresh| {
-            fresh
-              .as_ref()
-              .map_or_else(Vec::new, |tree| collect_interactive(tree).links)
-          })
-          .collect();
-        let mut pdf_page = document.start_page_with(PageSettings::new(page_size));
-        let mut surface = pdf_page.surface();
-
-        surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
-        paint_page_background(
-          options.background_color,
-          (page.width, page.height),
-          &mut surface,
-        );
-        if let (Some(band), Some(template)) = (&header_band, &options.header) {
-          let prepared;
-          let tree = if band.dynamic {
-            prepared = prepare_band(&inputs, template, slice.index + 1, pages, band_viewport)?;
-            &prepared
-          } else {
-            &band.measured
-          };
-
-          emit_band(
-            tree,
-            &mut fonts,
-            (0.0, BAND_EDGE_PADDING, page.width, header_height),
-            tag_collector.is_some(),
-            &issues,
-            document_lang,
-            &mut surface,
-          )?;
-        }
-
-        let content_top = margin.top;
-
-        for fixed in page_boxes
-          .iter()
-          .copied()
-          .filter(|tree| tree.paints_below())
-        {
-          emit_band(
-            fixed,
-            &mut fonts,
-            (margin.left, content_top, content_width, window_height),
-            tag_collector.is_some(),
-            &issues,
-            document_lang,
-            &mut surface,
-          )?;
-        }
-        // Paint stops at the next cut: the region between a raised cut and the
-        // page's full height belongs to the next page and stays blank, exactly
-        // like browser print fragmentation.
-        if let Some(path) =
-          KrillaRect::from_xywh(margin.left, content_top, content_width, slice.paint_height)
-            .and_then(rect_path)
-        {
-          surface.push_clip_path(&path, &FillRule::NonZero);
-          surface.push_transform(&Transform::from_translate(
-            margin.left,
-            content_top - slice.start,
-          ));
-          let mut emitter = content.emitter(
-            &mut fonts,
-            Some(&inline_map),
-            tag_collector.as_ref(),
-            &issues,
-            document_lang,
-          );
-
-          emitter.window = Some((slice.start, slice.start + slice.paint_height));
-          emitter.line_window = Some((
-            if slice.index == 0 {
-              f32::NEG_INFINITY
-            } else {
-              slice.start
-            },
-            slice.end,
-          ));
-          emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
-          surface.pop();
-          surface.pop();
-        }
-
-        for fixed in page_boxes
-          .iter()
-          .copied()
-          .filter(|tree| !tree.paints_below())
-        {
-          emit_band(
-            fixed,
-            &mut fonts,
-            (margin.left, content_top, content_width, window_height),
-            tag_collector.is_some(),
-            &issues,
-            document_lang,
-            &mut surface,
-          )?;
-        }
-
-        if let (Some(band), Some(template)) = (&footer_band, &options.footer) {
-          let prepared;
-          let tree = if band.dynamic {
-            prepared = prepare_band(&inputs, template, slice.index + 1, pages, band_viewport)?;
-            &prepared
-          } else {
-            &band.measured
-          };
-
-          emit_band(
-            tree,
-            &mut fonts,
-            (
-              0.0,
-              page.height - BAND_EDGE_PADDING - footer_height,
-              page.width,
-              footer_height,
-            ),
-            tag_collector.is_some(),
-            &issues,
-            document_lang,
-            &mut surface,
-          )?;
-        }
-
-        surface.pop();
-        surface.finish();
-        add_link_annotations(
-          &mut pdf_page,
-          &interactive.links,
-          (slice.start, slice.start + slice.paint_height),
-          (margin.left, content_top),
-          tag_collector.as_ref(),
-          |id| {
-            interactive
-              .anchors
-              .get(id)
-              .map(|anchor| destination(anchor.top, &anchor.path))
-          },
-        );
-        // A repeated box sits at the same place on every page, so its links are
-        // added per page against the page area rather than the content window.
-        // The box itself is an artifact, and its paths do not exist in the tag
-        // tree, so the annotations stay out of the structure too.
-        add_link_annotations(
-          &mut pdf_page,
-          kept_links
-            .iter()
-            .zip(&renumbered_links)
-            .flat_map(|(kept, fresh)| kept.iter().chain(fresh)),
-          (0.0, window_height),
-          (margin.left, content_top),
-          None,
-          |id| {
-            interactive
-              .anchors
-              .get(id)
-              .map(|anchor| destination(anchor.top, &anchor.path))
-          },
-        );
-        pdf_page.finish();
+        composer.compose(&mut document, &repeatables, &slice)?;
       }
+
+      let interactive = &paginated.interactive;
 
       if (options.outline || options.tagged.requires_outline()) && !interactive.headings.is_empty()
       {
         document.set_outline(build_outline(&interactive.headings, |heading| {
-          destination(heading.top, &heading.path)
+          composer.destination(heading.top, &heading.path)
         }));
       }
       if let Some(collector) = &tag_collector {
         document.set_tag_tree(build_tag_tree(
-          &content.root,
+          &paginated.content.root,
           inputs.lang.as_ref().map(Lang::as_str),
           &mut collector.borrow_mut(),
-          &destination_targets(&interactive),
+          &destination_targets(interactive),
         ));
       }
     }
@@ -632,7 +406,10 @@ mod tests {
   use takumi_core::units::ONE_IN_PX;
 
   use super::*;
-  use crate::pagination::{Atom, page_starts};
+  use crate::{
+    options::BAND_EDGE_PADDING,
+    pagination::{Atom, page_starts},
+  };
 
   const A4: (f32, f32) = (PageOptions::A4.width, PageOptions::A4.height);
 

--- a/takumi-pdf/src/page.rs
+++ b/takumi-pdf/src/page.rs
@@ -1,0 +1,276 @@
+//! One page: its resolved geometry, and the emit walk that draws it.
+
+use std::cell::RefCell;
+
+use takumi_core::{
+  context::RenderContext,
+  geometry::Rect,
+  style::{Affine, Color},
+  viewport::Viewport,
+};
+
+use crate::{
+  bands::{Repeatable, RepeatablePage},
+  emitter::{FontMap, RenderIssues},
+  inline::InlineMap,
+  interactive::add_link_annotations,
+  krilla::{
+    Document,
+    destination::XyzDestination,
+    geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
+    page::PageSettings,
+    paint::FillRule,
+    surface::Surface,
+  },
+  options::{PT_PER_PX, PageOptions, PdfError},
+  pagination::{PageGeometry, PageSlice, Paginated},
+  paint::{fill_from_rgba, rect_path},
+  tags::{TagCollector, tag_id},
+  tree::TreeInputs,
+};
+
+/// Page geometry resolved once: everything derived from [`PageOptions`] and
+/// the measured band heights.
+pub(crate) struct PageFrame {
+  /// Page size in px.
+  pub(crate) size: (f32, f32),
+  /// Page size in pt, the unit pages are written in.
+  pub(crate) page_size: KrillaSize,
+  pub(crate) margin: Rect<f32>,
+  pub(crate) content_width: f32,
+  pub(crate) window_height: f32,
+  /// Full page width, unbounded height: what a band lays out against.
+  pub(crate) band_viewport: Viewport,
+  /// The content box, which a repeated box positions against.
+  pub(crate) page_area: Viewport,
+}
+
+impl PageFrame {
+  /// Resolves the geometry. Bands are measured before this so an `auto` margin
+  /// can take the height they came out at; the content window is the full
+  /// margin box, and a band taller than its margin overlaps content, exactly
+  /// as in Chromium.
+  pub(crate) fn resolve(
+    page: &PageOptions,
+    band_viewport: Viewport,
+    header_height: Option<f32>,
+    footer_height: Option<f32>,
+  ) -> Result<Self, PdfError> {
+    let page_size = KrillaSize::from_wh(page.width * PT_PER_PX, page.height * PT_PER_PX)
+      .ok_or(PdfError::InvalidPageSize)?;
+    let margin = page
+      .margin
+      .resolve((page.width, page.height), header_height, footer_height);
+    let (content_width, content_height) = page.content_size(margin);
+
+    if !(content_width.is_finite()
+      && content_height.is_finite()
+      && content_width > 0.0
+      && content_height > 0.0)
+    {
+      return Err(PdfError::InvalidPageSize);
+    }
+
+    Ok(Self {
+      size: (page.width, page.height),
+      page_size,
+      margin,
+      content_width,
+      window_height: content_height,
+      band_viewport,
+      page_area: Viewport::new((content_width as u32, content_height as u32)),
+    })
+  }
+
+  /// What a pagination pass lays out against.
+  pub(crate) fn geometry(&self) -> PageGeometry {
+    PageGeometry {
+      viewport: Viewport::new((self.content_width as u32, None)),
+      page_area: self.page_area,
+      window_height: self.window_height,
+    }
+  }
+}
+
+/// Draws the paginated content one page at a time: background, the repeatables
+/// under the content, the content window, the repeatables over it, then the
+/// link annotations.
+pub(crate) struct PageComposer<'c, 'g> {
+  pub(crate) frame: &'c PageFrame,
+  pub(crate) paginated: &'c Paginated,
+  pub(crate) inputs: &'c TreeInputs<'g>,
+  pub(crate) page_context: RenderContext,
+  pub(crate) inline_map: &'c InlineMap<'c>,
+  pub(crate) fonts: &'c mut FontMap,
+  pub(crate) issues: &'c RefCell<RenderIssues>,
+  pub(crate) tag_collector: Option<&'c RefCell<TagCollector>>,
+  pub(crate) document_lang: Option<&'c str>,
+  pub(crate) background: Option<Color>,
+  /// Whether destinations name tag-tree structure elements.
+  pub(crate) structural: bool,
+}
+
+impl PageComposer<'_, '_> {
+  /// The destination a link or outline entry jumps to: the page `top` falls
+  /// on, at its position inside that page.
+  pub(crate) fn destination(&self, top: f32, path: &[usize]) -> XyzDestination {
+    let index = self.paginated.page_index(top);
+    let y = self.frame.margin.top + (top - self.paginated.starts[index]).max(0.0);
+    let dest = XyzDestination::new(
+      index,
+      Point::from_xy(self.frame.margin.left * PT_PER_PX, y * PT_PER_PX),
+    );
+
+    match self.structural {
+      true => dest.with_structure(tag_id(path)),
+      false => dest,
+    }
+  }
+
+  /// Draws one page. `repeatables` are in draw order: the header band, the
+  /// repeated boxes, the footer band.
+  pub(crate) fn compose(
+    &mut self,
+    document: &mut Document,
+    repeatables: &[Repeatable],
+    slice: &PageSlice,
+  ) -> Result<(), PdfError> {
+    let pages = self.paginated.starts.len();
+    let resolved = repeatables
+      .iter()
+      .map(|repeatable| {
+        repeatable.for_page(
+          self.inputs,
+          &self.page_context,
+          self.frame,
+          slice.index + 1,
+          pages,
+        )
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+    let mut pdf_page = document.start_page_with(PageSettings::new(self.frame.page_size));
+    let mut surface = pdf_page.surface();
+
+    surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
+    self.paint_background(&mut surface);
+    for repeatable in resolved.iter().filter(|page| page.draws_before_content()) {
+      repeatable.emit(
+        self.frame,
+        self.fonts,
+        self.tag_collector.is_some(),
+        self.issues,
+        self.document_lang,
+        &mut surface,
+      )?;
+    }
+    self.emit_content(slice, &mut surface)?;
+    for repeatable in resolved.iter().filter(|page| !page.draws_before_content()) {
+      repeatable.emit(
+        self.frame,
+        self.fonts,
+        self.tag_collector.is_some(),
+        self.issues,
+        self.document_lang,
+        &mut surface,
+      )?;
+    }
+    surface.pop();
+    surface.finish();
+    add_link_annotations(
+      &mut pdf_page,
+      &self.paginated.interactive.links,
+      (slice.start, slice.start + slice.paint_height),
+      (self.frame.margin.left, self.frame.margin.top),
+      self.tag_collector,
+      |id| {
+        self
+          .paginated
+          .interactive
+          .anchors
+          .get(id)
+          .map(|anchor| self.destination(anchor.top, &anchor.path))
+      },
+    );
+    // A repeated box sits at the same place on every page, so its links are
+    // added per page against the page area rather than the content window.
+    // The box itself is an artifact, and its paths do not exist in the tag
+    // tree, so the annotations stay out of the structure too.
+    add_link_annotations(
+      &mut pdf_page,
+      resolved.iter().flat_map(RepeatablePage::links),
+      (0.0, self.frame.window_height),
+      (self.frame.margin.left, self.frame.margin.top),
+      None,
+      |id| {
+        self
+          .paginated
+          .interactive
+          .anchors
+          .get(id)
+          .map(|anchor| self.destination(anchor.top, &anchor.path))
+      },
+    );
+    pdf_page.finish();
+    Ok(())
+  }
+
+  /// Fills the page box before anything else draws. An unset color leaves the
+  /// page empty rather than painting white, like Chromium's print path.
+  fn paint_background(&self, surface: &mut Surface) {
+    let Some(color) = self.background else {
+      return;
+    };
+    let Some(path) =
+      KrillaRect::from_xywh(0.0, 0.0, self.frame.size.0, self.frame.size.1).and_then(rect_path)
+    else {
+      return;
+    };
+
+    surface.set_fill(Some(fill_from_rgba(color.0, 1.0)));
+    surface.draw_path(&path);
+  }
+
+  /// Emits the content column through this page's window: clipped to the paint
+  /// height and translated so the slice lands at the content origin.
+  fn emit_content(&mut self, slice: &PageSlice, surface: &mut Surface) -> Result<(), PdfError> {
+    // Paint stops at the next cut: the region between a raised cut and the
+    // page's full height belongs to the next page and stays blank, exactly
+    // like browser print fragmentation.
+    let Some(path) = KrillaRect::from_xywh(
+      self.frame.margin.left,
+      self.frame.margin.top,
+      self.frame.content_width,
+      slice.paint_height,
+    )
+    .and_then(rect_path) else {
+      return Ok(());
+    };
+
+    surface.push_clip_path(&path, &FillRule::NonZero);
+    surface.push_transform(&Transform::from_translate(
+      self.frame.margin.left,
+      self.frame.margin.top - slice.start,
+    ));
+    let mut emitter = self.paginated.content.emitter(
+      self.fonts,
+      Some(self.inline_map),
+      self.tag_collector,
+      self.issues,
+      self.document_lang,
+    );
+
+    emitter.window = Some((slice.start, slice.start + slice.paint_height));
+    emitter.line_window = Some((
+      if slice.index == 0 {
+        f32::NEG_INFINITY
+      } else {
+        slice.start
+      },
+      slice.end,
+    ));
+    emitter.emit_context(0, Affine::IDENTITY, surface)?;
+    surface.pop();
+    surface.pop();
+    Ok(())
+  }
+}

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -68,6 +68,40 @@ pub(crate) struct Paginated {
   pub(crate) repeated: Vec<RepeatedBox>,
   pub(crate) starts: Vec<f32>,
   pub(crate) interactive: Interactive,
+  window: f32,
+}
+
+/// One page's window into the content column.
+pub(crate) struct PageSlice {
+  /// 0-based; display page numbers are `index + 1`.
+  pub(crate) index: usize,
+  pub(crate) start: f32,
+  /// Where the next page begins. The last page never runs out.
+  pub(crate) end: f32,
+  pub(crate) paint_height: f32,
+}
+
+impl Paginated {
+  /// 0-based index of the page `top` falls on.
+  pub(crate) fn page_index(&self, top: f32) -> usize {
+    self
+      .starts
+      .partition_point(|start| *start <= top)
+      .saturating_sub(1)
+  }
+
+  pub(crate) fn pages(&self) -> impl Iterator<Item = PageSlice> + '_ {
+    self.starts.iter().enumerate().map(|(index, &start)| {
+      let end = self.starts.get(index + 1).copied().unwrap_or(f32::INFINITY);
+
+      PageSlice {
+        index,
+        start,
+        end,
+        paint_height: (end - start).min(self.window),
+      }
+    })
+  }
 }
 
 /// What a pagination pass lays out against: the content column, the page area a
@@ -120,12 +154,7 @@ pub(crate) fn paginate(
 /// so the caller can see whether the numbers moved.
 fn substitute_counters(node: &mut Node, paginated: &Paginated, written: &mut Vec<String>) {
   let pages = paginated.starts.len();
-  let page_at = |top: &f32| {
-    paginated
-      .starts
-      .partition_point(|start| start <= top)
-      .max(1)
-  };
+  let page_at = |top: &f32| paginated.page_index(*top) + 1;
   // `fill_root` wraps the tree in a page-wide box, which takes preorder 0.
   let page_of = paginated
     .interactive
@@ -199,6 +228,7 @@ fn paginate_once(
     repeated,
     starts,
     interactive,
+    window: geometry.window_height,
   })
 }
 


### PR DESCRIPTION
## Why
The paged arm of `render` had grown to two hundred lines of loose locals: four near-identical band and fixed-box emit blocks, three copies of the same page lookup, and per-page link bookkeeping spread over four parallel vectors. The next pagination features (repeating table headers, per-page window changes) would each have added more special cases to the same function.

## What
Pagination grows page views: `PageSlice` and `Paginated::{page_index, pages}` replace the scattered `partition_point` calls. Header and footer bands and repeated `fixed` boxes unify behind one `Repeatable` type whose `for_page` picks the measured layout or a renumbered one. A new `page` module holds `PageFrame` (geometry resolved once) and `PageComposer` (background, repeatables, content window, annotations, in one walk per page). Pure refactor: every PDF golden is byte-identical.

The single-page arm stays separate: routing it through the composer would wrap it in clip and translate operators it never had, which changes the bytes for no behavior gain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved PDF page composition with more reliable page sizing, margins, and content boundaries.
  * Added more consistent pagination for multi-page content, including page-aware positioning.
  * Improved support for repeating headers, footers, and content blocks across pages.
  * Preserved links, outlines, and destinations when content is repeated or spans pages.
  * Improved clipping and layering of backgrounds and paginated content for cleaner PDF output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->