### PR TITLE
PDF: type the bundler entries' default export

### DIFF
--- a/.tegami/bundler-default-type.md
+++ b/.tegami/bundler-default-type.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "takumi-pdf":
+    type: patch
+---
+
+### Type the bundler entries' default export
+
+`export *` does not forward a default export, so the wasm init default was untyped on every bundler entry.

--- a/takumi-pdf-js/bundlers/node.d.ts
+++ b/takumi-pdf-js/bundlers/node.d.ts
@@ -1,1 +1,2 @@
 export * from "../dist/export.mjs";
+export { default } from "../dist/export.mjs";


### PR DESCRIPTION
`bundlers/node.mjs` exports the wasm init as default, but `node.d.ts` only had `export *`, which does not forward a default. Callers of `mod.default` (pdfcn among them) got a type error on an export that exists at runtime. Found while validating pdfcn against the local build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default export support to the Node bundler entrypoint, alongside existing named exports.

* **Documentation**
  * Added guidance on typing default exports for bundler entries, including WebAssembly initializer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->