### PR TITLE
PDF: emit windowed content through one ContentWindow

### DIFF
--- a/takumi-pdf/src/bands.rs
+++ b/takumi-pdf/src/bands.rs
@@ -3,22 +3,17 @@
 
 use std::cell::RefCell;
 
-use takumi_core::{context::RenderContext, layout::node::Node, style::Affine, viewport::Viewport};
+use takumi_core::{context::RenderContext, layout::node::Node, viewport::Viewport};
 
 use crate::{
   counters::{has_page_counters, substitute_page_counters, substitute_target_counters},
   emitter::{FontMap, RenderIssues},
   interactive::{LinkTarget, collect_interactive},
-  krilla::{
-    geom::{Rect as KrillaRect, Transform},
-    paint::FillRule,
-    surface::Surface,
-    tagging::{Artifact, ArtifactType, ContentTag},
-  },
+  krilla::surface::Surface,
   options::{BAND_EDGE_PADDING, PdfError},
   page::PageFrame,
-  paint::rect_path,
   tree::{PreparedTree, RepeatedBox, RepeatedTemplate, TreeInputs, prepare_repeated, prepare_tree},
+  window::ContentWindow,
 };
 
 /// Where a repeatable draws on the page.
@@ -197,31 +192,21 @@ impl RepeatablePage<'_> {
     surface: &mut Surface,
   ) -> Result<(), PdfError> {
     let (x, y, width, height) = self.repeatable.bounds.rect(frame, self.repeatable.height());
-    let Some(path) = KrillaRect::from_xywh(x, y, width, height).and_then(rect_path) else {
-      return Ok(());
-    };
 
-    if artifact {
-      // `Other` stays valid below PDF 2.0, where the header/footer artifact
-      // subtypes do not exist yet.
-      surface.start_tagged(ContentTag::Artifact(Artifact::new(
-        ArtifactType::Other,
-        None,
-      )));
+    ContentWindow {
+      clip: (x, y, width, height),
+      translate: (x, y),
+      window: None,
+      x_window: None,
+      line_window: None,
+      artifact,
     }
-    surface.push_clip_path(&path, &FillRule::NonZero);
-    surface.push_transform(&Transform::from_translate(x, y));
-    let mut emitter = self
-      .tree()
-      .emitter(fonts, None, None, issues, document_lang);
-
-    emitter.emit_context(0, Affine::IDENTITY, surface)?;
-    surface.pop();
-    surface.pop();
-    if artifact {
-      surface.end_tagged();
-    }
-    Ok(())
+    .emit(
+      self
+        .tree()
+        .emitter(fonts, None, None, issues, document_lang),
+      surface,
+    )
   }
 }
 

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -60,6 +60,7 @@ mod shadow;
 mod svg;
 mod tags;
 mod tree;
+mod window;
 
 #[allow(
   dead_code,

--- a/takumi-pdf/src/page.rs
+++ b/takumi-pdf/src/page.rs
@@ -2,12 +2,7 @@
 
 use std::cell::RefCell;
 
-use takumi_core::{
-  context::RenderContext,
-  geometry::Rect,
-  style::{Affine, Color},
-  viewport::Viewport,
-};
+use takumi_core::{context::RenderContext, geometry::Rect, style::Color, viewport::Viewport};
 
 use crate::{
   bands::{Repeatable, RepeatablePage},
@@ -19,15 +14,14 @@ use crate::{
     destination::XyzDestination,
     geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
     page::PageSettings,
-    paint::FillRule,
     surface::Surface,
-    tagging::{Artifact, ArtifactType, ContentTag},
   },
   options::{PT_PER_PX, PageOptions, PdfError},
   pagination::{PageGeometry, PageSlice, Paginated, header_replays},
   paint::{fill_from_rgba, rect_path},
   tags::{TagCollector, tag_id},
   tree::TreeInputs,
+  window::ContentWindow,
 };
 
 /// Page geometry resolved once: everything derived from [`PageOptions`] and
@@ -276,41 +270,39 @@ impl PageComposer<'_, '_> {
     // Paint stops at the next cut: the region between a raised cut and the
     // page's full height belongs to the next page and stays blank, exactly
     // like browser print fragmentation.
-    let Some(path) = KrillaRect::from_xywh(
-      self.frame.margin.left,
-      self.frame.margin.top + slice.reserved,
-      self.frame.content_width,
-      slice.paint_height,
-    )
-    .and_then(rect_path) else {
-      return Ok(());
-    };
-
-    surface.push_clip_path(&path, &FillRule::NonZero);
-    surface.push_transform(&Transform::from_translate(
-      self.frame.margin.left,
-      self.frame.margin.top + slice.reserved - slice.start,
-    ));
-    let mut emitter = self.paginated.content.emitter(
-      self.fonts,
-      Some(self.inline_map),
-      self.tag_collector,
-      self.issues,
-      self.document_lang,
-    );
-
-    emitter.window = Some((slice.start, slice.start + slice.paint_height));
-    emitter.line_window = Some((
-      if slice.index == 0 {
-        f32::NEG_INFINITY
-      } else {
-        slice.start
-      },
-      slice.end,
-    ));
-    emitter.emit_context(0, Affine::IDENTITY, surface)?;
-    surface.pop();
-    surface.pop();
+    ContentWindow {
+      clip: (
+        self.frame.margin.left,
+        self.frame.margin.top + slice.reserved,
+        self.frame.content_width,
+        slice.paint_height,
+      ),
+      translate: (
+        self.frame.margin.left,
+        self.frame.margin.top + slice.reserved - slice.start,
+      ),
+      window: Some((slice.start, slice.start + slice.paint_height)),
+      x_window: None,
+      line_window: Some((
+        if slice.index == 0 {
+          f32::NEG_INFINITY
+        } else {
+          slice.start
+        },
+        slice.end,
+      )),
+      artifact: false,
+    }
+    .emit(
+      self.paginated.content.emitter(
+        self.fonts,
+        Some(self.inline_map),
+        self.tag_collector,
+        self.issues,
+        self.document_lang,
+      ),
+      surface,
+    )?;
     if slice.reserved > 0.0 {
       self.emit_repeated_headers(slice, surface)?;
     }
@@ -326,41 +318,34 @@ impl PageComposer<'_, '_> {
   ) -> Result<(), PdfError> {
     for (offset, index) in self.replays(slice) {
       let band = &self.paginated.headers[index];
+
       // Clipping to the table keeps content beside it out of the replay.
-      let Some(path) = KrillaRect::from_xywh(
-        self.frame.margin.left + band.left,
-        self.frame.margin.top + offset,
-        band.right - band.left,
-        band.height(),
-      )
-      .and_then(rect_path) else {
-        continue;
-      };
-
-      surface.start_tagged(ContentTag::Artifact(Artifact::new(
-        ArtifactType::Other,
-        None,
-      )));
-      surface.push_clip_path(&path, &FillRule::NonZero);
-      surface.push_transform(&Transform::from_translate(
-        self.frame.margin.left,
-        self.frame.margin.top + offset - band.top,
-      ));
-      let mut emitter = self.paginated.content.emitter(
-        self.fonts,
-        Some(self.inline_map),
-        None,
-        self.issues,
-        self.document_lang,
-      );
-
-      emitter.window = Some((band.top, band.bottom));
-      emitter.x_window = Some((band.left, band.right));
-      emitter.line_window = Some((f32::NEG_INFINITY, band.bottom));
-      emitter.emit_context(0, Affine::IDENTITY, surface)?;
-      surface.pop();
-      surface.pop();
-      surface.end_tagged();
+      ContentWindow {
+        clip: (
+          self.frame.margin.left + band.left,
+          self.frame.margin.top + offset,
+          band.right - band.left,
+          band.height(),
+        ),
+        translate: (
+          self.frame.margin.left,
+          self.frame.margin.top + offset - band.top,
+        ),
+        window: Some((band.top, band.bottom)),
+        x_window: Some((band.left, band.right)),
+        line_window: Some((f32::NEG_INFINITY, band.bottom)),
+        artifact: true,
+      }
+      .emit(
+        self.paginated.content.emitter(
+          self.fonts,
+          Some(self.inline_map),
+          None,
+          self.issues,
+          self.document_lang,
+        ),
+        surface,
+      )?;
     }
     Ok(())
   }

--- a/takumi-pdf/src/window.rs
+++ b/takumi-pdf/src/window.rs
@@ -1,0 +1,66 @@
+//! A clipped, translated window through which a prepared tree emits onto a page.
+
+use crate::{
+  emitter::Emitter,
+  krilla::{
+    geom::{Rect as KrillaRect, Transform},
+    paint::FillRule,
+    surface::Surface,
+    tagging::{Artifact, ArtifactType, ContentTag},
+  },
+  options::PdfError,
+  paint::rect_path,
+};
+use takumi_core::style::Affine;
+
+/// One windowed emit: the page-space clip, the content translation, the
+/// content windows the emitter filters by, and whether the content is a
+/// repeated artifact.
+pub(crate) struct ContentWindow {
+  /// Clip rect on the page, as `(x, y, width, height)`.
+  pub(crate) clip: (f32, f32, f32, f32),
+  /// Translation from content to page coordinates.
+  pub(crate) translate: (f32, f32),
+  pub(crate) window: Option<(f32, f32)>,
+  pub(crate) x_window: Option<(f32, f32)>,
+  pub(crate) line_window: Option<(f32, f32)>,
+  /// A repeated occurrence is an artifact: the first one carried the tags.
+  /// `Other` stays valid below PDF 2.0, where the header/footer artifact
+  /// subtypes do not exist yet.
+  pub(crate) artifact: bool,
+}
+
+impl ContentWindow {
+  pub(crate) fn emit(
+    &self,
+    mut emitter: Emitter<'_>,
+    surface: &mut Surface,
+  ) -> Result<(), PdfError> {
+    let (x, y, width, height) = self.clip;
+    let Some(path) = KrillaRect::from_xywh(x, y, width, height).and_then(rect_path) else {
+      return Ok(());
+    };
+
+    if self.artifact {
+      surface.start_tagged(ContentTag::Artifact(Artifact::new(
+        ArtifactType::Other,
+        None,
+      )));
+    }
+    surface.push_clip_path(&path, &FillRule::NonZero);
+    surface.push_transform(&Transform::from_translate(
+      self.translate.0,
+      self.translate.1,
+    ));
+    emitter.window = self.window;
+    emitter.x_window = self.x_window;
+    emitter.line_window = self.line_window;
+    emitter.emit_context(0, Affine::IDENTITY, surface)?;
+    surface.pop();
+    surface.pop();
+    if self.artifact {
+      surface.end_tagged();
+    }
+    Ok(())
+  }
+}


### PR DESCRIPTION
The same clip, translate, window, and artifact sequence appeared in `emit_content`, `emit_repeated_headers`, and `bands.rs`. One `ContentWindow` type owns it, and the post-hoc `emitter.window = …` assignments move inside. Pure refactor; every fixture is byte-identical.