### PR TITLE
Core: share custom property maps across nodes

### DIFF
--- a/.tegami/share-custom-property-maps.md
+++ b/.tegami/share-custom-property-maps.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Share custom property maps across nodes
+
+`ComputedStyle::custom_properties` and `registered_custom_properties` are now `Arc`-shared, so inheriting them no longer copies the maps per node.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, mem::take, vec::IntoIter};
+use std::{borrow::Cow, collections::HashMap, mem::take, sync::Arc, vec::IntoIter};
 
 use parley::fontique::Attributes;
 use taffy::{
@@ -246,6 +246,8 @@ fn registered_custom_property_parent_style<'a>(
   }
 
   let mut adjusted_parent = parent_style.clone();
+  let registered = Arc::make_mut(&mut adjusted_parent.registered_custom_properties);
+  let custom = Arc::make_mut(&mut adjusted_parent.custom_properties);
 
   for sheet in stylesheets {
     for property_rule in sheet.property_rules() {
@@ -257,32 +259,20 @@ fn registered_custom_property_parent_style<'a>(
         continue;
       }
 
-      adjusted_parent
-        .registered_custom_properties
-        .insert(property_rule.name.clone(), property_rule.clone());
+      registered.insert(property_rule.name.clone(), property_rule.clone());
 
       if property_rule.inherits {
         if let Some(parent_value) = parent_style.custom_properties.get(&property_rule.name) {
-          adjusted_parent
-            .custom_properties
-            .insert(property_rule.name.clone(), parent_value.clone());
+          custom.insert(property_rule.name.clone(), parent_value.clone());
         } else if let Some(initial_value) = &property_rule.initial_value {
-          adjusted_parent
-            .custom_properties
-            .insert(property_rule.name.clone(), initial_value.clone());
+          custom.insert(property_rule.name.clone(), initial_value.clone());
         } else {
-          adjusted_parent
-            .custom_properties
-            .remove(&property_rule.name);
+          custom.remove(&property_rule.name);
         }
       } else {
-        adjusted_parent
-          .custom_properties
-          .remove(&property_rule.name);
+        custom.remove(&property_rule.name);
         if let Some(initial_value) = &property_rule.initial_value {
-          adjusted_parent
-            .custom_properties
-            .insert(property_rule.name.clone(), initial_value.clone());
+          custom.insert(property_rule.name.clone(), initial_value.clone());
         }
       }
     }
@@ -2220,7 +2210,7 @@ fn drop_collapsible_boundary_whitespace(
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
+  use std::{str::FromStr, sync::Arc};
 
   use taffy::NodeId as TaffyNodeId;
 
@@ -2263,9 +2253,7 @@ mod tests {
   #[test]
   fn registered_custom_property_can_disable_inheritance() {
     let mut parent = ComputedStyle::default();
-    parent
-      .custom_properties
-      .insert("--box-size".to_owned(), "50px".to_owned());
+    Arc::make_mut(&mut parent.custom_properties).insert("--box-size".to_owned(), "50px".to_owned());
 
     let stylesheets = [StyleSheet::from(vec![PropertyRule {
       name: "--box-size".to_owned(),
@@ -2286,9 +2274,7 @@ mod tests {
   #[test]
   fn registered_custom_property_preserves_parent_value_when_inheriting() {
     let mut parent = ComputedStyle::default();
-    parent
-      .custom_properties
-      .insert("--box-size".to_owned(), "50px".to_owned());
+    Arc::make_mut(&mut parent.custom_properties).insert("--box-size".to_owned(), "50px".to_owned());
 
     let stylesheets = [StyleSheet::from(vec![PropertyRule {
       name: "--box-size".to_owned(),
@@ -2358,9 +2344,7 @@ mod tests {
   #[test]
   fn registered_custom_property_later_inheriting_rule_restores_parent_value() {
     let mut parent = ComputedStyle::default();
-    parent
-      .custom_properties
-      .insert("--box-size".to_owned(), "50px".to_owned());
+    Arc::make_mut(&mut parent.custom_properties).insert("--box-size".to_owned(), "50px".to_owned());
 
     let stylesheets = [StyleSheet::from(vec![
       PropertyRule {

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, fmt, str::FromStr, sync::Arc};
 
 use cssparser::{Parser, ParserInput, RuleBodyParser, Token, match_ignore_ascii_case};
 use parley::Language;
@@ -624,7 +624,7 @@ macro_rules! define_style {
           for declaration in self.declarations.declarations {
             match declaration {
               StyleDeclaration::CustomProperty(name, value) => {
-                style.custom_properties.insert(name, value);
+                Arc::make_mut(&mut style.custom_properties).insert(name, value);
               }
               declaration => declarations.push(declaration),
             }
@@ -682,9 +682,9 @@ macro_rules! define_style {
       #[derive(Clone, Debug)]
       pub struct ComputedStyle {
         /// Resolved custom property values by name.
-        pub custom_properties: HashMap<String, String>,
+        pub custom_properties: Arc<HashMap<String, String>>,
         /// Registered `@property` rules by name.
-        pub registered_custom_properties: HashMap<String, PropertyRule>,
+        pub registered_custom_properties: Arc<HashMap<String, PropertyRule>>,
         /// Resolved BCP-47 language, inherited from the `lang` attribute. Drives
         /// locale-aware shaping (Han unification, line-breaking). Has no CSS property.
         pub lang: Option<Lang>,
@@ -732,16 +732,8 @@ macro_rules! define_style {
         /// Builds a child computed style inheriting from a parent.
         pub(crate) fn from_parent(parent: &Self) -> Self {
           Self {
-            custom_properties: if parent.custom_properties.is_empty() {
-              HashMap::new()
-            } else {
-              parent.custom_properties.clone()
-            },
-            registered_custom_properties: if parent.registered_custom_properties.is_empty() {
-              HashMap::new()
-            } else {
-              parent.registered_custom_properties.clone()
-            },
+            custom_properties: parent.custom_properties.clone(),
+            registered_custom_properties: parent.registered_custom_properties.clone(),
             lang: parent.lang,
             $($longhand: define_inherited_default!(parent.$longhand, define_style!(@default $($longhand_default)?) $(, $longhand_inherit)?),)*
           }
@@ -914,7 +906,7 @@ macro_rules! define_style {
               }
             }
             Self::CustomProperty(name, value) => {
-              style.custom_properties.insert(name, value);
+              Arc::make_mut(&mut style.custom_properties).insert(name, value);
             }
             Self::Deferred(deferred) => {
               apply_deferred_declaration(style, Some(parent), &deferred);
@@ -949,9 +941,7 @@ macro_rules! define_style {
               CssWideKeyword::Inherit | CssWideKeyword::Unset => {}
             },
             Self::CustomProperty(name, value) => {
-              style
-                .custom_properties
-                .insert(name.to_owned(), value.to_owned());
+              Arc::make_mut(&mut style.custom_properties).insert(name.to_owned(), value.to_owned());
             }
             Self::Deferred(deferred) => apply_deferred_declaration(style, None, deferred),
             $(Self::[<$longhand:camel>](value) => style.$longhand.clone_from(value),)*


### PR DESCRIPTION
## Why

`custom_properties` and `registered_custom_properties` are inherited `HashMap`s, so any tree using CSS variables deep-copies both maps (keys and values included) for every node.

## What

Both maps now live behind `Arc`. Inheriting bumps a refcount; the few writers (var declarations and `@property` adjustment) go through `Arc::make_mut`, so only nodes that actually change the maps copy them. Rendered output is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved style inheritance efficiency by sharing custom property data where possible.
  - Reduced unnecessary copying and memory use when styles are inherited across nodes.
  - Updates remain isolated when custom properties are modified, preserving existing behavior.

- **Documentation**
  - Added guidance describing how custom property data is shared across nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->