### PR TITLE
Core: cover every Tailwind theme namespace the parser can reach

### DIFF
--- a/.tegami/tw-theme.md
+++ b/.tegami/tw-theme.md
@@ -12,4 +12,4 @@ packages:
 
 The built-in Tailwind parser only knew Tailwind's own scales, so a project's brand color or spacing step had to be spelled as an arbitrary value on every element. Renders now take a `theme` option keyed by CSS custom property name: `--color-brand-500` makes `bg-brand-500` work, `--spacing-gutter` makes `p-gutter` work, and naming a built-in token such as `--color-red-500` replaces it.
 
-A value of `initial` removes a token, and `--color-*: initial` clears the namespace along with the built-in palette underneath it. Only `--color-*` and `--spacing-*` are read so far.
+Fifteen namespaces are wired up, covering colors, spacing, containers, type, radii, shadows, blur, aspect ratio and animations. A value of `initial` removes a token, and `--color-*: initial` clears the namespace along with the built-in palette underneath it.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -101,7 +101,7 @@ The `tw` prop runs a built-in parser with no build step. It won't cover every Ta
 
 ### Theme tokens
 
-Pass a `theme` keyed by CSS custom property name to give the parser your own tokens. `--color-*` reaches every color utility, `--spacing-*` every length utility.
+Pass a `theme` keyed by CSS custom property name to give the parser your own tokens. The namespace picks which utilities the token reaches, the same way it does in Tailwind.
 
 ```tsx
 const image = await render(<div tw="bg-brand-500 p-gutter" />, {
@@ -113,6 +113,26 @@ const image = await render(<div tw="bg-brand-500 p-gutter" />, {
   },
 });
 ```
+
+| Namespace         | Utilities                                                         |
+| ----------------- | ----------------------------------------------------------------- |
+| `--color-*`       | every color utility: `bg-*`, `text-*`, `border-*`, gradient stops |
+| `--spacing-*`     | every length utility: `p-*`, `m-*`, `w-*`, `gap-*`                |
+| `--container-*`   | `max-w-*`                                                         |
+| `--text-*`        | font sizes, `text-xl`                                             |
+| `--font-*`        | font families, `font-sans`                                        |
+| `--font-weight-*` | font weights, `font-bold`                                         |
+| `--tracking-*`    | `tracking-*`                                                      |
+| `--leading-*`     | `leading-*`                                                       |
+| `--radius-*`      | `rounded-*`                                                       |
+| `--shadow-*`      | `shadow-*`                                                        |
+| `--drop-shadow-*` | `drop-shadow-*`                                                   |
+| `--text-shadow-*` | `text-shadow-*`                                                   |
+| `--blur-*`        | `blur-*`                                                          |
+| `--aspect-*`      | `aspect-*`                                                        |
+| `--animate-*`     | `animate-*`                                                       |
+
+Tailwind's other namespaces have no utility to reach here: `--breakpoint-*`, `--ease-*`, `--inset-shadow-*`, `--perspective-*`, `--zoom-*`, `--tab-size-*`.
 
 Naming a built-in token replaces it, so `--color-red-500` changes what `bg-red-500` paints. A value of `initial` removes a token. `--color-*: initial` clears the whole namespace, built-in palette included.
 

--- a/takumi-core/src/style/properties/animation.rs
+++ b/takumi-core/src/style/properties/animation.rs
@@ -7,7 +7,7 @@ use crate::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
   ToCss, declare_enum_from_css_impl, next_is_comma,
   properties::write_css_string,
-  tw::{TailwindPropertyParser, Theme},
+  tw::{TailwindPropertyParser, Theme, TwNamespace},
   unexpected_token,
 };
 
@@ -412,6 +412,8 @@ impl<'i> FromCss<'i> for Animations {
 }
 
 impl TailwindPropertyParser for Animations {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Animate];
+
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
       "none" => Some(Box::from([Animation::default()])),
@@ -446,7 +448,11 @@ impl TailwindPropertyParser for Animations {
     }
   }
 
-  fn parse_tw_with_arbitrary(token: &str, _theme: &Theme) -> Option<Self> {
+  fn parse_tw_with_arbitrary(
+    token: &str,
+    theme: &Theme,
+    namespaces: &[TwNamespace],
+  ) -> Option<Self> {
     if let Some(value) = token
       .strip_prefix('[')
       .and_then(|value| value.strip_suffix(']'))
@@ -460,7 +466,7 @@ impl TailwindPropertyParser for Animations {
       return Self::from_css_str(&value).ok();
     }
 
-    Self::parse_tw(token)
+    Self::parse_tw_themed(token, theme, namespaces)
   }
 }
 
@@ -987,7 +993,11 @@ mod tests {
   #[test]
   fn parse_tailwind_animation_arbitrary_value() {
     assert_eq!(
-      Animations::parse_tw_with_arbitrary("[wiggle_1s_ease-in-out_infinite]", &Theme::default()),
+      Animations::parse_tw_with_arbitrary(
+        "[wiggle_1s_ease-in-out_infinite]",
+        &Theme::default(),
+        Animations::NAMESPACES,
+      ),
       Some(Box::from([Animation {
         duration: AnimationTime::from_milliseconds(1000.0),
         timing_function: AnimationTimingFunction::EaseInOut,

--- a/takumi-core/src/style/properties/aspect_ratio.rs
+++ b/takumi-core/src/style/properties/aspect_ratio.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use cssparser::Parser;
 
+use crate::style::TwNamespace;
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
   SizingContext, ToCss, lerp, tw::TailwindPropertyParser,
@@ -56,6 +57,8 @@ impl Animatable for AspectRatio {
 }
 
 impl TailwindPropertyParser for AspectRatio {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Aspect];
+
   fn parse_tw(token: &str) -> Option<Self> {
     Self::from_css_str(token).ok()
   }

--- a/takumi-core/src/style/properties/background_image.rs
+++ b/takumi-core/src/style/properties/background_image.rs
@@ -159,7 +159,8 @@ mod tests {
     assert_eq!(
       BackgroundImage::parse_tw_with_arbitrary(
         "[url(https://example.com/bg.png)]",
-        &Theme::default()
+        &Theme::default(),
+        BackgroundImage::NAMESPACES,
       ),
       Some(BackgroundImage::Url("https://example.com/bg.png".into()))
     );

--- a/takumi-core/src/style/properties/box_shadow.rs
+++ b/takumi-core/src/style/properties/box_shadow.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, fmt, fmt::Debug};
 use cssparser::{BasicParseErrorKind, ParseError, Parser};
 use typed_builder::TypedBuilder;
 
+use crate::style::TwNamespace;
 use crate::style::{
   Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length,
   ListInterpolationStrategy, MakeComputed, ParseResult, SizingContext, ToCss, next_is_comma,
@@ -156,6 +157,8 @@ impl<'i> FromCss<'i> for BoxShadow {
 }
 
 impl crate::style::tw::TailwindPropertyParser for BoxShadow {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Shadow];
+
   fn parse_tw(token: &str) -> Option<Self> {
     Self::from_css_str(token).ok()
   }

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -230,14 +230,18 @@ impl TailwindPropertyParser for ColorInput {
     Color::parse_tw(token).map(ColorInput::Value)
   }
 
-  fn parse_tw_with_arbitrary(token: &str, theme: &Theme) -> Option<Self> {
+  fn parse_tw_with_arbitrary(
+    token: &str,
+    theme: &Theme,
+    namespaces: &[TwNamespace],
+  ) -> Option<Self> {
     let Some((token, opacity)) = token.split_once('/') else {
-      return Self::parse_tw_themed(token, theme);
+      return Self::parse_tw_themed(token, theme, namespaces);
     };
 
     let opacity = (opacity.parse::<f32>().ok()? * 2.55).round() as u8;
 
-    match Self::parse_tw_themed(token, theme)? {
+    match Self::parse_tw_themed(token, theme, namespaces)? {
       ColorInput::Value(color) => Some(ColorInput::Value(color.with_opacity(opacity))),
       ColorInput::CurrentColor => Some(ColorInput::CurrentColor),
     }

--- a/takumi-core/src/style/properties/font_family.rs
+++ b/takumi-core/src/style/properties/font_family.rs
@@ -3,6 +3,7 @@ use std::{fmt, string::ToString, sync::Arc};
 use cssparser::{Parser, match_ignore_ascii_case};
 use parley::{FontFamilyName, GenericFamily};
 
+use crate::style::TwNamespace;
 use crate::style::{
   CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
   tw::TailwindPropertyParser,
@@ -94,6 +95,8 @@ impl<'i> FromCss<'i> for FontFamily {
 }
 
 impl TailwindPropertyParser for FontFamily {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Font];
+
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
       "sans" => Some(FontFamily::from_parlance_generic(GenericFamily::SansSerif)),

--- a/takumi-core/src/style/properties/font_weight.rs
+++ b/takumi-core/src/style/properties/font_weight.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use parley::style::FontWeight as ParleyFontWeight;
 
+use crate::style::TwNamespace;
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
   ToCss, lerp, tw::TailwindPropertyParser, unexpected_token,
@@ -93,6 +94,8 @@ impl<'i> FromCss<'i> for FontWeight {
 }
 
 impl TailwindPropertyParser for FontWeight {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::FontWeight];
+
   fn parse_tw(token: &str) -> Option<Self> {
     if let Ok(value) = token.parse::<f32>() {
       return Some(value.into());

--- a/takumi-core/src/style/properties/line_height.rs
+++ b/takumi-core/src/style/properties/line_height.rs
@@ -1,5 +1,6 @@
 use cssparser::{Parser, match_ignore_ascii_case};
 
+use crate::style::TwNamespace;
 use crate::style::{
   CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult, SizingContext, ToCss,
   parse_calc_number_expression, tw::TailwindPropertyParser,
@@ -25,6 +26,8 @@ impl From<Length> for LineHeight {
 }
 
 impl TailwindPropertyParser for LineHeight {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Leading];
+
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {&token,
       "none" => Some(LineHeight::Unitless(1.0)),
@@ -157,7 +160,7 @@ mod tests {
   #[test]
   fn tailwind_arbitrary_percentage_is_supported() {
     assert_eq!(
-      LineHeight::parse_tw_with_arbitrary("[90%]", &Theme::default()),
+      LineHeight::parse_tw_with_arbitrary("[90%]", &Theme::default(), LineHeight::NAMESPACES),
       Some(LineHeight::Length(Length::Percentage(90.0)))
     );
   }

--- a/takumi-core/src/style/properties/text_shadow.rs
+++ b/takumi-core/src/style/properties/text_shadow.rs
@@ -4,6 +4,7 @@ use cssparser::{BasicParseErrorKind, Parser};
 use typed_builder::TypedBuilder;
 
 use super::box_shadow::parse_offsets_blur;
+use crate::style::TwNamespace;
 use crate::style::{
   Animatable, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length,
   ListInterpolationStrategy, MakeComputed, ParseResult, SizingContext, ToCss, next_is_comma,
@@ -106,6 +107,8 @@ impl<'i> FromCss<'i> for TextShadow {
 }
 
 impl crate::style::tw::TailwindPropertyParser for TextShadow {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::TextShadow];
+
   fn parse_tw(token: &str) -> Option<Self> {
     Self::from_css_str(token).ok()
   }

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -1,13 +1,24 @@
 use phf::phf_map;
 
 use crate::style::{
-  tw::{TailwindProperty, TailwindPropertyParser, Theme, parser::*},
+  tw::{TailwindProperty, TailwindPropertyParser, Theme, TwNamespace, parser::*},
   *,
 };
 
+/// The namespaces a parser candidate reads: the value type's own list, or the
+/// override an entry spells in brackets.
+macro_rules! parser_namespaces {
+  ($parse:ty) => {
+    <$parse as TailwindPropertyParser>::NAMESPACES
+  };
+  ($parse:ty, $($namespace:expr),+) => {
+    &[$($namespace),+]
+  };
+}
+
 /// Generates the [`PropertyParser`] enum and its `parse()` dispatch from `(Variant, ArgType, ParseType)` triples.
 macro_rules! property_parsers {
-  ($($variant:ident($arg:ty) => $parse:ty),+ $(,)?) => {
+  ($($variant:ident($arg:ty) => $parse:ty $([$($namespace:expr),+ $(,)?])?),+ $(,)?) => {
     /// Maps a parsed argument type to a [`TailwindProperty`] constructor.
     #[derive(Clone, Copy)]
     pub(crate) enum PropertyParser {
@@ -23,9 +34,21 @@ macro_rules! property_parsers {
       /// Parses a utility suffix into a property via the wrapped constructor.
       pub fn parse(&self, suffix: &str, theme: &Theme) -> Option<TailwindProperty> {
         match self {
-          $(Self::$variant(f) => <$parse>::parse_tw_with_arbitrary(suffix, theme).map(f),)+
+          $(
+            Self::$variant(f) => <$parse>::parse_tw_with_arbitrary(
+              suffix,
+              theme,
+              parser_namespaces!($parse $(, $($namespace),+)?),
+            )
+            .map(f),
+          )+
           Self::GradientPosition(f) => {
-            TwGradientPosition::parse_tw_with_arbitrary(suffix, theme).map(|p| f(p.0))
+            TwGradientPosition::parse_tw_with_arbitrary(
+              suffix,
+              theme,
+              TwGradientPosition::NAMESPACES,
+            )
+            .map(|p| f(p.0))
           }
         }
       }
@@ -44,6 +67,7 @@ property_parsers! {
   BgSize(BackgroundSize) => BackgroundSize,
   BgImage(BackgroundImage) => BackgroundImage,
   LengthAuto(Length) => Length,
+  ContainerLength(Length) => Length [TwNamespace::Container, TwNamespace::Spacing],
   LengthZero(Length) => Length,
   FontWeight(FontWeight) => FontWeight,
   Justify(JustifyContent) => JustifyContent,
@@ -77,7 +101,7 @@ property_parsers! {
   Blur(TwBlur) => TwBlur,
   Filter(Filters) => Filters,
   BoxShadow(BoxShadow) => BoxShadow,
-  DropShadow(TextShadow) => TextShadow,
+  DropShadow(TextShadow) => TextShadow [TwNamespace::DropShadow],
   TextShadow(TextShadow) => TextShadow,
   BlendMode(BlendMode) => BlendMode,
   FontStretch(FontStretch) => FontStretch,
@@ -125,7 +149,7 @@ pub(crate) static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
   "h" => &[PropertyParser::LengthAuto(TailwindProperty::Height)],
   "min-w" => &[PropertyParser::LengthAuto(TailwindProperty::MinWidth)],
   "min-h" => &[PropertyParser::LengthAuto(TailwindProperty::MinHeight)],
-  "max-w" => &[PropertyParser::LengthAuto(TailwindProperty::MaxWidth)],
+  "max-w" => &[PropertyParser::ContainerLength(TailwindProperty::MaxWidth)],
   "max-h" => &[PropertyParser::LengthAuto(TailwindProperty::MaxHeight)],
   "size" => &[PropertyParser::LengthAuto(TailwindProperty::Size)],
   "font" => &[

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -712,12 +712,12 @@ pub(crate) trait TailwindPropertyParser: Sized + for<'i> FromCss<'i> {
   /// Arbitrary value, then theme token, then the built-in scale. A theme token
   /// is spelled as a CSS value, so it takes the arbitrary-value path rather
   /// than the utility-suffix grammar.
-  fn parse_tw_themed(token: &str, theme: &Theme) -> Option<Self> {
+  fn parse_tw_themed(token: &str, theme: &Theme, namespaces: &[TwNamespace]) -> Option<Self> {
     if let Some(value) = extract_arbitrary_value(token) {
       return Self::from_css_str(&value).ok();
     }
 
-    for &namespace in Self::NAMESPACES {
+    for &namespace in namespaces {
       match theme.lookup(namespace, token) {
         ThemeLookup::Value(value) => return Self::from_css_str(value).ok(),
         ThemeLookup::Removed => return None,
@@ -728,10 +728,16 @@ pub(crate) trait TailwindPropertyParser: Sized + for<'i> FromCss<'i> {
     Self::parse_tw(token)
   }
 
-  /// The entry point utility dispatch calls. Override to handle a modifier the
-  /// suffix carries, such as a color's `/50` opacity.
-  fn parse_tw_with_arbitrary(token: &str, theme: &Theme) -> Option<Self> {
-    Self::parse_tw_themed(token, theme)
+  /// The entry point utility dispatch calls. `namespaces` is the utility's own
+  /// list, which differs from `NAMESPACES` where one value grammar serves two
+  /// namespaces: `max-w-*` reads `--container-*` where `w-*` reads `--spacing-*`.
+  /// Override to handle a modifier the suffix carries, such as a color's `/50`.
+  fn parse_tw_with_arbitrary(
+    token: &str,
+    theme: &Theme,
+    namespaces: &[TwNamespace],
+  ) -> Option<Self> {
+    Self::parse_tw_themed(token, theme, namespaces)
   }
 }
 

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -27,6 +27,8 @@ impl<'i> FromCss<'i> for TwFontSize {
 }
 
 impl TailwindPropertyParser for TwFontSize {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Text];
+
   fn parse_tw(token: &str) -> Option<Self> {
     // text-xs/6 => font-size: 0.75rem, line-height: 1.5em
     if let Some((font_size, line_height)) = token.split_once('/') {
@@ -35,6 +37,7 @@ impl TailwindPropertyParser for TwFontSize {
         Some(LineHeight::parse_tw_with_arbitrary(
           line_height,
           &Theme::default(),
+          LineHeight::NAMESPACES,
         )?),
       ));
     }
@@ -162,6 +165,8 @@ impl Neg for TwLetterSpacing {
 }
 
 impl TailwindPropertyParser for TwLetterSpacing {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Tracking];
+
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
       "tighter" => Some(TwLetterSpacing(Length::Em(-0.05))),
@@ -191,6 +196,8 @@ impl<'i> FromCss<'i> for TwRounded {
 }
 
 impl TailwindPropertyParser for TwRounded {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Radius];
+
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
       "full" => Some(TwRounded(Length::Px(9999.0))),
@@ -256,6 +263,8 @@ impl<'i> FromCss<'i> for TwBlur {
 }
 
 impl TailwindPropertyParser for TwBlur {
+  const NAMESPACES: &'static [TwNamespace] = &[TwNamespace::Blur];
+
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
       "none" => Some(TwBlur(Length::Px(0.0))),

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -1214,3 +1214,64 @@ fn test_empty_theme_keeps_the_built_in_resolution() {
     themed_declarations("bg-red-500", &theme(&[("--spacing-gutter", "2.5rem")]))
   );
 }
+
+/// A theme token resolves to the same declarations the equivalent arbitrary
+/// value produces, which is what makes one namespace list enough per value type.
+fn assert_theme_matches_arbitrary(entry: (&str, &str), themed: &str, arbitrary: &str) {
+  assert_eq!(
+    themed_declarations(themed, &theme(&[entry])),
+    themed_declarations(arbitrary, &Theme::default()),
+    "{themed} should resolve like {arbitrary}"
+  );
+}
+
+#[test]
+fn test_theme_namespaces_reach_their_utilities() {
+  assert_theme_matches_arbitrary(("--text-hero", "4rem"), "text-hero", "text-[4rem]");
+  assert_theme_matches_arbitrary(("--font-display", "Inter"), "font-display", "font-[Inter]");
+  assert_theme_matches_arbitrary(("--font-weight-heavy", "850"), "font-heavy", "font-[850]");
+  assert_theme_matches_arbitrary(
+    ("--tracking-airy", "0.2em"),
+    "tracking-airy",
+    "tracking-[0.2em]",
+  );
+  assert_theme_matches_arbitrary(("--leading-cozy", "1.35"), "leading-cozy", "leading-[1.35]");
+  assert_theme_matches_arbitrary(("--radius-card", "12px"), "rounded-card", "rounded-[12px]");
+  assert_theme_matches_arbitrary(("--blur-soft", "3px"), "blur-soft", "blur-[3px]");
+  assert_theme_matches_arbitrary(("--aspect-card", "3/4"), "aspect-card", "aspect-[3/4]");
+  assert_theme_matches_arbitrary(
+    ("--container-prose", "40rem"),
+    "max-w-prose",
+    "max-w-[40rem]",
+  );
+  assert_theme_matches_arbitrary(
+    ("--shadow-card", "0 1px 2px black"),
+    "shadow-card",
+    "shadow-[0_1px_2px_black]",
+  );
+  assert_theme_matches_arbitrary(
+    ("--text-shadow-card", "0 1px 2px black"),
+    "text-shadow-card",
+    "text-shadow-[0_1px_2px_black]",
+  );
+  assert_theme_matches_arbitrary(
+    ("--drop-shadow-card", "0 1px 2px black"),
+    "drop-shadow-card",
+    "drop-shadow-[0_1px_2px_black]",
+  );
+  assert_theme_matches_arbitrary(
+    ("--animate-drift", "drift 2s linear infinite"),
+    "animate-drift",
+    "animate-[drift_2s_linear_infinite]",
+  );
+}
+
+#[test]
+fn test_max_width_prefers_container_over_spacing() {
+  let theme = theme(&[("--container-prose", "40rem"), ("--spacing-prose", "10rem")]);
+
+  assert_eq!(
+    themed_declarations("max-w-prose", &theme),
+    themed_declarations("max-w-[40rem]", &Theme::default())
+  );
+}

--- a/takumi-core/src/style/tw/theme.rs
+++ b/takumi-core/src/style/tw/theme.rs
@@ -7,6 +7,32 @@ pub enum TwNamespace {
   Color,
   /// `--spacing-*`
   Spacing,
+  /// `--container-*`
+  Container,
+  /// `--text-*`
+  Text,
+  /// `--font-*`
+  Font,
+  /// `--font-weight-*`
+  FontWeight,
+  /// `--tracking-*`
+  Tracking,
+  /// `--leading-*`
+  Leading,
+  /// `--radius-*`
+  Radius,
+  /// `--shadow-*`
+  Shadow,
+  /// `--drop-shadow-*`
+  DropShadow,
+  /// `--text-shadow-*`
+  TextShadow,
+  /// `--blur-*`
+  Blur,
+  /// `--aspect-*`
+  Aspect,
+  /// `--animate-*`
+  Animate,
 }
 
 impl TwNamespace {
@@ -14,13 +40,42 @@ impl TwNamespace {
     match self {
       TwNamespace::Color => "--color-",
       TwNamespace::Spacing => "--spacing-",
+      TwNamespace::Container => "--container-",
+      TwNamespace::Text => "--text-",
+      TwNamespace::Font => "--font-",
+      TwNamespace::FontWeight => "--font-weight-",
+      TwNamespace::Tracking => "--tracking-",
+      TwNamespace::Leading => "--leading-",
+      TwNamespace::Radius => "--radius-",
+      TwNamespace::Shadow => "--shadow-",
+      TwNamespace::DropShadow => "--drop-shadow-",
+      TwNamespace::TextShadow => "--text-shadow-",
+      TwNamespace::Blur => "--blur-",
+      TwNamespace::Aspect => "--aspect-",
+      TwNamespace::Animate => "--animate-",
     }
   }
 }
 
 /// Namespaces ordered longest-prefix-first, so `--font-weight-bold` never lands
 /// in `--font-*`. Upstream spells the same rule as an explicit ignore list.
-const NAMESPACES: &[TwNamespace] = &[TwNamespace::Spacing, TwNamespace::Color];
+const NAMESPACES: &[TwNamespace] = &[
+  TwNamespace::FontWeight,
+  TwNamespace::TextShadow,
+  TwNamespace::DropShadow,
+  TwNamespace::Container,
+  TwNamespace::Tracking,
+  TwNamespace::Spacing,
+  TwNamespace::Leading,
+  TwNamespace::Animate,
+  TwNamespace::Aspect,
+  TwNamespace::Radius,
+  TwNamespace::Shadow,
+  TwNamespace::Color,
+  TwNamespace::Text,
+  TwNamespace::Font,
+  TwNamespace::Blur,
+];
 
 /// The outcome of a theme lookup, where a removed token must not fall back to
 /// the built-in scale.
@@ -109,5 +164,39 @@ impl Theme {
       None if namespace.reset => ThemeLookup::Removed,
       None => ThemeLookup::Missing,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{NAMESPACES, Theme, ThemeLookup, TwNamespace};
+
+  #[test]
+  fn test_namespaces_are_ordered_longest_prefix_first() {
+    let lengths = NAMESPACES
+      .iter()
+      .map(|namespace| namespace.prefix().len())
+      .collect::<Vec<_>>();
+
+    assert!(
+      lengths.windows(2).all(|pair| pair[0] >= pair[1]),
+      "a shorter prefix placed first would swallow a longer one: {lengths:?}"
+    );
+  }
+
+  #[test]
+  fn test_longest_prefix_wins() {
+    let mut theme = Theme::default();
+
+    theme.insert("--font-weight-bold", "700");
+
+    assert!(matches!(
+      theme.lookup(TwNamespace::FontWeight, "bold"),
+      ThemeLookup::Value("700")
+    ));
+    assert!(matches!(
+      theme.lookup(TwNamespace::Font, "weight-bold"),
+      ThemeLookup::Missing
+    ));
   }
 }


### PR DESCRIPTION
## Why

Only `--color-*` and `--spacing-*` reached a utility, so a project could theme its palette and spacing step but not its type scale, radii, shadows or animations.

## What

Fifteen namespaces are wired up, every one Tailwind documents that has a utility here to reach: colors, spacing, containers, `--text-*`, `--font-*`, `--font-weight-*`, `--tracking-*`, `--leading-*`, `--radius-*`, `--shadow-*`, `--drop-shadow-*`, `--text-shadow-*`, `--blur-*`, `--aspect-*` and `--animate-*`. Each is one associated const on the value type. The remaining upstream namespaces (`--breakpoint-*`, `--ease-*`, `--inset-shadow-*`, `--perspective-*`, `--zoom-*`, `--tab-size-*`) have no matching utility in the parser.

Two cases broke the "one namespace list per value type" rule and get a per-candidate override in `map.rs`: `TextShadow` serves both `--text-shadow-*` and `--drop-shadow-*`, and `Length` reads `--container-*` for `max-w-*` where it reads `--spacing-*` everywhere else. Coverage is asserted by equivalence: a theme token must resolve to the same declarations as the matching arbitrary value, so `text-hero` with `--text-hero: 4rem` has to match `text-[4rem]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded theme token support across typography, sizing, containers, borders, shadows, blur, aspect ratios, and animations.
  * Added namespace-aware utility resolution, including container-specific sizing tokens.
  * Improved precedence when matching overlapping theme tokens.

* **Documentation**
  * Updated styling documentation with supported namespaces, utility mappings, and unsupported namespace details.

* **Tests**
  * Added coverage confirming themed utilities match equivalent arbitrary values across supported styling categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->