### PR TITLE
Core: reuse layout styles that do not depend on their query container

### DIFF
--- a/.tegami/taffy-style-reuse.md
+++ b/.tegami/taffy-style-reuse.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Reuse layout styles across sizing passes
+
+Layout runs several sizing passes over each node, and each pass rebuilt that node's layout style from scratch. Only container query units (`cqw`, `cqh`, `cqmin`, `cqmax`) can change between passes, so a style using none of them is now built once and reused. A deeply nested flex tree lays out about 36% faster.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -99,6 +99,9 @@ pub struct LayoutTree<'r> {
 
 struct LayoutNodeState {
   style: Style,
+  /// Whether the style is the same whatever query container it resolves
+  /// against, so taffy's repeated passes can reuse it.
+  container_independent: bool,
   cache: Cache,
   unrounded_layout: Layout,
   final_layout: Layout,
@@ -372,16 +375,25 @@ fn push_layout_node<'r>(
 
     render_nodes.push(render_node);
 
+    let (style, container_independent) = match &render_node.layout_style_override {
+      Some(style) => (style.clone(), true),
+      None => {
+        let sizing = &render_node.context.sizing;
+
+        // Resolution reports whether it read the query container, which is
+        // exact. Comparing two resolved sizes is not: `min(10px, 100cqw)`
+        // agrees across two large containers and disagrees with a small one.
+        sizing.container_read.set(false);
+        let style = render_node.context.style.to_taffy_style(sizing);
+        let independent = !sizing.container_read.get();
+
+        (style, independent)
+      }
+    };
+
     nodes.push(LayoutNodeState {
-      style: render_node
-        .layout_style_override
-        .clone()
-        .unwrap_or_else(|| {
-          render_node
-            .context
-            .style
-            .to_taffy_style(&render_node.context.sizing)
-        }),
+      style,
+      container_independent,
       cache: Cache::new(),
       unrounded_layout: Layout::new(),
       final_layout: Layout::new(),
@@ -564,6 +576,14 @@ impl<'r> LayoutTree<'r> {
     let Some(render_node) = self.render_nodes.get(idx) else {
       return;
     };
+
+    if self
+      .nodes
+      .get(idx)
+      .is_some_and(|node| node.container_independent)
+    {
+      return;
+    }
 
     let style = if let Some(style_override) = &render_node.layout_style_override {
       style_override.clone()

--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -724,6 +724,7 @@ mod tests {
     SizingContext {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 16.0,
       root_font_size: None,
       line_height: 0.0,

--- a/takumi-core/src/style/media_query.rs
+++ b/takumi-core/src/style/media_query.rs
@@ -115,6 +115,7 @@ impl MediaQueryList {
     let sizing = SizingContext {
       viewport,
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: viewport.font_size,
       root_font_size: None,
       line_height: viewport.font_size,

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -854,6 +854,7 @@ mod tests {
     SizingContext {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 16.0,
       root_font_size: None,
       line_height: 0.0,

--- a/takumi-core/src/style/properties/corner_shape.rs
+++ b/takumi-core/src/style/properties/corner_shape.rs
@@ -193,6 +193,7 @@ mod tests {
     SizingContext {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 16.0,
       root_font_size: None,
       line_height: 0.0,

--- a/takumi-core/src/style/properties/font_size.rs
+++ b/takumi-core/src/style/properties/font_size.rs
@@ -203,6 +203,7 @@ mod tests {
     let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 20.0,
       root_font_size: None,
       line_height: 0.0,
@@ -229,6 +230,7 @@ mod tests {
     let sizing = SizingContext {
       viewport: Viewport::new((1200, 630)),
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 16.0,
       root_font_size: None,
       line_height: 0.0,
@@ -248,6 +250,7 @@ mod tests {
     let sizing = SizingContext {
       viewport,
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: root_font_size_device_px,
       root_font_size: Some(root_font_size_device_px),
       line_height: 0.0,

--- a/takumi-core/src/style/properties/length.rs
+++ b/takumi-core/src/style/properties/length.rs
@@ -567,6 +567,7 @@ mod tests {
         device_pixel_ratio: 2.0,
       },
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 10.0,
       root_font_size: None,
       line_height: 30.0,
@@ -953,6 +954,35 @@ mod tests {
     assert_near(Length::CqH(50.0).to_px(&sizing, 0.0), 20.0);
     assert_near(Length::CqMin(50.0).to_px(&sizing, 0.0), 20.0);
     assert_near(Length::CqMax(50.0).to_px(&sizing, 0.0), 40.0);
+  }
+
+  /// Resolution reports reading the query container, which is what tells a
+  /// caller the result depends on one. Comparing two resolved values cannot:
+  /// a length clamped against a container agrees across two containers and
+  /// disagrees with a third.
+  #[test]
+  fn resolving_a_container_length_reports_the_read() {
+    let mut sizing = sizing();
+    sizing.container_size = Size {
+      width: Some(80.0),
+      height: Some(40.0),
+    };
+
+    sizing.container_read.set(false);
+    Length::Px(10.0).to_px(&sizing, 0.0);
+    assert!(!sizing.container_read.get(), "a px length reads nothing");
+
+    assert_near(Length::CqW(50.0).to_px(&sizing, 0.0), 40.0);
+    assert!(
+      sizing.container_read.get(),
+      "a cqw length reads the container"
+    );
+
+    // Zero resolves the same against every container, yet still reports the
+    // read: the flag tracks what was consulted, not whether it mattered.
+    sizing.container_read.set(false);
+    assert_near(Length::CqW(0.0).to_px(&sizing, 0.0), 0.0);
+    assert!(sizing.container_read.get());
   }
 
   #[test]

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -837,6 +837,7 @@ mod tests {
     SizingContext {
       viewport: Viewport::new((200, 100)),
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 16.0,
       root_font_size: None,
       line_height: 0.0,

--- a/takumi-core/src/style/properties/vertical_align.rs
+++ b/takumi-core/src/style/properties/vertical_align.rs
@@ -242,6 +242,7 @@ mod tests {
         device_pixel_ratio: 2.0,
       },
       container_size: Size::NONE,
+      container_read: Default::default(),
       font_size: 10.0,
       root_font_size: None,
       line_height: 0.0,

--- a/takumi-core/src/style/sizing.rs
+++ b/takumi-core/src/style/sizing.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{cell::Cell, rc::Rc};
 
 use typed_builder::TypedBuilder;
 
@@ -12,6 +12,10 @@ pub struct SizingContext {
   /// The nearest query container size (content box) in device pixels.
   #[builder(default, setter(skip))]
   pub(crate) container_size: Size<Option<f32>>,
+  /// Set when a length resolves against the query container, so a caller can
+  /// tell whether its result depends on one.
+  #[builder(default, setter(skip))]
+  pub(crate) container_read: Cell<bool>,
   /// The font size in pixels.
   #[builder(default = viewport.to_device(viewport.font_size))]
   pub font_size: f32,
@@ -91,6 +95,7 @@ impl SizingContext {
 
   /// Query container width in device pixels, falling back to the viewport.
   pub(crate) fn query_container_width(&self) -> f32 {
+    self.container_read.set(true);
     self
       .container_size
       .width
@@ -99,6 +104,7 @@ impl SizingContext {
 
   /// Query container height in device pixels, falling back to the viewport.
   pub(crate) fn query_container_height(&self) -> f32 {
+    self.container_read.set(true);
     self
       .container_size
       .height

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -856,6 +856,7 @@ fn test_creates_stacking_context_from_z_index_scope() {
   let sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 16.0,
     root_font_size: None,
     line_height: 0.0,
@@ -913,6 +914,7 @@ fn test_offset_path_moves_element_onto_path_and_creates_stacking_context() {
   let sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 16.0,
     root_font_size: None,
     line_height: 0.0,
@@ -952,6 +954,7 @@ fn test_non_identity_transform_detection() {
   let sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 16.0,
     root_font_size: None,
     line_height: 0.0,
@@ -978,6 +981,7 @@ fn test_transform_creates_stacking_context_without_offscreen_compositing() {
   let sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 16.0,
     root_font_size: None,
     line_height: 0.0,
@@ -1018,6 +1022,7 @@ fn test_position_absolute_blockifies_inline_display() {
   let sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 16.0,
     root_font_size: None,
     line_height: 0.0,
@@ -1041,6 +1046,7 @@ fn test_inherited_em_text_lengths_are_computed_once() {
   parent.make_computed(&SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 32.0,
     root_font_size: None,
     line_height: 0.0,
@@ -1052,6 +1058,7 @@ fn test_inherited_em_text_lengths_are_computed_once() {
   let inherited_child_sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 32.0,
     root_font_size: None,
     line_height: 0.0,
@@ -1068,6 +1075,7 @@ fn test_inherited_em_text_lengths_are_computed_once() {
   let child_sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 10.0,
     root_font_size: None,
     line_height: 0.0,
@@ -1316,6 +1324,7 @@ fn test_border_radius_calc_infinity_parses_from_stylesheet_declaration() {
   let sizing = SizingContext {
     viewport: Viewport::new((1200, 630)),
     container_size: Size::NONE,
+    container_read: Default::default(),
     font_size: 16.0,
     root_font_size: None,
     line_height: 0.0,

--- a/takumi/Cargo.toml
+++ b/takumi/Cargo.toml
@@ -110,6 +110,10 @@ name = "gradient"
 harness = false
 
 [[bench]]
+name = "layout"
+harness = false
+
+[[bench]]
 name = "svg"
 harness = false
 

--- a/takumi/benches/layout.rs
+++ b/takumi/benches/layout.rs
@@ -1,0 +1,60 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use takumi::{
+  prelude::{Fonts, Node, RenderOptions, Viewport},
+  render,
+};
+
+mod common;
+
+const FANOUT: usize = 4;
+const DEPTHS: [u32; 3] = [4, 5, 6];
+
+/// A nested flex tree, the shape that makes taffy run several sizing passes
+/// over every node.
+fn nested_flex(depth: u32) -> Node {
+  if depth == 0 {
+    return Node::container([]).with_tw("w-2 h-2 bg-white".parse().expect("valid classes"));
+  }
+
+  Node::container(
+    (0..FANOUT)
+      .map(|_| nested_flex(depth - 1))
+      .collect::<Vec<_>>(),
+  )
+  .with_tw("flex flex-row grow".parse().expect("valid classes"))
+}
+
+fn bench_nested_flex(c: &mut Criterion) {
+  let fonts = Fonts::default();
+  let mut group = c.benchmark_group("layout");
+
+  for depth in DEPTHS {
+    let node = nested_flex(depth);
+
+    group.bench_function(BenchmarkId::new("nested_flex", depth), |b| {
+      b.iter(|| {
+        black_box(
+          render(
+            RenderOptions::builder()
+              .viewport(Viewport::new((512, 512)))
+              .node(node.clone())
+              .fonts(&fonts)
+              .build(),
+          )
+          .expect("renders"),
+        )
+      })
+    });
+  }
+
+  group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = common::criterion();
+  targets = bench_nested_flex
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Why

Taffy calls `compute_child_layout` several times per node — min-content, max-content, and the flex passes. Every call rebuilt that node's `taffy::Style` from scratch, allocating grid template vectors and re-resolving every length.

The only reason to rebuild is `container_size`. The only things that read it are container query units, and most styles use none.

## What

Length resolution records whether it read the query container. A style that never read one is built once and reused; a style that did is rebuilt as before.

| nested flex | before | after |
| --- | --- | --- |
| depth 4 (~340 nodes) | 3.70ms | 2.18ms |
| depth 5 (~1.4k nodes) | 13.8ms | 7.90ms |
| depth 6 (~5.5k nodes) | 59.0ms | 36.8ms |

The `layout` benchmark is new. The suite had no deeply nested tree, which is why this went unmeasured.

An earlier version resolved the style twice against different containers and compared. That is not sound: `min(10px, 100cqw)` agrees across two large containers and disagrees with a small one. Recording the read is exact, and stays exact if a new property starts consulting the container.

Every fixture is byte-identical, including the container query ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved layout performance for deeply nested flex structures by reusing styles when container-query sizing does not affect them.
  * Reduced unnecessary style recalculation during repeated layout passes.

* **Benchmarks**
  * Added coverage for nested flex layouts across multiple tree depths and configurations.

* **Documentation**
  * Added a patch-release note describing the layout performance improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->