### PR TITLE
CI: deploy docs only when docs changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -891,10 +891,30 @@ jobs:
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           NPM_CONFIG_PROVENANCE: true
 
+  docs-changed:
+    name: Docs changed
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            docs:
+              - "docs/**"
+              - "bun.lock"
+
   deploy-docs:
     name: Deploy docs
     runs-on: ubuntu-slim
-    needs: pass-test
+    needs: [pass-test, docs-changed]
+    if: needs.docs-changed.outputs.docs == 'true'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Every PR paid for a Vercel preview build even when it touched no docs. A `docs-changed` job filters on `docs/**` and `bun.lock`, and `deploy-docs` runs only when it reports a change. The trade-off, deliberate: an engine-only change no longer redeploys the site, so the playground picks the new engine up with the next docs change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation deployments now run only when documentation-related files or the lockfile change.
  * Documentation deployment continues to require successful tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->