### PR TITLE
Core, PDF: retire address-based cache keys

### DIFF
--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -451,7 +451,7 @@ pub(crate) fn match_stylesheets_view<'a>(
 
   let mut ancestor_bloom_filter = BloomFilter::new();
   let mut ancestor_stack: Vec<usize> = Vec::new();
-  let mut selector_ancestor_hashes_cache: HashMap<usize, AncestorHashes> = HashMap::new();
+  let mut selector_ancestor_hashes_cache: HashMap<(usize, usize), AncestorHashes> = HashMap::new();
 
   let mut element_caches = SelectorCaches::default();
   let mut pseudo_caches = SelectorCaches::default();
@@ -496,7 +496,7 @@ pub(crate) fn match_stylesheets_view<'a>(
       let mut best_before: Option<u32> = None;
       let mut best_after: Option<u32> = None;
 
-      for selector in rule.selectors().slice() {
+      for (selector_index, selector) in rule.selectors().slice().iter().enumerate() {
         let Some(target) = selector_target(selector) else {
           continue;
         };
@@ -504,7 +504,7 @@ pub(crate) fn match_stylesheets_view<'a>(
           continue;
         }
 
-        let selector_key = selector as *const _ as usize;
+        let selector_key = (source_order, selector_index);
         let ancestor_hashes = selector_ancestor_hashes_cache
           .entry(selector_key)
           .or_insert_with(|| AncestorHashes::new(selector, QuirksMode::NoQuirks));

--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -3,7 +3,7 @@
 
 use takumi_core::{
   font_style::SizedFontStyle,
-  geometry::ComputedLayout as Layout,
+  geometry::{ComputedLayout as Layout, NodeId},
   layout::{
     node::NodeKind,
     tree::{LayoutResults, RenderNode},
@@ -13,9 +13,7 @@ use takumi_core::{
 };
 
 use crate::{
-  inline::{
-    InlineMap, build_inline_runs, inline_box_atoms, inline_key, node_inline_items, text_line_atoms,
-  },
+  inline::{InlineMap, build_inline_runs, inline_box_atoms, node_inline_items, text_line_atoms},
   options::PdfError,
   pagination::{Atom, Paragraph},
 };
@@ -131,11 +129,11 @@ impl AtomCollector<'_> {
     }
 
     if node.should_create_inline_layout() {
-      self.text_atoms(node, layout, y, atoms, paragraphs)?;
+      self.text_atoms(node, paint.node_id, layout, y, atoms, paragraphs)?;
     } else if !node.has_anonymous_text_item_child() {
       match node.node.as_ref().map(|n| &n.kind) {
         Some(NodeKind::Text(_)) => {
-          self.text_atoms(node, layout, y, atoms, paragraphs)?;
+          self.text_atoms(node, paint.node_id, layout, y, atoms, paragraphs)?;
         }
         Some(NodeKind::Image(_)) => {
           atoms.push((y, y + layout.size.height));
@@ -151,6 +149,7 @@ impl AtomCollector<'_> {
   fn text_atoms(
     &self,
     node: &RenderNode,
+    node_id: NodeId,
     layout: Layout,
     y: f32,
     atoms: &mut Vec<Atom>,
@@ -158,7 +157,7 @@ impl AtomCollector<'_> {
   ) -> Result<(), PdfError> {
     let start = atoms.len();
     let owned_runs;
-    let runs = match self.inline.and_then(|map| map.get(&inline_key(node))) {
+    let runs = match self.inline.and_then(|map| map.get(&node_id)) {
       Some(prepared) => &prepared.runs,
       None => {
         let context = &node.context;

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -47,7 +47,7 @@ use crate::{
   background::{Placement, cycled, place},
   filter::{ColorFilter, unsupported_filter},
   glyph::run_glyphs,
-  inline::{InlineMap, build_inline_runs, inline_key, node_inline_items},
+  inline::{InlineMap, build_inline_runs, node_inline_items},
   krilla::{
     Data,
     geom::{Point, Rect as KrillaRect, Transform},
@@ -468,7 +468,7 @@ impl Emitter<'_> {
         }
       }
     }
-    self.emit_own_content(node, layout, x, y, surface)?;
+    self.emit_own_content(node, paint.node_id, layout, x, y, surface)?;
     if tagged {
       surface.end_tagged();
     }
@@ -1079,19 +1079,20 @@ impl Emitter<'_> {
   fn emit_own_content(
     &mut self,
     node: &RenderNode,
+    node_id: NodeId,
     layout: Layout,
     x: f32,
     y: f32,
     surface: &mut Surface,
   ) -> Result<(), PdfError> {
     if node.should_create_inline_layout() {
-      return self.emit_node_text(node, layout, x, y, surface);
+      return self.emit_node_text(node, node_id, layout, x, y, surface);
     }
     if node.has_anonymous_text_item_child() {
       return Ok(());
     }
     match node.node.as_ref().map(|n| &n.kind) {
-      Some(NodeKind::Text(_)) => self.emit_node_text(node, layout, x, y, surface),
+      Some(NodeKind::Text(_)) => self.emit_node_text(node, node_id, layout, x, y, surface),
       #[cfg(feature = "images")]
       Some(NodeKind::Image(image)) => {
         self.emit_image(image, &node.context, layout, x, y, surface);
@@ -1229,12 +1230,13 @@ impl Emitter<'_> {
   fn emit_node_text(
     &mut self,
     node: &RenderNode,
+    node_id: NodeId,
     layout: Layout,
     x: f32,
     y: f32,
     surface: &mut Surface,
   ) -> Result<(), PdfError> {
-    if let Some(prepared) = self.inline.and_then(|map| map.get(&inline_key(node))) {
+    if let Some(prepared) = self.inline.and_then(|map| map.get(&node_id)) {
       let font_style = SizedFontStyle::from_style(&node.context.style, &node.context);
 
       return self.draw_runs(

--- a/takumi-pdf/src/inline.rs
+++ b/takumi-pdf/src/inline.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use takumi_core::{
   context::RenderContext,
   font_style::SizedFontStyle,
-  geometry::ComputedLayout as Layout,
+  geometry::{ComputedLayout as Layout, NodeId},
   layout::{
     inline::{
       BuiltInlineLayout, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineRunLayout,
@@ -14,7 +14,7 @@ use takumi_core::{
     node::{NodeKind, TextData},
     tree::RenderNode,
   },
-  scene::{NodePaint, PaintItemKind},
+  scene::NodePaint,
 };
 
 use crate::{options::PdfError, pagination::Atom, tree::PreparedTree};
@@ -26,44 +26,23 @@ pub(crate) struct PreparedInline<'c> {
   pub(crate) runs: InlineRunLayout,
 }
 
-/// Inline layouts keyed by the source [`RenderNode`]'s address.
-pub(crate) type InlineMap<'c> = HashMap<usize, PreparedInline<'c>>;
-
-pub(crate) fn inline_key(node: &RenderNode) -> usize {
-  std::ptr::from_ref(node) as usize
-}
+/// Inline layouts keyed by the box's layout [`NodeId`].
+pub(crate) type InlineMap<'c> = HashMap<NodeId, PreparedInline<'c>>;
 
 /// The text-bearing boxes of a prepared tree, with the resolved font style
 /// each inline layout borrows.
 pub(crate) fn collect_text_boxes<'t>(tree: &'t PreparedTree) -> Vec<TextBox<'t>> {
   let mut boxes = Vec::new();
 
-  collect_text_boxes_context(tree, 0, &mut boxes);
+  tree.for_each_paint(|paint| collect_text_boxes_paint(tree, paint, &mut boxes));
   boxes
 }
 
 pub(crate) struct TextBox<'t> {
   node: &'t RenderNode,
+  node_id: NodeId,
   layout: Layout,
   font_style: SizedFontStyle<'t>,
-}
-
-fn collect_text_boxes_context<'t>(tree: &'t PreparedTree, id: usize, boxes: &mut Vec<TextBox<'t>>) {
-  let Some(context) = tree.contexts.get(id) else {
-    return;
-  };
-
-  if let Some(paint) = context.root() {
-    collect_text_boxes_paint(tree, paint, boxes);
-  }
-  for bucket in context.in_paint_order() {
-    for item in bucket {
-      match &item.kind {
-        PaintItemKind::Node(paint) => collect_text_boxes_paint(tree, paint, boxes),
-        PaintItemKind::Context(child) => collect_text_boxes_context(tree, *child, boxes),
-      }
-    }
-  }
 }
 
 fn collect_text_boxes_paint<'t>(
@@ -84,6 +63,7 @@ fn collect_text_boxes_paint<'t>(
   if is_text {
     boxes.push(TextBox {
       node,
+      node_id: paint.node_id,
       layout,
       font_style: SizedFontStyle::from_style(&node.context.style, &node.context),
     });
@@ -110,7 +90,7 @@ pub(crate) fn build_inline_map<'c>(boxes: &'c [TextBox<'c>]) -> Result<InlineMap
       &text_box.node.context,
       text_box.layout,
     )? {
-      map.insert(inline_key(text_box.node), PreparedInline { built, runs });
+      map.insert(text_box.node_id, PreparedInline { built, runs });
     }
   }
   Ok(map)


### PR DESCRIPTION
Two address-based cache keys retire: the inline layout map keys by the box's layout `NodeId`, and the selector ancestor-hashes cache keys by `(rule, selector)` index. Both were safe within one pass, and both were the same address-reuse collision that once broke ShapeCache. Pure refactor; every fixture is byte-identical.