### PR TITLE
WASM: sets `opt-level = s` for smaller binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,8 +163,13 @@ lto = true
 panic = "abort"
 codegen-units = 1
 
+# The leaf crate is bindings and orchestration; per-pixel work lives in raster.
+# Every serde-wasm-bindgen monomorph for the node tree is instantiated here, so
+# this is where the bundle pays for them. Full "z" costs 18% of render time,
+# which is not worth the extra 6KB it saves over "s".
 [profile.release.package."takumi-wasm"]
 strip = "debuginfo"
+opt-level = "s"
 
 [profile.release.package."takumi-bindings-common"]
 opt-level = "z"


### PR DESCRIPTION
## Why

The wasm leaf crates set `strip` but no `opt-level`, so they compiled at the release default of 3. Their napi counterpart, `takumi-bindings-common`, has been at `"z"` all along.

Each crate is bindings and orchestration, but every serde-wasm-bindgen monomorph for the node tree is instantiated in it. That is what makes the setting expensive.

## What

`opt-level = "s"` for both. Measured through `wasm-pack build --release` plus brotli, timed with a 600-node tree rendered to WebP and a 300-node document rendered to PDF.

| | brotli | render |
| --- | --- | --- |
| takumi-wasm | 1,308,939 to 1,257,489 (-3.9%) | 28.5ms to 29.1ms |
| takumi-pdf-wasm | 1,361,748 to 1,345,245 (-1.2%) | 14.5ms to 15.4ms |

`"z"` on `takumi-wasm` buys another 6KB for 18% of render time, so `"s"` is where this lands. The few percent that remains falls on deserialization, and these trees are heavier than a typical card.

Per-pixel work is unaffected. That lives in `takumi-raster`, which stays at 3.
