### PR TITLE
Helpers: decode the numeric character references the spec defines

### DIFF
--- a/.tegami/numeric-character-references.md
+++ b/.tegami/numeric-character-references.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Decode the numeric character references the HTML spec defines
+
+`&#X41;` stayed literal text because the decoder matched only a lower-case `x`, while the spec accepts either case. A reference in the C1 range now resolves through the windows-1252 table the spec names, so `&#153;` renders as `™` rather than an invisible control character, and `&#0;` becomes the replacement character rather than a raw NUL.

--- a/takumi-helpers/src/html/entities.ts
+++ b/takumi-helpers/src/html/entities.ts
@@ -256,13 +256,17 @@ const namedHtmlEntities: Record<string, string> = {
   euro: "\u20ac",
 };
 
+// The windows-1252 characters a C1 numeric reference resolves to, 0x80 to 0x9f.
+// https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
+const windows1252C1 = "€\u0081‚ƒ„…†‡ˆ‰Š‹Œ\u008dŽ\u008f\u0090‘’“”•–—˜™š›œ\u009džŸ";
+
 export function decodeHtmlEntities(value: string): string {
   if (!value.includes("&")) {
     return value;
   }
 
   return value.replace(
-    /&(?:#(\d+)|#x([\da-fA-F]+)|([a-zA-Z][\w-]+));/g,
+    /&(?:#(\d+)|#[xX]([\da-fA-F]+)|([a-zA-Z][\w-]+));/g,
     (match, dec, hex, named) => {
       if (dec) {
         return decodeCodePoint(Number(dec)) ?? match;
@@ -284,6 +288,14 @@ function decodeCodePoint(codePoint: number): string | undefined {
 
   if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
     return;
+  }
+
+  if (codePoint === 0) {
+    return "\ufffd";
+  }
+
+  if (codePoint >= 0x80 && codePoint <= 0x9f) {
+    return windows1252C1[codePoint - 0x80];
   }
 
   try {

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -64,6 +64,30 @@ describe("fromHtml", () => {
 
     expect((node as TextNode).text).toBe("&#xd800;&#57343;");
   });
+
+  test("decodes an upper-case hex reference", () => {
+    const { node } = fromHtml("<div>&#X41;&#Xa9;&#X2764;</div>");
+
+    expect((node as TextNode).text).toBe("A©❤");
+  });
+
+  test("remaps C1 references to their windows-1252 characters", () => {
+    const { node } = fromHtml("<div>&#153;&#x99;&#128;&#x9F;&#x92;</div>");
+
+    expect((node as TextNode).text).toBe("™™€Ÿ’");
+  });
+
+  test("leaves C1 code points the table does not name", () => {
+    const { node } = fromHtml("<div>&#x81;</div>");
+
+    expect((node as TextNode).text).toBe("");
+  });
+
+  test("decodes a null reference as the replacement character", () => {
+    const { node } = fromHtml("<div>&#0;&#x0;</div>");
+
+    expect((node as TextNode).text).toBe("��");
+  });
 });
 
 describe("fromJsx", () => {


### PR DESCRIPTION
## Why

`&#X41;` stayed literal text because the decoder matched only a lower-case `x`, while the HTML spec accepts either case. A C1 reference such as `&#153;` decoded to an invisible control character instead of `™`; legacy encoders emit that range, and scraped or CMS-exported markup carries it. `&#0;` produced a raw NUL in a shaped text run.

## What

`decodeCodePoint` resolves 0x80 to 0x9f through the windows-1252 characters the spec names, held as a 32-character string indexed by `codePoint - 0x80`, so the five slots the spec leaves unnamed keep their own code point without a special case. A null reference becomes the replacement character. The hex branch of the regex accepts either case of `x`.

Surrogates and out-of-range code points still pass through as literal text rather than the replacement character the spec asks for. That is unchanged here and worth a separate look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML entity decoding for hexadecimal references using uppercase or lowercase prefixes.
  * Correctly converts Windows-1252 characters and preserves unmapped control characters.
  * Replaces null character references with the standard replacement character.
* **Tests**
  * Added coverage for the updated numeric and named character-reference decoding behavior.
* **Documentation**
  * Added release notes describing the HTML entity decoding fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->