### PR TITLE
CI: move the pinned nightly forward two months

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,9 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          # pinned: newer nightlies emit --fix-cortex-a53-843419 which zig rejects (cargo-zigbuild#451)
-          toolchain: nightly-2026-06-04
+          # held below nightly-2026-08-06: LLVM 23 (rust#158734) emits 4% more
+          # instructions per function and costs 33KB gzipped in the wasm bundle
+          toolchain: nightly-2026-08-05
           targets: ${{ matrix.settings.target }}
           components: rust-src
           stage: build
@@ -533,7 +534,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           # pinned to match build-and-test-napi (see comment there)
-          toolchain: nightly-2026-06-04
+          toolchain: nightly-2026-08-05
           targets: wasm32-unknown-unknown
           components: rust-src
           stage: build
@@ -580,7 +581,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           # pinned to match build-and-test-napi (see comment there)
-          toolchain: nightly-2026-06-04
+          toolchain: nightly-2026-08-05
           targets: wasm32-unknown-unknown
           components: rust-src
           stage: build


### PR DESCRIPTION
## Why

The nightly was pinned to 2026-06-04 because newer ones emitted `--fix-cortex-a53-843419`, which zig rejected. That was fixed in `cargo-zigbuild` v0.23.0 on 2026-06-18, and CI installs the tool unpinned, so it has been running the fix for two months. The comment saying otherwise is the only thing still holding the toolchain back.

## What

Pinned to nightly-2026-08-05, the last nightly before LLVM 23. Bisecting the wasm bundle across the window found the wall on the next day: 2026-08-05 gzips to 1,557,221 bytes and 2026-08-06 to 1,590,469, and rust#158734 (Update to LLVM 23) merged in between. The new pin costs 1,924 bytes gzipped against the old one, which is the noise two months of other changes add.

LLVM 23 emits about 4% more instructions for the same functions rather than restructuring them: function count moves 6594 to 6567 and `Call` moves 45,527 to 45,538, while `LocalGet` gains 13.5k, `Binary` 11.1k and `Const` 10k. Building without `+simd128` leaves the regression at 31.7KB, so it is not vectorization either. LLVM's release notes document nothing here; their IPO and vectorizer sections are empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rust nightly toolchain used for N-API, WASM, and PDF-WASM builds.
  * Documented the LLVM 23 regression threshold for N-API builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->