### PR TITLE
CI: keep credentials out of the docs detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -901,6 +901,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter


### PR DESCRIPTION
The `docs-changed` job only reads the diff, so its checkout sets `persist-credentials: false`. From CodeRabbit's review of #1310.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation validation workflow to improve credential handling during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->