### PR TITLE
fix(helpers): decode the numeric character references the spec defines

### DIFF
--- a/.tegami/numeric-character-references.md
+++ b/.tegami/numeric-character-references.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Decode the numeric character references the HTML spec defines
+
+`&#X41;` was left as literal text because only a lower-case `x` was matched, though the spec allows either case. References in the C1 range now resolve through the windows-1252 table the spec names, so `&#153;` renders as `™` instead of an invisible control character, and `&#0;` becomes the replacement character rather than a raw NUL.

--- a/takumi-helpers/src/html/entities.ts
+++ b/takumi-helpers/src/html/entities.ts
@@ -256,13 +256,50 @@ const namedHtmlEntities: Record<string, string> = {
   euro: "\u20ac",
 };
 
+// Numeric references the HTML spec remaps rather than decodes literally. The
+// C1 block is the windows-1252 table legacy encoders emit — `&#153;` is meant to
+// be a trademark sign, not an invisible control character — and a null reference
+// becomes the replacement character.
+// https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
+const remappedCodePoints: Record<number, string> = {
+  0x00: "�",
+  0x80: "€",
+  0x82: "‚",
+  0x83: "ƒ",
+  0x84: "„",
+  0x85: "…",
+  0x86: "†",
+  0x87: "‡",
+  0x88: "ˆ",
+  0x89: "‰",
+  0x8a: "Š",
+  0x8b: "‹",
+  0x8c: "Œ",
+  0x8e: "Ž",
+  0x91: "‘",
+  0x92: "’",
+  0x93: "“",
+  0x94: "”",
+  0x95: "•",
+  0x96: "–",
+  0x97: "—",
+  0x98: "˜",
+  0x99: "™",
+  0x9a: "š",
+  0x9b: "›",
+  0x9c: "œ",
+  0x9e: "ž",
+  0x9f: "Ÿ",
+};
+
 export function decodeHtmlEntities(value: string): string {
   if (!value.includes("&")) {
     return value;
   }
 
   return value.replace(
-    /&(?:#(\d+)|#x([\da-fA-F]+)|([a-zA-Z][\w-]+));/g,
+    // `x` may be either case: `&#X41;` is as valid as `&#x41;`.
+    /&(?:#(\d+)|#[xX]([\da-fA-F]+)|([a-zA-Z][\w-]+));/g,
     (match, dec, hex, named) => {
       if (dec) {
         return decodeCodePoint(Number(dec)) ?? match;
@@ -284,6 +321,11 @@ function decodeCodePoint(codePoint: number): string | undefined {
 
   if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
     return;
+  }
+
+  const remapped = remappedCodePoints[codePoint];
+  if (remapped !== undefined) {
+    return remapped;
   }
 
   try {

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -64,6 +64,33 @@ describe("fromHtml", () => {
 
     expect((node as TextNode).text).toBe("&#xd800;&#57343;");
   });
+
+  // The `x` of a hex reference may be either case.
+  test("decodes an upper-case hex reference", () => {
+    const { node } = fromHtml("<div>&#X41;&#Xa9;&#X2764;</div>");
+
+    expect((node as TextNode).text).toBe("A©❤");
+  });
+
+  // The C1 block is the windows-1252 table legacy encoders emit, so `&#153;`
+  // means a trademark sign rather than an invisible control character.
+  test("remaps C1 references to their windows-1252 characters", () => {
+    const { node } = fromHtml("<div>&#153;&#x99;&#128;&#x9F;&#x92;</div>");
+
+    expect((node as TextNode).text).toBe("™™€Ÿ’");
+  });
+
+  test("leaves C1 code points the table does not name", () => {
+    const { node } = fromHtml("<div>&#x81;</div>");
+
+    expect((node as TextNode).text).toBe("");
+  });
+
+  test("decodes a null reference as the replacement character", () => {
+    const { node } = fromHtml("<div>&#0;&#x0;</div>");
+
+    expect((node as TextNode).text).toBe("��");
+  });
 });
 
 describe("fromJsx", () => {


### PR DESCRIPTION
Three deviations in `decodeHtmlEntities`, all of which reach rendered output.

```
              before          after
&#X41;     -> "&#X41;"     -> "A"
&#Xa9;     -> "&#Xa9;"     -> "©"
&#153;     -> ""     -> "™"
&#x99;     -> ""     -> "™"
&#128;     -> ""     -> "€"
&#x92;     -> ""     -> "’"
&#0;       -> ""     -> "�"
&#x2764;   -> "❤"          -> unchanged
&#xd800;   -> "&#xd800;"   -> unchanged
&#x110000; -> "&#x110000;" -> unchanged
```

## 1. `&#X…` never decoded

The hex alternative matched only a lower-case `x`:

```js
/&(?:#(\d+)|#x([\da-fA-F]+)|([a-zA-Z][\w-]+));/g
```

`&#X41;` matches none of the three — `#(\d+)` stops at `X`, `#x` is case-sensitive, and the named branch needs a letter right after `&` — so it fell through and stayed literal. [The spec](https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-state) accepts either case and browsers decode both. Now `#[xX]`.

## 2. C1 references produced invisible control characters

`String.fromCodePoint(0x99)` is a control character, not `™`. The spec remaps the whole C1 block through the windows-1252 table precisely because legacy encoders emit it, and that content is common in scraped or CMS-exported markup — which is what an OG-image or invoice renderer tends to be fed. `&#153;` for `™`, `&#128;` for `€`, `&#146;`/`&#147;` for curly quotes.

The table is applied in `decodeCodePoint`, so it covers the decimal and hex branches together. The five slots the spec leaves unnamed (0x81, 0x8D, 0x8F, 0x90, 0x9D) are not in the table and keep their current behaviour — there is a test pinning that.

## 3. `&#0;` produced a raw NUL

The spec maps a null reference to the replacement character. That also matches what the function already does around it: it refuses surrogates and out-of-range code points rather than emitting something unrenderable, and a NUL in a shaped text run is the same class of problem.

## Tests

Four in `tests/html-markup.test.tsx`, alongside the existing entity cases: upper-case hex, the C1 remapping, the unnamed C1 slots staying put, and the null reference.

Negative control — reverting `entities.ts` alone fails exactly the three behavioural ones and leaves the rest of the file green:

```
(fail) fromHtml > decodes an upper-case hex reference
(fail) fromHtml > remaps C1 references to their windows-1252 characters
(fail) fromHtml > decodes a null reference as the replacement character
 11 pass
 3 fail
```

`bun test` across `takumi-helpers` on Windows, all files: **147 pass, 0 fail** (emoji 11, html-markup 14, fonts 23, renderer-facade 9, prepare-images 5, jsx 85). `tests/fetch-limits.test.ts` is the one I could not run — it hangs with no output here, which looks like it wants network; untouched by this change.

Changelog at `.tegami/numeric-character-references.md` as a patch to `@takumi-rs/helpers`.

The named-entity table is deliberately the HTML4 subset per the comment at the top of the file, so I left it alone — this is only about the numeric forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML entity decoding for uppercase hexadecimal references.
  * Added correct handling for Windows-1252 character mappings.
  * Null character references now decode to the replacement character.
* **Documentation**
  * Added release notes documenting the numeric character reference fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->