### PR TITLE
Raster: copy whole-pixel image draws instead of sampling them

### DIFF
--- a/.tegami/blit-fast-path.md
+++ b/.tegami/blit-fast-path.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Draw whole-pixel images without resampling them
+
+An image placed at a whole-pixel offset is copied row by row instead of going through the sampling pipeline. Drawing one into a node is about three times faster; clips, shadows and blurs that composite an image get a few percent.

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -526,23 +526,8 @@ pub(crate) fn overlay_sampled_paint_source(
   options: OverlayOptions,
   sampling: SamplingOptions,
 ) {
-  let direct_identity_mapping = options.border.is_zero()
-    && sampling.logical_to_source.is_identity()
-    && size.width == source.width()
-    && size.height == source.height();
-
-  if direct_identity_mapping
-    && try_draw_image_with_tiny_skia(
-      target,
-      source,
-      options.transform,
-      options.algorithm,
-      options.mode,
-    )
-  {
-    return;
-  }
-
+  // A whole-pixel translation copies row spans directly. Tiny-skia would take
+  // the same draw through its sampling pipeline, so this is tried first.
   if options.border.is_zero()
     && options.transform.only_translation()
     && options.transform.x.fract() == 0.0
@@ -560,6 +545,23 @@ pub(crate) fn overlay_sampled_paint_source(
       options.mode,
       target.combined_mask,
     );
+    return;
+  }
+
+  let direct_identity_mapping = options.border.is_zero()
+    && sampling.logical_to_source.is_identity()
+    && size.width == source.width()
+    && size.height == source.height();
+
+  if direct_identity_mapping
+    && try_draw_image_with_tiny_skia(
+      target,
+      source,
+      options.transform,
+      options.algorithm,
+      options.mode,
+    )
+  {
     return;
   }
 


### PR DESCRIPTION
## Why

`overlay_sampled_paint_source` had two fast paths in the wrong order. An image at an identity mapping went to tiny-skia first, which takes it through the highp sampling pipeline. The row-span copy for whole-pixel translations sat behind it and could never be reached, since a whole-pixel translation of a same-size image satisfies the identity check too.

Profiling `background/image_node` put 75% of its time in `tiny_skia::pipeline::highp`.

## What

The whole-pixel check runs first. Nothing else changes.

| benchmark | before | after |
| --- | --- | --- |
| background/image_node | 3.93ms | 1.27ms |
| canvas/gradient_clip_mask | 3.36ms | 3.11ms |
| effects/drop_shadow_md | 2.07ms | 2.01ms |

Text benchmarks are unchanged. The movement there was a stale criterion baseline, confirmed by re-running the unmodified tree.

Every fixture is byte-identical, which is the check that matters: both paths must agree for a whole-pixel draw.
