### PR TITLE
Chore: fix clippy lints new in Rust 1.98

### DIFF
--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -586,7 +586,7 @@ fn record_matches<'a>(
     return;
   };
   if !rule.normal_declarations.is_empty() {
-    let normal_layer_order = rule.layer_order.map_or(layer_count, |order| order);
+    let normal_layer_order = rule.layer_order.unwrap_or(layer_count);
     bucket.push(MatchedRule {
       important: false,
       layer_order: normal_layer_order,

--- a/takumi-core/src/resources/image_buffer.rs
+++ b/takumi-core/src/resources/image_buffer.rs
@@ -103,7 +103,7 @@ impl ImageBuffer {
 
 /// Converts premultiplied RGBA bytes to straight alpha in place.
 pub(crate) fn unpremultiply_in_place(data: &mut [u8]) {
-  for pixel in data.chunks_exact_mut(4) {
+  for pixel in data.as_chunks_mut::<4>().0 {
     let alpha = pixel[3];
     if alpha != 0 && alpha != 255 {
       let alpha = alpha as u16;
@@ -119,22 +119,22 @@ const ALPHA_MASK_U128: u128 =
 
 #[inline(always)]
 fn has_opaque_alpha(raw: &[u8]) -> bool {
-  let mut chunks = raw.chunks_exact(16);
-  for chunk in chunks.by_ref() {
-    let bytes: [u8; 16] = chunk.try_into().unwrap_or([0; 16]);
-    if u128::from_ne_bytes(bytes) & ALPHA_MASK_U128 != ALPHA_MASK_U128 {
+  let (chunks, remainder) = raw.as_chunks::<16>();
+  for chunk in chunks {
+    if u128::from_ne_bytes(*chunk) & ALPHA_MASK_U128 != ALPHA_MASK_U128 {
       return false;
     }
   }
-  chunks
-    .remainder()
-    .chunks_exact(4)
+  remainder
+    .as_chunks::<4>()
+    .0
+    .iter()
     .all(|pixel| pixel[3] == u8::MAX)
 }
 
 #[inline(always)]
 pub(crate) fn premultiply_rgba_in_place(raw: &mut [u8]) {
-  for pixel in raw.chunks_exact_mut(4) {
+  for pixel in raw.as_chunks_mut::<4>().0 {
     let alpha = pixel[3];
     if alpha == u8::MAX {
       continue;

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -302,7 +302,12 @@ fn decode_png_scaled(
     match channels {
       4 => rgba_row.copy_from_slice(row.data()),
       _ => {
-        for (rgba, pixel) in rgba_row.chunks_exact_mut(4).zip(row.data().chunks_exact(2)) {
+        for (rgba, pixel) in rgba_row
+          .as_chunks_mut::<4>()
+          .0
+          .iter_mut()
+          .zip(row.data().as_chunks::<2>().0)
+        {
           rgba[0] = pixel[0];
           rgba[1] = pixel[0];
           rgba[2] = pixel[0];

--- a/takumi-pdf/src/paint.rs
+++ b/takumi-pdf/src/paint.rs
@@ -93,7 +93,7 @@ pub(crate) fn overflow_clip_rect(
 /// embedded bytes never become premultiplied samples in the first place.
 #[cfg(feature = "images")]
 fn unpremultiply(data: &mut [u8]) {
-  for pixel in data.chunks_exact_mut(4) {
+  for pixel in data.as_chunks_mut::<4>().0 {
     let alpha = pixel[3];
     if alpha != 0 && alpha != 255 {
       let alpha16 = u16::from(alpha);
@@ -174,8 +174,8 @@ pub(crate) fn rasterized_image(
 
   unpremultiply(&mut data);
   if let Some(filter) = filter {
-    for pixel in data.chunks_exact_mut(4) {
-      pixel.copy_from_slice(&filter.apply([pixel[0], pixel[1], pixel[2], pixel[3]]));
+    for pixel in data.as_chunks_mut::<4>().0 {
+      *pixel = filter.apply(*pixel);
     }
   }
   Ok(Some(KrillaImage::from_rgba8(

--- a/takumi-raster/src/blend.rs
+++ b/takumi-raster/src/blend.rs
@@ -580,7 +580,7 @@ pub(crate) fn blend_premultiplied_pixel_normal(dst: &mut [u8], src: Premultiplie
 }
 
 pub(crate) fn composite_premultiplied_over_span(dst: &mut [u8], pixels: &[PremultipliedColorU8]) {
-  for (dst_pixel, src_pixel) in dst.chunks_exact_mut(4).zip(pixels) {
+  for (dst_pixel, src_pixel) in dst.as_chunks_mut::<4>().0.iter_mut().zip(pixels) {
     let src_a = src_pixel.alpha();
     let inv_src_a = (u8::MAX - src_a) as u32;
     dst_pixel[0] = src_pixel
@@ -601,7 +601,7 @@ pub(crate) fn fill_repeated_premultiplied_pixel(dst: &mut [u8], pixel: [u8; 4]) 
 }
 
 pub(crate) fn blend_repeated_premultiplied_pixel(dst: &mut [u8], pixel: PremultipliedColorU8) {
-  for dst_pixel in dst.chunks_exact_mut(4) {
+  for dst_pixel in dst.as_chunks_mut::<4>().0 {
     blend_premultiplied_pixel_normal(dst_pixel, pixel);
   }
 }

--- a/takumi-raster/src/canvas/gradient.rs
+++ b/takumi-raster/src/canvas/gradient.rs
@@ -258,7 +258,7 @@ fn try_overlay_radial_gradient_tile_fast_normal_unconstrained(
       let center_byte_end = center_byte_start + center_pixels * 4;
       let center_row = &mut row[center_byte_start..center_byte_end];
       let mut row_state = gradient.begin_row(active_x_start, src_y, lut_len);
-      for pixel in center_row.chunks_exact_mut(4) {
+      for pixel in center_row.as_chunks_mut::<4>().0 {
         let lut_idx = gradient.next_lut_index(&mut row_state);
         let src = gradient.sample_at(lut_idx);
         blend_premultiplied_pixel_normal(pixel, src);

--- a/takumi-raster/src/dithering.rs
+++ b/takumi-raster/src/dithering.rs
@@ -56,7 +56,7 @@ pub(crate) fn apply_dithering(image: &mut RgbaImage, algorithm: DitheringAlgorit
 fn apply_ordered_bayer(image: &mut RgbaImage) {
   let width = image.width() as usize;
 
-  for (pixel_index, pixel) in image.as_mut().chunks_exact_mut(4).enumerate() {
+  for (pixel_index, pixel) in image.as_mut().as_chunks_mut::<4>().0.iter_mut().enumerate() {
     if pixel[3] == 0 {
       continue;
     }
@@ -77,7 +77,7 @@ fn apply_floyd_steinberg(image: &mut RgbaImage) {
   let mut next_errors = vec![[0.0; 3]; width + 2];
 
   for row in image.as_mut().chunks_exact_mut(width * 4) {
-    for (x, pixel) in row.chunks_exact_mut(4).enumerate() {
+    for (x, pixel) in row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
       if pixel[3] == 0 {
         continue;
       }

--- a/takumi-raster/src/write.rs
+++ b/takumi-raster/src/write.rs
@@ -803,9 +803,9 @@ mod tests {
   fn write_image_does_not_apply_dithering() {
     let mut image = RgbaImage::new(8, 8);
 
-    for (index, pixel) in image.as_mut().chunks_exact_mut(4).enumerate() {
+    for (index, pixel) in image.as_mut().as_chunks_mut::<4>().0.iter_mut().enumerate() {
       let value = (index * 3) as u8;
-      pixel.copy_from_slice(&[value, value, value, 255]);
+      *pixel = [value, value, value, 255];
     }
 
     let mut dithered_image = image.clone();

--- a/takumi/tests/fixtures/paint_bounds_text_ink.rs
+++ b/takumi/tests/fixtures/paint_bounds_text_ink.rs
@@ -51,7 +51,9 @@ fn rightmost_ink_column(image: &Bitmap) -> u32 {
 
   image
     .as_raw()
-    .chunks_exact(4)
+    .as_chunks::<4>()
+    .0
+    .iter()
     .enumerate()
     .filter_map(|(index, pixel)| {
       let dark = pixel[3] > 0 && pixel[0].min(pixel[1]).min(pixel[2]) < 160;
@@ -94,7 +96,9 @@ fn bottommost_ink_row(image: &Bitmap) -> u32 {
 
   image
     .as_raw()
-    .chunks_exact(4)
+    .as_chunks::<4>()
+    .0
+    .iter()
     .enumerate()
     .filter_map(|(index, pixel)| {
       let dark = pixel[3] > 0 && pixel[0].min(pixel[1]).min(pixel[2]) < 160;

--- a/takumi/tests/fixtures/style_opacity.rs
+++ b/takumi/tests/fixtures/style_opacity.rs
@@ -25,7 +25,9 @@ fn darkest_pixel_in_range(image: &Bitmap, x_range: std::ops::Range<u32>) -> u8 {
 
   image
     .as_raw()
-    .chunks_exact(4)
+    .as_chunks::<4>()
+    .0
+    .iter()
     .enumerate()
     .filter_map(|(index, pixel)| {
       let x = index as u32 % width;

--- a/takumi/tests/fixtures/text.rs
+++ b/takumi/tests/fixtures/text.rs
@@ -1642,7 +1642,9 @@ fn rightmost_dark_column(image: &Bitmap) -> u32 {
 
   image
     .as_raw()
-    .chunks_exact(4)
+    .as_chunks::<4>()
+    .0
+    .iter()
     .enumerate()
     .filter_map(|(index, pixel)| {
       let dark = pixel[3] > 0 && pixel[0].min(pixel[1]).min(pixel[2]) < 160;

--- a/takumi/tests/font_tests.rs
+++ b/takumi/tests/font_tests.rs
@@ -60,13 +60,18 @@ fn render_devanagari(fonts: &Fonts, family: &str) -> Bitmap {
 }
 
 fn inked_pixels(bitmap: &Bitmap) -> u32 {
-  bitmap.as_raw().chunks_exact(4).filter(|p| p[3] > 0).count() as u32
+  let (pixels, _) = bitmap.as_raw().as_chunks::<4>();
+
+  pixels.iter().filter(|p| p[3] > 0).count() as u32
 }
 
 fn pixel_diff(a: &Bitmap, b: &Bitmap) -> u32 {
-  a.as_raw()
-    .chunks_exact(4)
-    .zip(b.as_raw().chunks_exact(4))
+  let (a_pixels, _) = a.as_raw().as_chunks::<4>();
+  let (b_pixels, _) = b.as_raw().as_chunks::<4>();
+
+  a_pixels
+    .iter()
+    .zip(b_pixels)
     .filter(|(x, y)| x != y)
     .count() as u32
 }


### PR DESCRIPTION
## Why

Rust stable moved to 1.98 and its Clippy added `map_or_identity` and `chunks_exact_to_as_chunks`. CI lints with `-D warnings`, so every PR now fails on code that predates the toolchain.

## What

Replaces `chunks_exact(N)` calls that use a constant size with `as_chunks::<N>()` and one `map_or` identity with `unwrap_or`. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal image and pixel processing efficiency through more direct RGBA data handling.
  * Streamlined blending, gradients, dithering, decoding, and alpha checks without changing rendered output.

* **Tests**
  * Updated pixel-based test utilities to use consistent fixed-size RGBA processing.
  * Existing pixel comparisons and rendering checks retain their previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->