### PR TITLE
Core: copy custom property maps only when a property rule matches

### DIFF
--- a/.tegami/calc-inline-terms.md
+++ b/.tegami/calc-inline-terms.md
@@ -1,7 +1,7 @@
 ---
 packages:
   "@takumi-rs/core":
-    type: patch
+    type: minor
 ---
 
 ### Store `calc()` as its non-zero terms

--- a/.tegami/share-custom-property-maps.md
+++ b/.tegami/share-custom-property-maps.md
@@ -1,7 +1,7 @@
 ---
 packages:
   "@takumi-rs/core":
-    type: patch
+    type: minor
 ---
 
 ### Share custom property maps across nodes

--- a/.tegami/share-inherited-font-lists.md
+++ b/.tegami/share-inherited-font-lists.md
@@ -1,7 +1,7 @@
 ---
 packages:
   "@takumi-rs/core":
-    type: patch
+    type: minor
 ---
 
 ### Share inherited font lists across nodes

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -248,8 +248,6 @@ fn registered_custom_property_parent_style<'a>(
   }
 
   let mut adjusted_parent = parent_style.clone();
-  let registered = Arc::make_mut(&mut adjusted_parent.registered_custom_properties);
-  let custom = Arc::make_mut(&mut adjusted_parent.custom_properties);
 
   for sheet in stylesheets {
     for property_rule in sheet.property_rules() {
@@ -260,6 +258,9 @@ fn registered_custom_property_parent_style<'a>(
       {
         continue;
       }
+
+      let registered = Arc::make_mut(&mut adjusted_parent.registered_custom_properties);
+      let custom = Arc::make_mut(&mut adjusted_parent.custom_properties);
 
       registered.insert(property_rule.name.clone(), property_rule.clone());
 


### PR DESCRIPTION
## Why

CodeRabbit on #1325: `registered_custom_property_parent_style` ran `Arc::make_mut` on both maps before the media-query check, so documents whose `@property` rules never match the viewport still deep-copied both maps per node. Its second finding also stands: the Arc field changes and the `Length` calc change are breaking for Rust users of these pub types, so all three pending changesets move from patch to minor (v0 rule).

## What

The `make_mut` calls move inside the loop after the media-query check, so only a matching rule pays the copy. Changesets for #1322/#1324/#1325 bumped to minor.