### PR TITLE
Docs: import render in README examples that call it

### DIFF
--- a/takumi-pdf-js/README.md
+++ b/takumi-pdf-js/README.md
@@ -78,6 +78,7 @@ const pdf = await render(report, {
 Headers and footers repeat on every page. `<PageNumber />` and `<TotalPages />` place the counters; the `format` prop picks a CSS counter style.
 
 ```tsx
+import { render } from "takumi-pdf";
 import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 const pdf = await render(report, {
@@ -124,6 +125,7 @@ Pass a font URL, font bytes, or the `googleFonts` helper. Registered fonts are d
 
 ```tsx
 import { googleFonts } from "@takumi-rs/helpers";
+import { render } from "takumi-pdf";
 
 const pdf = await render(doc, {
   fonts: [...(await googleFonts(["Inter"])), { name: "Brand Sans", weight: 700, data: fontBytes }],


### PR DESCRIPTION
## Why

Two takumi-pdf README examples call `render` without importing it. The headers-and-footers block lost the import when its primitives moved to the `takumi-pdf/primitives` subpath, and the fonts block never had one.

## What

Add `import { render } from "takumi-pdf"` to both blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Headers, Footers, and Fonts examples to explicitly import the `render` function for improved clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->