### PR TITLE
Docs: lead the READMEs with quick start and document repeated table headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,42 +17,6 @@ Takumi renders images in Node.js, Cloudflare Workers, browsers, and Rust applica
 
 </div>
 
-## Features
-
-Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser. One component tree renders as an image, an animation, or a paged PDF.
-
-### Images
-
-- **`text-fit`** grows or shrinks a headline to fill its line box, no measuring loop.
-- **`text-wrap: balance`** evens multi-line headlines. `pretty` spares the orphan word.
-- **Animations** sample the tree across time. `@keyframes` and `animate-spin` become WebP, APNG, GIF, or video frames.
-- **Stylesheets** apply as written, with complex selectors, `var()`, `calc()`, and media queries.
-- **CSS Grid**, block, inline, and float handle layout.
-- **`lang`** picks each language's own Han glyphs for the same code points.
-- **Text on a path** follows `offset-path`. `background-clip: text` and conic gradients paint it.
-- Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
-- **SVG filters** run through `filter: url(...)`, `feTurbulence` and `feDisplacementMap` included.
-- **`corner-shape`** swaps round corners for `squircle`, `bevel`, `scoop`, `notch`, or `superellipse(n)`.
-- **Tailwind v4** utilities apply directly, arbitrary values included.
-
-### PDF
-
-- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
-- **Widows and orphans** default to 2, keeping lone lines away from page breaks.
-- **Headers and footers** repeat on every page. Counters speak CSS counter styles, `trad-chinese-informal` included.
-- **Text** stays selectable and searchable. Fonts embed as subsets.
-- **Links** and metadata carry into the output. `outline: true` builds bookmarks from headings.
-- **Attachments** embed files, including Factur-X e-invoice XML.
-- **Tagged PDF** is on by default. PDF/A-2, A-3, A-4, and PDF/UA-1 pass veraPDF.
-- **Arabic**, bidi text, CJK, and emoji shape correctly.
-- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
-
-### Runtimes
-
-- **Node.js and Bun** load a native binding, prebuilt for macOS, Linux (glibc and musl), and Windows on x64 and ARM64.
-- **Cloudflare Workers** and browsers load the WebAssembly build.
-- **Rust** applications embed the `takumi` crate.
-
 ## Quick Start
 
 ```bash
@@ -79,20 +43,57 @@ await writeFile("./output.png", image);
 ### PDF
 
 ```tsx
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 import { writeFile } from "node:fs/promises";
 
 const pdf = await render(<Invoice data={data} />, {
   size: "a4",
   footer: (
     <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      Page <PageNumber /> of <TotalPages />
     </div>
   ),
 });
 
 await writeFile("invoice.pdf", pdf);
 ```
+
+## Features
+
+Takumi is a Rust rendering engine for markup and CSS. It handles layout, text shaping, compositing, and encoding without launching a browser. One component tree renders as an image, an animation, or a paged PDF.
+
+### Images
+
+- **`text-fit`** grows or shrinks a headline to fill its line box, no measuring loop.
+- **`text-wrap: balance`** evens multi-line headlines. `pretty` spares the orphan word.
+- **Animations** sample the tree across time. `@keyframes` and `animate-spin` become WebP, APNG, GIF, or video frames.
+- **Stylesheets** apply as written, with complex selectors, `var()`, `calc()`, and media queries.
+- **CSS Grid**, block, inline, and float handle layout.
+- **`lang`** picks each language's own Han glyphs for the same code points.
+- **Text on a path** follows `offset-path`. `background-clip: text` and conic gradients paint it.
+- Masks, `clip-path`, `backdrop-filter`, and blend modes composite the way browsers do.
+- **SVG filters** run through `filter: url(...)`, `feTurbulence` and `feDisplacementMap` included.
+- **`corner-shape`** swaps round corners for `squircle`, `bevel`, `scoop`, `notch`, or `superellipse(n)`.
+- **Tailwind v4** utilities apply directly, arbitrary values included.
+
+### PDF
+
+- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
+- **Widows and orphans** default to 2, keeping lone lines away from page breaks.
+- **Headers and footers** repeat on every page. `<PageNumber />` and `<TotalPages />` count in CSS counter styles, `trad-chinese-informal` included.
+- **Tables** share column widths across pages and repeat their `<thead>` on every page.
+- **Text** stays selectable and searchable. Fonts embed as subsets.
+- **Links** and metadata carry into the output. `outline: true` builds bookmarks from headings.
+- **Attachments** embed files, including Factur-X e-invoice XML.
+- **Tagged PDF** is on by default. PDF/A-2, A-3, A-4, and PDF/UA-1 pass veraPDF.
+- **Arabic**, bidi text, CJK, and emoji shape correctly.
+- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
+
+### Runtimes
+
+- **Node.js and Bun** load a native binding, prebuilt for macOS, Linux (glibc and musl), and Windows on x64 and ARM64.
+- **Cloudflare Workers** and browsers load the WebAssembly build.
+- **Rust** applications embed the `takumi` crate.
 
 ## Coming From Something Else
 

--- a/docs/content/docs/pdf/pagination.mdx
+++ b/docs/content/docs/pdf/pagination.mdx
@@ -67,6 +67,30 @@ const pdf = await render(
 );
 ```
 
+## Repeated table headers
+
+A `<thead>` paints again at the top of every page its table continues onto, following css-tables-3 repeated headers. The band is monolithic: a page break never lands inside it, and the spacing to the first body row repeats with it.
+
+```tsx twoslash
+declare const rows: import("react").ReactNode;
+// ---cut---
+import { render } from "takumi-pdf";
+
+const pdf = await render(
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Qty</th>
+      </tr>
+    </thead>
+    <tbody>{rows}</tbody>
+  </table>,
+);
+```
+
+A header taller than a quarter of the page does not repeat, matching Chromium. A header cell whose `rowspan` reaches into the body suppresses repetition for that table. `<tfoot>` renders once, after the body.
+
 ## Watermarks
 
 `position: fixed` paints a box on every page.

--- a/takumi-pdf-js/README.md
+++ b/takumi-pdf-js/README.md
@@ -30,7 +30,7 @@ bun add takumi-pdf
 ```tsx
 import { writeFile } from "node:fs/promises";
 import { googleFonts } from "@takumi-rs/helpers";
-import { render } from "takumi-pdf";
+import { PageNumber, TotalPages, render } from "takumi-pdf";
 
 const pdf = await render(
   <main tw="flex flex-col gap-4">
@@ -45,7 +45,7 @@ const pdf = await render(
     fonts: await googleFonts(["Inter"]),
     footer: (
       <div tw="flex w-full justify-center text-[10px] text-gray-500">
-        Page <span className="pageNumber" /> of <span className="totalPages" />
+        Page <PageNumber /> of <TotalPages />
       </div>
     ),
   },
@@ -74,28 +74,22 @@ const pdf = await render(report, {
 
 ## Headers and footers
 
-Headers and footers repeat on every page. Elements whose class list includes `pageNumber` or `totalPages` receive the counter as text.
+Headers and footers repeat on every page. `<PageNumber />` and `<TotalPages />` place the counters; the `format` prop picks a CSS counter style.
 
 ```tsx
+import { PageNumber, TotalPages } from "takumi-pdf";
+
 const pdf = await render(report, {
   footer: (
     <div style={{ fontSize: 12 }}>
-      Page <span className="pageNumber" /> of <span className="totalPages" />
+      第 <PageNumber format="trad-chinese-informal" /> 頁,共{" "}
+      <TotalPages format="trad-chinese-informal" /> 頁
     </div>
   ),
 });
 ```
 
-Add a CSS counter-style name to the class list to format the number:
-
-```tsx
-footer: (
-  <div style={{ fontSize: 12 }}>
-    第 <span className="pageNumber trad-chinese-informal" /> 頁,共{" "}
-    <span className="totalPages trad-chinese-informal" /> 頁
-  </div>
-),
-```
+The primitives render class hooks, the same `pageNumber` / `totalPages` names Chromium's print templates use, so HTML input writes `<span class="pageNumber"></span>` directly.
 
 | Counter style                               | Example       |
 | ------------------------------------------- | ------------- |
@@ -166,9 +160,27 @@ const pdf = await render(
 | `break-inside: avoid`         | Keeps the element on one page when it fits.             |
 | `box-decoration-break: clone` | Repeats borders and backgrounds on every page fragment. |
 
+## Tables
+
+`<table>` markup lays out on shared column tracks, so column x positions stay identical across pages. A `<thead>` paints again at the top of every page its table continues onto, when it is at most a quarter of the page tall.
+
+```tsx
+const pdf = await render(
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Qty</th>
+      </tr>
+    </thead>
+    <tbody>{rows}</tbody>
+  </table>,
+);
+```
+
 ## Links, outline, and metadata
 
-Anchors with an `href` become clickable link annotations. `outline: true` builds PDF bookmarks from `h1` through `h6` headings. `metadata` fills the document properties:
+Anchors with an `href` become clickable link annotations. `<TargetPageNumber />` prints the page a link's target lands on, which is what a table of contents needs. `outline: true` builds PDF bookmarks from `h1` through `h6` headings. `metadata` fills the document properties:
 
 ```tsx
 const pdf = await render(report, {
@@ -188,7 +200,7 @@ Omit `metadata` to keep output byte-identical across runs.
 
 Output is **tagged by default**: HTML semantics (`h1` through `h6`, `p`, `img` with `alt`, `a`, lists) become a PDF structure tree, like Chromium's print-to-PDF. Set `tagged: "ua1"` to validate against PDF/UA-1, or `tagged: false` to drop the tree when file size matters more than accessibility.
 
-`<table>` markup is not supported, and a table built out of flex rows carries no `Table` structure elements.
+`<table>` markup lays out and paints, but carries no `Table` structure elements yet.
 
 `pdfa` renders archival output. Validation runs during rendering. A document that cannot conform fails with the violated rule instead of writing a broken file. Every level, and PDF/UA-1, passes [veraPDF](https://verapdf.org).
 

--- a/takumi-pdf-js/README.md
+++ b/takumi-pdf-js/README.md
@@ -162,7 +162,7 @@ const pdf = await render(
 
 ## Tables
 
-`<table>` markup lays out on shared column tracks, so column x positions stay identical across pages. A `<thead>` paints again at the top of every page its table continues onto, when it is at most a quarter of the page tall.
+`<table>` markup lays out on shared column tracks, so column x positions stay identical across pages. A `<thead>` paints again at the top of every page its table continues onto, when it is at most a quarter of the page tall and no header cell spans into the body.
 
 ```tsx
 const pdf = await render(

--- a/takumi-pdf-js/src/primitives.ts
+++ b/takumi-pdf-js/src/primitives.ts
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { CSSProperties, ReactElement } from "react";
 
 /**
  * A `@counter-style` name the page counters can format in, matching the set
@@ -44,7 +44,7 @@ export type CounterProps = {
   /** Counter style the number formats in. Defaults to decimal. */
   format?: CounterStyle;
   className?: string;
-  style?: Record<string, unknown>;
+  style?: CSSProperties;
   tw?: string;
 };
 


### PR DESCRIPTION
## Why

Both READMEs buried the quick start under a feature wall, and neither mentioned tables, repeated headers, or the new page counter primitives. The npm README still claimed `<table>` markup is not supported.

## What

The root README opens with the quick start, then the features; the PDF quick start uses `<PageNumber />` / `<TotalPages />`. The takumi-pdf README gains a Tables section (shared column tracks, `<thead>` repeating per page), rewrites headers-and-footers around the primitives with the class hooks kept for HTML input, points tables of contents at `<TargetPageNumber />`, and corrects the stale tagged-output note. The pagination docs page documents repeated headers with the quarter-page and rowspan rules.

Merged after #1302, which ships the primitives these examples import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PDF quick-start examples to use built-in `PageNumber` and `TotalPages` components for footer pagination.
  * Expanded header and footer guidance, including CSS counter formatting and link destination page numbers.
  * Added documentation for repeated table headers, shared column layouts, spacing, and pagination behavior.
  * Clarified table rendering in tagged PDFs and updated feature descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->