### PR TITLE
Chore: size-optimize the pdf wasm binding crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,9 @@ codegen-units = 1
 strip = "debuginfo"
 opt-level = "s"
 
+[profile.release.package."takumi-pdf-wasm"]
+opt-level = "s"
+
 [profile.release.package."takumi-bindings-common"]
 opt-level = "z"
 


### PR DESCRIPTION
## Why

`takumi-pdf-wasm` still compiles at the release default of 3, the same gap #1360 closed for `takumi-wasm`. Like that crate, it is bindings and orchestration, and every serde-wasm-bindgen monomorph for the node tree is instantiated in it.

## What

`opt-level = "s"`. Measured through `wasm-pack build --release` plus brotli, timed with a 300-node document rendered to PDF.

| | brotli | render |
| --- | --- | --- |
| before | 1,361,748 | 14.5ms |
| after | 1,345,245 (-1.2%) | 15.4ms |

Smaller return than the image crate saw, and a slightly larger cost, since the pdf leaf carries less of the bundle. The trade is the same shape, and the few percent falls on deserialization rather than on rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the `takumi-pdf-wasm` release build for smaller output size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->