### PR TITLE
CI: keep renovate off the layout and font stack

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "group:allNonMajor"],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "taffy",
+        "parley",
+        "fontique",
+        "skrifa",
+        "read-fonts",
+        "font-types",
+        "write-fonts"
+      ],
+      "enabled": false,
+      "description": "The layout and font stack moves by hand: taffy is pinned by decision, and the fontations family is chained to the hinting-gate fork and parley's semver."
+    }
+  ]
 }


### PR DESCRIPTION
Renovate's non-major group bumped taffy to 0.13, which the workspace pins at 0.11 by decision, and the fontations family cannot move independently of the hinting-gate fork and parley's `^0.44`. Those crates now move by hand; renovate keeps everything else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated update settings for selected layout and font packages.
  * Helps keep visual presentation-related components stable by preventing unintended update changes.
  * Other automated update labeling behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->