### PR TITLE
Core: match selectors against the rules that could apply

### DIFF
--- a/.tegami/selector-index.md
+++ b/.tegami/selector-index.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Match selectors against the rules that could apply
+
+Stylesheet rules are grouped by what their rightmost selector requires, so a node only runs the matcher against rules naming one of its classes, its id or its tag. Rendering 800 nodes against 800 rules drops from 67ms to 2.5ms; the cost now grows with the rules that could match rather than with the whole stylesheet.

--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -11,7 +11,7 @@ use selectors::{
   attr::{CaseSensitivity, NamespaceConstraint},
   bloom::BloomFilter,
   matching::*,
-  parser::{AncestorHashes, Selector},
+  parser::{AncestorHashes, Component, Selector},
 };
 use smallvec::SmallVec;
 
@@ -419,6 +419,111 @@ enum SelectorTarget {
 
 /// Matches every rule in `stylesheet` against the tree rooted at `root`,
 /// returning the declaration blocks that apply to each node in tree order.
+/// What a selector's rightmost compound requires of the element it matches.
+///
+/// A rule whose rightmost compound names an id, class or tag can only match an
+/// element carrying that name, so other nodes skip it without running the
+/// matcher. Anything else, a bare `*` or an attribute selector, has to be
+/// considered for every node.
+enum SelectorKey {
+  Id(String),
+  Class(String),
+  /// Lowercased: tag names match case-insensitively.
+  Tag(String),
+  Any,
+}
+
+fn selector_key(selector: &Selector<SelectorImpl>) -> SelectorKey {
+  let mut key = SelectorKey::Any;
+
+  // `iter` walks the rightmost compound and stops at the first combinator.
+  for component in selector.iter() {
+    match component {
+      Component::ID(id) => return SelectorKey::Id(id.to_string()),
+      Component::Class(class) => key = SelectorKey::Class(class.to_string()),
+      Component::LocalName(name) if matches!(key, SelectorKey::Any) => {
+        key = SelectorKey::Tag(name.lower_name.to_ascii_lowercase());
+      }
+      _ => {}
+    }
+  }
+
+  key
+}
+
+/// Rules grouped by what their rightmost compound requires, so a node visits
+/// only the rules that could match it.
+#[derive(Default)]
+struct RuleIndex {
+  by_id: HashMap<String, Vec<usize>>,
+  by_class: HashMap<String, Vec<usize>>,
+  by_tag: HashMap<String, Vec<usize>>,
+  unindexed: Vec<usize>,
+}
+
+impl RuleIndex {
+  fn build(rules: &[&CssRule]) -> Self {
+    let mut index = Self::default();
+
+    for (order, rule) in rules.iter().enumerate() {
+      let keys: SmallVec<[SelectorKey; 4]> =
+        rule.selectors().slice().iter().map(selector_key).collect();
+
+      // A rule with one unindexable selector has to be visited by every node,
+      // so it goes wholly into the unindexed bucket.
+      if keys.iter().any(|key| matches!(key, SelectorKey::Any)) {
+        index.unindexed.push(order);
+        continue;
+      }
+
+      for key in keys {
+        let bucket = match key {
+          SelectorKey::Id(name) => index.by_id.entry(name),
+          SelectorKey::Class(name) => index.by_class.entry(name),
+          SelectorKey::Tag(name) => index.by_tag.entry(name),
+          SelectorKey::Any => unreachable!("handled above"),
+        }
+        .or_default();
+
+        if bucket.last() != Some(&order) {
+          bucket.push(order);
+        }
+      }
+    }
+
+    index
+  }
+
+  /// Rules that could match `node`, in source order.
+  fn candidates(&self, node: &Node, out: &mut Vec<usize>) {
+    out.clear();
+    out.extend_from_slice(&self.unindexed);
+
+    if let Some(id) = node.metadata.id.as_deref()
+      && let Some(rules) = self.by_id.get(id)
+    {
+      out.extend_from_slice(rules);
+    }
+
+    if let Some(classes) = node.metadata.class_name.as_deref() {
+      for class in classes.split_ascii_whitespace() {
+        if let Some(rules) = self.by_class.get(class) {
+          out.extend_from_slice(rules);
+        }
+      }
+    }
+
+    if let Some(tag) = node.metadata.tag_name.as_deref()
+      && let Some(rules) = self.by_tag.get(&tag.to_ascii_lowercase())
+    {
+      out.extend_from_slice(rules);
+    }
+
+    out.sort_unstable();
+    out.dedup();
+  }
+}
+
 pub(crate) fn match_stylesheets_view<'a>(
   root: &Node,
   stylesheet: &'a StyleSheet,
@@ -452,6 +557,9 @@ pub(crate) fn match_stylesheets_view<'a>(
   let mut ancestor_bloom_filter = BloomFilter::new();
   let mut ancestor_stack: Vec<usize> = Vec::new();
   let mut selector_ancestor_hashes_cache: HashMap<(usize, usize), AncestorHashes> = HashMap::new();
+
+  let index = RuleIndex::build(&flattened_rules);
+  let mut candidates = Vec::new();
 
   let mut element_caches = SelectorCaches::default();
   let mut pseudo_caches = SelectorCaches::default();
@@ -491,7 +599,10 @@ pub(crate) fn match_stylesheets_view<'a>(
       MatchingForInvalidation::No,
     );
 
-    for (source_order, &rule) in flattened_rules.iter().enumerate() {
+    index.candidates(arena.nodes[i].node, &mut candidates);
+
+    for &source_order in &candidates {
+      let rule = flattened_rules[source_order];
       let mut best_element: Option<u32> = None;
       let mut best_before: Option<u32> = None;
       let mut best_after: Option<u32> = None;

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -90,6 +90,10 @@ name = "background"
 harness = false
 
 [[bench]]
+name = "cascade"
+harness = false
+
+[[bench]]
 name = "canvas"
 harness = false
 

--- a/takumi/benches/cascade.rs
+++ b/takumi/benches/cascade.rs
@@ -1,0 +1,71 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use takumi::{
+  prelude::{Fonts, Node, RenderOptions, StyleSheet, Viewport},
+  render,
+};
+
+mod common;
+
+const SIZES: [(usize, usize); 3] = [(200, 200), (400, 400), (800, 800)];
+
+/// A stylesheet where almost nothing matches, which is what a utility framework
+/// looks like from any single node's point of view.
+fn stylesheet(rules: usize) -> StyleSheet {
+  let css: String = (0..rules)
+    .map(|rule| format!(".unused-{rule} {{ color: rgb({}, 0, 0); }}\n", rule % 256))
+    .collect();
+
+  StyleSheet::parse(&css).expect("valid stylesheet")
+}
+
+fn document(nodes: usize) -> Node {
+  Node::container(
+    (0..nodes)
+      .map(|node| {
+        Node::container([])
+          .with_class_name(format!("leaf-{node}"))
+          .with_tw("w-1 h-1".parse().expect("valid classes"))
+      })
+      .collect::<Vec<_>>(),
+  )
+}
+
+fn bench_cascade(c: &mut Criterion) {
+  let fonts = Fonts::default();
+  let mut group = c.benchmark_group("cascade");
+
+  for (nodes, rules) in SIZES {
+    let stylesheet = stylesheet(rules);
+    let node = document(nodes);
+
+    group.bench_function(
+      BenchmarkId::from_parameter(format!("{nodes}x{rules}")),
+      |b| {
+        b.iter(|| {
+          black_box(
+            render(
+              RenderOptions::builder()
+                .viewport(Viewport::new((64, 64)))
+                .node(node.clone())
+                .fonts(&fonts)
+                .stylesheet(stylesheet.clone().into())
+                .build(),
+            )
+            .expect("renders"),
+          )
+        })
+      },
+    );
+  }
+
+  group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = common::criterion();
+  targets = bench_cascade
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Why

Every node ran every selector of every media-active rule. The ancestor bloom filter helps only with combinators; a rule whose subject is `.some-class` still had its matcher run against every node in the document.

That is `O(nodes x rules)`, and nothing measured it: the benchmarks render small trees against small stylesheets. Against a utility framework, where a node matches a handful of several hundred rules, it dominates.

| nodes x rules | before |
| --- | --- |
| 200 x 200 | 4.48ms |
| 400 x 400 | 17.2ms |
| 800 x 800 | 67.3ms |

Four times the input costs fifteen times the work.

## What

Rules are grouped by what their rightmost compound requires — an id, a class, a tag, or nothing indexable — and a node collects the buckets matching its own id, classes and tag, plus the unindexable ones. Source order is preserved by merging bucket contents and sorting, so the cascade is unchanged.

A rule whose selector list contains anything unindexable goes wholly into the unindexed bucket, so a rule is never skipped when one of its selectors could have matched.

| nodes x rules | after | |
| --- | --- | --- |
| 200 x 200 | 0.52ms | 8.7x |
| 400 x 400 | 1.09ms | 15.8x |
| 800 x 800 | 2.49ms | 27x |

Growth now follows the rules that could match rather than the size of the stylesheet.

The `cascade` benchmark is new, and is the point of this PR as much as the change is: nothing in the suite scaled the stylesheet before, which is why this went unnoticed.

Every fixture is byte-identical and the cascade tests pass unchanged, which is the check that matters — this must not alter which declarations win.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved style rule matching to evaluate relevant rules more efficiently.
  * Preserved styling behavior and rule order while reducing unnecessary selector checks.
  * Added performance coverage for cascading styles across different document and stylesheet sizes.

* **Documentation**
  * Added guidance describing selector matching behavior and reported performance results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->