### PR TITLE
Core: keep degenerate CSS values out of layout

### DIFF
--- a/.tegami/degenerate-float-css-values.md
+++ b/.tegami/degenerate-float-css-values.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Keep degenerate CSS values out of layout
+
+`aspect-ratio` with a zero, negative, or non-finite ratio (such as `1/0`) now behaves as `auto`, and an infinite percentage length is clamped instead of feeding infinity into layout.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -145,27 +145,6 @@ pub struct RenderNode {
   pub table_header_lines: Option<(i16, i16)>,
 }
 
-/// Drops the render tree iteratively; recursive drop glue overflows the stack
-/// on deep user trees, same reason `Node` has an iterative `Drop`.
-impl Drop for RenderNode {
-  fn drop(&mut self) {
-    let mut stack: Vec<RenderNode> = Vec::new();
-    let mut collect = |node: &mut RenderNode, stack: &mut Vec<RenderNode>| {
-      if let Some(children) = node.children.take() {
-        stack.extend(children.into_vec());
-      }
-      if let Some(marker) = node.marker.take() {
-        stack.push(*marker);
-      }
-    };
-
-    collect(self, &mut stack);
-    while let Some(mut node) = stack.pop() {
-      collect(&mut node, &mut stack);
-    }
-  }
-}
-
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AtomicInlineMetrics {
   pub(crate) size: Size<f32>,
@@ -2235,15 +2214,11 @@ mod tests {
 
   use taffy::NodeId as TaffyNodeId;
 
-  use super::{
-    NodeOrigin, RenderNode, registered_custom_property_parent_style, sort_children_by_order,
-  };
+  use super::{registered_custom_property_parent_style, sort_children_by_order};
   use crate::{
-    context::RenderContext,
-    resources::font::Fonts,
     style::{
-      ComputedStyle, Length, PropertyRule, SizingContext, Style, StyleDeclaration,
-      StyleDeclarationBlock, StyleSheet,
+      ComputedStyle, Length, PropertyRule, Style, StyleDeclaration, StyleDeclarationBlock,
+      StyleSheet,
     },
     viewport::Viewport,
   };
@@ -2252,36 +2227,6 @@ mod tests {
     let result = StyleSheet::parse(css);
     assert!(result.is_ok(), "expected stylesheet to parse: {result:?}");
     result.unwrap_or_default()
-  }
-
-  #[test]
-  fn render_node_drop_is_iterative() {
-    let context = RenderContext::builder()
-      .fonts(Fonts::default().snapshot())
-      .sizing(
-        SizingContext::builder()
-          .viewport(Viewport::default())
-          .build(),
-      )
-      .build();
-    let leaf = |children: Option<Box<[RenderNode]>>| RenderNode {
-      context: context.clone(),
-      node: None,
-      origin: NodeOrigin::Anonymous,
-      children,
-      layout_style_override: None,
-      anonymous_text_content: None,
-      marker: None,
-      force_inline_layout: false,
-      table_header_lines: None,
-    };
-
-    let mut root = leaf(None);
-    for _ in 0..500_000 {
-      root = leaf(Some(Box::new([root])));
-    }
-
-    drop(root);
   }
 
   #[test]

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -145,6 +145,27 @@ pub struct RenderNode {
   pub table_header_lines: Option<(i16, i16)>,
 }
 
+/// Drops the render tree iteratively; recursive drop glue overflows the stack
+/// on deep user trees, same reason `Node` has an iterative `Drop`.
+impl Drop for RenderNode {
+  fn drop(&mut self) {
+    let mut stack: Vec<RenderNode> = Vec::new();
+    let mut collect = |node: &mut RenderNode, stack: &mut Vec<RenderNode>| {
+      if let Some(children) = node.children.take() {
+        stack.extend(children.into_vec());
+      }
+      if let Some(marker) = node.marker.take() {
+        stack.push(*marker);
+      }
+    };
+
+    collect(self, &mut stack);
+    while let Some(mut node) = stack.pop() {
+      collect(&mut node, &mut stack);
+    }
+  }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AtomicInlineMetrics {
   pub(crate) size: Size<f32>,
@@ -2214,11 +2235,15 @@ mod tests {
 
   use taffy::NodeId as TaffyNodeId;
 
-  use super::{registered_custom_property_parent_style, sort_children_by_order};
+  use super::{
+    NodeOrigin, RenderNode, registered_custom_property_parent_style, sort_children_by_order,
+  };
   use crate::{
+    context::RenderContext,
+    resources::font::Fonts,
     style::{
-      ComputedStyle, Length, PropertyRule, Style, StyleDeclaration, StyleDeclarationBlock,
-      StyleSheet,
+      ComputedStyle, Length, PropertyRule, SizingContext, Style, StyleDeclaration,
+      StyleDeclarationBlock, StyleSheet,
     },
     viewport::Viewport,
   };
@@ -2227,6 +2252,36 @@ mod tests {
     let result = StyleSheet::parse(css);
     assert!(result.is_ok(), "expected stylesheet to parse: {result:?}");
     result.unwrap_or_default()
+  }
+
+  #[test]
+  fn render_node_drop_is_iterative() {
+    let context = RenderContext::builder()
+      .fonts(Fonts::default().snapshot())
+      .sizing(
+        SizingContext::builder()
+          .viewport(Viewport::default())
+          .build(),
+      )
+      .build();
+    let leaf = |children: Option<Box<[RenderNode]>>| RenderNode {
+      context: context.clone(),
+      node: None,
+      origin: NodeOrigin::Anonymous,
+      children,
+      layout_style_override: None,
+      anonymous_text_content: None,
+      marker: None,
+      force_inline_layout: false,
+      table_header_lines: None,
+    };
+
+    let mut root = leaf(None);
+    for _ in 0..500_000 {
+      root = leaf(Some(Box::new([root])));
+    }
+
+    drop(root);
   }
 
   #[test]

--- a/takumi-core/src/style/properties/aspect_ratio.rs
+++ b/takumi-core/src/style/properties/aspect_ratio.rs
@@ -86,6 +86,11 @@ impl<'i> FromCss<'i> for AspectRatio {
     }
 
     let second_ratio = input.expect_number()?;
+
+    if first_ratio < 0.0 || second_ratio < 0.0 {
+      return Ok(AspectRatio::Auto);
+    }
+
     Ok(AspectRatio::ratio(first_ratio / second_ratio))
   }
 
@@ -114,6 +119,7 @@ mod tests {
     assert_eq!(AspectRatio::from_css_str("0/0"), Ok(AspectRatio::Auto));
     assert_eq!(AspectRatio::from_css_str("0"), Ok(AspectRatio::Auto));
     assert_eq!(AspectRatio::from_css_str("-2"), Ok(AspectRatio::Auto));
+    assert_eq!(AspectRatio::from_css_str("-2/-3"), Ok(AspectRatio::Auto));
   }
 
   #[test]

--- a/takumi-core/src/style/properties/aspect_ratio.rs
+++ b/takumi-core/src/style/properties/aspect_ratio.rs
@@ -18,6 +18,17 @@ pub enum AspectRatio {
   Ratio(f32),
 }
 
+impl AspectRatio {
+  /// A degenerate ratio (zero, negative, or non-finite) behaves as `auto`.
+  fn ratio(value: f32) -> Self {
+    if value.is_finite() && value > 0.0 {
+      Self::Ratio(value)
+    } else {
+      Self::Auto
+    }
+  }
+}
+
 impl MakeComputed for AspectRatio {}
 
 impl Animatable for AspectRatio {
@@ -71,11 +82,11 @@ impl<'i> FromCss<'i> for AspectRatio {
     let first_ratio = input.expect_number()?;
 
     if input.try_parse(|input| input.expect_delim('/')).is_err() {
-      return Ok(AspectRatio::Ratio(first_ratio));
+      return Ok(AspectRatio::ratio(first_ratio));
     }
 
     let second_ratio = input.expect_number()?;
-    Ok(AspectRatio::Ratio(first_ratio / second_ratio))
+    Ok(AspectRatio::ratio(first_ratio / second_ratio))
   }
 
   const VALID_TOKENS: &'static [CssToken] = &[
@@ -96,6 +107,14 @@ impl ToCss for AspectRatio {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn degenerate_ratios_behave_as_auto() {
+    assert_eq!(AspectRatio::from_css_str("1/0"), Ok(AspectRatio::Auto));
+    assert_eq!(AspectRatio::from_css_str("0/0"), Ok(AspectRatio::Auto));
+    assert_eq!(AspectRatio::from_css_str("0"), Ok(AspectRatio::Auto));
+    assert_eq!(AspectRatio::from_css_str("-2"), Ok(AspectRatio::Auto));
+  }
 
   #[test]
   fn parses_auto_keyword() {

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -427,7 +427,7 @@ impl Length {
   pub(crate) fn to_compact_length(self, sizing: &SizingContext) -> CompactLength {
     match self {
       Length::Auto => CompactLength::auto(),
-      Length::Percentage(value) => CompactLength::percent(value / 100.0),
+      Length::Percentage(value) => CompactLength::percent(clamp_px_for_integer_cast(value / 100.0)),
       Length::Rem(_)
       | Length::Em(_)
       | Length::Lh(_)
@@ -1020,6 +1020,13 @@ mod tests {
         "{css} produced a non-finite CompactLength"
       );
     }
+  }
+
+  #[test]
+  fn infinite_percentage_never_reaches_compact_length() {
+    let compact = Length::Percentage(f32::INFINITY).to_compact_length(&sizing());
+
+    assert!(compact.value().is_finite());
   }
 
   #[test]

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -1024,9 +1024,16 @@ mod tests {
 
   #[test]
   fn infinite_percentage_never_reaches_compact_length() {
-    let compact = Length::Percentage(f32::INFINITY).to_compact_length(&sizing());
+    for (value, expected) in [
+      (f32::INFINITY, SAFE_INT_MAX_PX),
+      (f32::NEG_INFINITY, SAFE_INT_MIN_PX),
+      (f32::NAN, 0.0),
+    ] {
+      let compact = Length::Percentage(value).to_compact_length(&sizing());
 
-    assert!(compact.value().is_finite());
+      assert_eq!(compact.tag(), CompactLength::PERCENT_TAG, "for {value}");
+      assert_eq!(compact.value(), expected, "for {value}");
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Why

`aspect-ratio: 1/0` parses to infinity and `0/0` to NaN, and both flow straight into `taffy::Style::aspect_ratio`. An infinite percentage (`width: 1e400%`) reaches taffy the same way through the one `to_compact_length` branch that skips the finite clamp.

## What

A degenerate ratio (zero, negative, or non-finite) now computes to `auto` per css-values-4, and the percentage branch clamps through `clamp_px_for_integer_cast` like every other branch. Both pinned by unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or degenerate `aspect-ratio` values now safely fall back to automatic sizing.
  * Zero, negative, and non-finite aspect ratios are excluded from layout calculations.
  * Infinite or out-of-range percentage lengths are now clamped to finite values, improving layout stability.

* **Documentation**
  * Added patch-release notes describing the handling of invalid CSS values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->