### PR TITLE
Chore: decode PNG at full optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,12 +195,15 @@ opt-level = "z"
 opt-level = "z"
 [profile.release.package.selectors]
 opt-level = "z"
+# PNG is the exception: an animated source decodes a frame per draw, so these
+# three sit on the per-image path many times over. Size-optimizing them costs
+# 24-33% on APNG frame decoding and saves 1.1KB brotli in the wasm bundle.
 [profile.release.package.png]
-opt-level = "z"
+opt-level = 3
 [profile.release.package.miniz_oxide]
-opt-level = "z"
+opt-level = 3
 [profile.release.package.fdeflate]
-opt-level = "z"
+opt-level = 3
 [profile.release.package.image]
 opt-level = "z"
 [profile.release.package.gif]


### PR DESCRIPTION
## Why

`png`, `miniz_oxide` and `fdeflate` were size-optimized under the rule stated in the profile comment: crates that run at most once per image, never per pixel. Animated PNG breaks that premise, since a source decodes a frame per draw.

## What

The three move to `opt-level = 3`. On the `animated_frames` benchmark, 300-frame 200x200 APNG: standalone frame seek 390us to 261us, dependent frame replay 37.2ms to 28.2ms.

The wasm bundle grows 2,118 bytes brotli, from 1,300,542 to 1,302,660.

PNG encoding does not measurably change. `encode/png` moved +2.4%, but `encode/webp` and `encode/jpeg`, which touch none of these crates, moved -6.8% and +1.3% in the same run; that spread is LTO reordering noise.

Cargo has no per-target profile override, so this applies to napi and wasm alike. Forcing wasm back to `"z"` through `--config` at build time works, but it would buy 2KB by making browser-side decoding 24-33% slower, and would need keeping in sync across CI, local scripts and `package.json`.
