### PR TITLE
CI: run Clippy against the wasm target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           binstall: cargo-audit,cargo-llvm-cov,cargo-rdme@1.5.1,cargo-machete
           components: rustfmt,clippy
+          targets: wasm32-unknown-unknown
           stage: test
 
       - name: Check formatting
@@ -66,6 +67,11 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # The host pass never sees the `target_arch = "wasm32"` half of the
+      # decoders, so it is blind to whatever the published wasm compiles.
+      - name: Run Clippy for wasm
+        run: cargo clippy --target wasm32-unknown-unknown -p takumi-wasm -p takumi-pdf-wasm -- -D warnings
 
       - name: Test README.md is up to date
         run: |

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -692,7 +692,7 @@ fn decode_webp(bytes: &[u8]) -> ImageResult<ImageBuffer> {
   }
 
   let mut rgba = Vec::with_capacity(width as usize * height as usize * 4);
-  for rgb in image_data.chunks_exact(3) {
+  for rgb in image_data.as_chunks::<3>().0 {
     rgba.extend_from_slice(&[rgb[0], rgb[1], rgb[2], u8::MAX]);
   }
 
@@ -947,7 +947,7 @@ pub(crate) fn decode_webp_frames(
 }
 
 /// The first frame, for the still-image decode paths.
-#[cfg(feature = "webp")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "webp"))]
 fn decode_animated_webp_first_frame(bytes: &[u8]) -> ImageResult<ImageBuffer> {
   let mut first = None;
   decode_webp_frames(bytes, 0, Some(1), None, |frame| first = Some(frame))?;


### PR DESCRIPTION
## Why

Clippy only ran on the host target, so the `target_arch = "wasm32"` half of the image decoders was never linted. Two problems sat in the published wasm: a dead `decode_animated_webp_first_frame` (its only caller is non-wasm) and a `chunks_exact` denial in the pure-Rust WebP path.

## What

Adds a second Clippy pass over `takumi-wasm` and `takumi-pdf-wasm` on `wasm32-unknown-unknown` with `-D warnings`, and fixes the two findings. Default features, not `--all-features`, so the pass covers what actually ships. Output is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and validation for WebAssembly builds.
  * Ensured animated WebP decoding is available only in supported environments.

* **Chores**
  * Added WebAssembly target checks to continuous integration.
  * Updated image processing internals for more efficient handling of WebP data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->