### PR TITLE
Helpers: keep a `;` inside an inline style value

### DIFF
--- a/.tegami/inline-style-semicolon-split.md
+++ b/.tegami/inline-style-semicolon-split.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Keep a `;` inside an inline style value
+
+`fromHtml` and `fromStaticMarkup` split the `style` attribute on every `;`, so a value carrying one of its own lost everything after it. `style="background-image:url(data:image/png;base64,...)"` resolved to `url(data:image/png` and rendered nothing. A quoted `font-family: "Foo; Bar"` was cut the same way. Only a `;` outside `url()` and a quoted string now ends a declaration.

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -231,23 +231,70 @@ function decodeAttributeMap(attributes: Record<string, string>): Record<string, 
 
 function parseInlineStyle(styleText: string): CSSProperties | undefined {
   const style: Record<string, string> = {};
+  let start = 0;
+  let colon = -1;
+  let depth = 0;
 
-  for (const declaration of styleText.split(";")) {
-    const [property, ...valueParts] = declaration.split(":");
-    if (!property || valueParts.length === 0) {
-      continue;
+  const commit = (end: number) => {
+    if (colon < 0) {
+      return;
     }
 
-    const name = property.trim();
-    const value = valueParts.join(":").trim();
-    if (!name || !value) {
-      continue;
-    }
+    const name = styleText.slice(start, colon).trim();
+    const value = styleText.slice(colon + 1, end).trim();
 
-    style[cssPropertyToJsProperty(name)] = value;
+    if (name && value) {
+      style[cssPropertyToJsProperty(name)] = value;
+    }
+  };
+
+  for (let index = 0; index < styleText.length; index += 1) {
+    const character = styleText[index];
+
+    if (character === "\\") {
+      index += 1;
+    } else if (character === '"' || character === "'") {
+      index = skipQuoted(styleText, index);
+    } else if (character === "/" && styleText[index + 1] === "*") {
+      index = skipComment(styleText, index);
+    } else if (character === "(") {
+      depth += 1;
+    } else if (character === ")") {
+      depth = Math.max(0, depth - 1);
+    } else if (depth > 0) {
+      continue;
+    } else if (character === ":" && colon < 0) {
+      colon = index;
+    } else if (character === ";") {
+      commit(index);
+      start = index + 1;
+      colon = -1;
+    }
   }
 
+  commit(styleText.length);
+
   return Object.keys(style).length > 0 ? (style as CSSProperties) : undefined;
+}
+
+function skipQuoted(styleText: string, start: number): number {
+  const quote = styleText[start];
+
+  for (let index = start + 1; index < styleText.length; index += 1) {
+    if (styleText[index] === "\\") {
+      index += 1;
+    } else if (styleText[index] === quote) {
+      return index;
+    }
+  }
+
+  return styleText.length;
+}
+
+function skipComment(styleText: string, start: number): number {
+  const end = styleText.indexOf("*/", start + 2);
+
+  return end < 0 ? styleText.length : end + 1;
 }
 
 function cssPropertyToJsProperty(property: string): string {

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -88,6 +88,48 @@ describe("fromHtml", () => {
 
     expect((node as TextNode).text).toBe("��");
   });
+
+  test("keeps a data URL intact in an inline style", () => {
+    const { node } = fromHtml(
+      `<div style="background-image:url(data:image/png;base64,iVBORw0KGgo=);color:red">x</div>`,
+    );
+
+    expect(node.style).toEqual({
+      backgroundImage: "url(data:image/png;base64,iVBORw0KGgo=)",
+      color: "red",
+    });
+  });
+
+  test("keeps a quoted semicolon inside a declaration value", () => {
+    const { node } = fromHtml(`<div style="font-family:'Foo; Bar', sans-serif;color:red">x</div>`);
+
+    expect(node.style).toEqual({ fontFamily: "'Foo; Bar', sans-serif", color: "red" });
+  });
+
+  test("still separates ordinary declarations", () => {
+    const { node } = fromHtml(`<div style="color:red;font-size:12px;">x</div>`);
+
+    expect(node.style).toEqual({ color: "red", fontSize: "12px" });
+  });
+
+  test("keeps an escaped semicolon outside quotes", () => {
+    const backslash = String.fromCharCode(92);
+    const { node } = fromHtml(`<div style="--value:foo${backslash};bar;color:red">x</div>`);
+
+    expect(node.style).toEqual({ "--value": `foo${backslash};bar`, color: "red" });
+  });
+
+  test("keeps a semicolon inside a comment out of the split", () => {
+    const { node } = fromHtml(`<div style="color:red/* ; */;font-size:12px">x</div>`);
+
+    expect(node.style).toEqual({ color: "red/* ; */", fontSize: "12px" });
+  });
+
+  test("tolerates an unclosed url() in an inline style", () => {
+    const { node } = fromHtml(`<div style="color:red;background-image:url(">x</div>`);
+
+    expect(node.style).toEqual({ color: "red", backgroundImage: "url(" });
+  });
 });
 
 describe("fromJsx", () => {


### PR DESCRIPTION
## Why

`parseInlineStyle` split the `style` attribute on every `;`, but the character is legal inside a declaration value. `style="background-image:url(data:image/png;base64,...)"` resolved to `url(data:image/png` and rendered nothing, with no warning; a data URL is the usual way markup embeds an image without a fetch. A quoted `font-family: "Foo; Bar"` was cut the same way.

## What

The parser walks the attribute once, tracking `url()` depth, quoted strings, backslash escapes, and `/* */` comments, and only a top-level `;` ends a declaration. Property and value come from the first top-level `:` by index, so a value keeps its own colons and no intermediate array is built. An unbalanced `(` degrades to one trailing declaration instead of losing the text.

A comment stays in the value text rather than being stripped: `cssparser` skips comment tokens on the Rust side, so `color:red/* ; */` still computes as `red`.

`fromJsx()` passes `style` as an object and never reaches this path. This is the only such split in the repo, JS and Rust alike.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline styles containing semicolons in URLs, quoted strings, comments, and escaped values.
  * Preserved colons and semicolons within valid style values during HTML and static markup processing.
  * Improved handling of unclosed URLs and final style declarations.

* **Tests**
  * Added coverage for inline-style parsing edge cases, including data URLs and quoted values.

* **Documentation**
  * Added a patch release entry for `@takumi-rs/helpers`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->