### PR TITLE
CI: always deploy docs from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -916,7 +916,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-slim
     needs: [pass-test, docs-changed]
-    if: needs.docs-changed.outputs.docs == 'true'
+    if: github.ref == 'refs/heads/master' || needs.docs-changed.outputs.docs == 'true'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Why

Merging #1318 cancelled the in-progress master run for #1317 through the concurrency group. That cancelled run was the only one whose paths filter saw the docs changes, so the docs deploy for #1317 never happened. The next run's filter only compares its own push, which had no docs changes.

## What

Deploy docs on every master push. The paths filter still gates PR branches, where the preview deploy is the only consumer.