### PR TITLE
PDF-JS: type tw from the primitives entry

### DIFF
--- a/.tegami/primitives-tw-augmentation.md
+++ b/.tegami/primitives-tw-augmentation.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "takumi-pdf":
+    type: patch
+---
+
+### Type `tw` from the primitives entry
+
+Move the `tw` JSX attribute augmentation into `takumi-pdf/primitives`, so importing only the primitives types it too.

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -16,12 +16,6 @@ export type { FontLoader, ImagesInput } from "@takumi-rs/helpers/renderer";
 export { PageNumber, TargetPageNumber, TotalPages } from "./primitives";
 export type { CounterProps, CounterStyle } from "./primitives";
 
-declare module "react" {
-  interface DOMAttributes<T> {
-    tw?: string;
-  }
-}
-
 /** Every class name in a tree, so the renderer can say what its counters draw. */
 function classNames(node: unknown): string[] {
   const into: string[] = [];

--- a/takumi-pdf-js/src/primitives.ts
+++ b/takumi-pdf-js/src/primitives.ts
@@ -1,5 +1,11 @@
 import type { CSSProperties, ReactElement } from "react";
 
+declare module "react" {
+  interface DOMAttributes<T> {
+    tw?: string;
+  }
+}
+
 /**
  * A `@counter-style` name the page counters can format in, matching the set
  * the renderer's `@counter-style` substitution knows.


### PR DESCRIPTION
## Why

The `tw` JSX attribute augmentation lives in the main entry, so a file that imports only `takumi-pdf/primitives` loses it and every `tw` prop fails with TS2322. The docs deploy caught this: after #1318 switched the examples to the primitives subpath, twoslash failed the build on the table-of-contents sample in `reports.mdx`.

## What

Move the `declare module "react"` augmentation from `src/export.ts` into `src/primitives.ts`. The main entry re-exports the primitives, so it keeps the augmentation through that import chain. Verified with a full docs build (182 files, twoslash clean).