### PR TITLE
fix(helpers): keep a `;` inside an inline style value

### DIFF
--- a/.tegami/inline-style-semicolon-split.md
+++ b/.tegami/inline-style-semicolon-split.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Keep a `;` inside an inline style value
+
+`fromHtml` / `fromStaticMarkup` split the `style` attribute on every `;`, so a value carrying one of its own was truncated at the first and the remainder dropped. `style="background-image:url(data:image/png;base64,...)"` resolved to `url(data:image/png` — a data URL is the usual way markup embeds an image without a fetch. A quoted `font-family: "Foo; Bar"` was cut the same way. Declarations are now split on top-level `;` only, outside `url()` and quoted strings.

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -235,22 +235,35 @@ function decodeAttributeMap(attributes: Record<string, string>): Record<string, 
  * Only a top-level `;` separates declarations. The character is legal inside a
  * value: `url(data:image/png;base64,...)` is how markup embeds an image without
  * a fetch, and a quoted family name such as `font-family: "Foo; Bar"` may carry
- * one too. Splitting on every `;` truncates the value at the first one and
- * leaves the remainder as a colon-less fragment that is then discarded.
+ * one too, as may an escaped `\;` outside either. Splitting on every `;`
+ * truncates the value at the first one and leaves the remainder as a
+ * colon-less fragment that is then discarded.
+ *
+ * A backslash escapes the next character in every state, which is how CSS
+ * treats it inside and outside a string alike.
  */
 function splitStyleDeclarations(styleText: string): string[] {
   const declarations: string[] = [];
   let start = 0;
   let depth = 0;
   let quote: string | undefined;
+  let escaped = false;
 
   for (let index = 0; index < styleText.length; index += 1) {
     const character = styleText[index];
 
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+
     if (quote !== undefined) {
-      if (character === "\\") {
-        index += 1;
-      } else if (character === quote) {
+      if (character === quote) {
         quote = undefined;
       }
       continue;

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -229,10 +229,54 @@ function decodeAttributeMap(attributes: Record<string, string>): Record<string, 
   return decodedAttributes;
 }
 
+/**
+ * Split a `style` attribute on declaration boundaries.
+ *
+ * Only a top-level `;` separates declarations. The character is legal inside a
+ * value: `url(data:image/png;base64,...)` is how markup embeds an image without
+ * a fetch, and a quoted family name such as `font-family: "Foo; Bar"` may carry
+ * one too. Splitting on every `;` truncates the value at the first one and
+ * leaves the remainder as a colon-less fragment that is then discarded.
+ */
+function splitStyleDeclarations(styleText: string): string[] {
+  const declarations: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote: string | undefined;
+
+  for (let index = 0; index < styleText.length; index += 1) {
+    const character = styleText[index];
+
+    if (quote !== undefined) {
+      if (character === "\\") {
+        index += 1;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === "(") {
+      depth += 1;
+    } else if (character === ")") {
+      depth = Math.max(0, depth - 1);
+    } else if (character === ";" && depth === 0) {
+      declarations.push(styleText.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  declarations.push(styleText.slice(start));
+
+  return declarations;
+}
+
 function parseInlineStyle(styleText: string): CSSProperties | undefined {
   const style: Record<string, string> = {};
 
-  for (const declaration of styleText.split(";")) {
+  for (const declaration of splitStyleDeclarations(styleText)) {
     const [property, ...valueParts] = declaration.split(":");
     if (!property || valueParts.length === 0) {
       continue;

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -91,6 +91,15 @@ describe("fromHtml", () => {
     expect(node.style).toEqual({ color: "red", fontSize: "12px" });
   });
 
+  // A backslash escapes the next character in CSS outside a string as well as
+  // inside one, so an escaped `;` is part of the value rather than a boundary.
+  test("keeps an escaped semicolon outside quotes", () => {
+    const backslash = String.fromCharCode(92);
+    const { node } = fromHtml(`<div style="--value:foo${backslash};bar;color:red">x</div>`);
+
+    expect(node.style).toEqual({ "--value": `foo${backslash};bar`, color: "red" });
+  });
+
   test("tolerates an unclosed url() in an inline style", () => {
     const { node } = fromHtml(`<div style="color:red;background-image:url(">x</div>`);
 

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -64,6 +64,38 @@ describe("fromHtml", () => {
 
     expect((node as TextNode).text).toBe("&#xd800;&#57343;");
   });
+
+  // A data URL carries its own `;`, and it is the usual way markup embeds an
+  // image without a fetch. Splitting the attribute on every `;` truncated the
+  // value and dropped `base64,...` as an unparsable declaration.
+  test("keeps a data URL intact in an inline style", () => {
+    const { node } = fromHtml(
+      `<div style="background-image:url(data:image/png;base64,iVBORw0KGgo=);color:red">x</div>`,
+    );
+
+    expect(node.style).toEqual({
+      backgroundImage: "url(data:image/png;base64,iVBORw0KGgo=)",
+      color: "red",
+    });
+  });
+
+  test("keeps a quoted semicolon inside a declaration value", () => {
+    const { node } = fromHtml(`<div style="font-family:'Foo; Bar', sans-serif;color:red">x</div>`);
+
+    expect(node.style).toEqual({ fontFamily: "'Foo; Bar', sans-serif", color: "red" });
+  });
+
+  test("still separates ordinary declarations", () => {
+    const { node } = fromHtml(`<div style="color:red;font-size:12px;">x</div>`);
+
+    expect(node.style).toEqual({ color: "red", fontSize: "12px" });
+  });
+
+  test("tolerates an unclosed url() in an inline style", () => {
+    const { node } = fromHtml(`<div style="color:red;background-image:url(">x</div>`);
+
+    expect(node.style).toEqual({ color: "red", backgroundImage: "url(" });
+  });
 });
 
 describe("fromJsx", () => {


### PR DESCRIPTION
`parseInlineStyle` splits the `style` attribute on every `;`, but the character is legal inside a declaration value. The value is truncated at the first one and the remainder becomes a colon-less fragment the loop then discards.

The case that matters: a base64 data URL, which is how markup embeds an image without a fetch.

```
<div style="background-image:url(data:image/png;base64,iVBORw0KGgo=);color:red">
```

| input | before | after |
|---|---|---|
| `background-image:url(data:image/png;base64,iVBORw0KGgo=);color:red` | `{"backgroundImage":"url(data:image/png","color":"red"}` | `{"backgroundImage":"url(data:image/png;base64,iVBORw0KGgo=)","color":"red"}` |
| `font-family:'Foo; Bar', sans-serif;color:red` | `{"fontFamily":"'Foo","color":"red"}` | `{"fontFamily":"'Foo; Bar', sans-serif","color":"red"}` |
| `color:red;font-size:12px` | `{"color":"red","fontSize":"12px"}` | unchanged |
| `background-image:url(https://a.example/b.png)` | `{"backgroundImage":"url(https://a.example/b.png)"}` | unchanged |

So the image resolves to `url(data:image/png` and silently renders as nothing — the `base64,…` half is dropped without a warning. Colons were already handled through `valueParts.join(":")`, which is why the `https://` row survives and why this only shows up with `;`.

## The change

Declarations are split on top-level `;` only, tracking `url()` depth and quoted strings — everything else in `parseInlineStyle` is untouched:

```ts
for (const declaration of splitStyleDeclarations(styleText)) {
```

Backslash escapes inside a quoted string are skipped so `content:"a\";b"` stays one declaration, and an unbalanced `(` degrades to a single trailing declaration rather than losing the text.

This is the only such split in the repo — I grepped the TS and Rust sides. It reaches `fromHtml` / `fromStaticMarkup`, which is also the React DOM Server fallback for `fromJsx()`; the ordinary JSX path passes `style` as an object and never went through here.

## Tests

Four cases in `tests/html-markup.test.tsx`: the data URL, the quoted semicolon, ordinary declarations still separating (with a trailing `;`), and the unbalanced-`url(` fallback.

Negative control — reverting the loop to `styleText.split(";")` fails exactly the two new cases and leaves the other twelve green:

```
(fail) fromHtml > keeps a data URL intact in an inline style
(fail) fromHtml > keeps a quoted semicolon inside a declaration value
 12 pass
 2 fail
```

`bun test` on `takumi-helpers`, all files, on Windows:

```
emoji            11 pass  0 fail      element-types             1 pass  0 fail
html-markup      14 pass  0 fail      hooks-dispatcher          7 pass  0 fail
fonts            23 pass  0 fail      jsx-processing           42 pass  0 fail
renderer-facade   9 pass  0 fail      preact                    2 pass  0 fail
prepare-images    5 pass  0 fail      style-presets-override   27 pass  0 fail
                                      svg-serialize             6 pass  0 fail
```

`oxfmt --check` and `oxlint` clean at the pinned versions (0.63.0 / 1.78.0). Changelog added at `.tegami/inline-style-semicolon-split.md` as a patch to `@takumi-rs/helpers`.

One note: I could not run `tests/fetch-limits.test.ts` — it hangs on this machine with no output, which looks like it wants network. Untouched by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline style parsing to preserve semicolons inside `url()` values, quoted strings, and parenthesized values.
  * Correctly separates ordinary declarations and handles unclosed `url()` values without corrupting styles.
* **Tests**
  * Added coverage for data URLs, escaped and quoted semicolons, standard declaration separators, and incomplete URL values.
* **Documentation**
  * Added release documentation describing the inline style parsing improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->