### PR TITLE
PDF: move atom collection off the emitter

### DIFF
--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -1,0 +1,186 @@
+//! Unsplittable vertical extents and paragraphs collected from the laid-out
+//! scene, which pagination cuts around.
+
+use takumi_core::{
+  font_style::SizedFontStyle,
+  geometry::ComputedLayout as Layout,
+  layout::{
+    node::NodeKind,
+    tree::{LayoutResults, RenderNode},
+  },
+  scene::{NodePaint, PaintItemKind, StackingContextNode},
+  style::{Affine, BreakBetween, BreakInside},
+};
+
+use crate::{
+  inline::{
+    InlineMap, build_inline_runs, inline_box_atoms, inline_key, node_inline_items, text_line_atoms,
+  },
+  options::PdfError,
+  pagination::{Atom, Paragraph},
+};
+
+/// Walks the scene like the emitter, recording unsplittable vertical extents
+/// instead of painting.
+pub(crate) struct AtomCollector<'a> {
+  pub(crate) root: &'a RenderNode,
+  pub(crate) contexts: &'a [StackingContextNode],
+  pub(crate) results: &'a LayoutResults,
+  pub(crate) inline: Option<&'a InlineMap<'a>>,
+}
+
+impl AtomCollector<'_> {
+  pub(crate) fn collect(
+    &self,
+    atoms: &mut Vec<Atom>,
+    forced: &mut Vec<f32>,
+    paragraphs: &mut Vec<Paragraph>,
+  ) -> Result<(), PdfError> {
+    self.context_atoms(0, Affine::IDENTITY, atoms, forced, paragraphs)
+  }
+}
+
+/// Records the box's lines as a [`Paragraph`] for the widow/orphan solver.
+fn push_paragraph(node: &RenderNode, lines: &[Atom], paragraphs: &mut Vec<Paragraph>) {
+  let style = &node.context.style;
+  let before = style.orphans.get();
+  let after = style.widows.get();
+
+  if lines.len() < 2 || (before <= 1 && after <= 1) {
+    return;
+  }
+  let mut lines = lines.to_vec();
+
+  lines.sort_by(|a, b| a.0.total_cmp(&b.0));
+  paragraphs.push(Paragraph {
+    lines,
+    before,
+    after,
+  });
+}
+
+impl AtomCollector<'_> {
+  fn context_atoms(
+    &self,
+    id: usize,
+    parent: Affine,
+    atoms: &mut Vec<Atom>,
+    forced: &mut Vec<f32>,
+    paragraphs: &mut Vec<Paragraph>,
+  ) -> Result<(), PdfError> {
+    let Some(context) = self.contexts.get(id) else {
+      return Ok(());
+    };
+
+    let child_frame = match context.root() {
+      Some(paint) => self.box_atoms(paint, parent, atoms, forced, paragraphs)?,
+      None => parent,
+    };
+
+    for bucket in context.in_paint_order() {
+      for item in bucket {
+        match &item.kind {
+          PaintItemKind::Node(paint) => {
+            self.box_atoms(paint, child_frame, atoms, forced, paragraphs)?;
+          }
+          PaintItemKind::Context(child) => {
+            self.context_atoms(*child, child_frame, atoms, forced, paragraphs)?;
+          }
+        }
+      }
+    }
+    Ok(())
+  }
+
+  /// Records one node's atoms and returns the frame its children sit in. A
+  /// node painted under a non-translation transform becomes a single atom
+  /// spanning its device bounds — windowing through a rotation would distort.
+  fn box_atoms(
+    &self,
+    paint: &NodePaint,
+    parent: Affine,
+    atoms: &mut Vec<Atom>,
+    forced: &mut Vec<f32>,
+    paragraphs: &mut Vec<Paragraph>,
+  ) -> Result<Affine, PdfError> {
+    let Some(node) = self.root.node_at_path(&paint.path) else {
+      return Ok(parent);
+    };
+    let Ok(layout) = self.results.layout(paint.node_id) else {
+      return Ok(parent);
+    };
+
+    let relative = parent.invert().unwrap_or(Affine::IDENTITY) * paint.transform;
+    if !relative.only_translation() {
+      if let Some(bounds) = paint.paint_bounds {
+        atoms.push((bounds.top as f32, bounds.bottom as f32));
+      }
+      return Ok(parent * relative);
+    }
+    let y = relative.y;
+    let style = &node.context.style;
+
+    if style.break_before == BreakBetween::Page {
+      forced.push(y);
+    }
+    if style.break_after == BreakBetween::Page {
+      forced.push(y + layout.size.height);
+    }
+    if style.break_inside == BreakInside::Avoid {
+      atoms.push((y, y + layout.size.height));
+    }
+
+    if node.should_create_inline_layout() {
+      self.text_atoms(node, layout, y, atoms, paragraphs)?;
+    } else if !node.has_anonymous_text_item_child() {
+      match node.node.as_ref().map(|n| &n.kind) {
+        Some(NodeKind::Text(_)) => {
+          self.text_atoms(node, layout, y, atoms, paragraphs)?;
+        }
+        Some(NodeKind::Image(_)) => {
+          atoms.push((y, y + layout.size.height));
+        }
+        _ => {}
+      }
+    }
+    Ok(parent)
+  }
+
+  /// One atom per text line: the union of each run's ascent-to-descent band.
+  /// The lines also form one [`Paragraph`] for the widow/orphan solver.
+  fn text_atoms(
+    &self,
+    node: &RenderNode,
+    layout: Layout,
+    y: f32,
+    atoms: &mut Vec<Atom>,
+    paragraphs: &mut Vec<Paragraph>,
+  ) -> Result<(), PdfError> {
+    let start = atoms.len();
+    let owned_runs;
+    let runs = match self.inline.and_then(|map| map.get(&inline_key(node))) {
+      Some(prepared) => &prepared.runs,
+      None => {
+        let context = &node.context;
+        let Some(items) = node_inline_items(node) else {
+          return Ok(());
+        };
+        let font_style = SizedFontStyle::from_style(&context.style, context);
+        let Some((_, runs)) = build_inline_runs(items, &font_style, context, layout)? else {
+          return Ok(());
+        };
+
+        owned_runs = runs;
+        &owned_runs
+      }
+    };
+
+    text_line_atoms(runs, layout, y, atoms);
+    // Box bands are indivisible but not text lines, so widow/orphan control
+    // does not count them.
+    let paragraph_end = atoms.len();
+    inline_box_atoms(runs, layout, y, atoms);
+    push_paragraph(node, &atoms[start..paragraph_end], paragraphs);
+    Ok(())
+  }
+}

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -32,8 +32,8 @@ use takumi_core::{
   shadow::SizedShadow,
   style::{
     Affine, BackgroundClip, BackgroundImage, BackgroundOrigin, BlendMode, BoxDecorationBreak,
-    BreakBetween, BreakInside, Color, Display, FillRule as CoreFillRule, Filter, Isolation, Lang,
-    ResolvedGradientStop, TextDecorationLines,
+    Color, Display, FillRule as CoreFillRule, Filter, Isolation, Lang, ResolvedGradientStop,
+    TextDecorationLines,
   },
 };
 
@@ -47,9 +47,7 @@ use crate::{
   background::{Placement, cycled, place},
   filter::{ColorFilter, unsupported_filter},
   glyph::run_glyphs,
-  inline::{
-    InlineMap, build_inline_runs, inline_box_atoms, inline_key, node_inline_items, text_line_atoms,
-  },
+  inline::{InlineMap, build_inline_runs, inline_key, node_inline_items},
   krilla::{
     Data,
     geom::{Point, Rect as KrillaRect, Transform},
@@ -64,7 +62,6 @@ use crate::{
     text::{Font, Tag},
   },
   options::PdfError,
-  pagination::{Atom, Paragraph},
   paint::{
     empty_path, expanded_radial_stops, fill_from_rgba, krilla_blend, krilla_path, krilla_stop,
     krilla_stops, overflow_clip_rect, pop_transforms, rect_path, spread,
@@ -1828,153 +1825,6 @@ impl Emitter<'_> {
 
     self.fonts.insert(key, font.clone());
     Some(font)
-  }
-}
-
-/// Records the box's lines as a [`Paragraph`] for the widow/orphan solver.
-fn push_paragraph(node: &RenderNode, lines: &[Atom], paragraphs: &mut Vec<Paragraph>) {
-  let style = &node.context.style;
-  let before = style.orphans.get();
-  let after = style.widows.get();
-
-  if lines.len() < 2 || (before <= 1 && after <= 1) {
-    return;
-  }
-  let mut lines = lines.to_vec();
-
-  lines.sort_by(|a, b| a.0.total_cmp(&b.0));
-  paragraphs.push(Paragraph {
-    lines,
-    before,
-    after,
-  });
-}
-
-impl Emitter<'_> {
-  /// Mirrors [`Self::emit_context`] but records unsplittable vertical extents
-  /// instead of painting.
-  pub(crate) fn collect_atoms(
-    &mut self,
-    id: usize,
-    parent: Affine,
-    atoms: &mut Vec<Atom>,
-    forced: &mut Vec<f32>,
-    paragraphs: &mut Vec<Paragraph>,
-  ) -> Result<(), PdfError> {
-    let Some(context) = self.contexts.get(id) else {
-      return Ok(());
-    };
-
-    let child_frame = match context.root() {
-      Some(paint) => self.collect_box_atoms(paint, parent, atoms, forced, paragraphs)?,
-      None => parent,
-    };
-
-    for bucket in context.in_paint_order() {
-      for item in bucket {
-        match &item.kind {
-          PaintItemKind::Node(paint) => {
-            self.collect_box_atoms(paint, child_frame, atoms, forced, paragraphs)?;
-          }
-          PaintItemKind::Context(child) => {
-            self.collect_atoms(*child, child_frame, atoms, forced, paragraphs)?;
-          }
-        }
-      }
-    }
-    Ok(())
-  }
-
-  /// Records one node's atoms and returns the frame its children sit in. A
-  /// node painted under a non-translation transform becomes a single atom
-  /// spanning its device bounds — windowing through a rotation would distort.
-  fn collect_box_atoms(
-    &mut self,
-    paint: &NodePaint,
-    parent: Affine,
-    atoms: &mut Vec<Atom>,
-    forced: &mut Vec<f32>,
-    paragraphs: &mut Vec<Paragraph>,
-  ) -> Result<Affine, PdfError> {
-    let Some(node) = self.root.node_at_path(&paint.path) else {
-      return Ok(parent);
-    };
-    let Ok(layout) = self.results.layout(paint.node_id) else {
-      return Ok(parent);
-    };
-
-    let relative = parent.invert().unwrap_or(Affine::IDENTITY) * paint.transform;
-    if !relative.only_translation() {
-      if let Some(bounds) = paint.paint_bounds {
-        atoms.push((bounds.top as f32, bounds.bottom as f32));
-      }
-      return Ok(parent * relative);
-    }
-    let y = relative.y;
-    let style = &node.context.style;
-
-    if style.break_before == BreakBetween::Page {
-      forced.push(y);
-    }
-    if style.break_after == BreakBetween::Page {
-      forced.push(y + layout.size.height);
-    }
-    if style.break_inside == BreakInside::Avoid {
-      atoms.push((y, y + layout.size.height));
-    }
-
-    if node.should_create_inline_layout() {
-      self.collect_text_atoms(node, layout, y, atoms, paragraphs)?;
-    } else if !node.has_anonymous_text_item_child() {
-      match node.node.as_ref().map(|n| &n.kind) {
-        Some(NodeKind::Text(_)) => {
-          self.collect_text_atoms(node, layout, y, atoms, paragraphs)?;
-        }
-        Some(NodeKind::Image(_)) => {
-          atoms.push((y, y + layout.size.height));
-        }
-        _ => {}
-      }
-    }
-    Ok(parent)
-  }
-
-  /// One atom per text line: the union of each run's ascent-to-descent band.
-  /// The lines also form one [`Paragraph`] for the widow/orphan solver.
-  fn collect_text_atoms(
-    &mut self,
-    node: &RenderNode,
-    layout: Layout,
-    y: f32,
-    atoms: &mut Vec<Atom>,
-    paragraphs: &mut Vec<Paragraph>,
-  ) -> Result<(), PdfError> {
-    let start = atoms.len();
-    let owned_runs;
-    let runs = match self.inline.and_then(|map| map.get(&inline_key(node))) {
-      Some(prepared) => &prepared.runs,
-      None => {
-        let context = &node.context;
-        let Some(items) = node_inline_items(node) else {
-          return Ok(());
-        };
-        let font_style = SizedFontStyle::from_style(&context.style, context);
-        let Some((_, runs)) = build_inline_runs(items, &font_style, context, layout)? else {
-          return Ok(());
-        };
-
-        owned_runs = runs;
-        &owned_runs
-      }
-    };
-
-    text_line_atoms(runs, layout, y, atoms);
-    // Box bands are indivisible but not text lines, so widow/orphan control
-    // does not count them.
-    let paragraph_end = atoms.len();
-    inline_box_atoms(runs, layout, y, atoms);
-    push_paragraph(node, &atoms[start..paragraph_end], paragraphs);
-    Ok(())
   }
 }
 

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -39,6 +39,7 @@
 
 use std::{cell::RefCell, mem::take, rc::Rc};
 
+mod atoms;
 mod background;
 mod bands;
 mod counters;
@@ -294,14 +295,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       let dynamic = header.as_ref().is_some_and(Repeatable::dynamic)
         || footer.as_ref().is_some_and(Repeatable::dynamic);
       let source = dynamic.then(|| options.node.clone());
-      let mut paginated = paginate(
-        options.node,
-        &inputs,
-        &mut fonts,
-        &issues,
-        document_lang,
-        &frame.geometry(),
-      )?;
+      let mut paginated = paginate(options.node, &inputs, &frame.geometry())?;
 
       if let Some(source) = source {
         const BAND_PASSES: usize = 3;
@@ -319,14 +313,7 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
             break;
           }
           frame = resolve(header.as_ref(), footer.as_ref())?;
-          paginated = paginate(
-            source.clone(),
-            &inputs,
-            &mut fonts,
-            &issues,
-            document_lang,
-            &frame.geometry(),
-          )?;
+          paginated = paginate(source.clone(), &inputs, &frame.geometry())?;
         }
       }
 

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -1,12 +1,12 @@
 //! Cutting the content column into pages without splitting unsplittable atoms.
 
-use std::{cell::RefCell, ops::Range};
+use std::ops::Range;
 
 use takumi_core::{
   geometry::transformed_rect_extents,
   layout::node::Node,
   scene::NodePaint,
-  style::{Affine, GridPlacement, GridPlacementSpan},
+  style::{GridPlacement, GridPlacementSpan},
   viewport::Viewport,
 };
 
@@ -14,7 +14,6 @@ use crate::{
   counters::{
     BoxPages, FlowCounters, has_page_counters, has_target_counters, substitute_target_counters,
   },
-  emitter::{FontMap, RenderIssues},
   inline::{build_inline_map, collect_text_boxes},
   interactive::{Interactive, collect_interactive},
   options::PdfError,
@@ -301,19 +300,16 @@ pub(crate) struct PageGeometry {
 pub(crate) fn paginate(
   mut node: Node,
   inputs: &TreeInputs<'_>,
-  fonts: &mut FontMap,
-  issues: &RefCell<RenderIssues>,
-  document_lang: Option<&str>,
   geometry: &PageGeometry,
 ) -> Result<Paginated, PdfError> {
   if !has_page_counters(&node) && !has_target_counters(&node) {
-    return paginate_once(node, inputs, fonts, issues, document_lang, geometry);
+    return paginate_once(node, inputs, geometry);
   }
   let mut previous: Vec<String> = Vec::new();
   let mut passes = 0;
 
   loop {
-    let paginated = paginate_once(node.clone(), inputs, fonts, issues, document_lang, geometry)?;
+    let paginated = paginate_once(node.clone(), inputs, geometry)?;
     let pages = paginated.starts.len();
     let mut written = Vec::new();
 
@@ -328,7 +324,7 @@ pub(crate) fn paginate(
     // The numbers are still moving, and this was the last pass allowed. They
     // are laid out once more so the page shows the numbers it was cut with.
     if passes == COUNTER_PASSES {
-      return paginate_once(node, inputs, fonts, issues, document_lang, geometry);
+      return paginate_once(node, inputs, geometry);
     }
   }
 }
@@ -374,9 +370,6 @@ fn substitute_counters(node: &mut Node, paginated: &Paginated, written: &mut Vec
 fn paginate_once(
   node: Node,
   inputs: &TreeInputs<'_>,
-  fonts: &mut FontMap,
-  issues: &RefCell<RenderIssues>,
-  document_lang: Option<&str>,
   geometry: &PageGeometry,
 ) -> Result<Paginated, PdfError> {
   let (content, repeated) =
@@ -388,14 +381,8 @@ fn paginate_once(
   let mut paragraphs = Vec::new();
 
   content
-    .emitter(fonts, Some(&inline_map), None, issues, document_lang)
-    .collect_atoms(
-      0,
-      Affine::IDENTITY,
-      &mut atoms,
-      &mut forced,
-      &mut paragraphs,
-    )?;
+    .atom_collector(Some(&inline_map))
+    .collect(&mut atoms, &mut forced, &mut paragraphs)?;
 
   let headers = collect_repeating_headers(&content, geometry.window_height);
 

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -20,6 +20,7 @@ use takumi_core::{
 };
 
 use crate::{
+  atoms::AtomCollector,
   counters::{has_page_counters, substitute_page_counters},
   emitter::{Emitter, FontMap, RenderIssues},
   inline::InlineMap,
@@ -77,6 +78,19 @@ impl PreparedTree {
       .is_some_and(
         |child| matches!(child.context.style.z_index, ZIndex::Integer(index) if index < 0),
       )
+  }
+
+  /// The scene's atom collector, for pagination.
+  pub(crate) fn atom_collector<'a>(
+    &'a self,
+    inline: Option<&'a InlineMap<'a>>,
+  ) -> AtomCollector<'a> {
+    AtomCollector {
+      root: &self.root,
+      contexts: &self.contexts,
+      results: &self.results,
+      inline,
+    }
   }
 
   /// Visits every node paint of the scene, in paint order.


### PR DESCRIPTION
Atom collection lived on `Emitter` but used none of its paint state. An `AtomCollector` of four read-only refs owns it, and `paginate` drops the fonts/issues plumbing it never needed. Pure refactor; every fixture is byte-identical.