### PR TITLE
Core: state each box's origin instead of an optional source order

### DIFF
--- a/takumi-core/src/layout/list_marker.rs
+++ b/takumi-core/src/layout/list_marker.rs
@@ -4,7 +4,7 @@ use crate::{
   context::RenderContext,
   layout::{
     node::{Node, resolve_image},
-    tree::{RenderNode, pseudo_computed_style},
+    tree::{NodeOrigin, RenderNode, pseudo_computed_style},
   },
   matching::MatchedDeclarationsView,
   style::{
@@ -53,7 +53,7 @@ pub(super) fn list_marker(item_context: &RenderContext, ordinal: i32) -> Option<
   Some(RenderNode {
     context,
     node: Some(Node::container([])),
-    source_order: None,
+    origin: NodeOrigin::Marker,
     children: Some(Box::new([content])),
     layout_style_override: None,
     anonymous_text_content: None,

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -106,6 +106,23 @@ struct LayoutNodeState {
   box_children: Box<[OrderedChild]>,
 }
 
+/// Who created a box: the author's node tree, or a layout-generated construct.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NodeOrigin {
+  /// An authored node, at its document-order position in the source tree.
+  /// Stylesheet matching keys its results by the same number.
+  Authored {
+    /// Position in the source tree, counted in document order.
+    source_order: usize,
+  },
+  /// A generated `::marker` box.
+  Marker,
+  /// A generated `::before`/`::after` box.
+  Pseudo,
+  /// An anonymous box layout invented, such as an inline-text wrapper.
+  Anonymous,
+}
+
 /// A styled node plus its children, ready for layout.
 #[derive(Clone)]
 pub struct RenderNode {
@@ -113,10 +130,8 @@ pub struct RenderNode {
   pub context: RenderContext,
   /// Source node, absent for anonymous wrappers.
   pub node: Option<Node>,
-  /// Position of [`node`](Self::node) in the source tree, counted in document
-  /// order, absent for the boxes layout generates. Stylesheet matching keys its
-  /// results by the same number.
-  pub source_order: Option<usize>,
+  /// Who created this box.
+  pub origin: NodeOrigin,
   /// Child render nodes.
   pub children: Option<Box<[RenderNode]>>,
   pub(crate) layout_style_override: Option<Style>,
@@ -963,7 +978,7 @@ impl RenderNode {
     Self {
       context,
       node: None,
-      source_order: None,
+      origin: NodeOrigin::Anonymous,
       children: None,
       layout_style_override: Some(Style {
         display: TaffyDisplay::Block,
@@ -979,7 +994,7 @@ impl RenderNode {
     Self {
       context: Self::anonymous_box_context(parent_context),
       node: None,
-      source_order: None,
+      origin: NodeOrigin::Anonymous,
       children: Some(children.into_boxed_slice()),
       layout_style_override: Some(Style {
         display: TaffyDisplay::Block,
@@ -1006,7 +1021,7 @@ impl RenderNode {
       BackgroundImage::Url(url) => Self {
         context: Self::anonymous_box_context(parent_context),
         node: Some(Node::image(url)),
-        source_order: None,
+        origin: NodeOrigin::Anonymous,
         children: None,
         layout_style_override: Some(Style {
           max_size,
@@ -1022,7 +1037,7 @@ impl RenderNode {
         Self {
           context,
           node: Some(Node::container([])),
-          source_order: None,
+          origin: NodeOrigin::Anonymous,
           children: None,
           // css-images-3 §5.1 default object size when the parent is auto.
           layout_style_override: Some(Style {
@@ -1121,7 +1136,7 @@ impl RenderNode {
     Some(Self {
       context: pseudo_context,
       node: Some(Node::container([])),
-      source_order: None,
+      origin: NodeOrigin::Pseudo,
       children: Some(children),
       layout_style_override: None,
       anonymous_text_content: None,
@@ -1190,6 +1205,14 @@ impl RenderNode {
   /// The generated marker box attached to this node's first inline formatting context.
   pub fn marker(&self) -> Option<&RenderNode> {
     self.marker.as_deref()
+  }
+
+  /// The authored node's document-order position, absent for generated boxes.
+  pub fn source_order(&self) -> Option<usize> {
+    match self.origin {
+      NodeOrigin::Authored { source_order } => Some(source_order),
+      _ => None,
+    }
   }
 
   /// Resolves the descendant at `path` (child indices from this node). An empty
@@ -1477,7 +1500,7 @@ impl RenderNode {
         return RenderNode {
           context: parent_context.clone(),
           node: Some(Node::container([])),
-          source_order: None,
+          origin: NodeOrigin::Anonymous,
           children: None,
           layout_style_override: None,
           anonymous_text_content: None,
@@ -1503,7 +1526,7 @@ impl RenderNode {
         return RenderNode {
           context: parent_context.clone(),
           node: Some(Node::container([])),
-          source_order: None,
+          origin: NodeOrigin::Anonymous,
           children: None,
           layout_style_override: None,
           anonymous_text_content: None,
@@ -1542,7 +1565,9 @@ impl RenderNode {
           RenderNode {
             context: finished.context,
             node: Some(finished.node),
-            source_order: Some(finished.source_order),
+            origin: NodeOrigin::Authored {
+              source_order: finished.source_order,
+            },
             children: Some(children.into_boxed_slice()),
             layout_style_override: None,
             anonymous_text_content: None,
@@ -1586,7 +1611,9 @@ impl RenderNode {
             RenderNode {
               context: finished.context,
               node: Some(finished.node),
-              source_order: Some(finished.source_order),
+              origin: NodeOrigin::Authored {
+                source_order: finished.source_order,
+              },
               children: Some(children),
               layout_style_override: None,
               anonymous_text_content: None,
@@ -1613,7 +1640,9 @@ impl RenderNode {
             RenderNode {
               context: finished.context,
               node: Some(finished.node),
-              source_order: Some(finished.source_order),
+              origin: NodeOrigin::Authored {
+                source_order: finished.source_order,
+              },
               children: Some(final_children.into_boxed_slice()),
               layout_style_override: None,
               anonymous_text_content: None,
@@ -1640,7 +1669,9 @@ impl RenderNode {
           RenderNode {
             context: finished.context,
             node: Some(finished.node),
-            source_order: Some(finished.source_order),
+            origin: NodeOrigin::Authored {
+              source_order: finished.source_order,
+            },
             children: Some([anonymous_text_item].into()),
             layout_style_override: None,
             anonymous_text_content: None,
@@ -1651,7 +1682,9 @@ impl RenderNode {
           RenderNode {
             context: finished.context,
             node: Some(finished.node),
-            source_order: Some(finished.source_order),
+            origin: NodeOrigin::Authored {
+              source_order: finished.source_order,
+            },
             children: None,
             layout_style_override: None,
             anonymous_text_content: None,

--- a/takumi-pdf/src/interactive.rs
+++ b/takumi-pdf/src/interactive.rs
@@ -174,7 +174,7 @@ fn collect_interactive_paint(tree: &PreparedTree, paint: &NodePaint, collected: 
     return;
   };
 
-  if let Some(index) = node.source_order {
+  if let Some(index) = node.source_order() {
     // `transform` moves where a box paints without moving the flow it left
     // behind, so the flow edge is measured with the box's own transform undone.
     let in_flow = !matches!(

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -202,7 +202,7 @@ pub(crate) fn prepare_paged_tree(
     .map(|(node, parent)| {
       let template = source
         .as_ref()
-        .zip(node.source_order)
+        .zip(node.source_order())
         .and_then(|(source, index)| Some((index, node_in_source_order(source, index)?)))
         .filter(|(_, template)| has_page_counters(template))
         .map(|(source_order, template)| RepeatedTemplate {


### PR DESCRIPTION
`RenderNode` grows an `origin` field naming who created each box: `Authored { source_order }`, `Marker`, `Pseudo`, or `Anonymous`. The four origins already existed, each encoded by a different convention (`source_order: None`, the tree-external marker field, fake container nodes). Folding `source_order` into the `Authored` variant lets the compiler enforce that generated boxes never carry one. Pure refactor: every golden is byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of element origins during layout and rendering.
  * Preserved source positions for authored content while correctly handling generated markers, pseudo-elements, and anonymous boxes.
  * Improved source-order resolution for interactive elements and repeated fixed content.
  * Increased consistency when mapping rendered content back to its original document position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->