### PR TITLE
Docs: show the playground browser pane again

### DIFF
--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -126,7 +126,8 @@ function usePaintFrame(paint: Paint | undefined) {
   const pendingRef = useRef<Paint>(undefined);
   const [contentHeight, setContentHeight] = useState<number>();
   // The frame is blank until its first paint lands, which would flash white
-  // over the pane.
+  // over the pane. Delivery is what counts as painted: the frame's own report
+  // rides a port a later announce may already have closed.
   const [hasPainted, setHasPainted] = useState(false);
 
   useEffect(() => {
@@ -137,7 +138,6 @@ function usePaintFrame(paint: Paint | undefined) {
 
       if (message?.type === "height" && Number.isFinite(message.value)) {
         setContentHeight(Math.min(Math.max(Number(message.value), 0), MAX_FRAME_HEIGHT));
-        setHasPainted(true);
       }
     };
 
@@ -153,7 +153,11 @@ function usePaintFrame(paint: Paint | undefined) {
       portRef.current = port;
       port.onmessage = onPortMessage;
       port.start();
-      if (pendingRef.current) port.postMessage(pendingRef.current);
+
+      if (!pendingRef.current) return;
+
+      port.postMessage(pendingRef.current);
+      setHasPainted(true);
     };
 
     window.addEventListener("message", onMessage);
@@ -169,7 +173,11 @@ function usePaintFrame(paint: Paint | undefined) {
     if (!paint) return;
 
     pendingRef.current = paint;
-    portRef.current?.postMessage(paint);
+
+    if (!portRef.current) return;
+
+    portRef.current.postMessage(paint);
+    setHasPainted(true);
   }, [paint]);
 
   return { frameRef, contentHeight, hasPainted };


### PR DESCRIPTION
## Why

The browser pane stayed `visibility: hidden` after a render, so the playground showed the Takumi output next to an empty box. The pane only revealed itself once the frame reported its height back over the message port, and that report can go missing: the frame announces a fresh port on parse and again on `hello`, and the page closes the older port as soon as the newer one arrives. A height sent on the port being closed never lands. Nothing else in the fixed-height layout needs that number.

## What

Delivery of a paint to a live port is what reveals the frame. The height report keeps its one job, sizing the pane that grows with its content.

No screenshot: the fix needs the docs dev server with the sibling packages built, which I did not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview visibility timing so the browser preview appears only after its content has been successfully delivered.
  * Prevented height updates from incorrectly marking the preview as ready before it has rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->