### PR TITLE
PDF: drop the debug wasm build script

### DIFF
--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -126,7 +126,6 @@
   "scripts": {
     "build": "wasm-pack build ../takumi-pdf-wasm --no-pack --release --out-dir ../takumi-pdf-js/pkg --target web && bun build:js",
     "build:js": "tsdown",
-    "build:debug": "wasm-pack build ../takumi-pdf-wasm --no-pack --dev --out-dir ../takumi-pdf-js/pkg --target web && bun build:js",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {


### PR DESCRIPTION
A debug wasm build silently overwrites `pkg/` with a 30MB artifact that looks like a size regression. The release build is the only one worth having locally.