### PR TITLE
Tests: embed the fixture stylesheet in repro HTML

### DIFF
--- a/takumi/tests/fixtures-generated/clip_path_circle.html
+++ b/takumi/tests/fixtures-generated/clip_path_circle.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>clip_path_circle</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/clip_path_inset_round_clips_children.html
+++ b/takumi/tests/fixtures-generated/clip_path_inset_round_clips_children.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>clip_path_inset_round_clips_children</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(255, 255, 255)">

--- a/takumi/tests/fixtures-generated/clip_path_inset_rounded.html
+++ b/takumi/tests/fixtures-generated/clip_path_inset_rounded.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>clip_path_inset_rounded</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/clip_path_text_stroke_filled.html
+++ b/takumi/tests/fixtures-generated/clip_path_text_stroke_filled.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>clip_path_text_stroke_filled</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/clip_path_triangle_gradient.html
+++ b/takumi/tests/fixtures-generated/clip_path_triangle_gradient.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>clip_path_triangle_gradient</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/clip_path_triangle_vercel.html
+++ b/takumi/tests/fixtures-generated/clip_path_triangle_vercel.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>clip_path_triangle_vercel</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/color_artifacts.html
+++ b/takumi/tests/fixtures-generated/color_artifacts.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>color_artifacts</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/deep_nesting_stack_overflow.html
+++ b/takumi/tests/fixtures-generated/deep_nesting_stack_overflow.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>deep_nesting_stack_overflow</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/direction_flex_row.html
+++ b/takumi/tests/fixtures-generated/direction_flex_row.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>direction_flex_row</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/direction_grid.html
+++ b/takumi/tests/fixtures-generated/direction_grid.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>direction_grid</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_atomic_containers.html
+++ b/takumi/tests/fixtures-generated/inline_atomic_containers.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_atomic_containers</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_block_in_inline.html
+++ b/takumi/tests/fixtures-generated/inline_block_in_inline.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_block_in_inline</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_box_in_rotated_container.html
+++ b/takumi/tests/fixtures-generated/inline_box_in_rotated_container.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_box_in_rotated_container</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_complex_nested_fixture.html
+++ b/takumi/tests/fixtures-generated/inline_complex_nested_fixture.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_complex_nested_fixture</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_empty_atomic_baseline.html
+++ b/takumi/tests/fixtures-generated/inline_empty_atomic_baseline.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_empty_atomic_baseline</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_float_wrap.html
+++ b/takumi/tests/fixtures-generated/inline_float_wrap.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_float_wrap</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_image.html
+++ b/takumi/tests/fixtures-generated/inline_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_image_em_regression.html
+++ b/takumi/tests/fixtures-generated/inline_image_em_regression.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_image_em_regression</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_nested_flex_block.html
+++ b/takumi/tests/fixtures-generated/inline_nested_flex_block.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_nested_flex_block</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_outline_span_boundaries.html
+++ b/takumi/tests/fixtures-generated/inline_outline_span_boundaries.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_outline_span_boundaries</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_social_post_regression.html
+++ b/takumi/tests/fixtures-generated/inline_social_post_regression.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_social_post_regression</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_span_background_color.html
+++ b/takumi/tests/fixtures-generated/inline_span_background_color.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_span_background_color</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_span_text_stroke.html
+++ b/takumi/tests/fixtures-generated/inline_span_text_stroke.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_span_text_stroke</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_span_text_stroke_off.html
+++ b/takumi/tests/fixtures-generated/inline_span_text_stroke_off.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_span_text_stroke_off</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_text_decorations.html
+++ b/takumi/tests/fixtures-generated/inline_text_decorations.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_text_decorations</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_top_bottom_box_line_box_height.html
+++ b/takumi/tests/fixtures-generated/inline_top_bottom_box_line_box_height.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_top_bottom_box_line_box_height</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/inline_vertical_align_types.html
+++ b/takumi/tests/fixtures-generated/inline_vertical_align_types.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>inline_vertical_align_types</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/lang_han_unification.html
+++ b/takumi/tests/fixtures-generated/lang_han_unification.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>lang_han_unification</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/list_markers.html
+++ b/takumi/tests/fixtures-generated/list_markers.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>list_markers</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .root {
         display: flex;

--- a/takumi/tests/fixtures-generated/list_markers.html
+++ b/takumi/tests/fixtures-generated/list_markers.html
@@ -4,6 +4,79 @@
     <meta charset="utf-8" />
     <title>list_markers</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .root {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 16px;
+        width: 100%;
+        height: 100%;
+        background: rgb(243, 244, 246);
+        align-content: flex-start;
+        font-family: "Geist";
+      }
+      .cell {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        width: 282px;
+        height: 190px;
+        background: white;
+        border-radius: 8px;
+        padding: 10px 12px;
+      }
+      .label {
+        font-size: 11px;
+        color: rgb(100, 116, 139);
+        font-family: "Geist Mono";
+      }
+      .list {
+        display: block;
+        padding-left: 40px;
+        font-size: 16px;
+        color: rgb(17, 24, 39);
+      }
+      .item {
+        display: list-item;
+      }
+      .decimal {
+        list-style-type: decimal;
+      }
+      .disc {
+        list-style-type: disc;
+      }
+      .circle {
+        list-style-type: circle;
+      }
+      .roman {
+        list-style-type: upper-roman;
+      }
+      .alpha {
+        list-style-type: lower-alpha;
+      }
+      .padded {
+        list-style-type: decimal-leading-zero;
+      }
+      .arrow {
+        list-style-type: "→ ";
+      }
+      .hidden {
+        list-style-type: none;
+      }
+      .inside {
+        list-style-position: inside;
+      }
+      .image {
+        list-style-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAEklEQVR42mOwbvr2Hx9mGBkKAKAwrIFG5bLTAAAAAElFTkSuQmCC);
+      }
+      .nested {
+        padding-left: 24px;
+      }
+      .block {
+        display: block;
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="root">

--- a/takumi/tests/fixtures-generated/offset_path_along_curve.html
+++ b/takumi/tests/fixtures-generated/offset_path_along_curve.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>offset_path_along_curve</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/offset_path_circular_text.html
+++ b/takumi/tests/fixtures-generated/offset_path_circular_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>offset_path_circular_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/offset_path_ray_burst.html
+++ b/takumi/tests/fixtures-generated/offset_path_ray_burst.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>offset_path_ray_burst</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/offset_path_wave_text.html
+++ b/takumi/tests/fixtures-generated/offset_path_wave_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>offset_path_wave_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/paint-bounds-text-ink-descender-opacity.html
+++ b/takumi/tests/fixtures-generated/paint-bounds-text-ink-descender-opacity.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>paint-bounds-text-ink-descender-opacity</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/paint-bounds-text-ink-italic-opacity.html
+++ b/takumi/tests/fixtures-generated/paint-bounds-text-ink-italic-opacity.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>paint-bounds-text-ink-italic-opacity</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/pseudo_display_image.html
+++ b/takumi/tests/fixtures-generated/pseudo_display_image.html
@@ -4,6 +4,145 @@
     <meta charset="utf-8" />
     <title>pseudo_display_image</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .root {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 16px;
+        width: 100%;
+        height: 100%;
+        background: rgb(243, 244, 246);
+        align-content: flex-start;
+        font-family: "Geist";
+      }
+      .cell {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        width: 282px;
+        height: 138px;
+        background: white;
+        border-radius: 8px;
+        padding: 10px 12px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+      }
+      .label {
+        font-size: 11px;
+        color: rgb(100, 116, 139);
+        font-family: "Geist Mono";
+      }
+      .demo {
+        flex-grow: 1;
+        font-size: 18px;
+        color: rgb(17, 24, 39);
+        display: flex;
+        align-items: center;
+      }
+
+      .g1::before {
+        content: "[in]";
+        background: rgb(254, 226, 226);
+        color: rgb(190, 18, 60);
+        padding: 0 6px;
+        margin-right: 6px;
+        border-radius: 4px;
+      }
+      .g2::before {
+        content: "BLOCK";
+        display: block;
+        background: rgb(220, 252, 231);
+        color: rgb(21, 128, 61);
+        padding: 2px 8px;
+        margin-bottom: 4px;
+        border-radius: 4px;
+      }
+      .g3::before {
+        content: "IB";
+        display: inline-block;
+        background: rgb(219, 234, 254);
+        color: rgb(29, 78, 216);
+        padding: 2px 8px;
+        margin-right: 6px;
+        border-radius: 4px;
+      }
+      .g4::before {
+        content: "FLEX";
+        display: flex;
+        background: rgb(254, 240, 138);
+        color: rgb(133, 77, 14);
+        padding: 2px 8px;
+        margin-bottom: 4px;
+        border-radius: 4px;
+      }
+      .g5::before {
+        content: "★";
+        display: inline-block;
+        background: rgb(254, 226, 226);
+        border: 2px solid rgb(220, 38, 38);
+        border-radius: 50%;
+        padding: 0 8px;
+        color: rgb(127, 29, 29);
+        margin-right: 8px;
+      }
+      .g5::after {
+        content: " ◆";
+        color: rgb(124, 58, 237);
+      }
+      .g6::before {
+        content: linear-gradient(135deg, #ff3b30, #ffcc00);
+        display: block;
+        width: 240px;
+        height: 60px;
+        border-radius: 6px;
+      }
+      .g7::before {
+        content: radial-gradient(circle, #00e5ff, #5856d6);
+        display: block;
+        width: 240px;
+        height: 60px;
+        border-radius: 6px;
+      }
+      .g8::before {
+        content: conic-gradient(from 0deg, red, yellow, green, blue, red);
+        display: block;
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+      }
+      .g9::before {
+        content: repeating-linear-gradient(45deg, #f59e0b 0 10px, #1e293b 10px 20px);
+        display: block;
+        width: 240px;
+        height: 60px;
+        border-radius: 6px;
+      }
+      .g10::before {
+        content: url("assets/images/yeecord.png");
+        display: block;
+        width: 56px;
+        height: 56px;
+      }
+      .g11::before {
+        content: linear-gradient(red, blue) linear-gradient(green, yellow);
+        display: block;
+        width: 240px;
+        height: 60px;
+      }
+      .g12 {
+        width: 96px;
+        height: 96px;
+        object-fit: contain;
+      }
+      .g12::before {
+        content: "X";
+        color: red;
+      }
+      .g12::after {
+        content: "Y";
+        color: red;
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="root">

--- a/takumi/tests/fixtures-generated/pseudo_display_image.html
+++ b/takumi/tests/fixtures-generated/pseudo_display_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>pseudo_display_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .root {
         display: flex;

--- a/takumi/tests/fixtures-generated/pseudo_text_attr.html
+++ b/takumi/tests/fixtures-generated/pseudo_text_attr.html
@@ -4,6 +4,85 @@
     <meta charset="utf-8" />
     <title>pseudo_text_attr</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .root {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 16px;
+        width: 100%;
+        height: 100%;
+        background: rgb(243, 244, 246);
+        align-content: flex-start;
+        font-family: "Geist";
+      }
+      .cell {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        width: 282px;
+        height: 138px;
+        background: white;
+        border-radius: 8px;
+        padding: 10px 12px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+      }
+      .label {
+        font-size: 11px;
+        color: rgb(100, 116, 139);
+        font-family: "Geist Mono";
+      }
+      .demo {
+        flex-grow: 1;
+        font-size: 18px;
+        color: rgb(17, 24, 39);
+        display: flex;
+        align-items: center;
+      }
+
+      .d1::before {
+        content: "★ ";
+        color: rgb(234, 179, 8);
+      }
+      .d2::after {
+        content: " ✓";
+        color: rgb(34, 197, 94);
+      }
+      .d3::before {
+        content: "[";
+        color: rgb(59, 130, 246);
+      }
+      .d3::after {
+        content: "]";
+        color: rgb(59, 130, 246);
+      }
+      .d4::before {
+        content: "[" "(";
+        color: rgb(99, 102, 241);
+      }
+      .d4::after {
+        content: ")" "]";
+        color: rgb(99, 102, 241);
+      }
+      .d5::before {
+        content: attr(data-tag) " — ";
+        color: rgb(244, 63, 94);
+      }
+      .d6::before {
+        content: attr(missing, "FB") " ";
+        color: rgb(168, 85, 247);
+      }
+      .d7::before {
+        content: "#" attr(id) " ";
+        color: rgb(20, 184, 166);
+      }
+      .d8 {
+        color: rgb(234, 88, 12);
+      }
+      .d8::before {
+        content: "★ ";
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="root">

--- a/takumi/tests/fixtures-generated/pseudo_text_attr.html
+++ b/takumi/tests/fixtures-generated/pseudo_text_attr.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>pseudo_text_attr</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .root {
         display: flex;

--- a/takumi/tests/fixtures-generated/showcase_aurora_grain.html
+++ b/takumi/tests/fixtures-generated/showcase_aurora_grain.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>showcase_aurora_grain</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .stage {
         position: relative;

--- a/takumi/tests/fixtures-generated/showcase_aurora_grain.html
+++ b/takumi/tests/fixtures-generated/showcase_aurora_grain.html
@@ -4,6 +4,64 @@
     <meta charset="utf-8" />
     <title>showcase_aurora_grain</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .stage {
+        position: relative;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        font-family: Geist;
+      }
+      .layer {
+        position: absolute;
+        inset: 0;
+      }
+
+      .stage {
+        background-color: #05010f;
+        flex-direction: column;
+        gap: 18px;
+      }
+      .mesh {
+        background-image:
+          radial-gradient(ellipse 80% 60% at 70% 20%, rgba(139, 92, 246, 0.55), transparent 68%),
+          radial-gradient(ellipse 70% 60% at 20% 80%, rgba(236, 72, 153, 0.45), transparent 68%),
+          radial-gradient(ellipse 60% 50% at 60% 65%, rgba(45, 212, 191, 0.4), transparent 68%),
+          radial-gradient(ellipse 65% 40% at 30% 30%, rgba(99, 102, 241, 0.5), transparent 68%);
+      }
+      .veil {
+        inset: 10%;
+        background-image: conic-gradient(
+          from 120deg at 50% 30%,
+          #3a29ff,
+          #2dd4bf,
+          #ec4899,
+          #8b5cf6,
+          #3a29ff
+        );
+        filter: blur(80px) saturate(1.4);
+        opacity: 0.4;
+      }
+      .grain {
+        filter: url(data:image/svg+xml,%3Cfilter%20x%3D%220%22%20y%3D%220%22%20width%3D%22100%25%22%20height%3D%22100%25%22%3E%3CfeTurbulence%20type%3D%22fractalNoise%22%20baseFrequency%3D%220.8%22%20numOctaves%3D%222%22%20stitchTiles%3D%22stitch%22%2F%3E%3CfeColorMatrix%20type%3D%22matrix%22%20values%3D%220%200%200%200%200.9%200%200%200%200%200.9%200%200%200%200%200.9%200%200%200%200.22%200%22%2F%3E%3C%2Ffilter%3E);
+        mix-blend-mode: overlay;
+      }
+      .title {
+        font-size: 108px;
+        font-weight: 800;
+        letter-spacing: -3px;
+        background-image: linear-gradient(to right in oklch longer hue, #ff5f6d, #ffc371);
+        background-clip: text;
+        color: transparent;
+      }
+      .subtitle {
+        font-family: "Geist Mono";
+        font-size: 26px;
+        color: rgba(255, 255, 255, 0.55);
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="stage">

--- a/takumi/tests/fixtures-generated/showcase_chrome_text.html
+++ b/takumi/tests/fixtures-generated/showcase_chrome_text.html
@@ -4,6 +4,60 @@
     <meta charset="utf-8" />
     <title>showcase_chrome_text</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .stage {
+        position: relative;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        font-family: Geist;
+      }
+      .layer {
+        position: absolute;
+        inset: 0;
+      }
+
+      .stage {
+        background-color: #0b0617;
+        background-image:
+          repeating-conic-gradient(
+            from 0deg at 50% 130%,
+            rgba(94, 80, 163, 0.35) 0deg 5deg,
+            rgba(11, 6, 23, 0) 5deg 10deg
+          ),
+          radial-gradient(ellipse 80% 60% at 50% 0%, rgba(120, 180, 255, 0.25), transparent 70%);
+        flex-direction: column;
+        gap: 8px;
+      }
+      .chrome {
+        font-size: 172px;
+        font-weight: 900;
+        letter-spacing: -6px;
+        background-image: linear-gradient(
+          180deg,
+          #0b1020 0%,
+          #34304b 14%,
+          #c3b9d5 26%,
+          #ffffff 34%,
+          #5a6cae 48%,
+          #ffffff 56%,
+          #e8ecff 84%,
+          #c3b9d5 90%,
+          #211c35 100%
+        );
+        background-clip: text;
+        color: transparent;
+        filter: url(data:image/svg+xml,%3Cfilter%20x%3D%22-20%25%22%20y%3D%22-20%25%22%20width%3D%22140%25%22%20height%3D%22140%25%22%3E%3CfeGaussianBlur%20stdDeviation%3D%221.4%22%20in%3D%22SourceGraphic%22%20result%3D%22blur%22%2F%3E%3CfeSpecularLighting%20surfaceScale%3D%221.6%22%20specularConstant%3D%220.9%22%20specularExponent%3D%2240%22%20lighting-color%3D%22%23ffffff%22%20in%3D%22blur%22%20result%3D%22spec%22%3E%3CfePointLight%20x%3D%22600%22%20y%3D%22-60%22%20z%3D%22900%22%2F%3E%3C%2FfeSpecularLighting%3E%3CfeComposite%20operator%3D%22in%22%20in%3D%22spec%22%20in2%3D%22SourceAlpha%22%20result%3D%22rim%22%2F%3E%3CfeMerge%3E%3CfeMergeNode%20in%3D%22SourceGraphic%22%2F%3E%3CfeMergeNode%20in%3D%22rim%22%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E);
+      }
+      .tagline {
+        font-family: "Geist Mono";
+        font-size: 26px;
+        letter-spacing: 10px;
+        color: rgba(195, 185, 213, 0.8);
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="stage">

--- a/takumi/tests/fixtures-generated/showcase_chrome_text.html
+++ b/takumi/tests/fixtures-generated/showcase_chrome_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>showcase_chrome_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .stage {
         position: relative;

--- a/takumi/tests/fixtures-generated/showcase_grid_hero.html
+++ b/takumi/tests/fixtures-generated/showcase_grid_hero.html
@@ -4,6 +4,58 @@
     <meta charset="utf-8" />
     <title>showcase_grid_hero</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .stage {
+        position: relative;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        font-family: Geist;
+      }
+      .layer {
+        position: absolute;
+        inset: 0;
+      }
+
+      .stage {
+        background-color: #030409;
+      }
+      .grid {
+        background-image:
+          linear-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(255, 255, 255, 0.09) 1px, transparent 1px);
+        background-size: 40px 40px;
+        mask-image: radial-gradient(ellipse 70% 60% at 50% 100%, #000 60%, transparent 100%);
+      }
+      .glow {
+        background-image:
+          radial-gradient(ellipse 100% 100% at 100% 100%, rgba(34, 197, 94, 0.18), transparent 60%),
+          radial-gradient(ellipse 100% 100% at 0% 0%, rgba(56, 189, 248, 0.14), transparent 60%);
+      }
+      .card {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        padding: 44px 56px;
+        background-color: #fdfdf7;
+        border: 4px solid #111;
+        box-shadow: 18px 18px 0 #22c55e;
+      }
+      .kicker {
+        font-family: "Geist Mono";
+        font-size: 22px;
+        letter-spacing: 8px;
+        color: #16a34a;
+      }
+      .headline {
+        font-size: 84px;
+        font-weight: 900;
+        letter-spacing: -2px;
+        color: #111;
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="stage">

--- a/takumi/tests/fixtures-generated/showcase_grid_hero.html
+++ b/takumi/tests/fixtures-generated/showcase_grid_hero.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>showcase_grid_hero</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .stage {
         position: relative;

--- a/takumi/tests/fixtures-generated/showcase_halftone.html
+++ b/takumi/tests/fixtures-generated/showcase_halftone.html
@@ -4,6 +4,51 @@
     <meta charset="utf-8" />
     <title>showcase_halftone</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .stage {
+        position: relative;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        font-family: Geist;
+      }
+      .layer {
+        position: absolute;
+        inset: 0;
+      }
+
+      .stage {
+        background-color: #fff;
+        isolation: isolate;
+      }
+      .dots {
+        background-image:
+          radial-gradient(circle closest-side, #666, #fff), linear-gradient(115deg, #333, #fff);
+        background-size:
+          14px 14px,
+          100% 100%;
+        background-repeat: space, no-repeat;
+        background-blend-mode: multiply;
+        filter: contrast(14);
+      }
+      .ink {
+        background-color: #e11d48;
+        mix-blend-mode: lighten;
+      }
+      .poster {
+        padding: 18px 54px;
+        background-color: #fffdf5;
+        border: 6px solid #111;
+        border-radius: 18px;
+        box-shadow: 14px 14px 0 #111;
+        font-size: 132px;
+        font-weight: 900;
+        letter-spacing: -4px;
+        color: #111;
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="stage">

--- a/takumi/tests/fixtures-generated/showcase_halftone.html
+++ b/takumi/tests/fixtures-generated/showcase_halftone.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>showcase_halftone</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .stage {
         position: relative;

--- a/takumi/tests/fixtures-generated/showcase_neon_terminal.html
+++ b/takumi/tests/fixtures-generated/showcase_neon_terminal.html
@@ -4,6 +4,61 @@
     <meta charset="utf-8" />
     <title>showcase_neon_terminal</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .stage {
+        position: relative;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        align-items: center;
+        justify-content: center;
+        font-family: Geist;
+      }
+      .layer {
+        position: absolute;
+        inset: 0;
+      }
+
+      .stage {
+        background-color: #050508;
+        flex-direction: column;
+        gap: 20px;
+      }
+      .neon {
+        font-size: 96px;
+        font-weight: 800;
+        color: #fff;
+        text-shadow:
+          0 0 6px #fff,
+          0 0 18px #ff2d95,
+          0 0 42px #ff2d95,
+          0 0 90px #ff2d95;
+      }
+      .chromatic {
+        font-family: "Geist Mono";
+        font-size: 30px;
+        color: rgba(210, 255, 244, 0.9);
+        text-shadow:
+          -2px 0 rgba(255, 0, 85, 0.7),
+          2px 0 rgba(0, 255, 255, 0.7);
+      }
+      .scanlines {
+        background-image: repeating-linear-gradient(
+          180deg,
+          rgba(0, 0, 0, 0) 0px,
+          rgba(0, 0, 0, 0) 3px,
+          rgba(0, 0, 0, 0.3) 3px,
+          rgba(0, 0, 0, 0.3) 5px
+        );
+      }
+      .vignette {
+        background-image: radial-gradient(
+          ellipse at 50% 50%,
+          transparent 55%,
+          rgba(0, 0, 0, 0.6) 100%
+        );
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="stage">

--- a/takumi/tests/fixtures-generated/showcase_neon_terminal.html
+++ b/takumi/tests/fixtures-generated/showcase_neon_terminal.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>showcase_neon_terminal</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .stage {
         position: relative;

--- a/takumi/tests/fixtures-generated/style_absolute_captured_by_filter.html
+++ b/takumi/tests/fixtures-generated/style_absolute_captured_by_filter.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_absolute_captured_by_filter</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_absolute_in_block_relative_with_sibling.html
+++ b/takumi/tests/fixtures-generated/style_absolute_in_block_relative_with_sibling.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_absolute_in_block_relative_with_sibling</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_absolute_paint_order_under_z_sibling.html
+++ b/takumi/tests/fixtures-generated/style_absolute_paint_order_under_z_sibling.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_absolute_paint_order_under_z_sibling</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_absolute_percentage_resolves_against_cb.html
+++ b/takumi/tests/fixtures-generated/style_absolute_percentage_resolves_against_cb.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_absolute_percentage_resolves_against_cb</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_absolute_skips_static_ancestor.html
+++ b/takumi/tests/fixtures-generated/style_absolute_skips_static_ancestor.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_absolute_skips_static_ancestor</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_align_items.html
+++ b/takumi/tests/fixtures-generated/style_align_items.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_align_items</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_backdrop_filter.html
+++ b/takumi/tests/fixtures-generated/style_backdrop_filter.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_backdrop_filter</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_backdrop_filter_frosted_glass.html
+++ b/takumi/tests/fixtures-generated/style_backdrop_filter_frosted_glass.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_backdrop_filter_frosted_glass</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_backdrop_filter_with_mask.html
+++ b/takumi/tests/fixtures-generated/style_backdrop_filter_with_mask.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_backdrop_filter_with_mask</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_border_area.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_border_area.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_border_area</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_border_box.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_border_box.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_border_box</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_comparison.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_comparison.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_comparison</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_content_box.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_content_box.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_content_box</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_gradient_padding.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_gradient_padding.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_gradient_padding</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_padding_box.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_padding_box.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_padding_box</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_text_gradient.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_text_gradient.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_text_gradient</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_text_multiline.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_text_multiline.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_text_multiline</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_clip_text_radial.html
+++ b/takumi/tests/fixtures-generated/style_background_clip_text_radial.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_clip_text_radial</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_color.html
+++ b/takumi/tests/fixtures-generated/style_background_color.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_color</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(255, 0, 0)"></div>

--- a/takumi/tests/fixtures-generated/style_background_image_builder_gradient_layers.html
+++ b/takumi/tests/fixtures-generated/style_background_image_builder_gradient_layers.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_builder_gradient_layers</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_conic_basic.html
+++ b/takumi/tests/fixtures-generated/style_background_image_conic_basic.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_conic_basic</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_dotted_pattern.html
+++ b/takumi/tests/fixtures-generated/style_background_image_dotted_pattern.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_dotted_pattern</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_gradient.html
+++ b/takumi/tests/fixtures-generated/style_background_image_gradient.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_gradient</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_gradient_alt.html
+++ b/takumi/tests/fixtures-generated/style_background_image_gradient_alt.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_gradient_alt</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_gradient_color_space_comparison.html
+++ b/takumi/tests/fixtures-generated/style_background_image_gradient_color_space_comparison.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_gradient_color_space_comparison</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; flex-direction: column">

--- a/takumi/tests/fixtures-generated/style_background_image_gradient_hard_stop.html
+++ b/takumi/tests/fixtures-generated/style_background_image_gradient_hard_stop.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_gradient_hard_stop</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_grid_pattern.html
+++ b/takumi/tests/fixtures-generated/style_background_image_grid_pattern.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_grid_pattern</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_linear_radial_mixed.html
+++ b/takumi/tests/fixtures-generated/style_background_image_linear_radial_mixed.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_linear_radial_mixed</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_radial_basic.html
+++ b/takumi/tests/fixtures-generated/style_background_image_radial_basic.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_radial_basic</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_radial_mixed.html
+++ b/takumi/tests/fixtures-generated/style_background_image_radial_mixed.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_radial_mixed</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_image_repeating_gradients.html
+++ b/takumi/tests/fixtures-generated/style_background_image_repeating_gradients.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_repeating_gradients</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; flex-direction: column; width: 100%; height: 100%">

--- a/takumi/tests/fixtures-generated/style_background_image_repeating_hard_stop.html
+++ b/takumi/tests/fixtures-generated/style_background_image_repeating_hard_stop.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_image_repeating_hard_stop</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_no_repeat_center_200x120.html
+++ b/takumi/tests/fixtures-generated/style_background_no_repeat_center_200x120.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_no_repeat_center_200x120</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_origin.html
+++ b/takumi/tests/fixtures-generated/style_background_origin.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_origin</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_position_percent_25_75.html
+++ b/takumi/tests/fixtures-generated/style_background_position_percent_25_75.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_position_percent_25_75</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_repeat_round.html
+++ b/takumi/tests/fixtures-generated/style_background_repeat_round.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_repeat_round</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_repeat_space.html
+++ b/takumi/tests/fixtures-generated/style_background_repeat_space.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_repeat_space</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_repeat_tile_from_top_left.html
+++ b/takumi/tests/fixtures-generated/style_background_repeat_tile_from_top_left.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_repeat_tile_from_top_left</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_size_auto_axis_round.html
+++ b/takumi/tests/fixtures-generated/style_background_size_auto_axis_round.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_size_auto_axis_round</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_size_contain.html
+++ b/takumi/tests/fixtures-generated/style_background_size_contain.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_size_contain</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_size_cover.html
+++ b/takumi/tests/fixtures-generated/style_background_size_cover.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_size_cover</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_background_size_percent_20_20.html
+++ b/takumi/tests/fixtures-generated/style_background_size_percent_20_20.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_background_size_percent_20_20</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_fractional_width.html
+++ b/takumi/tests/fixtures-generated/style_border_fractional_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_fractional_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_non_uniform_patterns.html
+++ b/takumi/tests/fixtures-generated/style_border_non_uniform_patterns.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_non_uniform_patterns</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_per_side_color_and_width.html
+++ b/takumi/tests/fixtures-generated/style_border_per_side_color_and_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_per_side_color_and_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_radius.html
+++ b/takumi/tests/fixtures-generated/style_border_radius.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_radius</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_radius_circle.html
+++ b/takumi/tests/fixtures-generated/style_border_radius_circle.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_radius_circle</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_radius_circle_avatar.html
+++ b/takumi/tests/fixtures-generated/style_border_radius_circle_avatar.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_radius_circle_avatar</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_radius_per_corner.html
+++ b/takumi/tests/fixtures-generated/style_border_radius_per_corner.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_radius_per_corner</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_radius_width_offset.html
+++ b/takumi/tests/fixtures-generated/style_border_radius_width_offset.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_radius_width_offset</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_styles.html
+++ b/takumi/tests/fixtures-generated/style_border_styles.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_styles</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_width.html
+++ b/takumi/tests/fixtures-generated/style_border_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_width_on_image_node.html
+++ b/takumi/tests/fixtures-generated/style_border_width_on_image_node.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_width_on_image_node</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_border_width_with_radius.html
+++ b/takumi/tests/fixtures-generated/style_border_width_with_radius.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_border_width_with_radius</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_box_shadow.html
+++ b/takumi/tests/fixtures-generated/style_box_shadow.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_box_shadow</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(0, 0, 255)">

--- a/takumi/tests/fixtures-generated/style_box_shadow_inset.html
+++ b/takumi/tests/fixtures-generated/style_box_shadow_inset.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_box_shadow_inset</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(0, 0, 255)">

--- a/takumi/tests/fixtures-generated/style_box_shadow_inset_with_border.html
+++ b/takumi/tests/fixtures-generated/style_box_shadow_inset_with_border.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_box_shadow_inset_with_border</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(230, 230, 230)">

--- a/takumi/tests/fixtures-generated/style_corner_shape.html
+++ b/takumi/tests/fixtures-generated/style_corner_shape.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_corner_shape</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter.html
+++ b/takumi/tests/fixtures-generated/style_filter.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_blur.html
+++ b/takumi/tests/fixtures-generated/style_filter_blur.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_blur</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_combined.html
+++ b/takumi/tests/fixtures-generated/style_filter_combined.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_combined</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_combined_transform.html
+++ b/takumi/tests/fixtures-generated/style_filter_combined_transform.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_combined_transform</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_drop_shadow.html
+++ b/takumi/tests/fixtures-generated/style_filter_drop_shadow.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_drop_shadow</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_reference_dither.html
+++ b/takumi/tests/fixtures-generated/style_filter_reference_dither.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_reference_dither</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_reference_duotone.html
+++ b/takumi/tests/fixtures-generated/style_filter_reference_duotone.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_reference_duotone</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_filter_sepia.html
+++ b/takumi/tests/fixtures-generated/style_filter_sepia.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_filter_sepia</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_fixed_anchors_to_viewport.html
+++ b/takumi/tests/fixtures-generated/style_fixed_anchors_to_viewport.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_fixed_anchors_to_viewport</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_fixed_captured_by_transform.html
+++ b/takumi/tests/fixtures-generated/style_fixed_captured_by_transform.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_fixed_captured_by_transform</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: block; width: 100%; height: 100%; background-color: rgb(255, 255, 255)">

--- a/takumi/tests/fixtures-generated/style_flex_basis.html
+++ b/takumi/tests/fixtures-generated/style_flex_basis.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_flex_basis</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_flex_direction.html
+++ b/takumi/tests/fixtures-generated/style_flex_direction.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_flex_direction</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_gap.html
+++ b/takumi/tests/fixtures-generated/style_gap.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_gap</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_grid_template_columns.html
+++ b/takumi/tests/fixtures-generated/style_grid_template_columns.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_grid_template_columns</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_grid_template_rows.html
+++ b/takumi/tests/fixtures-generated/style_grid_template_rows.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_grid_template_rows</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_height.html
+++ b/takumi/tests/fixtures-generated/style_height.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_height</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_justify_content.html
+++ b/takumi/tests/fixtures-generated/style_justify_content.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_justify_content</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_margin.html
+++ b/takumi/tests/fixtures-generated/style_margin.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_margin</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(0, 0, 255)">

--- a/takumi/tests/fixtures-generated/style_mask_image_corner_fade.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_corner_fade.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_corner_fade</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_diagonal_gradient.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_diagonal_gradient.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_diagonal_gradient</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_linear_gradient.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_linear_gradient.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_linear_gradient</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_multiple_gradients.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_multiple_gradients.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_multiple_gradients</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_on_image.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_on_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_on_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_radial_ellipse.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_radial_ellipse.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_radial_ellipse</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_radial_gradient.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_radial_gradient.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_radial_gradient</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_stripes.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_stripes.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_stripes</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_url.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_url.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_url</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mask_image_with_background.html
+++ b/takumi/tests/fixtures-generated/style_mask_image_with_background.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mask_image_with_background</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_max_height.html
+++ b/takumi/tests/fixtures-generated/style_max_height.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_max_height</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_max_width.html
+++ b/takumi/tests/fixtures-generated/style_max_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_max_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_min_height.html
+++ b/takumi/tests/fixtures-generated/style_min_height.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_min_height</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_min_width.html
+++ b/takumi/tests/fixtures-generated/style_min_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_min_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_color.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_color.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_color</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_color_burn.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_color_burn.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_color_burn</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_color_dodge.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_color_dodge.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_color_dodge</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_darken.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_darken.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_darken</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_difference.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_difference.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_difference</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_exclusion.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_exclusion.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_exclusion</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_hard_light.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_hard_light.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_hard_light</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_hue.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_hue.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_hue</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_isolation.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_isolation.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_isolation</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_lighten.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_lighten.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_lighten</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_luminosity.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_luminosity.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_luminosity</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_multiply.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_multiply.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_multiply</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_normal.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_normal.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_normal</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_overlay.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_overlay.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_overlay</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_plus_darker.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_plus_darker.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_plus_darker</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_plus_lighter.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_plus_lighter.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_plus_lighter</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_saturation.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_saturation.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_saturation</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_screen.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_screen.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_screen</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_soft_light.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_soft_light.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_soft_light</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_mix_blend_mode_text_regression.html
+++ b/takumi/tests/fixtures-generated/style_mix_blend_mode_text_regression.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_mix_blend_mode_text_regression</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_nested_hoisting_fixed_cb.html
+++ b/takumi/tests/fixtures-generated/style_nested_hoisting_fixed_cb.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_nested_hoisting_fixed_cb</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_object_fit_contain.html
+++ b/takumi/tests/fixtures-generated/style_object_fit_contain.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_fit_contain</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_fit_cover.html
+++ b/takumi/tests/fixtures-generated/style_object_fit_cover.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_fit_cover</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_fit_fill.html
+++ b/takumi/tests/fixtures-generated/style_object_fit_fill.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_fit_fill</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_fit_none.html
+++ b/takumi/tests/fixtures-generated/style_object_fit_none.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_fit_none</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_fit_scale_down.html
+++ b/takumi/tests/fixtures-generated/style_object_fit_scale_down.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_fit_scale_down</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_contain_bottom_right.html
+++ b/takumi/tests/fixtures-generated/style_object_position_contain_bottom_right.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_contain_bottom_right</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_contain_center.html
+++ b/takumi/tests/fixtures-generated/style_object_position_contain_center.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_contain_center</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_contain_top_left.html
+++ b/takumi/tests/fixtures-generated/style_object_position_contain_top_left.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_contain_top_left</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_cover_center.html
+++ b/takumi/tests/fixtures-generated/style_object_position_cover_center.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_cover_center</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_cover_top_left.html
+++ b/takumi/tests/fixtures-generated/style_object_position_cover_top_left.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_cover_top_left</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_none_center.html
+++ b/takumi/tests/fixtures-generated/style_object_position_none_center.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_none_center</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_none_top_left.html
+++ b/takumi/tests/fixtures-generated/style_object_position_none_top_left.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_none_top_left</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_object_position_percentage_25_75.html
+++ b/takumi/tests/fixtures-generated/style_object_position_percentage_25_75.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_object_position_percentage_25_75</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <img

--- a/takumi/tests/fixtures-generated/style_opacity.html
+++ b/takumi/tests/fixtures-generated/style_opacity.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_opacity</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_opacity_flex_text_node_vs_nested_container.html
+++ b/takumi/tests/fixtures-generated/style_opacity_flex_text_node_vs_nested_container.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_opacity_flex_text_node_vs_nested_container</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_opacity_image_with_text.html
+++ b/takumi/tests/fixtures-generated/style_opacity_image_with_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_opacity_image_with_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_outline.html
+++ b/takumi/tests/fixtures-generated/style_outline.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_outline</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_outline_over_child_box.html
+++ b/takumi/tests/fixtures-generated/style_outline_over_child_box.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_outline_over_child_box</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_outline_over_children_and_text.html
+++ b/takumi/tests/fixtures-generated/style_outline_over_children_and_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_outline_over_children_and_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_outline_styles.html
+++ b/takumi/tests/fixtures-generated/style_outline_styles.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_outline_styles</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_outline_with_text.html
+++ b/takumi/tests/fixtures-generated/style_outline_with_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_outline_with_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_clip_image.html
+++ b/takumi/tests/fixtures-generated/style_overflow_clip_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_clip_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_clip_text.html
+++ b/takumi/tests/fixtures-generated/style_overflow_clip_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_clip_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_clip_visible_identity_transform.html
+++ b/takumi/tests/fixtures-generated/style_overflow_clip_visible_identity_transform.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_clip_visible_identity_transform</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: block; width: 100%; height: 100%; background-color: rgb(255, 255, 255)">

--- a/takumi/tests/fixtures-generated/style_overflow_clip_visible_image.html
+++ b/takumi/tests/fixtures-generated/style_overflow_clip_visible_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_clip_visible_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_hidden_image.html
+++ b/takumi/tests/fixtures-generated/style_overflow_hidden_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_hidden_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_hidden_text.html
+++ b/takumi/tests/fixtures-generated/style_overflow_hidden_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_hidden_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_hidden_visible_text.html
+++ b/takumi/tests/fixtures-generated/style_overflow_hidden_visible_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_hidden_visible_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_issue_630_grid.html
+++ b/takumi/tests/fixtures-generated/style_overflow_issue_630_grid.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_issue_630_grid</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_visible_image.html
+++ b/takumi/tests/fixtures-generated/style_overflow_visible_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_visible_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_overflow_visible_text.html
+++ b/takumi/tests/fixtures-generated/style_overflow_visible_text.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_overflow_visible_text</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_padding.html
+++ b/takumi/tests/fixtures-generated/style_padding.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_padding</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_position.html
+++ b/takumi/tests/fixtures-generated/style_position.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_position</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(0, 0, 255)">

--- a/takumi/tests/fixtures-generated/style_rotate.html
+++ b/takumi/tests/fixtures-generated/style_rotate.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_rotate</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_rotate_image.html
+++ b/takumi/tests/fixtures-generated/style_rotate_image.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_rotate_image</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_stacking_context_flex_item_z_index.html
+++ b/takumi/tests/fixtures-generated/style_stacking_context_flex_item_z_index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_stacking_context_flex_item_z_index</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(245, 245, 245)">

--- a/takumi/tests/fixtures-generated/style_stacking_context_nested_context_atomicity.html
+++ b/takumi/tests/fixtures-generated/style_stacking_context_nested_context_atomicity.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_stacking_context_nested_context_atomicity</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(255, 255, 255)">

--- a/takumi/tests/fixtures-generated/style_stacking_context_z_index_siblings.html
+++ b/takumi/tests/fixtures-generated/style_stacking_context_z_index_siblings.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_stacking_context_z_index_siblings</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(245, 245, 245)">

--- a/takumi/tests/fixtures-generated/style_static_z_index_ignored.html
+++ b/takumi/tests/fixtures-generated/style_static_z_index_ignored.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_static_z_index_ignored</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_text_decoration.html
+++ b/takumi/tests/fixtures-generated/style_text_decoration.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_text_decoration</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/style_text_decoration_thickness.html
+++ b/takumi/tests/fixtures-generated/style_text_decoration_thickness.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_text_decoration_thickness</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_text_underline_offset.html
+++ b/takumi/tests/fixtures-generated/style_text_underline_offset.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_text_underline_offset</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_text_underline_position.html
+++ b/takumi/tests/fixtures-generated/style_text_underline_position.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_text_underline_position</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_transform_origin_center.html
+++ b/takumi/tests/fixtures-generated/style_transform_origin_center.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_transform_origin_center</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(255, 255, 255)">

--- a/takumi/tests/fixtures-generated/style_transform_origin_top_left.html
+++ b/takumi/tests/fixtures-generated/style_transform_origin_top_left.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_transform_origin_top_left</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_transform_translate_and_scale.html
+++ b/takumi/tests/fixtures-generated/style_transform_translate_and_scale.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_transform_translate_and_scale</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/style_width.html
+++ b/takumi/tests/fixtures-generated/style_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>style_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/stylesheets.html
+++ b/takumi/tests/fixtures-generated/stylesheets.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>stylesheets</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .card {
         width: 560px;

--- a/takumi/tests/fixtures-generated/stylesheets.html
+++ b/takumi/tests/fixtures-generated/stylesheets.html
@@ -4,6 +4,33 @@
     <meta charset="utf-8" />
     <title>stylesheets</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .card {
+        width: 560px;
+        height: 260px;
+        background-color: rgb(17, 24, 39);
+        border-radius: 24px;
+        padding: 32px;
+        row-gap: 16px;
+      }
+
+      #hero-card {
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+      }
+
+      section .title {
+        color: rgb(255, 255, 255);
+        font-size: 56px;
+        font-weight: 700;
+        text-align: center;
+      }
+
+      section .subtitle {
+        color: rgb(148, 163, 184);
+        font-size: 24px;
+        text-align: center;
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/stylesheets_background_multiple_gradients.html
+++ b/takumi/tests/fixtures-generated/stylesheets_background_multiple_gradients.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8" />
     <title>stylesheets_background_multiple_gradients</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .multi-gradient-card {
+        background:
+          radial-gradient(circle at 80% 20%, #ff3d00 0%, transparent 40%),
+          radial-gradient(circle at 20% 80%, #00e5ff 0%, transparent 40%);
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/stylesheets_background_multiple_gradients.html
+++ b/takumi/tests/fixtures-generated/stylesheets_background_multiple_gradients.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>stylesheets_background_multiple_gradients</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .multi-gradient-card {
         background:

--- a/takumi/tests/fixtures-generated/svg_attr_size_in_absolute_flex_container.html
+++ b/takumi/tests/fixtures-generated/svg_attr_size_in_absolute_flex_container.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>svg_attr_size_in_absolute_flex_container</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(35, 35, 35)">

--- a/takumi/tests/fixtures-generated/svg_current_color_inherits_host_color.html
+++ b/takumi/tests/fixtures-generated/svg_current_color_inherits_host_color.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>svg_current_color_inherits_host_color</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/svg_luma_logo_gradient_background.html
+++ b/takumi/tests/fixtures-generated/svg_luma_logo_gradient_background.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>svg_luma_logo_gradient_background</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/svg_twemoji.html
+++ b/takumi/tests/fixtures-generated/svg_twemoji.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>svg_twemoji</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/tables.html
+++ b/takumi/tests/fixtures-generated/tables.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>tables</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
     <style>
       .root {
         display: flex;

--- a/takumi/tests/fixtures-generated/tables.html
+++ b/takumi/tests/fixtures-generated/tables.html
@@ -4,6 +4,75 @@
     <meta charset="utf-8" />
     <title>tables</title>
     <link rel="stylesheet" href="../shared.css" />
+    <style>
+      .root {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 16px;
+        width: 100%;
+        height: 100%;
+        background: rgb(243, 244, 246);
+        align-content: flex-start;
+        font-family: "Geist";
+      }
+      .cell {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        width: 282px;
+        height: 190px;
+        background: white;
+        border-radius: 8px;
+        padding: 10px 12px;
+      }
+      .label {
+        font-size: 11px;
+        color: rgb(100, 116, 139);
+        font-family: "Geist Mono";
+      }
+      .table {
+        display: table;
+        width: 100%;
+        font-size: 13px;
+        color: rgb(17, 24, 39);
+      }
+      .thead {
+        display: table-header-group;
+      }
+      .tbody {
+        display: table-row-group;
+      }
+      .tfoot {
+        display: table-footer-group;
+      }
+      .tr {
+        display: table-row;
+      }
+      .td {
+        display: table-cell;
+        padding: 3px 8px;
+        border: 1px solid rgb(203, 213, 225);
+      }
+      .th {
+        background: rgb(226, 232, 240);
+        font-weight: bold;
+      }
+      .caption {
+        display: table-caption;
+        font-size: 11px;
+        color: rgb(100, 116, 139);
+      }
+      .caption-bottom {
+        caption-side: bottom;
+      }
+      .stripe {
+        background: rgb(241, 245, 249);
+      }
+      .w80 {
+        width: 80px;
+      }
+    </style>
   </head>
   <body style="width: 1200px; height: 630px">
     <div class="root">

--- a/takumi/tests/fixtures-generated/text_align_center.html
+++ b/takumi/tests/fixtures-generated/text_align_center.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_align_center</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_align_center_chinese_in_block_container.html
+++ b/takumi/tests/fixtures-generated/text_align_center_chinese_in_block_container.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_align_center_chinese_in_block_container</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_align_right.html
+++ b/takumi/tests/fixtures-generated/text_align_right.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_align_right</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_align_start.html
+++ b/takumi/tests/fixtures-generated/text_align_start.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_align_start</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_basic.html
+++ b/takumi/tests/fixtures-generated/text_basic.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_basic</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span style="display: flex; background-color: rgb(240, 240, 240)"

--- a/takumi/tests/fixtures-generated/text_chinese_ellipsis.html
+++ b/takumi/tests/fixtures-generated/text_chinese_ellipsis.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_chinese_ellipsis</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_decoration_skip_ink_parapsychologists.html
+++ b/takumi/tests/fixtures-generated/text_decoration_skip_ink_parapsychologists.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_decoration_skip_ink_parapsychologists</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_devanagari_noto_sans.html
+++ b/takumi/tests/fixtures-generated/text_devanagari_noto_sans.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_devanagari_noto_sans</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_ellipsis_line_clamp_2.html
+++ b/takumi/tests/fixtures-generated/text_ellipsis_line_clamp_2.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_ellipsis_line_clamp_2</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_ellipsis_nowrap_unbreakable.html
+++ b/takumi/tests/fixtures-generated/text_ellipsis_nowrap_unbreakable.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_ellipsis_nowrap_unbreakable</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_ellipsis_text_nowrap.html
+++ b/takumi/tests/fixtures-generated/text_ellipsis_text_nowrap.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_ellipsis_text_nowrap</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_emoji_variation_selector.html
+++ b/takumi/tests/fixtures-generated/text_emoji_variation_selector.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_emoji_variation_selector</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_fit_center_aligned_per_line_all.html
+++ b/takumi/tests/fixtures-generated/text_fit_center_aligned_per_line_all.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_fit_center_aligned_per_line_all</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_fit_grow_bg_clip_transparent_stroke.html
+++ b/takumi/tests/fixtures-generated/text_fit_grow_bg_clip_transparent_stroke.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_fit_grow_bg_clip_transparent_stroke</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_fit_line_height_behavior.html
+++ b/takumi/tests/fixtures-generated/text_fit_line_height_behavior.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_fit_line_height_behavior</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_fit_overview.html
+++ b/takumi/tests/fixtures-generated/text_fit_overview.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_fit_overview</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_flex_centered_text_node_vs_nested_container.html
+++ b/takumi/tests/fixtures-generated/text_flex_centered_text_node_vs_nested_container.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_flex_centered_text_node_vs_nested_container</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_font_kerning.html
+++ b/takumi/tests/fixtures-generated/text_font_kerning.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_font_kerning</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_font_stretch.html
+++ b/takumi/tests/fixtures-generated/text_font_stretch.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_font_stretch</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_font_synthesis_style_auto_none.html
+++ b/takumi/tests/fixtures-generated/text_font_synthesis_style_auto_none.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_font_synthesis_style_auto_none</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_font_synthesis_weight_auto_none.html
+++ b/takumi/tests/fixtures-generated/text_font_synthesis_weight_auto_none.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_font_synthesis_weight_auto_none</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_font_synthesis_weight_emoji.html
+++ b/takumi/tests/fixtures-generated/text_font_synthesis_weight_emoji.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_font_synthesis_weight_emoji</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_group_opacity_small_mono_regression.html
+++ b/takumi/tests/fixtures-generated/text_group_opacity_small_mono_regression.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_group_opacity_small_mono_regression</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_indent_variants.html
+++ b/takumi/tests/fixtures-generated/text_indent_variants.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_indent_variants</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_inline.html
+++ b/takumi/tests/fixtures-generated/text_inline.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_inline</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_mask_image_gradient_emoji.html
+++ b/takumi/tests/fixtures-generated/text_mask_image_gradient_emoji.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_mask_image_gradient_emoji</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_shadow.html
+++ b/takumi/tests/fixtures-generated/text_shadow.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_shadow</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_shadow_no_blur_radius.html
+++ b/takumi/tests/fixtures-generated/text_shadow_no_blur_radius.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_shadow_no_blur_radius</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_stroke_background_clip.html
+++ b/takumi/tests/fixtures-generated/text_stroke_background_clip.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_stroke_background_clip</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_stroke_black_red.html
+++ b/takumi/tests/fixtures-generated/text_stroke_black_red.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_stroke_black_red</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_super_bold_stroke_background_clip.html
+++ b/takumi/tests/fixtures-generated/text_super_bold_stroke_background_clip.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_super_bold_stroke_background_clip</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_tab_size_pre.html
+++ b/takumi/tests/fixtures-generated/text_tab_size_pre.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_tab_size_pre</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; flex-direction: column; background-color: rgb(240, 240, 240)">

--- a/takumi/tests/fixtures-generated/text_transform_all.html
+++ b/takumi/tests/fixtures-generated/text_transform_all.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_transform_all</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div style="display: flex; width: 100%; height: 100%; background-color: rgb(240, 240, 240)">

--- a/takumi/tests/fixtures-generated/text_typography_letter_spacing_2px.html
+++ b/takumi/tests/fixtures-generated/text_typography_letter_spacing_2px.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_typography_letter_spacing_2px</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_typography_line_height_variants.html
+++ b/takumi/tests/fixtures-generated/text_typography_line_height_variants.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_typography_line_height_variants</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_typography_medium_weight_500.html
+++ b/takumi/tests/fixtures-generated/text_typography_medium_weight_500.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_typography_medium_weight_500</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span

--- a/takumi/tests/fixtures-generated/text_typography_regular_24px.html
+++ b/takumi/tests/fixtures-generated/text_typography_regular_24px.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_typography_regular_24px</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <span style="display: flex; background-color: rgb(240, 240, 240); font-size: 24px"

--- a/takumi/tests/fixtures-generated/text_typography_variable_weight.html
+++ b/takumi/tests/fixtures-generated/text_typography_variable_weight.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_typography_variable_weight</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_typography_variable_width.html
+++ b/takumi/tests/fixtures-generated/text_typography_variable_width.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_typography_variable_width</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_whitespace_collapse.html
+++ b/takumi/tests/fixtures-generated/text_whitespace_collapse.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_whitespace_collapse</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_wrap_nowrap.html
+++ b/takumi/tests/fixtures-generated/text_wrap_nowrap.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_wrap_nowrap</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures-generated/text_wrap_style_all.html
+++ b/takumi/tests/fixtures-generated/text_wrap_style_all.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>text_wrap_style_all</title>
-    <link rel="stylesheet" href="../shared.css" />
+    <base href="../../../" />
+    <link rel="stylesheet" href="takumi/tests/shared.css" />
   </head>
   <body style="width: 1200px; height: 630px">
     <div

--- a/takumi/tests/fixtures/lists.rs
+++ b/takumi/tests/fixtures/lists.rs
@@ -1,6 +1,6 @@
 use takumi::prelude::*;
 
-use crate::test_utils::{CONTEXT, attrs, create_test_viewport, run_fixture_test_with_options};
+use crate::test_utils::{CONTEXT, attrs, create_test_viewport, run_fixture_test_with_css};
 
 fn item(text: &str) -> Node {
   Node::container([Node::text(text.to_string())]).with_class_name("item")
@@ -172,5 +172,5 @@ fn test_list_markers() {
     .stylesheet(StyleSheet::parse(CSS).unwrap().into())
     .build();
 
-  run_fixture_test_with_options(options, "list_markers");
+  run_fixture_test_with_css(options, CSS, "list_markers");
 }

--- a/takumi/tests/fixtures/pseudo.rs
+++ b/takumi/tests/fixtures/pseudo.rs
@@ -1,7 +1,7 @@
 use takumi::prelude::*;
 
 use crate::test_utils::{
-  CONTEXT, TEST_IMAGES, attrs, create_test_viewport, run_fixture_test_with_options,
+  CONTEXT, TEST_IMAGES, attrs, create_test_viewport, run_fixture_test_with_css,
 };
 
 fn cell(class: &str, label: &str, seed: &str) -> Node {
@@ -90,18 +90,15 @@ fn test_pseudo_text_attr() {
 
   let root = Node::container(cells).with_class_name("root");
 
+  let css = format!("{SHARED_CSS}{pseudo_css}");
   let options = RenderOptions::builder()
     .viewport(create_test_viewport())
     .node(root)
     .fonts(&CONTEXT)
-    .stylesheet(
-      StyleSheet::parse(&format!("{SHARED_CSS}{pseudo_css}"))
-        .unwrap()
-        .into(),
-    )
+    .stylesheet(StyleSheet::parse(&css).unwrap().into())
     .build();
 
-  run_fixture_test_with_options(options, "pseudo_text_attr");
+  run_fixture_test_with_css(options, &css, "pseudo_text_attr");
 }
 
 #[test]
@@ -150,17 +147,14 @@ fn test_pseudo_display_image() {
 
   let root = Node::container(cells).with_class_name("root");
 
+  let css = format!("{SHARED_CSS}{pseudo_css}");
   let options = RenderOptions::builder()
     .viewport(create_test_viewport())
     .node(root)
     .fonts(&CONTEXT)
     .images(TEST_IMAGES.clone())
-    .stylesheet(
-      StyleSheet::parse(&format!("{SHARED_CSS}{pseudo_css}"))
-        .unwrap()
-        .into(),
-    )
+    .stylesheet(StyleSheet::parse(&css).unwrap().into())
     .build();
 
-  run_fixture_test_with_options(options, "pseudo_display_image");
+  run_fixture_test_with_css(options, &css, "pseudo_display_image");
 }

--- a/takumi/tests/fixtures/stylesheets.rs
+++ b/takumi/tests/fixtures/stylesheets.rs
@@ -1,6 +1,6 @@
 use takumi::prelude::{Length::*, *};
 
-use crate::test_utils::{CONTEXT, create_test_viewport, run_fixture_test_with_options};
+use crate::test_utils::{CONTEXT, create_test_viewport, run_fixture_test_with_css};
 
 #[test]
 fn test_stylesheets() {
@@ -38,46 +38,41 @@ fn test_stylesheets() {
       ))),
   );
 
+  let css = r#"
+    .card {
+      width: 560px;
+      height: 260px;
+      background-color: rgb(17, 24, 39);
+      border-radius: 24px;
+      padding: 32px;
+      row-gap: 16px;
+    }
+
+    #hero-card {
+      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+    }
+
+    section .title {
+      color: rgb(255, 255, 255);
+      font-size: 56px;
+      font-weight: 700;
+      text-align: center;
+    }
+
+    section .subtitle {
+      color: rgb(148, 163, 184);
+      font-size: 24px;
+      text-align: center;
+    }
+  "#;
   let options = RenderOptions::builder()
     .viewport(create_test_viewport())
     .node(root)
     .fonts(&CONTEXT)
-    .stylesheet(
-      StyleSheet::parse(
-        r#"
-          .card {
-            width: 560px;
-            height: 260px;
-            background-color: rgb(17, 24, 39);
-            border-radius: 24px;
-            padding: 32px;
-            row-gap: 16px;
-          }
-  
-          #hero-card {
-            box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
-          }
-  
-          section .title {
-            color: rgb(255, 255, 255);
-            font-size: 56px;
-            font-weight: 700;
-            text-align: center;
-          }
-  
-          section .subtitle {
-            color: rgb(148, 163, 184);
-            font-size: 24px;
-            text-align: center;
-          }
-        "#,
-      )
-      .unwrap()
-      .into(),
-    )
+    .stylesheet(StyleSheet::parse(css).unwrap().into())
     .build();
 
-  run_fixture_test_with_options(options, "stylesheets");
+  run_fixture_test_with_css(options, css, "stylesheets");
 }
 
 #[test]
@@ -106,21 +101,24 @@ fn test_stylesheets_background_multiple_gradients() {
       ))),
   );
 
+  let css = r#"
+    .multi-gradient-card {
+      background: radial-gradient(circle at 80% 20%, #FF3D00 0%, transparent 40%), radial-gradient(circle at 20% 80%, #00E5FF 0%, transparent 40%);
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    }
+  "#;
   let build_options = || {
     RenderOptions::builder()
       .viewport(create_test_viewport())
       .node(root.clone())
       .fonts(&CONTEXT)
-      .stylesheet(StyleSheet::parse(
-        r#"
-          .multi-gradient-card {
-            background: radial-gradient(circle at 80% 20%, #FF3D00 0%, transparent 40%), radial-gradient(circle at 20% 80%, #00E5FF 0%, transparent 40%);
-            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
-          }
-        "#,
-      )
-      .unwrap().into()).build()
+      .stylesheet(StyleSheet::parse(css).unwrap().into())
+      .build()
   };
 
-  run_fixture_test_with_options(build_options(), "stylesheets_background_multiple_gradients");
+  run_fixture_test_with_css(
+    build_options(),
+    css,
+    "stylesheets_background_multiple_gradients",
+  );
 }

--- a/takumi/tests/fixtures/tables.rs
+++ b/takumi/tests/fixtures/tables.rs
@@ -1,6 +1,6 @@
 use takumi::prelude::*;
 
-use crate::test_utils::{CONTEXT, attrs, create_test_viewport, run_fixture_test_with_options};
+use crate::test_utils::{CONTEXT, attrs, create_test_viewport, run_fixture_test_with_css};
 
 fn cell(label: &str, content: Node) -> Node {
   Node::container([
@@ -143,5 +143,5 @@ fn test_tables() {
     .stylesheet(StyleSheet::parse(CSS).unwrap().into())
     .build();
 
-  run_fixture_test_with_options(options, "tables");
+  run_fixture_test_with_css(options, CSS, "tables");
 }

--- a/takumi/tests/fixtures/visual_showcase.rs
+++ b/takumi/tests/fixtures/visual_showcase.rs
@@ -5,7 +5,7 @@ use takumi::prelude::*;
 
 use crate::{
   style_filter_reference::filter_url,
-  test_utils::{CONTEXT, TEST_IMAGES, create_test_viewport, run_fixture_test_with_options},
+  test_utils::{CONTEXT, TEST_IMAGES, create_test_viewport, run_fixture_test_with_css},
 };
 
 fn run_showcase(node: Node, css: &str, fixture_name: &str) {
@@ -33,7 +33,7 @@ fn run_showcase(node: Node, css: &str, fixture_name: &str) {
     .stylesheet(StyleSheet::parse(&stylesheet).unwrap().into())
     .build();
 
-  run_fixture_test_with_options(options, fixture_name);
+  run_fixture_test_with_css(options, &stylesheet, fixture_name);
 }
 
 fn stage(children: Vec<Node>) -> Node {

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -161,6 +161,14 @@ pub fn run_fixture_test(node: Node, fixture_name: &str) {
 
 #[allow(dead_code)]
 pub fn run_fixture_test_with_options(options: RenderOptions<'_>, fixture_name: &str) {
+  run_fixture_test_with_css(options, "", fixture_name);
+}
+
+/// `css` is the raw stylesheet the render applies, embedded in the repro HTML
+/// so a browser shows the same page. `RenderOptions` only carries the parsed
+/// sheet, which cannot serialize back.
+#[allow(dead_code)]
+pub fn run_fixture_test_with_css(options: RenderOptions<'_>, css: &str, fixture_name: &str) {
   let viewport_width = options.viewport().size.width.unwrap_or(1200);
   let viewport_height = options.viewport().size.height.unwrap_or(630);
 
@@ -185,19 +193,24 @@ pub fn run_fixture_test_with_options(options: RenderOptions<'_>, fixture_name: &
     );
   }
 
+  let style_block = if css.is_empty() {
+    String::new()
+  } else {
+    format!("\n  <style>{css}</style>")
+  };
   let html_content = format!(
     r#"<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <title>{}</title>
-  <link rel="stylesheet" href="../shared.css">
+  <link rel="stylesheet" href="../shared.css">{}
 </head>
 <body style="width: {}px; height: {}px;">
   {}
 </body>
 </html>"#,
-    fixture_name, viewport_width, viewport_height, node_html
+    fixture_name, style_block, viewport_width, viewport_height, node_html
   );
 
   write(

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -164,8 +164,7 @@ pub fn run_fixture_test_with_options(options: RenderOptions<'_>, fixture_name: &
   run_fixture_test_with_css(options, "", fixture_name);
 }
 
-/// `css` is the raw stylesheet the render applies, embedded in the repro HTML
-/// so a browser shows the same page. `RenderOptions` only carries the parsed
+/// Embeds `css` in the repro HTML; `RenderOptions` only carries the parsed
 /// sheet, which cannot serialize back.
 #[allow(dead_code)]
 pub fn run_fixture_test_with_css(options: RenderOptions<'_>, css: &str, fixture_name: &str) {
@@ -203,14 +202,13 @@ pub fn run_fixture_test_with_css(options: RenderOptions<'_>, css: &str, fixture_
 <html>
 <head>
   <meta charset="utf-8">
-  <title>{}</title>
-  <link rel="stylesheet" href="../shared.css">{}
+  <title>{fixture_name}</title>
+  <link rel="stylesheet" href="../shared.css">{style_block}
 </head>
-<body style="width: {}px; height: {}px;">
-  {}
+<body style="width: {viewport_width}px; height: {viewport_height}px;">
+  {node_html}
 </body>
-</html>"#,
-    fixture_name, style_block, viewport_width, viewport_height, node_html
+</html>"#
   );
 
   write(

--- a/takumi/tests/test_utils.rs
+++ b/takumi/tests/test_utils.rs
@@ -203,7 +203,8 @@ pub fn run_fixture_test_with_css(options: RenderOptions<'_>, css: &str, fixture_
 <head>
   <meta charset="utf-8">
   <title>{fixture_name}</title>
-  <link rel="stylesheet" href="../shared.css">{style_block}
+  <base href="../../../">
+  <link rel="stylesheet" href="takumi/tests/shared.css">{style_block}
 </head>
 <body style="width: {viewport_width}px; height: {viewport_height}px;">
   {node_html}


### PR DESCRIPTION
A generated repro HTML linked `shared.css` but dropped the stylesheet the test passes through `RenderOptions`, so opening one in a browser showed unstyled text. `RenderOptions` only carries the parsed sheet, which cannot serialize back; the fixtures now hand their raw CSS to `run_fixture_test_with_css`, and the repro embeds it in a `<style>` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved visual fixture testing with explicit CSS support.
  - Fixture tests now consistently apply locally defined styles during rendering.
  - Expanded stylesheet coverage across lists, pseudo-elements, tables, stylesheets, and showcase examples.
  - Preserved existing rendering options and generated artifacts while improving test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->