### PR TITLE
Core: restore changeset for shared font lists

### DIFF
--- a/.tegami/share-inherited-font-lists.md
+++ b/.tegami/share-inherited-font-lists.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Share inherited font lists across nodes
+
+`font-family`, `font-variation-settings`, and `font-feature-settings` lists are now `Arc`-shared, so inheriting them no longer copies the list per node.


### PR DESCRIPTION
## Why

PR #1324 auto-merged before its changeset commit was pushed, so the release note for the Arc-shared font lists never landed on master.

## What

Restores `.tegami/share-inherited-font-lists.md` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for a patch release improving inherited font settings, including font families, variation settings, and feature settings.
  * Documented more efficient sharing of inherited font lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->