### PR TITLE
Docs: keep the playground rendering when Google Fonts is blocked

### DIFF
--- a/docs/app/components/playground/playground.tsx
+++ b/docs/app/components/playground/playground.tsx
@@ -33,6 +33,8 @@ function formatStats(result: RenderSuccess) {
     `${Math.round(result.duration)} ms`,
   );
 
+  if (result.notice) parts.push(result.notice);
+
   return parts.join(" · ");
 }
 

--- a/docs/app/playground/fonts.ts
+++ b/docs/app/playground/fonts.ts
@@ -21,3 +21,6 @@ export function googleFontsCssUrl(): string {
   ).join("&");
   return `https://fonts.googleapis.com/css2?${families}&display=swap`;
 }
+
+/** Latin-only face served from this site, used when the Google Fonts request fails. */
+export const FALLBACK_FONT_URL = "/fonts/Geist.woff2";

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -40,6 +40,8 @@ const renderSuccessSchema = z.object({
   label: z.string(),
   /** What the PDF bytes turned out to contain, for PDF output. */
   inspection: z.optional(z.custom<PdfInspection>()),
+  /** What degraded in this render, shown in the status bar. */
+  notice: z.optional(z.string()),
 });
 
 const renderErrorSchema = z.object({

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -12,7 +12,7 @@ import type { JSXElementConstructor } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { evaluateCodeExports } from "./evaluate";
 import { renderReact } from "./render-react";
-import { FONT_FAMILIES } from "./fonts";
+import { FALLBACK_FONT_URL, FONT_FAMILIES } from "./fonts";
 import { inspectPdf } from "./inspect-pdf";
 import { keyframesToCss } from "./preview-css";
 import { messageSchema, type OutputKind, type RenderMessageInput } from "./schema";
@@ -91,15 +91,20 @@ function loadPdfRenderer() {
 async function loadResources(node: Node, stylesheets: string[]) {
   const [images, fonts] = await Promise.all([
     prepareImages<FetchedImage>({ node, fetchCache }),
-    googleFonts(GOOGLE_FONTS),
+    googleFonts(GOOGLE_FONTS).catch(() => undefined),
   ]);
 
-  return { images, fonts, stylesheets };
+  return {
+    images,
+    fonts: fonts ?? [FALLBACK_FONT_URL],
+    stylesheets,
+    notice: fonts ? undefined : "Google Fonts unreachable · Latin fallback",
+  };
 }
 
 type Resources = Awaited<ReturnType<typeof loadResources>>;
 
-type RenderInput = Resources & {
+type RenderInput = Omit<Resources, "notice"> & {
   renderer: Renderer;
   node: Node;
   options: PlaygroundOptions;
@@ -187,13 +192,14 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
   const emojified = extractEmojis(node, options.emoji ?? "twemoji");
   const resources = await loadResources(emojified, effectiveStylesheets);
 
+  const { notice, ...renderResources } = resources;
   const start = performance.now();
   const output = await renderOutput({
     renderer,
     node: emojified,
     options,
     geometry,
-    ...resources,
+    ...renderResources,
   });
   const duration = performance.now() - start;
   const inspection = output.kind === "pdf" ? await inspectPdf(output.buffer) : undefined;
@@ -210,6 +216,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
         outputFormat: output.format,
         label: geometry.label,
         inspection,
+        notice,
       },
     },
     [output.buffer.buffer],


### PR DESCRIPTION
## Why

Privacy add-ons redirect `fonts.googleapis.com` to an extension URL, and a worker `fetch` cannot follow a redirect off `https`. The css2 request threw `NetworkError when attempting to fetch resource`, which failed the whole render, so the playground's Takumi pane stayed blank in Firefox.

## What

A failed Google Fonts request now falls back to `Geist.woff2`, already served from this site, and the status bar says the render used it. Coverage drops to Latin, so CJK templates render tofu until the fetch works again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fallback font for more reliable rendering when Google Fonts cannot be loaded.
  - Rendering now continues under degraded font-loading conditions and displays a notice explaining the limitation.
  - Playground status information includes relevant rendering notices when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->