### PR TITLE
Core: store calc() as its non-zero terms

### DIFF
--- a/.tegami/calc-inline-terms.md
+++ b/.tegami/calc-inline-terms.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Store `calc()` as its non-zero terms
+
+`Length` shrinks from 84 to 20 bytes, and a computed style from 5.9KB to 2.3KB. A `calc()` expression mixing more than four distinct units now fails to parse.

--- a/takumi-core/src/style/calc.rs
+++ b/takumi-core/src/style/calc.rs
@@ -94,34 +94,156 @@ pub struct CalcFormula {
   pub(crate) pc: f32,
 }
 
-impl CalcFormula {
-  /// Hashes every coefficient by bit pattern. Keep in sync with the fields
-  /// above.
+/// A `calc(...)` unit with a non-zero coefficient.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum CalcUnit {
+  #[default]
+  Px,
+  Percent,
+  Rem,
+  Em,
+  Lh,
+  Rlh,
+  Vh,
+  Vw,
+  Cqh,
+  Cqw,
+  CqMin,
+  CqMax,
+  VMin,
+  VMax,
+  Cm,
+  Mm,
+  Inch,
+  Q,
+  Pt,
+  Pc,
+}
+
+impl CalcUnit {
+  pub(crate) fn suffix(self) -> &'static str {
+    match self {
+      Self::Px => "px",
+      Self::Percent => "%",
+      Self::Rem => "rem",
+      Self::Em => "em",
+      Self::Lh => "lh",
+      Self::Rlh => "rlh",
+      Self::Vh => "vh",
+      Self::Vw => "vw",
+      Self::Cqh => "cqh",
+      Self::Cqw => "cqw",
+      Self::CqMin => "cqmin",
+      Self::CqMax => "cqmax",
+      Self::VMin => "vmin",
+      Self::VMax => "vmax",
+      Self::Cm => "cm",
+      Self::Mm => "mm",
+      Self::Inch => "in",
+      Self::Q => "q",
+      Self::Pt => "pt",
+      Self::Pc => "pc",
+    }
+  }
+}
+
+/// One `value * unit` term of a compressed `calc(...)` expression.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct CalcTerm {
+  pub(crate) unit: CalcUnit,
+  pub(crate) value: f32,
+}
+
+impl CalcTerm {
+  /// The value as CSS serializes it: percentages store a fraction.
+  pub(crate) fn display_value(self) -> f32 {
+    match self.unit {
+      CalcUnit::Percent => self.value * 100.0,
+      _ => self.value,
+    }
+  }
+}
+
+/// A parsed `calc(...)` expression, compressed to its non-zero terms so it
+/// stays inline in `Length`. Naive versus CSS: an expression mixing more than
+/// [`MAX_CALC_TERMS`] distinct units fails to parse.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct CalcTerms {
+  units: [CalcUnit; MAX_CALC_TERMS],
+  values: [f32; MAX_CALC_TERMS],
+}
+
+/// Distinct units one compressed `calc(...)` expression can carry.
+pub(crate) const MAX_CALC_TERMS: usize = 4;
+
+impl CalcTerms {
+  /// The stored terms; trailing zero-valued slots are padding.
+  pub(crate) fn terms(&self) -> impl Iterator<Item = CalcTerm> {
+    self
+      .units
+      .into_iter()
+      .zip(self.values)
+      .filter(|(_, value)| *value != 0.0)
+      .map(|(unit, value)| CalcTerm { unit, value })
+  }
+
+  pub(crate) fn neg(self) -> Self {
+    Self {
+      units: self.units,
+      values: self.values.map(|value| -value),
+    }
+  }
+
+  /// Collapses the terms into a `px + percent * basis` linear form.
+  pub fn resolve(self, sizing: &SizingContext) -> CalcLinear {
+    let viewport_width = sizing.viewport.size.width.unwrap_or_default() as f32;
+    let viewport_height = sizing.viewport.size.height.unwrap_or_default() as f32;
+    let container_width = sizing.query_container_width();
+    let container_height = sizing.query_container_height();
+    let mut absolute_css = 0.0;
+    let mut px = 0.0;
+    let mut percent = 0.0;
+
+    for (unit, value) in self.units.into_iter().zip(self.values) {
+      match unit {
+        // Absolute units are authored in CSS px and cross the dpr boundary
+        // once; every relative unit already resolves against a device-pixel
+        // basis.
+        CalcUnit::Px => absolute_css += value,
+        CalcUnit::Cm => absolute_css += value * ONE_CM_IN_PX,
+        CalcUnit::Mm => absolute_css += value * ONE_MM_IN_PX,
+        CalcUnit::Inch => absolute_css += value * ONE_IN_PX,
+        CalcUnit::Q => absolute_css += value * ONE_Q_IN_PX,
+        CalcUnit::Pt => absolute_css += value * ONE_PT_IN_PX,
+        CalcUnit::Pc => absolute_css += value * ONE_PC_IN_PX,
+        CalcUnit::Percent => percent += value,
+        CalcUnit::Rem => px += value * sizing.rem_basis(),
+        CalcUnit::Em => px += value * sizing.font_size,
+        CalcUnit::Lh => px += value * sizing.line_height,
+        CalcUnit::Rlh => px += value * sizing.root_line_height_basis(),
+        CalcUnit::Vh => px += value * viewport_height / 100.0,
+        CalcUnit::Vw => px += value * viewport_width / 100.0,
+        CalcUnit::Cqh => px += value * container_height / 100.0,
+        CalcUnit::Cqw => px += value * container_width / 100.0,
+        CalcUnit::CqMin => px += value * container_width.min(container_height) / 100.0,
+        CalcUnit::CqMax => px += value * container_width.max(container_height) / 100.0,
+        CalcUnit::VMin => px += value * viewport_width.min(viewport_height) / 100.0,
+        CalcUnit::VMax => px += value * viewport_width.max(viewport_height) / 100.0,
+      }
+    }
+
+    CalcLinear {
+      px: sizing.to_device(absolute_css) + px,
+      percent,
+    }
+  }
+
+  /// Hashes each term's unit and value by bit pattern.
   pub(crate) fn hash_bits(&self, hasher: &mut impl core::hash::Hasher) {
     use core::hash::Hash;
 
-    for value in [
-      self.px,
-      self.percent,
-      self.rem,
-      self.em,
-      self.lh,
-      self.rlh,
-      self.vh,
-      self.vw,
-      self.cqh,
-      self.cqw,
-      self.cqmin,
-      self.cqmax,
-      self.vmin,
-      self.vmax,
-      self.cm,
-      self.mm,
-      self.inch,
-      self.q,
-      self.pt,
-      self.pc,
-    ] {
+    for (unit, value) in self.units.into_iter().zip(self.values) {
+      (unit as u8).hash(hasher);
       value.to_bits().hash(hasher);
     }
   }
@@ -192,43 +314,46 @@ impl CalcFormula {
 }
 
 impl CalcFormula {
-  /// Collapses the symbolic formula into a `px + percent * basis` linear form.
-  pub fn resolve(self, sizing: &SizingContext) -> CalcLinear {
-    let viewport_width = sizing.viewport.size.width.unwrap_or_default() as f32;
-    let viewport_height = sizing.viewport.size.height.unwrap_or_default() as f32;
-    let viewport_min = viewport_width.min(viewport_height);
-    let viewport_max = viewport_width.max(viewport_height);
-    let container_width = sizing.query_container_width();
-    let container_height = sizing.query_container_height();
-    let container_min = container_width.min(container_height);
-    let container_max = container_width.max(container_height);
+  /// Compresses to the non-zero terms, or `None` when more than
+  /// [`MAX_CALC_TERMS`] distinct units appear.
+  pub(crate) fn compress(self) -> Option<CalcTerms> {
+    let coefficients = [
+      (CalcUnit::Px, self.px),
+      (CalcUnit::Percent, self.percent),
+      (CalcUnit::Rem, self.rem),
+      (CalcUnit::Em, self.em),
+      (CalcUnit::Lh, self.lh),
+      (CalcUnit::Rlh, self.rlh),
+      (CalcUnit::Vh, self.vh),
+      (CalcUnit::Vw, self.vw),
+      (CalcUnit::Cqh, self.cqh),
+      (CalcUnit::Cqw, self.cqw),
+      (CalcUnit::CqMin, self.cqmin),
+      (CalcUnit::CqMax, self.cqmax),
+      (CalcUnit::VMin, self.vmin),
+      (CalcUnit::VMax, self.vmax),
+      (CalcUnit::Cm, self.cm),
+      (CalcUnit::Mm, self.mm),
+      (CalcUnit::Inch, self.inch),
+      (CalcUnit::Q, self.q),
+      (CalcUnit::Pt, self.pt),
+      (CalcUnit::Pc, self.pc),
+    ];
+    let mut terms = CalcTerms::default();
+    let mut count = 0;
 
-    // Absolute units are authored in CSS px and cross the dpr boundary once;
-    // every relative unit already resolves against a device-pixel basis.
-    let absolute_css = self.px
-      + self.cm * ONE_CM_IN_PX
-      + self.mm * ONE_MM_IN_PX
-      + self.inch * ONE_IN_PX
-      + self.q * ONE_Q_IN_PX
-      + self.pt * ONE_PT_IN_PX
-      + self.pc * ONE_PC_IN_PX;
-
-    CalcLinear {
-      px: sizing.to_device(absolute_css)
-        + self.rem * sizing.rem_basis()
-        + self.em * sizing.font_size
-        + self.lh * sizing.line_height
-        + self.rlh * sizing.root_line_height_basis()
-        + self.vh * viewport_height / 100.0
-        + self.vw * viewport_width / 100.0
-        + self.cqh * container_height / 100.0
-        + self.cqw * container_width / 100.0
-        + self.cqmin * container_min / 100.0
-        + self.cqmax * container_max / 100.0
-        + self.vmin * viewport_min / 100.0
-        + self.vmax * viewport_max / 100.0,
-      percent: self.percent,
+    for (unit, value) in coefficients {
+      if value == 0.0 {
+        continue;
+      }
+      if count == MAX_CALC_TERMS {
+        return None;
+      }
+      terms.units[count] = unit;
+      terms.values[count] = value;
+      count += 1;
     }
+    Some(terms)
   }
 }
 

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -6,7 +6,7 @@ use taffy::{CompactLength, Dimension, LengthPercentage, LengthPercentageAuto};
 use crate::style::{
   AspectRatio, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
   SizingContext, ToCss,
-  calc::{CalcFormula, CalcLinear, CalcValue, parse_calc_sum},
+  calc::{CalcLinear, CalcTerms, CalcValue, parse_calc_sum},
   tw::{TW_VAR_SPACING, TailwindPropertyParser},
   unexpected_token,
 };
@@ -138,7 +138,7 @@ pub enum Length {
   /// Specific pixel value
   Px(f32),
   /// calc(...) expression
-  Calc(CalcFormula),
+  Calc(CalcTerms),
 }
 
 impl Length {
@@ -257,44 +257,22 @@ impl ToCss for Length {
       Self::Pc(v) => write!(dest, "{}pc", v),
       Self::Px(v) => write!(dest, "{}px", v),
       Self::Calc(f) => {
-        let terms: &[(&str, f32)] = &[
-          ("px", f.px),
-          ("%", f.percent * 100.0),
-          ("rem", f.rem),
-          ("em", f.em),
-          ("lh", f.lh),
-          ("rlh", f.rlh),
-          ("vh", f.vh),
-          ("vw", f.vw),
-          ("cqh", f.cqh),
-          ("cqw", f.cqw),
-          ("cqmin", f.cqmin),
-          ("cqmax", f.cqmax),
-          ("vmin", f.vmin),
-          ("vmax", f.vmax),
-          ("cm", f.cm),
-          ("mm", f.mm),
-          ("in", f.inch),
-          ("q", f.q),
-          ("pt", f.pt),
-          ("pc", f.pc),
-        ];
-        if terms.iter().all(|(_, v)| *v == 0.0) {
+        if f.terms().next().is_none() {
           return dest.write_str("0px");
         }
         dest.write_str("calc(")?;
         let mut first = true;
-        for (unit, value) in terms {
-          if *value == 0.0 {
-            continue;
-          }
+        for (unit, value) in f
+          .terms()
+          .map(|term| (term.unit.suffix(), term.display_value()))
+        {
           if first {
-            if *value < 0.0 {
+            if value < 0.0 {
               write!(dest, "-{}{}", -value, unit)?;
             } else {
               write!(dest, "{}{}", value, unit)?;
             }
-          } else if *value < 0.0 {
+          } else if value < 0.0 {
             write!(dest, " - {}{}", -value, unit)?;
           } else {
             write!(dest, " + {}{}", value, unit)?;
@@ -375,9 +353,14 @@ impl<'i> FromCss<'i> for Length {
         _ => Err(unexpected_token!(location, token)),
       },
       Token::Function(function) if function.eq_ignore_ascii_case("calc") => {
+        let token = token.clone();
+
         match input.parse_nested_block(parse_calc_sum)? {
           CalcValue::Number(value) => Ok(Self::Px(value)),
-          CalcValue::Formula(formula) => Ok(Self::Calc(formula)),
+          CalcValue::Formula(formula) => formula
+            .compress()
+            .map(Self::Calc)
+            .ok_or_else(|| unexpected_token!(location, &token)),
         }
       }
       Token::Dimension { value, unit, .. } => length_from_dimension_unit(unit.as_ref(), *value)
@@ -570,7 +553,11 @@ mod tests {
   use std::{assert_matches, rc::Rc};
 
   use super::*;
-  use crate::{geometry::Size, style::calc::CalcArena, viewport::Viewport};
+  use crate::{
+    geometry::Size,
+    style::calc::{CalcArena, CalcFormula},
+    viewport::Viewport,
+  };
 
   fn sizing() -> SizingContext {
     SizingContext {
@@ -594,14 +581,23 @@ mod tests {
   }
 
   #[test]
+  fn parse_calc_more_than_four_units_fails() {
+    assert!(Length::from_css_str("calc(1px + 1em + 1rem + 1vh + 1vw)").is_err());
+  }
+
+  #[test]
   fn parse_calc_mixed_returns_formula() {
     assert_eq!(
       Length::from_css_str("calc(100% - 12px)"),
-      Ok(Length::Calc(CalcFormula {
-        percent: 1.0,
-        px: -12.0,
-        ..Default::default()
-      }))
+      Ok(Length::Calc(
+        CalcFormula {
+          percent: 1.0,
+          px: -12.0,
+          ..Default::default()
+        }
+        .compress()
+        .unwrap()
+      ))
     );
   }
 
@@ -625,11 +621,15 @@ mod tests {
 
   #[test]
   fn negative_calc_keeps_value_sign_consistent() {
-    let value: Length = Length::Calc(CalcFormula {
-      percent: 0.5,
-      px: 10.0,
-      ..Default::default()
-    });
+    let value: Length = Length::Calc(
+      CalcFormula {
+        percent: 0.5,
+        px: 10.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     let negated = -value;
     let sizing = sizing();
     assert_near(value.to_px(&sizing, 200.0), 120.0);
@@ -638,22 +638,30 @@ mod tests {
 
   #[test]
   fn make_computed_collapses_formula_without_percent_to_px() {
-    let mut value: Length = Length::Calc(CalcFormula {
-      rem: 1.0,
-      px: 5.0,
-      ..Default::default()
-    });
+    let mut value: Length = Length::Calc(
+      CalcFormula {
+        rem: 1.0,
+        px: 5.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     value.make_computed(&sizing());
     assert_eq!(value, Length::Px(21.0));
   }
 
   #[test]
   fn make_computed_collapsed_px_applies_dpr_only_once_in_to_px() {
-    let mut value: Length = Length::Calc(CalcFormula {
-      rem: 1.0,
-      px: 5.0,
-      ..Default::default()
-    });
+    let mut value: Length = Length::Calc(
+      CalcFormula {
+        rem: 1.0,
+        px: 5.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     let sizing = sizing();
     value.make_computed(&sizing);
 
@@ -663,39 +671,55 @@ mod tests {
 
   #[test]
   fn make_computed_collapses_formula_with_only_percent_to_percentage() {
-    let mut value: Length = Length::Calc(CalcFormula {
-      percent: 0.5,
-      ..Default::default()
-    });
+    let mut value: Length = Length::Calc(
+      CalcFormula {
+        percent: 0.5,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     value.make_computed(&sizing());
     assert_eq!(value, Length::Percentage(50.0));
   }
 
   #[test]
   fn make_computed_keeps_mixed_formula_as_calc() {
-    let mut value: Length = Length::Calc(CalcFormula {
-      percent: 0.5,
-      px: 10.0,
-      ..Default::default()
-    });
-    value.make_computed(&sizing());
-    assert_eq!(
-      value,
-      Length::Calc(CalcFormula {
+    let mut value: Length = Length::Calc(
+      CalcFormula {
         percent: 0.5,
         px: 10.0,
         ..Default::default()
-      })
+      }
+      .compress()
+      .unwrap(),
+    );
+    value.make_computed(&sizing());
+    assert_eq!(
+      value,
+      Length::Calc(
+        CalcFormula {
+          percent: 0.5,
+          px: 10.0,
+          ..Default::default()
+        }
+        .compress()
+        .unwrap()
+      )
     );
   }
 
   #[test]
   fn compact_length_calc_pointer_resolves_through_callback() {
-    let value: Length = Length::Calc(CalcFormula {
-      percent: 0.5,
-      px: 10.0,
-      ..Default::default()
-    });
+    let value: Length = Length::Calc(
+      CalcFormula {
+        percent: 0.5,
+        px: 10.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     let sizing = sizing();
     let compact = value.to_compact_length(&sizing);
     assert!(compact.is_calc());
@@ -744,10 +768,14 @@ mod tests {
   #[test]
   fn calc_with_rem_does_not_double_apply_dpr_when_root_font_size_set() {
     let sizing = descendant_sizing();
-    let value: Length = Length::Calc(CalcFormula {
-      rem: 1.0,
-      ..Default::default()
-    });
+    let value: Length = Length::Calc(
+      CalcFormula {
+        rem: 1.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     assert_near(value.to_px(&sizing, 0.0), 32.0);
   }
 
@@ -768,21 +796,29 @@ mod tests {
   #[test]
   fn calc_with_rem_and_px_does_not_double_apply_dpr_when_root_font_size_set() {
     let sizing = descendant_sizing();
-    let value: Length = Length::Calc(CalcFormula {
-      rem: 1.0,
-      px: 5.0,
-      ..Default::default()
-    });
+    let value: Length = Length::Calc(
+      CalcFormula {
+        rem: 1.0,
+        px: 5.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     assert_near(value.to_px(&sizing, 0.0), 42.0);
   }
 
   #[test]
   fn make_computed_calc_with_rem_collapses_correctly_when_root_font_size_set() {
-    let mut value: Length = Length::Calc(CalcFormula {
-      rem: 1.0,
-      px: 5.0,
-      ..Default::default()
-    });
+    let mut value: Length = Length::Calc(
+      CalcFormula {
+        rem: 1.0,
+        px: 5.0,
+        ..Default::default()
+      }
+      .compress()
+      .unwrap(),
+    );
     let sizing = descendant_sizing();
     value.make_computed(&sizing);
     assert_eq!(value, Length::Px(21.0));
@@ -845,12 +881,16 @@ mod tests {
     let parsed = Length::from_css_str("calc(1lh + 2rlh - 3px)");
     assert_eq!(
       parsed,
-      Ok(Length::Calc(CalcFormula {
-        lh: 1.0,
-        rlh: 2.0,
-        px: -3.0,
-        ..Default::default()
-      }))
+      Ok(Length::Calc(
+        CalcFormula {
+          lh: 1.0,
+          rlh: 2.0,
+          px: -3.0,
+          ..Default::default()
+        }
+        .compress()
+        .unwrap()
+      ))
     );
   }
 
@@ -860,11 +900,15 @@ mod tests {
     let parsed = Length::from_css_str("calc(1lh + 2px)");
     assert_eq!(
       parsed,
-      Ok(Length::Calc(CalcFormula {
-        lh: 1.0,
-        px: 2.0,
-        ..Default::default()
-      }))
+      Ok(Length::Calc(
+        CalcFormula {
+          lh: 1.0,
+          px: 2.0,
+          ..Default::default()
+        }
+        .compress()
+        .unwrap()
+      ))
     );
     if let Ok(value) = parsed {
       assert_near(value.to_px(&sizing, 0.0), 34.0);
@@ -885,12 +929,16 @@ mod tests {
     let parsed = Length::from_css_str("calc(20cqmax + 5px - 2cqb)");
     assert_eq!(
       parsed,
-      Ok(Length::Calc(CalcFormula {
-        cqmax: 20.0,
-        cqh: -2.0,
-        px: 5.0,
-        ..Default::default()
-      }))
+      Ok(Length::Calc(
+        CalcFormula {
+          cqmax: 20.0,
+          cqh: -2.0,
+          px: 5.0,
+          ..Default::default()
+        }
+        .compress()
+        .unwrap()
+      ))
     );
   }
 


### PR DESCRIPTION
## Why

Every `Length` carried an inline 80-byte coefficient table for `calc()`, a value most lengths never use. With 60 `Length`-typed fields, that put `ComputedStyle` at 5.9KB, and every node clones one during inheritance.

## What

Parse still runs on the dense coefficient form, then compresses the result to its non-zero `(unit, value)` terms, stored inline as four-slot arrays. `Length` drops from 84 to 20 bytes and `ComputedStyle` from 5.9KB to 2.3KB, with `Copy` kept and no call-site changes. The four-slot limit means a `calc()` mixing more than four distinct units now fails to parse; a test pins that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced the storage size of CSS `calc()` expressions by omitting zero-value terms, improving memory efficiency for lengths and computed styles.

* **Bug Fixes**
  * Improved handling of `calc()` expressions using absolute, percentage, viewport, container, and font-relative units.
  * Expressions combining more than four distinct units are now rejected during parsing instead of being stored incompletely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->