### PR TITLE
Docs: use a real table in the report template and type the playground imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ await writeFile("./output.png", image);
 ### PDF
 
 ```tsx
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 import { writeFile } from "node:fs/promises";
 
 const pdf = await render(<Invoice data={data} />, {

--- a/docs/app/components/playground/component-editor.tsx
+++ b/docs/app/components/playground/component-editor.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
 import { createHighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine-oniguruma.mjs";
+import pdfPrimitivesTypings from "../../../node_modules/takumi-pdf/dist/primitives.d.mts?raw";
 import takumiTypings from "../../../node_modules/@takumi-rs/wasm/pkg/takumi_wasm_bg.wasm.d.ts?raw";
 import reactTypings from "../../../node_modules/@types/react/index.d.ts?raw";
 import reactJsxRuntimeTypings from "../../../node_modules/@types/react/jsx-runtime.d.ts?raw";
@@ -137,6 +138,14 @@ export function ComponentEditor({
           {
             content: takumiTypings,
             filePath: "file:///node_modules/@takumi-rs/wasm/index.d.ts",
+          },
+          {
+            content: pdfPrimitivesTypings,
+            filePath: "file:///node_modules/takumi-pdf/index.d.ts",
+          },
+          {
+            content: pdfPrimitivesTypings,
+            filePath: "file:///node_modules/takumi-pdf/primitives.d.ts",
           },
           {
             content: playgroundOptionsTypings,

--- a/docs/app/components/playground/component-editor.tsx
+++ b/docs/app/components/playground/component-editor.tsx
@@ -141,10 +141,6 @@ export function ComponentEditor({
           },
           {
             content: pdfPrimitivesTypings,
-            filePath: "file:///node_modules/takumi-pdf/index.d.ts",
-          },
-          {
-            content: pdfPrimitivesTypings,
             filePath: "file:///node_modules/takumi-pdf/primitives.d.ts",
           },
           {

--- a/docs/app/playground/evaluate.ts
+++ b/docs/app/playground/evaluate.ts
@@ -7,7 +7,6 @@ import { optionsSchema } from "./schema";
 /// Modules a template may import. The wasm entry stays out: the playground
 /// renders through its own worker.
 const MODULES: Record<string, unknown> = {
-  "takumi-pdf": primitives,
   "takumi-pdf/primitives": primitives,
 };
 

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -1,4 +1,4 @@
-import { PageNumber, TotalPages } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const sections = [
   {

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -24,8 +24,11 @@ const sections = [
   },
 ];
 
-const weeks = Array.from({ length: 84 }, (_, index) => ({
-  week: `W${String(index + 1).padStart(2, "0")}`,
+const days = Array.from({ length: 90 }, (_, index) => ({
+  day: new Date(2026, 0, index + 1).toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+  }),
   median: 41 - (index % 13),
   p95: 96 - (index % 13) * 2,
   size: 78 - (index % 13) * 1.2,
@@ -52,21 +55,27 @@ export default function Report() {
         </div>
       ))}
 
-      <h2 tw="mt-8 mb-0 text-lg font-semibold">Weekly measurements</h2>
-      <div tw="mt-3 flex border-b border-[#e5e7eb] pb-2 text-[11px] font-semibold text-[#6b7280]">
-        <span tw="flex-1">Week</span>
-        <span tw="w-[110px] text-right">Median (ms)</span>
-        <span tw="w-[110px] text-right">p95 (ms)</span>
-        <span tw="w-[110px] text-right">Size (KB)</span>
-      </div>
-      {weeks.map((row) => (
-        <div key={row.week} tw="flex break-inside-avoid pt-2 text-xs">
-          <span tw="flex-1">{row.week}</span>
-          <span tw="w-[110px] text-right text-[#374151]">{row.median}</span>
-          <span tw="w-[110px] text-right text-[#374151]">{row.p95}</span>
-          <span tw="w-[110px] text-right text-[#374151]">{row.size.toFixed(1)}</span>
-        </div>
-      ))}
+      <h2 tw="mt-8 mb-0 text-lg font-semibold">Daily measurements</h2>
+      <table tw="mt-3 w-full text-xs">
+        <thead>
+          <tr tw="text-[11px] font-semibold text-[#6b7280]">
+            <th tw="border-b border-[#e5e7eb] pb-2 text-left">Day</th>
+            <th tw="w-[110px] border-b border-[#e5e7eb] pb-2 text-right">Median (ms)</th>
+            <th tw="w-[110px] border-b border-[#e5e7eb] pb-2 text-right">p95 (ms)</th>
+            <th tw="w-[110px] border-b border-[#e5e7eb] pb-2 text-right">Size (KB)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {days.map((row) => (
+            <tr key={row.day}>
+              <td tw="pt-2">{row.day}</td>
+              <td tw="pt-2 text-right text-[#374151]">{row.median}</td>
+              <td tw="pt-2 text-right text-[#374151]">{row.p95}</td>
+              <td tw="pt-2 text-right text-[#374151]">{row.size.toFixed(1)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/docs/app/playground/templates/watermark.tsx
+++ b/docs/app/playground/templates/watermark.tsx
@@ -1,4 +1,4 @@
-import { PageNumber, TotalPages } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const clauses = [
   {

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -35,7 +35,8 @@ declare const html: string;
 // takumi-pdf
 import { googleFonts } from "@takumi-rs/helpers";
 import { fromHtml } from "@takumi-rs/helpers/html";
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 // [!code highlight]
 const { node, stylesheets } = fromHtml(html);

--- a/docs/content/docs/pdf/from-react-pdf.mdx
+++ b/docs/content/docs/pdf/from-react-pdf.mdx
@@ -86,7 +86,8 @@ react-pdf repeats a band by marking a `<View>` as `fixed` inside the page. Takum
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
   // [!code highlight]

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -10,7 +10,8 @@ icon: PanelTop
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
   // [!code highlight]
@@ -31,7 +32,8 @@ A band draws in the page margin, so the margin has to be tall enough to hold it.
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
   footer: (
@@ -101,7 +103,8 @@ The `format` prop names a CSS `@counter-style` and formats the number. On a clas
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
   footer: (

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -28,7 +28,8 @@ import type { ReactNode } from "react";
 declare const data: { total: number };
 declare function Invoice(props: { data: typeof data }): ReactNode;
 // ---cut---
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 import { googleFonts } from "@takumi-rs/helpers";
 import { writeFile } from "node:fs/promises";
 

--- a/docs/content/docs/pdf/invoices.mdx
+++ b/docs/content/docs/pdf/invoices.mdx
@@ -16,7 +16,8 @@ declare const invoice: { number: string };
 declare function InvoiceDocument(props: { data: typeof invoice }): ReactNode;
 // ---cut---
 import { googleFonts } from "@takumi-rs/helpers";
-import { PageNumber, TotalPages, measure, render } from "takumi-pdf";
+import { measure, render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const footer = (
   <div tw="flex w-full justify-between px-12 text-[10px] text-[#6b7280]">

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -42,7 +42,8 @@ Clicking it moves to the page holding that element. A fragment matching no eleme
 `<TargetPageNumber />` prints the page its link points at. The link is the nearest enclosing element carrying an `href`, usually the `<a>` around the entry, so one piece of markup gives an entry that is both clickable and numbered. Pass `href` instead to have it render its own link. Underneath it is the `targetPageNumber` class hook, which HTML input uses directly.
 
 ```tsx twoslash
-import { TargetPageNumber, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { TargetPageNumber } from "takumi-pdf/primitives";
 
 const pdf = await render(
   <div>

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -55,7 +55,7 @@ A table of contents is the same chapters as links, with the page each one starts
 ```tsx twoslash
 declare const chapters: { id: string; title: string }[];
 // ---cut---
-import { TargetPageNumber } from "takumi-pdf";
+import { TargetPageNumber } from "takumi-pdf/primitives";
 
 <nav tw="flex flex-col gap-1 text-sm">
   {chapters.map((chapter) => (

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -79,7 +79,8 @@ A report header usually names the document and the period. A footer usually carr
 import type { ReactNode } from "react";
 declare const report: ReactNode;
 // ---cut---
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
   // [!code highlight]

--- a/takumi-pdf-js/README.md
+++ b/takumi-pdf-js/README.md
@@ -30,7 +30,8 @@ bun add takumi-pdf
 ```tsx
 import { writeFile } from "node:fs/promises";
 import { googleFonts } from "@takumi-rs/helpers";
-import { PageNumber, TotalPages, render } from "takumi-pdf";
+import { render } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(
   <main tw="flex flex-col gap-4">
@@ -77,7 +78,7 @@ const pdf = await render(report, {
 Headers and footers repeat on every page. `<PageNumber />` and `<TotalPages />` place the counters; the `format` prop picks a CSS counter style.
 
 ```tsx
-import { PageNumber, TotalPages } from "takumi-pdf";
+import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
   footer: (


### PR DESCRIPTION
## Why

The report template built its measurements list out of flex rows, so the playground never showed the repeated table header feature. The editor also flagged `import { PageNumber } from "takumi-pdf"` with TS2307, because monaco had no typings for that module.

## What

- Rebuild the report template's measurements as a real `<table>` with `<thead>` and `<tbody>`. 90 daily rows spread the table across four pages, and the header row repeats on each one.
- Register `takumi-pdf/dist/primitives.d.mts` as monaco extra libs for both `takumi-pdf` and `takumi-pdf/primitives`, matching the module names the evaluate shim resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editor type information and autocomplete support for PDF primitives in the playground.
  * Updated the report example to display 90 days of localized data.
  * Replaced stacked measurement rows with a structured table featuring daily headers and values.
* **Documentation**
  * Updated PDF examples and quick-start guides to use the current import paths for rendering and PDF primitives.
  * Revised playground examples to reflect the latest primitive usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->