### PR TITLE
Core: decode a standalone animated frame without replaying the timeline

### DIFF
--- a/.tegami/animated-frame-seek.md
+++ b/.tegami/animated-frame-seek.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Draw animated frames without replaying the ones before them
+
+A frame that covers the whole canvas and replaces what is under it does not depend on the frames before it, so it is now decoded on its own. Reaching the last frame of a 300-frame animation drops from 16.6ms to 0.13ms for GIF, 158ms to 0.39ms for APNG, and 97ms to 0.05ms for WebP. Frames that do blend onto their predecessors still replay, as they must.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,9 @@ version = "2.10.0"
 dependencies = [
  "criterion",
  "image",
+ "image-webp",
  "parley",
+ "png",
  "rayon",
  "resvg",
  "serde_json",

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -24,7 +24,8 @@ use xxhash_rust::xxh3::{Xxh3, xxh3_64};
 use crate::resources::image_decoder::decoder_compiled_out;
 #[cfg(feature = "webp")]
 use crate::resources::image_decoder::{
-  animated_webp_dimensions, decode_webp_frames, is_animated_webp, webp_frame_durations,
+  animated_webp_dimensions, decode_webp_frame_alone, decode_webp_frames, is_animated_webp,
+  webp_frame_durations,
 };
 #[cfg(feature = "svg")]
 use crate::resvg::{
@@ -40,9 +41,9 @@ use crate::{
   resources::{
     image_buffer::ImageBuffer,
     image_decoder::{
-      apng_dimensions, apng_frame_durations, bitmap_dimensions, decode_apng_frames,
-      decode_bitmap_scaled, decode_gif_frames, decode_image, gif_dimensions, gif_frame_durations,
-      is_apng, is_gif,
+      MAX_ANIMATION_FRAMES, apng_dimensions, apng_frame_durations, bitmap_dimensions,
+      decode_apng_frame_alone, decode_apng_frames, decode_bitmap_scaled, decode_gif_frame_alone,
+      decode_gif_frames, decode_image, gif_dimensions, gif_frame_durations, is_apng, is_gif,
     },
   },
   style::{Color, ImageScalingAlgorithm, IntrinsicSizing, SizingContext, StyleSheet},
@@ -238,6 +239,26 @@ impl AnimatedFormat {
     }
   }
 
+  /// Decodes one frame without replaying the frames before it. `None` when the
+  /// container shows the frame depends on them.
+  fn decode_frame_alone(
+    self,
+    bytes: &[u8],
+    index: usize,
+    target: (u32, u32, ImageScalingAlgorithm),
+  ) -> Option<ImageBuffer> {
+    if index >= MAX_ANIMATION_FRAMES {
+      return None;
+    }
+
+    match self {
+      Self::Gif => decode_gif_frame_alone(bytes, index, Some(target)),
+      Self::Apng => decode_apng_frame_alone(bytes, index, Some(target)),
+      #[cfg(feature = "webp")]
+      Self::WebP => decode_webp_frame_alone(bytes, index, Some(target)),
+    }
+  }
+
   /// Per-frame delays in stream order, read without decoding pixels.
   fn frame_durations(self, bytes: &[u8]) -> Result<Box<[u32]>, image::ImageError> {
     match self {
@@ -271,8 +292,7 @@ impl AnimatedSource {
   fn from_bytes(format: AnimatedFormat, bytes: &[u8]) -> Result<Self, ImageError> {
     let (width, height) = format.dimensions(bytes).map_err(ImageError::decode)?;
 
-    // Decoded here only to reject a stream that carries no frame at all; the
-    // pixels are dropped, and every draw decodes the frame it needs.
+    // Decoded only to reject a stream carrying no frame at all; the pixels go.
     let mut decodable = false;
     format
       .decode_frames(bytes, 0, Some(1), None, |_| decodable = true)
@@ -369,19 +389,25 @@ impl AnimatedSource {
       })
   }
 
-  /// Decodes a single frame by stream index, resampled to `target`.
-  ///
-  /// ponytail: decode-to-index each call — frame disposal is stateful, so
-  /// reaching frame N replays frames 0..N. O(N) per sample, nothing retained;
-  /// fine for a static render (one sample per animation). An animation
-  /// re-encoded to an animation samples every frame → O(N²); if that path gets
-  /// hot, cache a thread-local resumable decode cursor keyed by source id.
+  /// Decodes a single frame by stream index, resampled to `target`. A frame
+  /// that depends on earlier ones is reached by replaying them, since disposal
+  /// is stateful.
   fn decode_frame(
     &self,
     index: usize,
     (target_width, target_height): (u32, u32),
     algorithm: ImageScalingAlgorithm,
   ) -> Option<Arc<ImageBuffer>> {
+    if index > 0
+      && let Some(frame) = self.inner.format.decode_frame_alone(
+        &self.inner.bytes,
+        index,
+        (target_width, target_height, algorithm),
+      )
+    {
+      return Some(Arc::new(frame));
+    }
+
     let mut frame = None;
     if let Err(error) = self.inner.format.decode_frames(
       &self.inner.bytes,
@@ -396,8 +422,7 @@ impl AnimatedSource {
     frame
   }
 
-  /// Bytes retained for cache budgeting: the encoded stream alone. Frames are
-  /// decoded on demand and dropped, so they never count.
+  /// Bytes retained for cache budgeting: decoded frames are never held.
   fn decoded_bytes(&self) -> usize {
     self.inner.bytes.len()
   }
@@ -1515,8 +1540,7 @@ mod tests {
     bytes
   }
 
-  /// Encodes one 4x4 solid frame per `(color index, delay ms)` pair as an APNG
-  /// whose default image is the first frame.
+  /// One 4x4 solid frame per `(color index, delay ms)` pair, as an APNG.
   fn encoded_apng(frames: &[(usize, u32)]) -> Vec<u8> {
     use png::{BitDepth, ColorType, Encoder};
 
@@ -1567,8 +1591,6 @@ mod tests {
     assert_eq!(smaller.pixel(1, 1), FRAME_COLORS[1]);
   }
 
-  /// A subframe drawn with `BlendOp::Over` composites onto the frame before it
-  /// instead of replacing the canvas.
   #[test]
   fn apng_composites_a_blended_subframe() {
     use png::{BitDepth, BlendOp, ColorType, DisposeOp, Encoder};
@@ -1599,14 +1621,10 @@ mod tests {
       unreachable!("valid apng");
     };
 
-    // The subframe covers the top-left quadrant, half-blended over the opaque
-    // red beneath it; the rest of the first frame stays put.
     assert_eq!(apng.frame_at_time(150).pixel(0, 0), [127, 0, 128, 255]);
     assert_eq!(apng.frame_at_time(150).pixel(3, 3), FRAME_COLORS[0]);
   }
 
-  /// An APNG whose `IDAT` carries a separate default image: the animation is
-  /// the `fdAT` frames alone.
   #[test]
   fn apng_default_image_stays_off_the_timeline() {
     use png::{BitDepth, ColorType, Encoder};
@@ -1643,6 +1661,112 @@ mod tests {
   }
 
   #[test]
+  fn seeking_a_frame_matches_replaying_to_it() {
+    let sources: Vec<(&str, Vec<u8>)> = vec![
+      #[cfg(feature = "gif")]
+      ("gif", encoded_gif(&[(0, 100), (1, 100), (2, 100)])),
+      ("apng", encoded_apng(&[(0, 100), (1, 100), (2, 100)])),
+      #[cfg(feature = "webp")]
+      (
+        "webp",
+        encoded_animated_webp(&[(0, 100), (1, 100), (2, 100)]),
+      ),
+    ];
+
+    for (format, bytes) in sources {
+      let Ok(ImageSource::Animated(source)) = ImageSource::from_bytes(&bytes) else {
+        unreachable!("valid {format}");
+      };
+      let animated_format = source.inner.format;
+
+      for index in 1..3 {
+        let seeked = animated_format
+          .decode_frame_alone(&bytes, index, (4, 4, ImageScalingAlgorithm::Auto))
+          .unwrap_or_else(|| panic!("{format} frame {index} should seek"));
+
+        let mut replayed = None;
+        animated_format
+          .decode_frames(&bytes, index, Some(1), None, |frame| replayed = Some(frame))
+          .expect("replay decodes");
+        let replayed = replayed.expect("replayed frame");
+
+        assert_eq!(
+          seeked.data(),
+          replayed.data(),
+          "{format} frame {index} differs between seek and replay"
+        );
+      }
+    }
+  }
+
+  #[cfg(feature = "webp")]
+  #[test]
+  fn a_webp_frame_lying_about_its_size_declines_to_seek() {
+    let mut bytes = encoded_animated_webp(&[(0, 100), (1, 100)]);
+
+    // 2x2 bitstream under an ANMF header that still claims the 4x4 canvas.
+    let small = {
+      use image_webp::{ColorType, WebPEncoder};
+
+      let mut encoded = Vec::new();
+      WebPEncoder::new(&mut encoded)
+        .encode(&FRAME_COLORS[1].repeat(4), 2, 2, ColorType::Rgba8)
+        .unwrap();
+      encoded[12..].to_vec()
+    };
+
+    let last_anmf = bytes
+      .windows(4)
+      .rposition(|window| window == b"ANMF")
+      .expect("an ANMF chunk");
+    let payload_start = last_anmf + 8;
+    let header: Vec<u8> = bytes[payload_start..payload_start + 16].to_vec();
+
+    bytes.truncate(payload_start);
+    bytes.extend_from_slice(&header);
+    bytes.extend_from_slice(&small);
+    let size = (16 + small.len()) as u32;
+    bytes[last_anmf + 4..last_anmf + 8].copy_from_slice(&size.to_le_bytes());
+    let riff_size = (bytes.len() - 8) as u32;
+    bytes[4..8].copy_from_slice(&riff_size.to_le_bytes());
+
+    assert!(
+      AnimatedFormat::WebP
+        .decode_frame_alone(&bytes, 1, (4, 4, ImageScalingAlgorithm::Auto))
+        .is_none()
+    );
+  }
+
+  #[test]
+  fn a_dependent_frame_declines_to_seek() {
+    use png::{BitDepth, BlendOp, ColorType, Encoder};
+
+    let mut bytes = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, 4, 4);
+    encoder.set_color(ColorType::Rgba);
+    encoder.set_depth(BitDepth::Eight);
+    encoder.set_animated(2, 0).unwrap();
+
+    let mut writer = encoder.write_header().unwrap();
+    writer.set_frame_delay(100, 1000).unwrap();
+    writer
+      .write_image_data(&FRAME_COLORS[0].repeat(16))
+      .unwrap();
+    writer.set_frame_delay(100, 1000).unwrap();
+    writer.set_frame_dimension(2, 2).unwrap();
+    writer.set_frame_position(0, 0).unwrap();
+    writer.set_blend_op(BlendOp::Over).unwrap();
+    writer.write_image_data(&FRAME_COLORS[1].repeat(4)).unwrap();
+    writer.finish().unwrap();
+
+    assert!(
+      AnimatedFormat::Apng
+        .decode_frame_alone(&bytes, 1, (4, 4, ImageScalingAlgorithm::Auto))
+        .is_none()
+    );
+  }
+
+  #[test]
   fn still_png_stays_a_bitmap() {
     use png::{BitDepth, ColorType, Encoder};
 
@@ -1659,9 +1783,7 @@ mod tests {
     assert_matches!(ImageSource::from_bytes(&bytes), Ok(ImageSource::Bitmap(_)));
   }
 
-  /// Encodes one 4x4 solid frame per `(color index, delay ms)` pair into an
-  /// animated WebP: a `VP8X` canvas with the animation flag, an `ANIM` header,
-  /// then one `ANMF` per frame wrapping a lossless still.
+  /// One 4x4 solid frame per `(color index, delay ms)` pair, as an animated WebP.
   #[cfg(feature = "webp")]
   fn encoded_animated_webp(frames: &[(usize, u32)]) -> Vec<u8> {
     fn chunk(id: &[u8; 4], payload: &[u8]) -> Vec<u8> {
@@ -1747,8 +1869,6 @@ mod tests {
     assert_eq!(smaller.pixel(1, 1), FRAME_COLORS[1]);
   }
 
-  /// The SVG backend and the still-image cache both reach WebP through
-  /// `decode_image`, which must not hand animated bytes to libwebp.
   #[cfg(feature = "webp")]
   #[test]
   fn animated_webp_decodes_as_a_still_first_frame() {

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -47,7 +47,7 @@ const MAX_IMAGE_PIXELS: u64 = MAX_IMAGE_DIMENSION as u64 * MAX_IMAGE_DIMENSION a
 const MAX_ANIMATION_TOTAL_PIXELS: u64 = 4 * MAX_IMAGE_PIXELS;
 /// Frames past this point are dropped from a timeline. The pixel budget alone
 /// leaves a tiny canvas free to carry an unbounded frame list.
-const MAX_ANIMATION_FRAMES: usize = 1024;
+pub(crate) const MAX_ANIMATION_FRAMES: usize = 1024;
 
 /// Rejects decoded images whose pixel count exceeds [`MAX_IMAGE_PIXELS`].
 #[cfg(feature = "webp")]
@@ -695,6 +695,12 @@ fn decode_webp_into(
     .and_then(|image| rgba_to_buffer(image, ImageFormat::WebP))
 }
 
+/// Whether a frame rectangle spans the entire canvas.
+fn covers_canvas(rect: (u32, u32, u32, u32), canvas: (u32, u32)) -> bool {
+  let (x, y, width, height) = rect;
+  x == 0 && y == 0 && width == canvas.0 && height == canvas.1
+}
+
 /// Whether the `VP8X` header sets the animation flag.
 #[cfg(feature = "webp")]
 pub(crate) fn is_animated_webp(bytes: &[u8]) -> bool {
@@ -713,8 +719,9 @@ fn webp_chunks(bytes: &[u8]) -> impl Iterator<Item = ([u8; 4], &[u8])> {
   std::iter::from_fn(move || {
     let header: [u8; 8] = bytes.get(offset..offset + 8)?.try_into().ok()?;
     let size = u32::from_le_bytes([header[4], header[5], header[6], header[7]]) as usize;
-    let payload = bytes.get(offset + 8..(offset + 8).checked_add(size)?)?;
-    offset = offset + 8 + size + (size & 1);
+    let start = offset.checked_add(8)?;
+    let payload = bytes.get(start..start.checked_add(size)?)?;
+    offset = start.checked_add(size)?.checked_add(size & 1)?;
     Some(([header[0], header[1], header[2], header[3]], payload))
   })
 }
@@ -830,6 +837,109 @@ fn decode_animated_webp_first_frame(bytes: &[u8]) -> ImageResult<ImageBuffer> {
     .ok_or_else(invalid_buffer_error)
 }
 
+/// Decodes frame `index` on its own, skipping the frames before it, when the
+/// `ANMF` header shows the frame covers the whole canvas and does not blend
+/// onto what came before. `None` when the frame depends on its predecessors.
+///
+/// Blink reaches individual frames through libwebp's demuxer
+/// (`WebPDemuxGetFrame`); walking the RIFF chunks keeps this available on wasm,
+/// where that demuxer is not.
+#[cfg(feature = "webp")]
+pub(crate) fn decode_webp_frame_alone(
+  bytes: &[u8],
+  index: usize,
+  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+) -> Option<ImageBuffer> {
+  let read_24 = |bytes: &[u8], offset: usize| {
+    Some(u32::from_le_bytes([
+      *bytes.get(offset)?,
+      *bytes.get(offset + 1)?,
+      *bytes.get(offset + 2)?,
+      0,
+    ]))
+  };
+
+  // One walk for both: `VP8X` carries the canvas size, the Nth `ANMF` the frame.
+  let mut canvas = None;
+  let mut payload = None;
+  let mut seen = 0;
+  for (id, chunk) in webp_chunks(bytes) {
+    match &id {
+      b"VP8X" => canvas = Some((read_24(chunk, 4)? + 1, read_24(chunk, 7)? + 1)),
+      b"ANMF" if seen == index => {
+        payload = Some(chunk);
+        break;
+      }
+      b"ANMF" => seen += 1,
+      _ => {}
+    }
+  }
+
+  let (canvas_width, canvas_height) = canvas?;
+  let payload = payload?;
+  let header = payload.get(..16)?;
+  let read_24 = |offset: usize| read_24(header, offset).unwrap_or_default();
+  let rect = (read_24(0), read_24(3), read_24(6) + 1, read_24(9) + 1);
+  // Bit 1 of the frame flags: replace the canvas rect rather than blend onto it.
+  let replaces_canvas = header[15] & 0b0000_0010 != 0;
+  if !covers_canvas(rect, (canvas_width, canvas_height)) || !replaces_canvas {
+    return None;
+  }
+
+  let still = webp_frame_as_still(payload.get(16..)?, canvas_width, canvas_height)?;
+  let frame = decode_webp(&still).ok()?;
+
+  // The `ANMF` rectangle only claims a size; the bitstream is what has one.
+  if frame.width() != canvas_width || frame.height() != canvas_height {
+    return None;
+  }
+
+  fit_to_target(frame, target).ok()
+}
+
+/// Wraps one frame's bitstream in a RIFF container so the still decoder can
+/// read it. A lossy frame carrying a separate `ALPH` chunk needs a `VP8X`
+/// header too, which only the animation container had.
+#[cfg(feature = "webp")]
+fn webp_frame_as_still(bitstream: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
+  let mut body = Vec::with_capacity(bitstream.len() + 18);
+
+  if bitstream.get(..4)? == b"ALPH" {
+    let (last_width, last_height) = (width.checked_sub(1)?, height.checked_sub(1)?);
+    body.extend_from_slice(b"VP8X");
+    body.extend_from_slice(&10_u32.to_le_bytes());
+    // Alpha flag, then the canvas size as two 24-bit values.
+    body.extend_from_slice(&[0b0001_0000, 0, 0, 0]);
+    body.extend_from_slice(&last_width.to_le_bytes()[..3]);
+    body.extend_from_slice(&last_height.to_le_bytes()[..3]);
+  }
+  body.extend_from_slice(bitstream);
+
+  let mut still = b"RIFF".to_vec();
+  still.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+  still.extend_from_slice(b"WEBP");
+  still.extend_from_slice(&body);
+
+  Some(still)
+}
+
+/// Resamples a full-canvas buffer down to `target`, or hands it back untouched.
+fn fit_to_target(
+  buffer: ImageBuffer,
+  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+) -> ImageResult<ImageBuffer> {
+  let Some((width, height, algorithm)) = target else {
+    return Ok(buffer);
+  };
+  if width >= buffer.width() && height >= buffer.height() {
+    return Ok(buffer);
+  }
+
+  let source = (buffer.width(), buffer.height());
+  resample_premultiplied(buffer.data(), source, (width, height), algorithm)
+    .ok_or_else(invalid_buffer_error)
+}
+
 /// One composited canvas as a premultiplied buffer, resampled to `target`.
 #[cfg(feature = "webp")]
 fn webp_canvas_to_buffer(
@@ -851,17 +961,8 @@ fn webp_canvas_to_buffer(
 
   let buffer =
     ImageBuffer::from_rgba_bytes(rgba, width, height).ok_or_else(invalid_buffer_error)?;
-  let Some((target_width, target_height, algorithm)) = target else {
-    return Ok(buffer);
-  };
 
-  resample_premultiplied(
-    buffer.data(),
-    (width, height),
-    (target_width, target_height),
-    algorithm,
-  )
-  .ok_or_else(invalid_buffer_error)
+  fit_to_target(buffer, target)
 }
 
 /// Whether the PNG carries an `acTL` animation control chunk.
@@ -873,11 +974,11 @@ pub(crate) fn is_apng(bytes: &[u8]) -> bool {
 fn png_chunks(bytes: &[u8]) -> impl Iterator<Item = ([u8; 4], &[u8])> {
   let mut offset = PNG_SIGNATURE.len();
   std::iter::from_fn(move || {
-    let header: [u8; 8] = bytes.get(offset..offset + 8)?.try_into().ok()?;
+    let header: [u8; 8] = bytes.get(offset..offset.checked_add(8)?)?.try_into().ok()?;
     let length = u32::from_be_bytes([header[0], header[1], header[2], header[3]]) as usize;
     let start = offset + 8;
     let data = bytes.get(start..start.checked_add(length)?)?;
-    offset = start + length + 4;
+    offset = start.checked_add(length)?.checked_add(4)?;
     Some(([header[4], header[5], header[6], header[7]], data))
   })
 }
@@ -943,6 +1044,98 @@ fn apng_reader(bytes: &[u8]) -> ImageResult<png::Reader<Cursor<&[u8]>>> {
   }
 
   Ok(reader)
+}
+
+/// Decodes frame `index` on its own, advancing through the earlier frames by
+/// their headers alone, when its `fcTL` shows it covers the whole canvas and
+/// replaces rather than blends. Returns `None` when the frame depends on its
+/// predecessors.
+///
+/// This is the narrow case of Blink's dependency walk in
+/// `ImageDecoder::FindRequiredPreviousFrame`: a full-canvas, non-blending frame
+/// needs no starting state.
+pub(crate) fn decode_apng_frame_alone(
+  bytes: &[u8],
+  index: usize,
+  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+) -> Option<ImageBuffer> {
+  let mut reader = apng_reader(bytes).ok()?;
+  let (canvas_width, canvas_height) = (reader.info().width, reader.info().height);
+  let channels = match reader.output_color_type() {
+    (ColorType::Rgba, BitDepth::Eight) => 4,
+    (ColorType::GrayscaleAlpha, BitDepth::Eight) => 2,
+    _ => return None,
+  };
+
+  // A default image no `fcTL` claims sits outside the animation.
+  if reader.info().frame_control.is_none() {
+    reader.next_frame_info().ok()?;
+  }
+  for _ in 0..index {
+    reader.next_frame_info().ok()?;
+  }
+  let frame = reader.info().frame_control?;
+
+  let rect = (frame.x_offset, frame.y_offset, frame.width, frame.height);
+  if !covers_canvas(rect, (canvas_width, canvas_height)) || frame.blend_op != BlendOp::Source {
+    return None;
+  }
+
+  let mut subframe = vec![0; reader.output_buffer_size()?];
+  reader.next_frame(&mut subframe).ok()?;
+
+  // A full-canvas replacing frame already is the canvas.
+  let mut rgba = match channels {
+    4 => subframe,
+    _ => subframe
+      .as_chunks::<2>()
+      .0
+      .iter()
+      .flat_map(|&[luma, alpha]| [luma, luma, luma, alpha])
+      .collect(),
+  };
+  premultiply_rgba_in_place(&mut rgba);
+
+  let buffer = ImageBuffer::from_premultiplied_rgba(rgba, canvas_width, canvas_height)?;
+
+  fit_to_target(buffer, target).ok()
+}
+
+/// Decodes frame `index` on its own when the GIF's frame headers show it covers
+/// the whole canvas opaquely. Frames before it are advanced past by header,
+/// never decoded.
+#[cfg(feature = "gif")]
+pub(crate) fn decode_gif_frame_alone(
+  bytes: &[u8],
+  index: usize,
+  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+) -> Option<ImageBuffer> {
+  let mut decoder = gif_decoder(bytes).ok()?;
+  let (canvas_width, canvas_height) = (decoder.width() as u32, decoder.height() as u32);
+
+  for _ in 0..index {
+    decoder.next_frame_info().ok()??;
+  }
+
+  let frame = decoder.next_frame_info().ok()??;
+  let rect = (
+    frame.left as u32,
+    frame.top as u32,
+    frame.width as u32,
+    frame.height as u32,
+  );
+  if !covers_canvas(rect, (canvas_width, canvas_height)) || frame.transparent.is_some() {
+    return None;
+  }
+
+  let mut pixels = vec![0; decoder.buffer_size()];
+  decoder.read_into_buffer(&mut pixels).ok()?;
+
+  // GIF alpha is 0 or 255, so an opaque full-canvas frame is already valid
+  // premultiplied RGBA.
+  let buffer = ImageBuffer::from_premultiplied_rgba(pixels, canvas_width, canvas_height)?;
+
+  fit_to_target(buffer, target).ok()
 }
 
 /// Decodes APNG frames in stream order, passing each frame past the first
@@ -1043,7 +1236,6 @@ impl ApngCanvas {
     }
   }
 
-  /// Rows and columns of the frame rect that land inside the canvas.
   fn clamped_span(&self, frame: FrameControl) -> (u32, u32) {
     (
       frame.height.min(self.height.saturating_sub(frame.y_offset)),
@@ -1051,8 +1243,7 @@ impl ApngCanvas {
     )
   }
 
-  /// Draws one subframe at its `fcTL` offset, either overwriting the frame rect
-  /// or alpha-blending onto it.
+  /// Draws one subframe at its `fcTL` offset.
   fn composite(&mut self, frame: FrameControl, subframe: &[u8], channels: usize) {
     if frame.dispose_op == DisposeOp::Previous {
       self.restore.clear();
@@ -1063,6 +1254,14 @@ impl ApngCanvas {
     for row in 0..rows {
       let source_row = row as usize * frame.width as usize * channels;
       let target_row = ((frame.y_offset + row) * self.width + frame.x_offset) as usize * 4;
+
+      // Replacing RGBA is the same bytes on both sides, so the row copies whole.
+      if channels == 4 && frame.blend_op == BlendOp::Source {
+        let span = columns as usize * 4;
+        self.pixels[target_row..target_row + span]
+          .copy_from_slice(&subframe[source_row..source_row + span]);
+        continue;
+      }
 
       for column in 0..columns {
         let source = source_row + column as usize * channels;
@@ -1197,6 +1396,15 @@ pub(crate) fn gif_dimensions(_bytes: &[u8]) -> ImageResult<(u32, u32)> {
 #[cfg(not(feature = "gif"))]
 pub(crate) fn gif_frame_durations(_bytes: &[u8]) -> ImageResult<Box<[u32]>> {
   Err(format_compiled_out_error())
+}
+
+#[cfg(not(feature = "gif"))]
+pub(crate) fn decode_gif_frame_alone(
+  _bytes: &[u8],
+  _index: usize,
+  _target: Option<(u32, u32, ImageScalingAlgorithm)>,
+) -> Option<ImageBuffer> {
+  None
 }
 
 #[cfg(not(feature = "gif"))]

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -54,6 +54,8 @@ from-html = ["dep:takumi-html"]
 
 [dev-dependencies]
 criterion.workspace = true
+image-webp.workspace = true
+png.workspace = true
 parley.workspace = true
 rayon.workspace = true
 resvg.workspace = true
@@ -78,6 +80,10 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "animated_frames"
+harness = false
 
 [[bench]]
 name = "background"

--- a/takumi/benches/animated_frames.rs
+++ b/takumi/benches/animated_frames.rs
@@ -1,0 +1,182 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use takumi::prelude::{ImageScalingAlgorithm, ImageSource};
+
+mod common;
+
+const SIZE: u32 = 200;
+const FRAME_COUNTS: [usize; 3] = [30, 120, 300];
+
+fn frame_color(index: usize) -> [u8; 4] {
+  [(index * 7 % 256) as u8, 40, 200, 255]
+}
+
+fn encoded_gif(frames: usize) -> Vec<u8> {
+  use image::{Delay, Frame, Rgba, RgbaImage, codecs::gif::GifEncoder};
+
+  let mut bytes = Vec::new();
+  let mut encoder = GifEncoder::new(&mut bytes);
+  encoder
+    .encode_frames((0..frames).map(|index| {
+      Frame::from_parts(
+        RgbaImage::from_pixel(SIZE, SIZE, Rgba(frame_color(index))),
+        0,
+        0,
+        Delay::from_numer_denom_ms(100, 1),
+      )
+    }))
+    .unwrap();
+  drop(encoder);
+
+  bytes
+}
+
+fn encoded_apng(frames: usize) -> Vec<u8> {
+  encoded_apng_frames(frames, None)
+}
+
+/// Every frame a half-canvas subframe blended onto the one before it, so no
+/// frame stands alone and each sample replays the whole timeline.
+fn encoded_dependent_apng(frames: usize) -> Vec<u8> {
+  encoded_apng_frames(frames, Some(SIZE / 2))
+}
+
+/// `subframe` set makes every frame past the first a blended subframe of that
+/// size; otherwise each frame fills and replaces the canvas.
+fn encoded_apng_frames(frames: usize, subframe: Option<u32>) -> Vec<u8> {
+  use png::{BitDepth, BlendOp, ColorType, Encoder};
+
+  let mut bytes = Vec::new();
+  let mut encoder = Encoder::new(&mut bytes, SIZE, SIZE);
+  encoder.set_color(ColorType::Rgba);
+  encoder.set_depth(BitDepth::Eight);
+  encoder.set_animated(frames as u32, 0).unwrap();
+
+  let mut writer = encoder.write_header().unwrap();
+  for index in 0..frames {
+    let size = subframe.filter(|_| index > 0).unwrap_or(SIZE);
+    writer.set_frame_delay(100, 1000).unwrap();
+    if size != SIZE {
+      writer.set_frame_dimension(size, size).unwrap();
+      writer.set_frame_position(0, 0).unwrap();
+      writer.set_blend_op(BlendOp::Over).unwrap();
+    }
+    writer
+      .write_image_data(&frame_color(index).repeat((size * size) as usize))
+      .unwrap();
+  }
+  writer.finish().unwrap();
+
+  bytes
+}
+
+/// A `VP8X` canvas with the animation flag, then one `ANMF` per frame wrapping
+/// a lossless still.
+fn encoded_animated_webp(frames: usize) -> Vec<u8> {
+  use image_webp::{ColorType, WebPEncoder};
+
+  fn chunk(id: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+    let mut bytes = id.to_vec();
+    bytes.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    bytes.extend_from_slice(payload);
+    if payload.len() % 2 == 1 {
+      bytes.push(0);
+    }
+    bytes
+  }
+
+  fn still(color: [u8; 4]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    WebPEncoder::new(&mut bytes)
+      .encode(
+        &color.repeat((SIZE * SIZE) as usize),
+        SIZE,
+        SIZE,
+        ColorType::Rgba8,
+      )
+      .unwrap();
+    bytes[12..].to_vec()
+  }
+
+  let dimension = (SIZE - 1).to_le_bytes();
+  let mut body = chunk(
+    b"VP8X",
+    &[
+      0b0000_0010,
+      0,
+      0,
+      0,
+      dimension[0],
+      dimension[1],
+      dimension[2],
+      dimension[0],
+      dimension[1],
+      dimension[2],
+    ],
+  );
+  body.extend_from_slice(&chunk(b"ANIM", &[0, 0, 0, 0, 0, 0]));
+
+  for index in 0..frames {
+    let mut payload = vec![0, 0, 0, 0, 0, 0];
+    payload.extend_from_slice(&dimension[..3]);
+    payload.extend_from_slice(&dimension[..3]);
+    payload.extend_from_slice(&100_u32.to_le_bytes()[..3]);
+    // Bit 1 set: replace the canvas rect instead of blending onto it.
+    payload.push(0b0000_0010);
+    payload.extend_from_slice(&still(frame_color(index)));
+    body.extend_from_slice(&chunk(b"ANMF", &payload));
+  }
+
+  let mut bytes = b"RIFF".to_vec();
+  bytes.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+  bytes.extend_from_slice(b"WEBP");
+  bytes.extend_from_slice(&body);
+
+  bytes
+}
+
+/// Samples the last frame of an animation, the worst case for a decoder that
+/// replays from the start.
+///
+/// The `standalone` sources are full-canvas frames that replace what is under
+/// them, so each is decoded on its own. The `dependent` source blends
+/// half-canvas subframes, which no shortcut can serve, so it is the replay
+/// path's own cost.
+fn bench_last_frame(c: &mut Criterion) {
+  let mut group = c.benchmark_group("animated_frames");
+
+  for (format, encode) in [
+    ("standalone/gif", encoded_gif as fn(usize) -> Vec<u8>),
+    ("standalone/apng", encoded_apng),
+    ("standalone/webp", encoded_animated_webp),
+    ("dependent/apng", encoded_dependent_apng),
+  ] {
+    for frames in FRAME_COUNTS {
+      let Ok(ImageSource::Animated(animated)) = ImageSource::from_bytes(&encode(frames)) else {
+        panic!("{format} did not decode as an animated source");
+      };
+      let last_frame_ms = (frames as u64 - 1) * 100;
+
+      group.bench_function(BenchmarkId::new(format, frames), |b| {
+        b.iter(|| {
+          black_box(animated.frame_at_time_covering(
+            last_frame_ms,
+            SIZE,
+            SIZE,
+            ImageScalingAlgorithm::Auto,
+          ))
+        })
+      });
+    }
+  }
+
+  group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = common::criterion();
+  targets = bench_last_frame
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Why

Frame disposal is stateful, so reaching frame N meant compositing 0..N. Sampling an animation at every frame was quadratic, and a long source rendered into an output animation ran into tens of seconds.

Most frames do not need that. A frame covering the whole canvas that replaces what is under it has no dependency on its predecessors, which is the sprite-sheet shape both animated image issues were about.

## What

Each format answers "does this frame stand alone?" from container metadata, without decoding pixels, then decodes it directly when it does:

- WebP walks the RIFF chunks to the Nth `ANMF` and lifts its bitstream into a still container. A lossy frame with a separate `ALPH` chunk gets a `VP8X` header rebuilt, since only the animation container carried one. The decoded frame's real dimensions are checked against the rectangle the `ANMF` claimed, so a header that overstates its bitstream goes back to replay instead of drawing at the wrong size.
- APNG advances by `next_frame_info()` and decodes the frame it lands on.
- GIF advances the same way without reading pixels into a buffer.

Dependent frames still replay. Blink decides this in `ImageDecoder::FindRequiredPreviousFrame` and reaches WebP frames through libwebp's `WebPDemuxGetFrame`; walking RIFF by hand keeps it working on wasm, where that demuxer is absent.

`ApngCanvas::composite` copies whole rows when RGBA pixels replace what they land on, and the standalone APNG path skips the compositing surface, since a full-canvas replacing frame already is the canvas.

Sampling the last frame of a 300-frame 200x200 animation:

| source | before | after |
| --- | --- | --- |
| standalone WebP | 96.8ms | 0.049ms |
| standalone GIF | 16.6ms | 0.128ms |
| standalone APNG | 158.5ms | 0.387ms |
| dependent APNG | 38.6ms | 38.6ms |

The last row is why the benchmark has a `dependent` group: nothing here helps a frame that genuinely blends onto its predecessor. Caching the nearest ancestor such a frame needs, as `ClearCacheExceptTwoFrames` does, is the next step and is not in this PR.

Three tests guard the risk that a frame looks standalone but is not: seek and replay must produce byte-identical pixels for the same frame, a partial-canvas `BlendOp::Over` frame must decline to seek, and an `ANMF` claiming the full canvas while carrying a smaller bitstream must decline too.
