### PR TITLE
Core: resume an animation replay where the last one stopped

### DIFF
--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "svg")]
 use std::borrow::Cow;
 use std::str::{FromStr, from_utf8};
-use std::sync::{Arc, OnceLock, Weak};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use quick_cache::{
   Weighter,
@@ -41,10 +41,10 @@ use crate::{
   resources::{
     image_buffer::ImageBuffer,
     image_decoder::{
-      FrameInfo, MAX_ANIMATION_FRAMES, apng_dimensions, apng_frame_infos, bitmap_dimensions,
-      decode_apng_frame_alone, decode_apng_frames, decode_bitmap_scaled, decode_gif_frame_alone,
-      decode_gif_frames, decode_image, gif_dimensions, gif_frame_infos, is_apng, is_gif,
-      required_previous_frame,
+      ApngResume, FrameInfo, MAX_ANIMATION_FRAMES, apng_dimensions, apng_frame_infos,
+      bitmap_dimensions, decode_apng_frame_alone, decode_apng_frames, decode_apng_frames_from,
+      decode_bitmap_scaled, decode_gif_frame_alone, decode_gif_frames, decode_image,
+      gif_dimensions, gif_frame_infos, is_apng, is_gif, required_previous_frame,
     },
   },
   style::{Color, ImageScalingAlgorithm, IntrinsicSizing, SizingContext, StyleSheet},
@@ -274,6 +274,10 @@ struct AnimatedInner {
   width: u32,
   height: u32,
   timing: OnceLock<AnimationTiming>,
+  /// Where the last replay finished, so the next one forward can carry on from
+  /// there instead of starting over. Empty until a replay actually happens, so
+  /// a source whose frames all stand alone never allocates one.
+  resume: Mutex<ApngResume>,
 }
 
 /// Per-frame metadata for the whole animation, read once without pixels.
@@ -305,6 +309,7 @@ impl AnimatedSource {
         width,
         height,
         timing: OnceLock::new(),
+        resume: Mutex::new(ApngResume::default()),
       }),
     })
   }
@@ -415,17 +420,67 @@ impl AnimatedSource {
     }
 
     let mut frame = None;
-    if let Err(error) = self.inner.format.decode_frames(
-      &self.inner.bytes,
-      index,
-      Some(1),
-      Some((target_width, target_height, algorithm)),
-      |decoded| frame = Some(decoded),
-    ) {
+    let decoded = match self.inner.format {
+      AnimatedFormat::Apng => {
+        self.replay_apng(index, target_width, target_height, algorithm, |f| {
+          frame = Some(f)
+        })
+      }
+      _ => self.inner.format.decode_frames(
+        &self.inner.bytes,
+        index,
+        Some(1),
+        Some((target_width, target_height, algorithm)),
+        |decoded| frame = Some(decoded),
+      ),
+    };
+    if let Err(error) = decoded {
       log::warn!("Failed to decode frame {index} of an animated image: {error}");
     }
 
     frame
+  }
+
+  /// Replays to `index`, starting from the canvas the last replay left when
+  /// that lands before this frame.
+  fn replay_apng(
+    &self,
+    index: usize,
+    width: u32,
+    height: u32,
+    algorithm: ImageScalingAlgorithm,
+    push: impl FnMut(Arc<ImageBuffer>),
+  ) -> Result<bool, image::ImageError> {
+    // Never wait on the lock: a replay in flight is tens of milliseconds of
+    // work, and starting one from scratch beats blocking behind it.
+    let Ok(mut cached) = self.inner.resume.try_lock() else {
+      return self.inner.format.decode_frames(
+        &self.inner.bytes,
+        index,
+        Some(1),
+        Some((width, height, algorithm)),
+        push,
+      );
+    };
+
+    let previous = std::mem::take(&mut *cached);
+    let resume = (!previous.canvas.is_empty() && previous.index < index)
+      .then_some((previous.index, previous.canvas.as_slice()));
+
+    let mut next = ApngResume::default();
+    let ended = decode_apng_frames_from(
+      &self.inner.bytes,
+      resume,
+      index,
+      Some(1),
+      Some((width, height, algorithm)),
+      push,
+      Some(&mut next),
+    );
+
+    *cached = next;
+
+    ended
   }
 
   /// Bytes retained for cache budgeting: decoded frames are never held.
@@ -1842,6 +1897,86 @@ mod tests {
       .expect("replays");
 
     assert_eq!(seeked.data(), replayed.expect("replayed frame").data());
+  }
+
+  /// Resuming a replay from a captured canvas must land on the same pixels as
+  /// replaying the whole timeline, for every resume point.
+  #[test]
+  fn resuming_a_replay_matches_replaying_from_the_start() {
+    use crate::resources::image_decoder::{ApngResume, decode_apng_frames_from};
+    use png::{BitDepth, BlendOp, ColorType, Encoder};
+
+    let mut bytes = Vec::new();
+    let mut encoder = Encoder::new(&mut bytes, 4, 4);
+    encoder.set_color(ColorType::Rgba);
+    encoder.set_depth(BitDepth::Eight);
+    encoder.set_animated(4, 0).unwrap();
+
+    let mut writer = encoder.write_header().unwrap();
+    writer.set_frame_delay(100, 1000).unwrap();
+    writer
+      .write_image_data(&FRAME_COLORS[0].repeat(16))
+      .unwrap();
+    // Half-canvas frames blending onto what came before: no frame stands alone.
+    for index in 1..4 {
+      writer.set_frame_delay(100, 1000).unwrap();
+      writer.set_frame_dimension(2, 2).unwrap();
+      writer.set_frame_position(1, 1).unwrap();
+      writer.set_blend_op(BlendOp::Over).unwrap();
+      writer
+        .write_image_data(&[0, 0, 255, 128].repeat(4))
+        .unwrap();
+      let _ = index;
+    }
+    writer.finish().unwrap();
+
+    for target in 1..4 {
+      let mut expected = None;
+      decode_apng_frames_from(
+        &bytes,
+        None,
+        target,
+        Some(1),
+        None,
+        |f| expected = Some(f),
+        None,
+      )
+      .expect("replays");
+      let expected = expected.expect("a frame");
+
+      for resume_at in 0..target {
+        let mut captured = ApngResume::default();
+        decode_apng_frames_from(
+          &bytes,
+          None,
+          resume_at,
+          Some(1),
+          None,
+          |_| {},
+          Some(&mut captured),
+        )
+        .expect("captures");
+        assert_eq!(captured.index, resume_at);
+
+        let mut resumed = None;
+        decode_apng_frames_from(
+          &bytes,
+          Some((captured.index, &captured.canvas)),
+          target,
+          Some(1),
+          None,
+          |f| resumed = Some(f),
+          None,
+        )
+        .expect("resumes");
+
+        assert_eq!(
+          resumed.expect("a frame").data(),
+          expected.data(),
+          "frame {target} resumed from {resume_at}"
+        );
+      }
+    }
   }
 
   #[test]

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -1418,7 +1418,31 @@ pub(crate) fn decode_apng_frames(
   skip: usize,
   limit: Option<usize>,
   target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  push: impl FnMut(Arc<ImageBuffer>),
+) -> ImageResult<bool> {
+  decode_apng_frames_from(bytes, None, skip, limit, target, push, None)
+}
+
+/// The canvas an APNG replay left behind, and the frame it belongs to.
+#[derive(Debug, Default)]
+pub(crate) struct ApngResume {
+  pub(crate) index: usize,
+  pub(crate) canvas: Vec<u8>,
+}
+
+/// [`decode_apng_frames`], resuming from the canvas a frame left behind.
+///
+/// `resume` is `(index, canvas)` where `canvas` is the straight-alpha RGBA the
+/// animation held after frame `index` was disposed of. The frames up to and
+/// including `index` are advanced past by header rather than decoded.
+pub(crate) fn decode_apng_frames_from(
+  bytes: &[u8],
+  resume: Option<(usize, &[u8])>,
+  skip: usize,
+  limit: Option<usize>,
+  target: Option<(u32, u32, ImageScalingAlgorithm)>,
   mut push: impl FnMut(Arc<ImageBuffer>),
+  mut capture: Option<&mut ApngResume>,
 ) -> ImageResult<bool> {
   let mut reader = apng_reader(bytes)?;
   let (width, height) = (reader.info().width, reader.info().height);
@@ -1429,11 +1453,28 @@ pub(crate) fn decode_apng_frames(
     _ => return Err(invalid_buffer_error()),
   };
 
-  let mut canvas = ApngCanvas::new(width, height);
+  let mut canvas = match resume {
+    Some((_, pixels)) => ApngCanvas::resumed(width, height, pixels)?,
+    None => ApngCanvas::new(width, height),
+  };
   let mut subframe = Vec::new();
   let mut total_pixels = 0_u64;
   let mut pushed = 0_usize;
   let mut index = 0_usize;
+
+  // The resume canvas already accounts for every frame up to `resume_index`,
+  // so advance past them by header.
+  let mut resumed = false;
+  if let Some((resume_index, _)) = resume {
+    if reader.info().frame_control.is_none() {
+      reader.next_frame_info().map_err(png_decode_error)?;
+    }
+    for _ in 0..=resume_index {
+      reader.next_frame_info().map_err(png_decode_error)?;
+    }
+    index = resume_index + 1;
+    resumed = true;
+  }
 
   // One read past the cap: an unclaimed default image costs a read without
   // taking a slot on the timeline.
@@ -1445,7 +1486,8 @@ pub(crate) fn decode_apng_frames(
       return Ok(false);
     }
 
-    if read > 0 && reader.next_frame_info().is_err() {
+    // A resumed replay is already positioned on its first frame.
+    if read > 0 && !(resumed && read == 1) && reader.next_frame_info().is_err() {
       break;
     }
 
@@ -1480,6 +1522,16 @@ pub(crate) fn decode_apng_frames(
     }
 
     canvas.dispose(frame);
+
+    // Only the frames that are asked for are worth remembering; copying the
+    // canvas for every frame replayed past would cost more than it saves.
+    if current >= skip
+      && let Some(resume) = capture.as_deref_mut()
+    {
+      resume.index = current;
+      resume.canvas.clear();
+      resume.canvas.extend_from_slice(canvas.pixels());
+    }
   }
 
   Ok(true)
@@ -1495,6 +1547,25 @@ struct ApngCanvas {
 }
 
 impl ApngCanvas {
+  /// A canvas holding what an earlier replay left behind.
+  fn resumed(width: u32, height: u32, pixels: &[u8]) -> ImageResult<Self> {
+    if pixels.len() != width as usize * height as usize * 4 {
+      return Err(invalid_buffer_error());
+    }
+
+    Ok(Self {
+      pixels: pixels.to_vec(),
+      restore: Vec::new(),
+      width,
+      height,
+    })
+  }
+
+  /// The straight-alpha RGBA the canvas currently holds.
+  fn pixels(&self) -> &[u8] {
+    &self.pixels
+  }
+
   fn new(width: u32, height: u32) -> Self {
     Self {
       pixels: vec![0; width as usize * height as usize * 4],

--- a/takumi/benches/animated_frames.rs
+++ b/takumi/benches/animated_frames.rs
@@ -174,9 +174,41 @@ fn bench_last_frame(c: &mut Criterion) {
   group.finish();
 }
 
+/// Walks the whole timeline, one sample per frame, the way rendering an
+/// animation does.
+fn bench_whole_timeline(c: &mut Criterion) {
+  let mut group = c.benchmark_group("animated_timeline");
+
+  for (format, encode) in [
+    ("standalone/apng", encoded_apng as fn(usize) -> Vec<u8>),
+    ("dependent/apng", encoded_dependent_apng),
+  ] {
+    for frames in FRAME_COUNTS {
+      let Ok(ImageSource::Animated(animated)) = ImageSource::from_bytes(&encode(frames)) else {
+        panic!("{format} did not decode as an animated source");
+      };
+
+      group.bench_function(BenchmarkId::new(format, frames), |b| {
+        b.iter(|| {
+          for frame in 0..frames {
+            black_box(animated.frame_at_time_covering(
+              frame as u64 * 100,
+              SIZE,
+              SIZE,
+              ImageScalingAlgorithm::Auto,
+            ));
+          }
+        })
+      });
+    }
+  }
+
+  group.finish();
+}
+
 criterion_group! {
   name = benches;
   config = common::criterion();
-  targets = bench_last_frame
+  targets = bench_last_frame, bench_whole_timeline
 }
 criterion_main!(benches);


### PR DESCRIPTION
## Why

A frame that blends onto its predecessor cannot be seeked to, so it is reached by replaying from frame 0. Rendering an animation samples every frame, which made the whole timeline quadratic. A 300-frame dependent APNG cost 4.14 seconds.

## What

A replay starts from the canvas the last replay left, when the next request is for a later frame. The frames it already covers are advanced past by header rather than decoded.

| frames | before | after |
| --- | --- | --- |
| 30 | 44.7ms | 5.7ms |
| 120 | 674ms | 25.3ms |
| 300 | 4.14s | 75.4ms |

Growth goes from quadratic to linear. Sampling a single frame is unchanged, which is why the existing benchmark does not move: it asks for the same frame every iteration. The new `animated_timeline` group measures what rendering an animation actually does.

The canvas is captured only for frames that were asked for. Copying it for every frame replayed past cost more than it saved.

A test asserts that resuming from every possible point lands on byte-identical pixels, for every target frame. That is the whole risk of this change.

Costs: one canvas per animated source, allocated only once a replay happens. The lock is never waited on — a busy source replays from scratch rather than blocking. GIF could take the same treatment; WebP cannot, since `image-webp` offers no way to seed its canvas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved APNG decoding when seeking or sampling later frames.
  * Added efficient resume support to reduce unnecessary animation replay.
  * Improved handling of partial APNG frames and animation compositing.
  * Preserved existing behavior for standalone images and other formats.

* **Bug Fixes**
  * Improved compositing accuracy for animated APNG frames.

* **Tests**
  * Added coverage confirming resumed playback matches full replay across animation positions.
  * Added benchmarks for sampling complete animated-image timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->