### PR TITLE
PDF: add page counter primitives

### DIFF
--- a/.tegami/page-counter-primitives.md
+++ b/.tegami/page-counter-primitives.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "takumi-pdf":
+    type: minor
+---
+
+### Add page counter primitives
+
+`PageNumber`, `TotalPages`, and `TargetPageNumber` components wrap the counter class hooks, with a typed `format` prop for the supported `@counter-style` names.

--- a/docs/app/playground/evaluate.ts
+++ b/docs/app/playground/evaluate.ts
@@ -1,7 +1,24 @@
 import * as React from "react";
 import { transform } from "sucrase";
+import * as primitives from "takumi-pdf/primitives";
 import * as z from "zod/mini";
 import { optionsSchema } from "./schema";
+
+/// Modules a template may import. The wasm entry stays out: the playground
+/// renders through its own worker.
+const MODULES: Record<string, unknown> = {
+  "takumi-pdf": primitives,
+  "takumi-pdf/primitives": primitives,
+};
+
+function requireModule(id: string): unknown {
+  const module = MODULES[id];
+
+  if (module === undefined) {
+    throw new Error(`the playground cannot import "${id}"`);
+  }
+  return module;
+}
 
 const exportsSchema = z.object({
   default: z.function(),
@@ -18,7 +35,7 @@ function transformCode(code: string) {
 export function evaluateCodeExports(code: string, react: typeof React) {
   const exports = {};
 
-  new Function("exports", "React", transformCode(code))(exports, react);
+  new Function("exports", "require", "React", transformCode(code))(exports, requireModule, react);
 
   return exportsSchema.parse(exports);
 }

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -1,3 +1,5 @@
+import { PageNumber, TotalPages } from "takumi-pdf";
+
 const sections = [
   {
     title: "Summary",
@@ -90,8 +92,8 @@ export const options: PlaygroundOptions = {
           匠 Werkstatt · Kawagoe, Saitama · werkstatt.example
         </span>
         <span tw="mt-1 text-[10px] text-[#9ca3af]">
-          第 <span className="pageNumber trad-chinese-informal" /> 頁,共{" "}
-          <span className="totalPages trad-chinese-informal" /> 頁
+          第 <PageNumber format="trad-chinese-informal" /> 頁,共{" "}
+          <TotalPages format="trad-chinese-informal" /> 頁
         </span>
       </div>
     ),

--- a/docs/app/playground/templates/watermark.tsx
+++ b/docs/app/playground/templates/watermark.tsx
@@ -1,3 +1,5 @@
+import { PageNumber, TotalPages } from "takumi-pdf";
+
 const clauses = [
   {
     title: "1. Confidential information",
@@ -127,7 +129,7 @@ function Footer() {
     <div tw="flex w-full justify-between px-14 pb-5 text-[10px] text-[#9ca3af]">
       <span>Confidential · draft for review</span>
       <span>
-        <span className="pageNumber" /> / <span className="totalPages" />
+        <PageNumber /> / <TotalPages />
       </span>
     </div>
   );

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -35,7 +35,7 @@ declare const html: string;
 // takumi-pdf
 import { googleFonts } from "@takumi-rs/helpers";
 import { fromHtml } from "@takumi-rs/helpers/html";
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 // [!code highlight]
 const { node, stylesheets } = fromHtml(html);
@@ -46,7 +46,7 @@ const pdf = await render(node, {
   stylesheets,
   footer: (
     <div tw="flex w-full justify-center text-[10px]">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </div>
   ),
   fonts: await googleFonts(["Inter"]),

--- a/docs/content/docs/pdf/from-react-pdf.mdx
+++ b/docs/content/docs/pdf/from-react-pdf.mdx
@@ -61,7 +61,7 @@ const pdf = await render(
 | `renderToBuffer`                        | `render()` returns a `Uint8Array`     |
 | `renderToStream`, `renderToFile`        | write the returned bytes yourself     |
 | a `fixed` header or footer `<View>`     | the `header` and `footer` options     |
-| `render={({ pageNumber, totalPages })}` | `pageNumber` and `totalPages` classes |
+| `render={({ pageNumber, totalPages })}` | `<PageNumber />` and `<TotalPages />` |
 | the `break` prop                        | `break-before: page`                  |
 | `wrap={false}`                          | `break-inside: avoid`                 |
 | `orphans`, `widows`                     | the same CSS properties               |
@@ -86,13 +86,13 @@ react-pdf repeats a band by marking a `<View>` as `fixed` inside the page. Takum
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 const pdf = await render(report, {
   // [!code highlight]
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </div>
   ),
   margin: { top: 48, bottom: 72 },

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -10,13 +10,13 @@ icon: PanelTop
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 const pdf = await render(report, {
   // [!code highlight]
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </div>
   ),
 });
@@ -31,12 +31,12 @@ A band draws in the page margin, so the margin has to be tall enough to hold it.
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 const pdf = await render(report, {
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </div>
   ),
 });
@@ -69,12 +69,13 @@ Passing `viewport` instead of a page size measures the tree as-is. Counter hooks
 
 ## Page counters
 
-Text and container nodes classed `pageNumber` or `totalPages` receive counter text. The counter replaces what the node holds, so an empty `<span />` is enough. Chromium's print templates use the same two names.
+`<PageNumber />` is the current page, counting from 1. `<TotalPages />` is the number of pages in the document. Both take a `format` prop for a [counter style](#counter-styles), and pass `className`, `style`, and `tw` through.
 
-| Class        | Value                               |
-| ------------ | ----------------------------------- |
-| `pageNumber` | The current page, counting from 1   |
-| `totalPages` | The number of pages in the document |
+The primitives render class hooks. A node classed `pageNumber` or `totalPages` receives the counter text, replacing what it holds, so an empty `<span />` is enough. Chromium's print templates use the same two names, and HTML input uses them directly:
+
+```html
+Page <span class="pageNumber"></span> of <span class="totalPages"></span>
+```
 
 A node carrying both classes gets the page number.
 
@@ -84,7 +85,7 @@ A hook fills wherever it sits. A `fixed` box repeats on every page, so it lays o
 
 ```tsx
 <div style={{ position: "fixed", bottom: 24, left: 24, right: 24 }}>
-  Page <span className="pageNumber" /> of <span className="totalPages" />
+  Page <PageNumber /> of <TotalPages />
 </div>
 ```
 
@@ -94,20 +95,20 @@ A hook in the page content names the page it lands on, which is what a cover pag
 
 ## Counter styles
 
-Add a CSS `@counter-style` name next to the hook class. It formats the number. The first supported name wins. Unsupported names are ignored, and a hook without one counts in `decimal`.
+The `format` prop names a CSS `@counter-style` and formats the number. On a class hook, add the style name next to the hook class. The first supported name wins. Unsupported names are ignored, and a counter without one counts in `decimal`.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 const pdf = await render(report, {
   footer: (
     <div style={{ fontSize: 12 }}>
       {/* [!code highlight:2] */}
-      第 <span className="pageNumber trad-chinese-informal" /> 頁,共{" "}
-      <span className="totalPages trad-chinese-informal" /> 頁
+      第 <PageNumber format="trad-chinese-informal" /> 頁,共{" "}
+      <TotalPages format="trad-chinese-informal" /> 頁
     </div>
   ),
 });

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -28,7 +28,7 @@ import type { ReactNode } from "react";
 declare const data: { total: number };
 declare function Invoice(props: { data: typeof data }): ReactNode;
 // ---cut---
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 import { googleFonts } from "@takumi-rs/helpers";
 import { writeFile } from "node:fs/promises";
 
@@ -39,7 +39,7 @@ const pdf = await render(<Invoice data={data} />, {
   fonts: await googleFonts(["Inter"]),
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </div>
   ),
 });

--- a/docs/content/docs/pdf/invoices.mdx
+++ b/docs/content/docs/pdf/invoices.mdx
@@ -16,13 +16,13 @@ declare const invoice: { number: string };
 declare function InvoiceDocument(props: { data: typeof invoice }): ReactNode;
 // ---cut---
 import { googleFonts } from "@takumi-rs/helpers";
-import { measure, render } from "takumi-pdf";
+import { PageNumber, TotalPages, measure, render } from "takumi-pdf";
 
 const footer = (
   <div tw="flex w-full justify-between px-12 text-[10px] text-[#6b7280]">
     <span>Invoice {invoice.number}</span>
     <span tw="flex">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </span>
   </div>
 );

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -39,10 +39,10 @@ Clicking it moves to the page holding that element. A fragment matching no eleme
 
 ## Table of contents
 
-A node classed `targetPageNumber` prints the page its link points at. The link is the nearest enclosing element carrying an `href`, usually the `<a>` around the entry, so one piece of markup gives an entry that is both clickable and numbered:
+`<TargetPageNumber />` prints the page its link points at. The link is the nearest enclosing element carrying an `href`, usually the `<a>` around the entry, so one piece of markup gives an entry that is both clickable and numbered. Pass `href` instead to have it render its own link. Underneath it is the `targetPageNumber` class hook, which HTML input uses directly.
 
 ```tsx twoslash
-import { render } from "takumi-pdf";
+import { TargetPageNumber, render } from "takumi-pdf";
 
 const pdf = await render(
   <div>
@@ -50,7 +50,7 @@ const pdf = await render(
       <span>Results</span>
       <span tw="flex-1 border-b border-dotted border-gray-400" />
       {/* [!code highlight] */}
-      <span className="targetPageNumber" tw="w-8 shrink-0 text-right" />
+      <TargetPageNumber tw="w-8 shrink-0 text-right" />
     </a>
     <h1 id="results" style={{ breakBefore: "page" }}>
       Results
@@ -59,7 +59,7 @@ const pdf = await render(
 );
 ```
 
-The stretched span draws the dot leader. Counter styles work here too, so `targetPageNumber upper-roman` prints `IV`. See [Counter styles](/docs/pdf/headers-and-footers#counter-styles) for the full list.
+The stretched span draws the dot leader. Counter styles work here too, so `format="upper-roman"` prints `IV`. See [Counter styles](/docs/pdf/headers-and-footers#counter-styles) for the full list.
 
 A fragment naming no element prints nothing. This follows the rule links already use.
 
@@ -69,7 +69,7 @@ A page number exists only after pagination. Takumi paginates, fills the numbers 
 
 A number that cannot widen its line settles on the second pass. That is what `w-8 shrink-0 text-right` does above. Reserve enough width for the highest page number the document reaches.
 
-Headers and footers are laid out per page, outside this loop. A `targetPageNumber` in a band renders nothing.
+Headers and footers are laid out per page, outside this loop. A `<TargetPageNumber />` in a band renders nothing.
 
 ## Outline
 

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -50,12 +50,12 @@ const pdf = await render(report, {
 });
 ```
 
-A table of contents is the same chapters as links, with the page each one starts on. `targetPageNumber` fills the page in:
+A table of contents is the same chapters as links, with the page each one starts on. `<TargetPageNumber />` fills the page in:
 
 ```tsx twoslash
 declare const chapters: { id: string; title: string }[];
 // ---cut---
-import "takumi-pdf";
+import { TargetPageNumber } from "takumi-pdf";
 
 <nav tw="flex flex-col gap-1 text-sm">
   {chapters.map((chapter) => (
@@ -63,7 +63,7 @@ import "takumi-pdf";
       <span>{chapter.title}</span>
       <span tw="flex-1 border-b border-dotted border-gray-300" />
       {/* [!code highlight] */}
-      <span className="targetPageNumber" tw="w-8 shrink-0 text-right" />
+      <TargetPageNumber tw="w-8 shrink-0 text-right" />
     </a>
   ))}
 </nav>;
@@ -79,7 +79,7 @@ A report header usually names the document and the period. A footer usually carr
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 const pdf = await render(report, {
   // [!code highlight]
@@ -92,7 +92,7 @@ const pdf = await render(report, {
   // [!code highlight]
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      <span className="pageNumber" /> / <span className="totalPages" />
+      <PageNumber /> / <TotalPages />
     </div>
   ),
   margin: { top: 64, bottom: 64, left: 48, right: 48 },

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -98,6 +98,16 @@
       "types": "./bundlers/node.d.ts",
       "default": "./bundlers/next.mjs"
     },
+    "./primitives": {
+      "import": {
+        "types": "./dist/primitives.d.mts",
+        "default": "./dist/primitives.mjs"
+      },
+      "require": {
+        "types": "./dist/primitives.d.cts",
+        "default": "./dist/primitives.cjs"
+      }
+    },
     "./no-init": {
       "import": {
         "types": "./dist/export.d.mts",

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -13,6 +13,8 @@ import { counterCharacters, PdfRenderer as PdfRendererInternal } from "../pkg/ta
 
 export { default, initSync } from "../pkg/takumi_pdf_wasm";
 export type { FontLoader, ImagesInput } from "@takumi-rs/helpers/renderer";
+export { PageNumber, TargetPageNumber, TotalPages } from "./primitives";
+export type { CounterProps, CounterStyle } from "./primitives";
 
 declare module "react" {
   interface DOMAttributes<T> {

--- a/takumi-pdf-js/src/primitives.ts
+++ b/takumi-pdf-js/src/primitives.ts
@@ -1,0 +1,90 @@
+import type { ReactElementLike } from "@takumi-rs/helpers";
+
+/**
+ * A `@counter-style` name the page counters can format in, matching the set
+ * the renderer's `@counter-style` substitution knows.
+ */
+export type CounterStyle =
+  | "decimal"
+  | "decimal-leading-zero"
+  | "lower-roman"
+  | "upper-roman"
+  | "lower-alpha"
+  | "lower-latin"
+  | "upper-alpha"
+  | "upper-latin"
+  | "lower-greek"
+  | "hiragana"
+  | "katakana"
+  | "trad-chinese-informal"
+  | "cjk-ideographic"
+  | "cjk-decimal"
+  | "arabic-indic"
+  | "bengali"
+  | "cambodian"
+  | "khmer"
+  | "devanagari"
+  | "gujarati"
+  | "gurmukhi"
+  | "kannada"
+  | "lao"
+  | "malayalam"
+  | "mongolian"
+  | "myanmar"
+  | "oriya"
+  | "persian"
+  | "urdu"
+  | "tamil"
+  | "telugu"
+  | "thai"
+  | "tibetan";
+
+/** Props shared by the page counter primitives. */
+export type CounterProps = {
+  /** Counter style the number formats in. Defaults to decimal. */
+  format?: CounterStyle;
+  className?: string;
+  style?: Record<string, unknown>;
+  tw?: string;
+};
+
+// Marks the returned objects as JSX elements, so the node/JSX input split
+// routes them through `fromJsx` instead of reading them as takumi nodes.
+const ELEMENT = Symbol.for("react.transitional.element");
+
+function counter(hook: string, { format, className, ...rest }: CounterProps): ReactElementLike {
+  return {
+    $$typeof: ELEMENT,
+    type: "span",
+    props: {
+      ...rest,
+      className: [hook, format, className].filter(Boolean).join(" "),
+    },
+  };
+}
+
+/**
+ * The number of the page this element lands on. Meaningful inside a `header`
+ * or `footer` band (or a `position: fixed` box), where it renumbers per page.
+ */
+export function PageNumber(props: CounterProps = {}): ReactElementLike {
+  return counter("pageNumber", props);
+}
+
+/** The document's total page count. Same placement rules as {@link PageNumber}. */
+export function TotalPages(props: CounterProps = {}): ReactElementLike {
+  return counter("totalPages", props);
+}
+
+/**
+ * The number of the page `href`'s target element lands on, for cross
+ * references like "see page 12". Rendered as a link to the target.
+ */
+export function TargetPageNumber({
+  href,
+  ...props
+}: CounterProps & { href: string }): ReactElementLike {
+  const span = counter("targetPageNumber", props);
+
+  return { $$typeof: ELEMENT, type: "a", props: { href, children: span } };
+}

--- a/takumi-pdf-js/src/primitives.ts
+++ b/takumi-pdf-js/src/primitives.ts
@@ -1,4 +1,4 @@
-import type { ReactElementLike } from "@takumi-rs/helpers";
+import type { ReactElement } from "react";
 
 /**
  * A `@counter-style` name the page counters can format in, matching the set
@@ -52,39 +52,45 @@ export type CounterProps = {
 // routes them through `fromJsx` instead of reading them as takumi nodes.
 const ELEMENT = Symbol.for("react.transitional.element");
 
-function counter(hook: string, { format, className, ...rest }: CounterProps): ReactElementLike {
-  return {
-    $$typeof: ELEMENT,
-    type: "span",
-    props: {
-      ...rest,
-      className: [hook, format, className].filter(Boolean).join(" "),
-    },
-  };
+function counter(hook: string, { format, className, ...rest }: CounterProps): ReactElement {
+  return element("span", {
+    ...rest,
+    className: [hook, format, className].filter(Boolean).join(" "),
+  });
+}
+
+function element(type: string, props: Record<string, unknown>): ReactElement {
+  // `$$typeof` joins after construction: the base object matches
+  // `ReactElement` structurally, and the marker routes it through `fromJsx`.
+  return Object.assign({ type, props, key: null }, { $$typeof: ELEMENT });
 }
 
 /**
  * The number of the page this element lands on. Meaningful inside a `header`
  * or `footer` band (or a `position: fixed` box), where it renumbers per page.
  */
-export function PageNumber(props: CounterProps = {}): ReactElementLike {
+export function PageNumber(props: CounterProps = {}): ReactElement {
   return counter("pageNumber", props);
 }
 
 /** The document's total page count. Same placement rules as {@link PageNumber}. */
-export function TotalPages(props: CounterProps = {}): ReactElementLike {
+export function TotalPages(props: CounterProps = {}): ReactElement {
   return counter("totalPages", props);
 }
 
 /**
- * The number of the page `href`'s target element lands on, for cross
- * references like "see page 12". Rendered as a link to the target.
+ * The number of the page a link's target element lands on, for cross
+ * references like "see page 12" and tables of contents. Without `href` it
+ * reads the nearest enclosing `<a>`; with one it renders its own link.
  */
 export function TargetPageNumber({
   href,
   ...props
-}: CounterProps & { href: string }): ReactElementLike {
+}: CounterProps & { href?: string }): ReactElement {
   const span = counter("targetPageNumber", props);
 
-  return { $$typeof: ELEMENT, type: "a", props: { href, children: span } };
+  if (href === undefined) {
+    return span;
+  }
+  return element("a", { href, children: span });
 }

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { expect, test } from "bun:test";
 import { container, text } from "@takumi-rs/helpers";
-import { PdfRenderer } from "../bundlers/node.mjs";
+import { PageNumber, PdfRenderer, TotalPages } from "../bundlers/node.mjs";
 
 const renderer = new PdfRenderer();
 
@@ -76,6 +76,51 @@ test("paginates and substitutes footer counters", async () => {
   });
 
   expect(pageCount(pdf)).toBeGreaterThan(1);
+});
+
+test("page counter primitives fill per page and pull their counter face", async () => {
+  let loaded = false;
+  const pdf = await renderer.render(
+    container({
+      style: { display: "flex", flexDirection: "column", width: "100%" },
+      children: Array.from({ length: 60 }, (_, i) => text(`Row ${i + 1}`, { fontSize: 16 })),
+    }),
+    {
+      size: { width: 400, height: 300 },
+      margin: 24,
+      fonts: [
+        {
+          name: "Primitive CJK",
+          ranges: [[0x4e00, 0x9fff]],
+          data: () => {
+            loaded = true;
+            return new Uint8Array(
+              readFileSync(
+                new URL(
+                  "../../assets/fonts/noto-sans/NotoSansTC-VariableFont_wght.woff2",
+                  import.meta.url,
+                ),
+              ),
+            );
+          },
+        },
+      ],
+      footer: {
+        $$typeof: Symbol.for("react.transitional.element"),
+        type: "div",
+        props: {
+          style: { display: "flex", fontSize: 12 },
+          children: [
+            PageNumber({ format: "trad-chinese-informal" }),
+            TotalPages({ format: "trad-chinese-informal" }),
+          ],
+        },
+      },
+    },
+  );
+
+  expect(pageCount(pdf)).toBeGreaterThan(1);
+  expect(loaded).toBeTrue();
 });
 
 test("keeps a face the page counter needs but the document never uses", async () => {

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -111,8 +111,13 @@ test("page counter primitives fill per page and pull their counter face", async 
         props: {
           style: { display: "flex", fontSize: 12 },
           children: [
+            // Direct call and JSX element forms both resolve.
             PageNumber({ format: "trad-chinese-informal" }),
-            TotalPages({ format: "trad-chinese-informal" }),
+            {
+              $$typeof: Symbol.for("react.transitional.element"),
+              type: TotalPages,
+              props: { format: "trad-chinese-informal" },
+            },
           ],
         },
       },

--- a/takumi-pdf-js/tsdown.config.ts
+++ b/takumi-pdf-js/tsdown.config.ts
@@ -6,6 +6,7 @@ const exportOutputs = ["export.mjs", "export.cjs"];
 export default defineConfig({
   entry: {
     export: "src/export.ts",
+    primitives: "src/primitives.ts",
   },
   format: ["esm", "cjs"],
   dts: true,


### PR DESCRIPTION
## Why

Page counters were reachable only through class hooks (`pageNumber`, `totalPages`, `targetPageNumber`): stringly-typed, undiscoverable from an editor, and every consumer (pdfcn included) wraps them by hand.

## What

`takumi-pdf` exports `<PageNumber />`, `<TotalPages />`, and `<TargetPageNumber />`. Each renders the class hook underneath, with a typed `format` prop for the supported `@counter-style` names; `className`, `style`, and `tw` pass through. `TargetPageNumber` reads the nearest enclosing `<a>`, or renders its own link when given `href`. A `takumi-pdf/primitives` subpath carries them without the wasm entry.

The docs use the primitives as the primary API, with the class hooks kept as the underlying contract for HTML input. The playground gains a small import map so templates can import them too.

## Result

Works called directly and as JSX components; a test covers both forms plus the `format`-driven font subsetting pull. `attw` and `publint` pass with the new subpath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `PageNumber`, `TotalPages`, and `TargetPageNumber` components for displaying PDF pagination.
  - Added support for localized and custom counter formats, styling, and optional links for target page numbers.
  - Made pagination primitives available through a dedicated package import.

- **Documentation**
  - Updated PDF guides, examples, reports, invoices, and playground templates to use the new pagination components.
  - Added guidance for formatting, styling, links, and compatibility with existing templates.

- **Tests**
  - Added coverage for multi-page rendering, JSX usage, and localized page counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->