### PR TITLE
Raster: copy opaque effect layers onto their parent

### DIFF
--- a/.tegami/subcanvas-blit.md
+++ b/.tegami/subcanvas-blit.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Composite opaque effect layers without resampling them
+
+A blur, shadow or opacity group that is fully opaque and composites normally is copied onto its parent row by row instead of going through the sampling pipeline. Such a drop shadow is about 40% faster to render, such a blur about 30%. A group with partial opacity or a blend mode is unaffected.

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -13,6 +13,7 @@ mod skia;
 
 use std::{borrow::Cow, mem::replace, sync::Arc};
 
+use blit::blit_paint_source_translation;
 pub(crate) use blit::{
   composite_mask_source_to_pixmap, overlay_image, overlay_sampled_paint_source,
 };
@@ -217,6 +218,22 @@ impl Canvas {
 
     let isolated_image = replace(&mut self.image, image);
     self.restore_subcanvas_state(origin, constraint_mask_stack);
+
+    // A fully opaque subcanvas lands whole-pixel over the parent, so it copies
+    // row by row; tiny-skia would take the same draw through its pipeline.
+    if opacity == 1.0 && mode == BlendMode::Normal {
+      blit_paint_source_translation(
+        &mut self.image.as_mut(),
+        PaintSource::Pixmap(isolated_image.as_ref()),
+        Point {
+          x: offset.x as f32,
+          y: offset.y as f32,
+        },
+        mode,
+        None,
+      );
+      return;
+    }
 
     if let Some(blend_mode) = to_tiny_blend_mode(mode) {
       let paint = PixmapPaint {

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -184,7 +184,7 @@ pub(super) fn blit_rows_from_sampler(
   }
 }
 
-fn blit_paint_source_translation(
+pub(super) fn blit_paint_source_translation(
   pixmap: &mut PixmapMut<'_>,
   source: PaintSource<'_>,
   offset: Point<f32>,


### PR DESCRIPTION
## Why

`composite_subcanvas` finishes every blur, shadow and opacity group with `draw_pixmap`. The offset is whole-pixel and the transform is identity, but tiny-skia still takes it through the sampling pipeline. This is the same shape as the image draw fixed in #1361.

## What

A subcanvas that is fully opaque and composites in Normal mode is copied row by row instead. Anything with partial opacity or a blend mode still goes to `draw_pixmap`, which is where the work those need actually lives.

| benchmark | before | after |
| --- | --- | --- |
| effects/drop_shadow_md | 2.02ms | 1.23ms |
| effects/blur_md | 2.74ms | 1.94ms |
| effects/shadow_md | 1.26ms | 1.26ms |

`shadow_md` does not move because its layer is not composited through this path.

Every render fixture is byte-identical, which is the check that matters: the two paths must agree for a whole-pixel opaque draw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved rendering performance for standard composite effects by copying layers directly when possible.
  * Drop-shadow rendering is approximately 40% faster.
  * Blur rendering is approximately 30% faster.
  * Existing behavior remains unchanged for transparency and non-standard blending modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->