### PR TITLE
PDF: walk scene paints through one visitor

### DIFF
--- a/takumi-pdf/src/interactive.rs
+++ b/takumi-pdf/src/interactive.rs
@@ -15,7 +15,7 @@ use takumi_core::{
     },
     tree::RenderNode,
   },
-  scene::{NodePaint, PaintItemKind},
+  scene::NodePaint,
   style::{Affine, Position},
 };
 
@@ -135,29 +135,9 @@ pub(crate) fn collect_interactive(tree: &PreparedTree) -> Interactive {
     extents: HashMap::new(),
   };
 
-  collect_interactive_context(tree, 0, &mut collected);
+  tree.for_each_paint(|paint| collect_interactive_paint(tree, paint, &mut collected));
   collected.headings.sort_by(|a, b| a.top.total_cmp(&b.top));
   collected
-}
-
-fn collect_interactive_context(tree: &PreparedTree, id: usize, collected: &mut Interactive) {
-  let Some(context) = tree.contexts.get(id) else {
-    return;
-  };
-
-  if let Some(paint) = context.root() {
-    collect_interactive_paint(tree, paint, collected);
-  }
-  for bucket in context.in_paint_order() {
-    for item in bucket {
-      match &item.kind {
-        PaintItemKind::Node(paint) => collect_interactive_paint(tree, paint, collected),
-        PaintItemKind::Context(child) => {
-          collect_interactive_context(tree, *child, collected);
-        }
-      }
-    }
-  }
 }
 
 fn collect_interactive_paint(tree: &PreparedTree, paint: &NodePaint, collected: &mut Interactive) {

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, ops::Range};
 use takumi_core::{
   geometry::transformed_rect_extents,
   layout::node::Node,
-  scene::{NodePaint, PaintItemKind},
+  scene::NodePaint,
   style::{Affine, GridPlacement, GridPlacementSpan},
   viewport::Viewport,
 };
@@ -139,28 +139,10 @@ pub(crate) fn header_replays(
 fn collect_repeating_headers(tree: &PreparedTree, window: f32) -> Vec<HeaderBand> {
   let mut bands = Vec::new();
 
-  collect_headers_context(tree, 0, &mut bands);
+  tree.for_each_paint(|paint| collect_headers_paint(tree, paint, &mut bands));
   bands.retain(|band| band.height() > 0.0 && band.height() <= window / 4.0);
   bands.sort_by(|a, b| a.top.total_cmp(&b.top));
   bands
-}
-
-fn collect_headers_context(tree: &PreparedTree, id: usize, bands: &mut Vec<HeaderBand>) {
-  let Some(context) = tree.contexts.get(id) else {
-    return;
-  };
-
-  if let Some(paint) = context.root() {
-    collect_headers_paint(tree, paint, bands);
-  }
-  for bucket in context.in_paint_order() {
-    for item in bucket {
-      match &item.kind {
-        PaintItemKind::Node(paint) => collect_headers_paint(tree, paint, bands),
-        PaintItemKind::Context(child) => collect_headers_context(tree, *child, bands),
-      }
-    }
-  }
 }
 
 fn collect_headers_paint(tree: &PreparedTree, paint: &NodePaint, bands: &mut Vec<HeaderBand>) {

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -11,7 +11,7 @@ use takumi_core::{
     tree::{LayoutResults, LayoutTree, RenderNode},
   },
   resources::image::ImageSource,
-  scene::{StackingContextNode, build_stacking_contexts},
+  scene::{NodePaint, PaintItemKind, StackingContextNode, build_stacking_contexts},
   style::{
     Affine, ComputedStyle, Display, FlexDirection, FontFamily, Lang, Length, Position,
     SizingContext, Style, StyleDeclaration, StyleSheet, ZIndex,
@@ -77,6 +77,29 @@ impl PreparedTree {
       .is_some_and(
         |child| matches!(child.context.style.z_index, ZIndex::Integer(index) if index < 0),
       )
+  }
+
+  /// Visits every node paint of the scene, in paint order.
+  pub(crate) fn for_each_paint(&self, mut visit: impl FnMut(&NodePaint)) {
+    fn walk(tree: &PreparedTree, id: usize, visit: &mut impl FnMut(&NodePaint)) {
+      let Some(context) = tree.contexts.get(id) else {
+        return;
+      };
+
+      if let Some(paint) = context.root() {
+        visit(paint);
+      }
+      for bucket in context.in_paint_order() {
+        for item in bucket {
+          match &item.kind {
+            PaintItemKind::Node(paint) => visit(paint),
+            PaintItemKind::Context(child) => walk(tree, *child, visit),
+          }
+        }
+      }
+    }
+
+    walk(self, 0, &mut visit);
   }
 
   pub(crate) fn emitter<'a>(


### PR DESCRIPTION
Three hand-rolled copies of the same stacking-context walk (interactive, header bands, text boxes) collapse into `PreparedTree::for_each_paint`. Pure refactor; every fixture is byte-identical.