### PR TITLE
Core: share inherited font lists across nodes

### DIFF
--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -322,7 +322,7 @@ impl SizedFontStyle<'_> {
       }
     }
     parent.font_stretch.percentage().to_bits().hash(hasher);
-    for variation in &parent.font_variation_settings {
+    for variation in parent.font_variation_settings.iter() {
       variation.tag.hash(hasher);
       variation.value.to_bits().hash(hasher);
     }

--- a/takumi-core/src/style/properties/font_family.rs
+++ b/takumi-core/src/style/properties/font_family.rs
@@ -1,4 +1,4 @@
-use std::{fmt, string::ToString};
+use std::{fmt, string::ToString, sync::Arc};
 
 use cssparser::{Parser, match_ignore_ascii_case};
 use parley::{FontFamilyName, GenericFamily};
@@ -11,7 +11,7 @@ use crate::style::{
 /// Represents a font family for text rendering.
 /// Multi value fallback is supported.
 #[derive(Debug, Clone, PartialEq)]
-pub struct FontFamily(Box<[FontFamilyToken]>);
+pub struct FontFamily(Arc<[FontFamilyToken]>);
 
 impl Default for FontFamily {
   fn default() -> Self {
@@ -41,7 +41,7 @@ impl FontFamily {
       .collect::<Vec<_>>();
     tokens.push(FontFamilyToken::Generic(GenericFamily::SansSerif));
 
-    Self(tokens.into_boxed_slice())
+    Self(tokens.into())
   }
 
   /// The families as parley `FontFamilyName`s, in declaration order.
@@ -53,7 +53,7 @@ impl FontFamily {
   }
 
   pub(crate) fn from_parlance_generic(generic: GenericFamily) -> Self {
-    Self(Box::new([FontFamilyToken::Generic(generic)]))
+    Self(Arc::new([FontFamilyToken::Generic(generic)]))
   }
 }
 
@@ -87,7 +87,7 @@ impl<'i> FromCss<'i> for FontFamily {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     let list = input.parse_comma_separated(FontFamilyToken::from_css)?;
 
-    Ok(Self(list.into_boxed_slice()))
+    Ok(Self(list.into()))
   }
 
   const VALID_TOKENS: &'static [CssToken] = FontFamilyToken::VALID_TOKENS;
@@ -148,6 +148,8 @@ impl ToCss for FontFamily {
 
 #[cfg(test)]
 mod tests {
+  use std::sync::Arc;
+
   use parley::GenericFamily;
 
   use super::{FontFamily, FontFamilyToken};
@@ -157,7 +159,7 @@ mod tests {
   fn parses_single_generic_family() {
     assert_eq!(
       FontFamily::from_css_str("serif"),
-      Ok(FontFamily(Box::new([FontFamilyToken::Generic(
+      Ok(FontFamily(Arc::new([FontFamilyToken::Generic(
         GenericFamily::Serif,
       )])))
     );
@@ -167,7 +169,7 @@ mod tests {
   fn parses_fallback_family_list() {
     assert_eq!(
       FontFamily::from_css_str("\"Inter\", Arial, serif"),
-      Ok(FontFamily(Box::new([
+      Ok(FontFamily(Arc::new([
         FontFamilyToken::Owned(String::from("Inter")),
         FontFamilyToken::Owned(String::from("Arial")),
         FontFamilyToken::Generic(GenericFamily::Serif),
@@ -179,7 +181,7 @@ mod tests {
   fn parses_unquoted_multi_word_family_name() {
     assert_eq!(
       FontFamily::from_css_str("Noto Sans TC"),
-      Ok(FontFamily(Box::new([FontFamilyToken::Owned(
+      Ok(FontFamily(Arc::new([FontFamilyToken::Owned(
         "Noto Sans TC".to_string()
       )])))
     );
@@ -189,7 +191,7 @@ mod tests {
   fn from_names_appends_sans_serif_last_resort() {
     assert_eq!(
       FontFamily::from_names(["Geist".to_string(), "Inter".to_string()]),
-      FontFamily(Box::new([
+      FontFamily(Arc::new([
         FontFamilyToken::Owned(String::from("Geist")),
         FontFamilyToken::Owned(String::from("Inter")),
         FontFamilyToken::Generic(GenericFamily::SansSerif),
@@ -201,13 +203,13 @@ mod tests {
   fn parses_tailwind_aliases() {
     assert_eq!(
       FontFamily::parse_tw("sans"),
-      Some(FontFamily(Box::new([FontFamilyToken::Generic(
+      Some(FontFamily(Arc::new([FontFamilyToken::Generic(
         GenericFamily::SansSerif,
       )])))
     );
     assert_eq!(
       FontFamily::parse_tw("mono"),
-      Some(FontFamily(Box::new([FontFamilyToken::Generic(
+      Some(FontFamily(Arc::new([FontFamilyToken::Generic(
         GenericFamily::Monospace,
       )])))
     );

--- a/takumi-core/src/style/properties/font_feature_settings.rs
+++ b/takumi-core/src/style/properties/font_feature_settings.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use cssparser::{Parser, Token};
 
@@ -86,7 +86,7 @@ impl FontFeature {
 ///
 /// This allows enabling/disabling specific typographic features in OpenType fonts
 /// such as ligatures, kerning, small caps, and other advanced typography features.
-pub(crate) type FontFeatureSettings = Box<[FontFeature]>;
+pub(crate) type FontFeatureSettings = Arc<[FontFeature]>;
 
 impl MakeComputed for FontFeatureSettings {}
 
@@ -96,7 +96,7 @@ impl<'i> FromCss<'i> for FontFeatureSettings {
       .try_parse(|input| input.expect_ident_matching("normal"))
       .is_ok()
     {
-      return Ok(Box::new([]));
+      return Ok(Arc::new([]));
     }
 
     let list = input.parse_comma_separated(|input| {
@@ -120,7 +120,7 @@ impl<'i> FromCss<'i> for FontFeatureSettings {
       Ok(FontFeature { tag, value })
     })?;
 
-    Ok(list.into_boxed_slice())
+    Ok(list.into())
   }
 
   const VALID_TOKENS: &'static [CssToken] = &[

--- a/takumi-core/src/style/properties/font_variation_settings.rs
+++ b/takumi-core/src/style/properties/font_variation_settings.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use cssparser::Parser;
 
@@ -32,7 +32,7 @@ impl FontVariation {
 ///
 /// This allows fine-grained control over variable font characteristics like weight,
 /// width, slant, and other custom axes defined in the font.
-pub(crate) type FontVariationSettings = Box<[FontVariation]>;
+pub(crate) type FontVariationSettings = Arc<[FontVariation]>;
 
 impl MakeComputed for FontVariationSettings {}
 
@@ -42,7 +42,7 @@ impl<'i> FromCss<'i> for FontVariationSettings {
       .try_parse(|input| input.expect_ident_matching("normal"))
       .is_ok()
     {
-      return Ok(Box::new([]));
+      return Ok(Arc::new([]));
     }
 
     let list = input.parse_comma_separated(|input| {
@@ -52,7 +52,7 @@ impl<'i> FromCss<'i> for FontVariationSettings {
       Ok(FontVariation { tag, value })
     })?;
 
-    Ok(list.into_boxed_slice())
+    Ok(list.into())
   }
 
   const VALID_TOKENS: &'static [CssToken] = &[
@@ -78,14 +78,14 @@ mod tests {
   #[test]
   fn test_parse_font_variation_settings() {
     for (css, expected) in [
-      ("normal", Box::new([]) as FontVariationSettings),
+      ("normal", Arc::new([]) as FontVariationSettings),
       (
         "\"wght\" 400",
-        Box::new([FontVariation::new(Tag::new(b"wght"), 400.0)]),
+        Arc::new([FontVariation::new(Tag::new(b"wght"), 400.0)]),
       ),
       (
         "\"wght\" 400, \"slnt\" -10",
-        Box::new([
+        Arc::new([
           FontVariation::new(Tag::new(b"wght"), 400.0),
           FontVariation::new(Tag::new(b"slnt"), -10.0),
         ]),

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -525,6 +525,34 @@ impl<T: Animatable + Clone> Animatable for Box<[T]> {
   }
 }
 
+impl<T: Animatable + Clone> Animatable for Arc<[T]> {
+  fn missing_value() -> Option<Self> {
+    match T::list_interpolation_strategy() {
+      ListInterpolationStrategy::Discrete => None,
+      ListInterpolationStrategy::RepeatToLcm
+      | ListInterpolationStrategy::PadToLongestWithNeutral => Some(Arc::from([])),
+    }
+  }
+
+  fn interpolate(
+    &mut self,
+    from: &Self,
+    to: &Self,
+    progress: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) {
+    *self =
+      interpolate_list(from, to, progress, sizing, current_color, Vec::into).unwrap_or_else(|| {
+        if progress >= 0.5 {
+          to.clone()
+        } else {
+          from.clone()
+        }
+      });
+  }
+}
+
 impl<T: Animatable + Clone> Animatable for Vec<T> {
   fn missing_value() -> Option<Self> {
     match T::list_interpolation_strategy() {
@@ -696,6 +724,12 @@ fn write_css_list<W: fmt::Write, T: ToCss>(items: &[T], dest: &mut W) -> fmt::Re
 }
 
 impl<T: ToCss> ToCss for Box<[T]> {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
+    write_css_list(self, dest)
+  }
+}
+
+impl<T: ToCss> ToCss for Arc<[T]> {
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
     write_css_list(self, dest)
   }

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde_json::{from_value, json};
 use takumi::{
   prelude::{Length::*, *},
@@ -49,7 +51,7 @@ fn text_typography_variable_width() {
       .with_style(
         Style::default()
           .with(StyleDeclaration::display(Display::Flex))
-          .with(StyleDeclaration::font_variation_settings(Box::new([
+          .with(StyleDeclaration::font_variation_settings(Arc::new([
             FontVariation::new(Tag::new(b"wdth"), *width),
           ]))),
       )
@@ -1723,7 +1725,7 @@ fn test_nowrap_ellipsis_without_break_opportunity() {
   assert_ne!(clipped.as_raw(), ellipsized.as_raw());
 }
 
-fn kerning_row(label: &str, kerning: FontKerning, features: Box<[FontFeature]>) -> Node {
+fn kerning_row(label: &str, kerning: FontKerning, features: Arc<[FontFeature]>) -> Node {
   Node::container([
     Node::text(label.to_string()).with_style(
       Style::default()
@@ -1744,12 +1746,12 @@ fn kerning_row(label: &str, kerning: FontKerning, features: Box<[FontFeature]>) 
 #[test]
 fn text_font_kerning() {
   let container = Node::container([
-    kerning_row("auto", FontKerning::Auto, Box::new([])),
-    kerning_row("none", FontKerning::None, Box::new([])),
+    kerning_row("auto", FontKerning::Auto, Arc::new([])),
+    kerning_row("none", FontKerning::None, Arc::new([])),
     kerning_row(
       "none+fss",
       FontKerning::None,
-      Box::new([FontFeature::new(Tag::new(b"kern"), 1)]),
+      Arc::new([FontFeature::new(Tag::new(b"kern"), 1)]),
     ),
   ])
   .with_style(


### PR DESCRIPTION
## Why

`font-family`, `font-variation-settings`, and `font-feature-settings` store their lists in `Box<[T]>`, so inheriting them deep-copies the list (and each family name string) for every node in the tree.

## What

Those three lists now live behind `Arc<[T]>`. Inheriting a style bumps a refcount instead of allocating. `text-shadow` stays boxed because `make_computed` rewrites its lengths per node. Rendered output is unchanged.