### PR TITLE
Core: start backwards-filled step animations on the first step

### DIFF
--- a/.tegami/steps-before-flag.md
+++ b/.tegami/steps-before-flag.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Start backwards-filled step animations on the first step
+
+An animation with `animation-fill-mode: backwards` or `both` and a positive delay held the second step during the delay when its timing function was `steps(n, jump-start)` or `steps(n, jump-both)`. Samples taken before the active phase now land on the step below the jump, as the CSS easing algorithm requires.
+
+`steps()` also serializes the way the spec asks: `steps(4, end)` and `steps(4, jump-end)` both print as `steps(4)`, since an end position is the default.

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -79,7 +79,7 @@ pub(crate) fn apply_stylesheet_animations(
     let timing_function =
       timing_function_at(&base_snapshot.animation_timing_function, animation_index);
 
-    let Some(progress) = sample_animation_progress(
+    let Some(sample) = sample_animation_progress(
       time as f32,
       duration.milliseconds,
       delay.milliseconds,
@@ -91,11 +91,12 @@ pub(crate) fn apply_stylesheet_animations(
     };
 
     let resolved_frames = resolve_keyframes(&keyframes, &base_snapshot);
-    let Some(segment) = sample_keyframe_segment(&resolved_frames, &base_snapshot, progress) else {
+    let Some(segment) = sample_keyframe_segment(&resolved_frames, &base_snapshot, sample.progress)
+    else {
       continue;
     };
 
-    let eased_progress = apply_timing_function(&timing_function, segment.progress);
+    let eased_progress = apply_timing_function(&timing_function, segment.progress, sample.before);
     base_style.apply_interpolated_properties(
       segment.from_style,
       segment.to_style,
@@ -212,6 +213,32 @@ fn keyframe<const N: usize>(offset: f32, declarations: [StyleDeclaration; N]) ->
   }
 }
 
+/// One sampled point on an animation's timeline.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct AnimationSample {
+  /// Progress through the current iteration.
+  progress: f32,
+  /// Whether the sample comes from before the active phase, which the step
+  /// easing functions treat as sitting on the lower step.
+  before: bool,
+}
+
+impl AnimationSample {
+  fn active(progress: f32) -> Self {
+    Self {
+      progress,
+      before: false,
+    }
+  }
+
+  fn before(progress: f32) -> Self {
+    Self {
+      progress,
+      before: true,
+    }
+  }
+}
+
 fn sample_animation_progress(
   time_ms: f32,
   duration_ms: f32,
@@ -219,18 +246,20 @@ fn sample_animation_progress(
   iteration_count: AnimationIterationCount,
   direction: AnimationDirection,
   fill_mode: AnimationFillMode,
-) -> Option<f32> {
+) -> Option<AnimationSample> {
   let active_time = time_ms - delay_ms;
 
   if duration_ms <= 0.0 {
     if active_time < 0.0 {
       return match fill_mode {
-        AnimationFillMode::Backwards | AnimationFillMode::Both => Some(start_progress(direction)),
+        AnimationFillMode::Backwards | AnimationFillMode::Both => {
+          Some(AnimationSample::before(start_progress(direction)))
+        }
         _ => None,
       };
     }
 
-    return Some(end_progress(direction, 0));
+    return Some(AnimationSample::active(end_progress(direction, 0)));
   }
 
   let total_active_duration = match iteration_count {
@@ -240,7 +269,9 @@ fn sample_animation_progress(
 
   if active_time < 0.0 {
     return match fill_mode {
-      AnimationFillMode::Backwards | AnimationFillMode::Both => Some(start_progress(direction)),
+      AnimationFillMode::Backwards | AnimationFillMode::Both => {
+        Some(AnimationSample::before(start_progress(direction)))
+      }
       _ => None,
     };
   }
@@ -261,7 +292,7 @@ fn sample_animation_progress(
             }
           }
         };
-        Some(end_progress)
+        Some(AnimationSample::active(end_progress))
       }
       _ => None,
     };
@@ -275,7 +306,11 @@ fn sample_animation_progress(
     iteration_index = iteration_index.saturating_sub(1);
   }
 
-  Some(apply_direction(progress, direction, iteration_index))
+  Some(AnimationSample::active(apply_direction(
+    progress,
+    direction,
+    iteration_index,
+  )))
 }
 
 fn start_progress(direction: AnimationDirection) -> f32 {
@@ -1071,6 +1106,22 @@ mod tests {
   }
 
   #[test]
+  fn backwards_fill_samples_from_before_the_active_phase() {
+    let sample = sample_animation_progress(
+      0.0,
+      1000.0,
+      500.0,
+      AnimationIterationCount::Number(1.0),
+      AnimationDirection::Normal,
+      AnimationFillMode::Backwards,
+    )
+    .expect("backwards fill applies during the delay");
+
+    assert_eq!(sample.progress, 0.0);
+    assert!(sample.before);
+  }
+
+  #[test]
   fn animation_progress_uses_next_iteration_start_at_boundaries() {
     let progress = sample_animation_progress(
       1000.0,
@@ -1081,7 +1132,7 @@ mod tests {
       AnimationFillMode::Both,
     );
 
-    assert_eq!(progress, Some(1.0));
+    assert_eq!(progress.map(|sample| sample.progress), Some(1.0));
   }
 
   #[test]
@@ -1095,7 +1146,7 @@ mod tests {
       AnimationFillMode::Forwards,
     );
 
-    assert_eq!(progress, Some(0.0));
+    assert_eq!(progress.map(|sample| sample.progress), Some(0.0));
   }
 
   #[test]
@@ -1109,7 +1160,7 @@ mod tests {
       AnimationFillMode::Forwards,
     );
 
-    assert_eq!(progress, Some(0.5));
+    assert_eq!(progress.map(|sample| sample.progress), Some(0.5));
   }
 
   #[test]
@@ -1123,7 +1174,7 @@ mod tests {
       AnimationFillMode::Both,
     );
 
-    assert_eq!(progress, Some(1.0));
+    assert_eq!(progress.map(|sample| sample.progress), Some(1.0));
   }
 
   #[test]

--- a/takumi-core/src/style/properties/animation.rs
+++ b/takumi-core/src/style/properties/animation.rs
@@ -599,7 +599,7 @@ fn cubic_bezier_sample(x1: f32, y1: f32, x2: f32, y2: f32, progress: f32) -> f32
   sample_curve(ay, by, cy, t)
 }
 
-fn steps_sample(step_count: u32, position: StepPosition, progress: f32) -> f32 {
+fn steps_sample(step_count: u32, position: StepPosition, progress: f32, before: bool) -> f32 {
   let steps = step_count as f32;
   let progress = progress.clamp(0.0, 1.0);
 
@@ -612,19 +612,35 @@ fn steps_sample(step_count: u32, position: StepPosition, progress: f32) -> f32 {
     StepPosition::JumpNone => ((steps - 1.0).max(1.0), 0.0),
   };
 
-  ((progress * steps + start_offset).floor().clamp(0.0, jumps)) / jumps
+  let scaled = progress * steps;
+  let mut current_step = (scaled + start_offset).floor();
+  if before && scaled.fract() == 0.0 {
+    current_step -= 1.0;
+  }
+
+  current_step.clamp(0.0, jumps) / jumps
 }
 
-pub(crate) fn apply_timing_function(function: &AnimationTimingFunction, progress: f32) -> f32 {
+/// Samples the easing curve at `progress`. `before` marks a sample taken from
+/// the interval before the animation's active phase, where a step function
+/// sitting exactly on a jump takes the lower step.
+/// https://drafts.csswg.org/css-easing-1/#step-easing-algo
+pub(crate) fn apply_timing_function(
+  function: &AnimationTimingFunction,
+  progress: f32,
+  before: bool,
+) -> f32 {
   match function {
     AnimationTimingFunction::Linear => progress,
     AnimationTimingFunction::Ease => cubic_bezier_sample(0.25, 0.1, 0.25, 1.0, progress),
     AnimationTimingFunction::EaseIn => cubic_bezier_sample(0.42, 0.0, 1.0, 1.0, progress),
     AnimationTimingFunction::EaseOut => cubic_bezier_sample(0.0, 0.0, 0.58, 1.0, progress),
     AnimationTimingFunction::EaseInOut => cubic_bezier_sample(0.42, 0.0, 0.58, 1.0, progress),
-    AnimationTimingFunction::StepStart => steps_sample(1, StepPosition::Start, progress),
-    AnimationTimingFunction::StepEnd => steps_sample(1, StepPosition::End, progress),
-    AnimationTimingFunction::Steps(count, position) => steps_sample(*count, *position, progress),
+    AnimationTimingFunction::StepStart => steps_sample(1, StepPosition::Start, progress, before),
+    AnimationTimingFunction::StepEnd => steps_sample(1, StepPosition::End, progress, before),
+    AnimationTimingFunction::Steps(count, position) => {
+      steps_sample(*count, *position, progress, before)
+    }
     AnimationTimingFunction::CubicBezier(x1, y1, x2, y2) => {
       cubic_bezier_sample(*x1, *y1, *x2, *y2, progress)
     }
@@ -659,10 +675,11 @@ impl ToCss for AnimationTimingFunction {
       Self::StepStart => dest.write_str("step-start"),
       Self::StepEnd => dest.write_str("step-end"),
       Self::Steps(count, position) => {
-        dest.write_str("steps(")?;
-        write!(dest, "{}", count)?;
-        dest.write_str(", ")?;
-        position.to_css(dest)?;
+        write!(dest, "steps({count}")?;
+        if *position != StepPosition::End {
+          dest.write_str(", ")?;
+          position.to_css(dest)?;
+        }
         dest.write_char(')')
       }
       Self::CubicBezier(x1, y1, x2, y2) => write!(dest, "cubic-bezier({x1}, {y1}, {x2}, {y2})"),
@@ -795,6 +812,7 @@ mod tests {
       apply_timing_function(
         &AnimationTimingFunction::from_css_str(css).unwrap(),
         progress,
+        false,
       )
     };
 
@@ -813,6 +831,47 @@ mod tests {
     for (progress, expected) in [(0.0, 0.25), (0.3, 0.5), (0.6, 0.75), (1.0, 1.0)] {
       assert_eq!(sample("steps(4, jump-start)", progress), expected);
     }
+  }
+
+  #[test]
+  fn steps_timing_functions_hold_the_lower_step_before_the_active_phase() {
+    let sample = |css: &str, progress: f32| {
+      apply_timing_function(
+        &AnimationTimingFunction::from_css_str(css).unwrap(),
+        progress,
+        true,
+      )
+    };
+
+    // A backwards-filled delay samples progress 0, which sits on a jump for
+    // every start-anchored position.
+    assert_eq!(sample("steps(4, jump-start)", 0.0), 0.0);
+    assert_eq!(sample("steps(4, jump-both)", 0.0), 0.0);
+    assert_eq!(sample("steps(4, jump-end)", 0.0), 0.0);
+    assert_eq!(sample("step-start", 0.0), 0.0);
+
+    // Reverse playback fills from the far end instead.
+    assert_eq!(sample("steps(4, jump-end)", 1.0), 0.75);
+    assert_eq!(sample("steps(4, jump-start)", 1.0), 1.0);
+
+    // Away from a jump the flag changes nothing.
+    assert_eq!(sample("steps(4, jump-end)", 0.3), 0.25);
+  }
+
+  #[test]
+  fn steps_timing_functions_serialize_without_a_default_position() {
+    let round_trip = |css: &str| {
+      AnimationTimingFunction::from_css_str(css)
+        .unwrap()
+        .to_css_string()
+    };
+
+    assert_eq!(round_trip("steps(4)"), "steps(4)");
+    assert_eq!(round_trip("steps(4, end)"), "steps(4)");
+    assert_eq!(round_trip("steps(4, jump-end)"), "steps(4)");
+    assert_eq!(round_trip("steps(4, jump-start)"), "steps(4, start)");
+    assert_eq!(round_trip("steps(4, jump-none)"), "steps(4, jump-none)");
+    assert_eq!(round_trip("steps(4, jump-both)"), "steps(4, jump-both)");
   }
 
   #[test]
@@ -846,8 +905,8 @@ mod tests {
       return;
     };
 
-    let early = apply_timing_function(&function, 0.2);
-    let late = apply_timing_function(&function, 0.8);
+    let early = apply_timing_function(&function, 0.2, false);
+    let late = apply_timing_function(&function, 0.8, false);
 
     assert!(early < 0.0, "expected negative overshoot, got {early}");
     assert!(late > 1.0, "expected positive overshoot, got {late}");


### PR DESCRIPTION
## Why

The step easing algorithm needs to know whether a sample was taken before the animation's active phase: a sample sitting exactly on a jump belongs to the step below it. Nothing carried that flag, so an animation with `animation-fill-mode: backwards` or `both` and a positive delay held the wrong value throughout the delay. `steps(4, jump-start)` sat at 0.25 and `steps(4, jump-both)` at 0.2, where both should have been 0.

Serialization had a second, smaller gap: an end position is the default, so `steps(4, end)` and `steps(4, jump-end)` are supposed to print as `steps(4)`.

## What

`sample_animation_progress` returns an `AnimationSample` carrying the progress and a `before` flag, which `apply_timing_function` passes to the step sampler; on an integral step boundary a before-sample takes the step below, following the algorithm in css-easing-1. Other timing functions ignore the flag, as they should. `to_css` leaves out an end position.

Found by an adversarial review of #1346.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed step-based animations with positive delays so backwards-filled states display the correct preceding step.
  * Corrected sampling at exact step boundaries during pre-animation phases.
  * Improved serialization of `steps()` timing functions by omitting the default end position.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->