### PR TITLE
fix(helpers): enforce fetch policy on cached images

### DIFF
--- a/.tegami/fetch-cache-policy.md
+++ b/.tegami/fetch-cache-policy.md
@@ -6,4 +6,4 @@ packages:
 
 ### Enforce fetch policies on shared image cache entries
 
-`prepareImages` with a shared `fetchCache` returned cached bytes without running the calling render's `allowUrl` or `maxBytes`, so bytes fetched under one tenant's policy could serve a render whose policy forbids them. Cache hits now run `allowUrl` over the URL and its recorded redirect chain, re-check `maxBytes` against the resolved bytes, and refetch privately when the shared entry was capped tighter than the current call allows.
+`prepareImages` with a shared `fetchCache` returned cached bytes without running the calling render's `allowUrl` or `maxBytes`, so bytes fetched under one tenant's policy could serve a render whose policy forbids them. Cache hits now run `allowUrl` over the URL and its recorded redirect chain, re-check `maxBytes` against the resolved bytes, and refetch privately when the shared entry was capped tighter than the current call allows. Entries with no recorded redirect chain are not trusted by callers carrying `allowUrl`; those callers refetch them under their own policy.

--- a/.tegami/fetch-cache-policy.md
+++ b/.tegami/fetch-cache-policy.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Enforce fetch policies on shared image cache entries
+
+`prepareImages` with a shared `fetchCache` returned cached bytes without running the calling render's `allowUrl` or `maxBytes`, so bytes fetched under one tenant's policy could serve a render whose policy forbids them. Cache hits now run `allowUrl` over the URL and its recorded redirect chain, re-check `maxBytes` against the resolved bytes, and refetch privately when the shared entry was capped tighter than the current call allows.

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -170,7 +170,8 @@ function extractImageUrls(node: Node): string[] {
  * requests for the same URL (single-flight) and reuses their bytes. Any object with `Map`-like
  * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in. Each entry remembers the
  * options of the call that created it, so later calls still run their own `allowUrl` and
- * `maxBytes` against the shared bytes.
+ * `maxBytes` against the shared bytes. Entries created without `allowUrl` carry no recorded
+ * chain, so callers with `allowUrl` refetch those instead of trusting them.
  */
 export interface ImageFetchCache {
   get(url: string): Promise<ArrayBuffer> | undefined;
@@ -217,22 +218,29 @@ function fetchUncached(
  * rejected fetch is evicted so a later call can retry instead of replaying the failure.
  *
  * Cached entries serve under the current call's policy, not the creator's: `allowUrl` runs over
- * the recorded redirect chain, `maxBytes` runs over the resolved bytes, and an entry capped
- * tighter than this call allows refetches privately instead of failing this call too. */
+ * the recorded redirect chain, `maxBytes` runs over the resolved bytes, an entry capped tighter
+ * than this call allows refetches privately instead of failing this call too. An entry without
+ * recorded hops — created with no `allowUrl`, pre-seeded by hand, or from another module
+ * instance — is unprovenance, so any caller carrying `allowUrl` refetches it rather than trust
+ * bytes whose origin cannot be rechecked. */
 function fetchImageData(
   url: string,
   options: FetchOptions,
   fetchCache?: ImageFetchCache,
 ): Promise<ArrayBuffer> {
   const maxBytes = options.maxBytes ?? defaultMaxFetchBytes;
+  const { allowUrl } = options;
 
   const cached = fetchCache?.get(url);
   if (cached) {
     const meta = entryMeta.get(cached);
 
-    if (options.allowUrl) {
-      const checked = meta?.hops.length ? meta.hops : [url];
-      const blocked = checked.find((hop) => !options.allowUrl(hop));
+    if (allowUrl && !meta?.hops.length) {
+      return fetchUncached(url, options, maxBytes);
+    }
+
+    if (allowUrl && meta) {
+      const blocked = meta.hops.find((hop) => !allowUrl(hop));
       if (blocked) {
         return Promise.reject(new Error(`URL blocked by allowUrl policy: ${blocked}`));
       }

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -177,19 +177,32 @@ export interface ImageFetchCache {
 }
 
 /** Fetches a URL's bytes, coalescing concurrent requests for the same URL through `cache`. A
- * rejected fetch is evicted so a later call can retry instead of replaying the failure. */
+ * rejected fetch is evicted so a later call can retry instead of replaying the failure. Cached
+ * entries pass the current call's `allowUrl` and `maxBytes` too: a shared cache can hold bytes
+ * fetched under another call's options. */
 function fetchImageData(
   url: string,
   options: FetchOptions,
   fetchCache?: ImageFetchCache,
 ): Promise<ArrayBuffer> {
+  const maxBytes = options.maxBytes ?? defaultMaxFetchBytes;
+
   const cached = fetchCache?.get(url);
   if (cached) {
-    return cached;
+    if (options.allowUrl && !options.allowUrl(url)) {
+      return Promise.reject(new Error(`URL blocked by allowUrl policy: ${url}`));
+    }
+
+    return cached.then((data) => {
+      if (data.byteLength > maxBytes) {
+        throw new Error(`Response exceeds ${maxBytes} bytes`);
+      }
+      return data;
+    });
   }
 
   const promise = fetchOk(url, options)
-    .then((response) => readBodyLimited(response, options.maxBytes ?? defaultMaxFetchBytes))
+    .then((response) => readBodyLimited(response, maxBytes))
     .catch((error) => {
       fetchCache?.delete(url);
       throw error;

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -68,11 +68,26 @@ async function followRedirectsWithPolicy(
   throw new Error(`Too many redirects fetching ${url}`);
 }
 
+/** A body larger than the reader's byte cap. Carries the cap, so cache consumers can tell a
+ * creator's tighter limit from their own without parsing messages. */
+class ResponseTooLargeError extends Error {
+  constructor(
+    readonly limit: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ResponseTooLargeError";
+  }
+}
+
 /** Reads a response body, rejecting once it exceeds `maxBytes` (by content-length or streamed size). */
 export async function readBodyLimited(response: Response, maxBytes: number): Promise<ArrayBuffer> {
   const declared = Number(response.headers.get("content-length"));
   if (Number.isFinite(declared) && declared > maxBytes) {
-    throw new Error(`Response exceeds ${maxBytes} bytes (content-length ${declared})`);
+    throw new ResponseTooLargeError(
+      maxBytes,
+      `Response exceeds ${maxBytes} bytes (content-length ${declared})`,
+    );
   }
 
   const body = response.body;
@@ -92,7 +107,7 @@ export async function readBodyLimited(response: Response, maxBytes: number): Pro
     total += value.byteLength;
     if (total > maxBytes) {
       await reader.cancel().catch(() => {});
-      throw new Error(`Response exceeds ${maxBytes} bytes`);
+      throw new ResponseTooLargeError(maxBytes, `Response exceeds ${maxBytes} bytes`);
     }
     chunks.push(value);
   }
@@ -255,13 +270,13 @@ function fetchImageData(
       },
       (error) => {
         // The shared stream died under its creator's tighter cap; these bytes may still fit
-        // this call. Refetch privately rather than inherit that rejection. Match
-        // readBodyLimited's message, so unrelated failures keep propagating to every consumer.
+        // this call. Refetch privately rather than inherit that rejection. Only the typed
+        // size error qualifies, so unrelated failures keep propagating to every consumer.
         const capped =
           meta !== undefined &&
           meta.maxBytes < maxBytes &&
-          error instanceof Error &&
-          error.message.startsWith(`Response exceeds ${meta.maxBytes} bytes`);
+          error instanceof ResponseTooLargeError &&
+          error.limit === meta.maxBytes;
         return capped ? fetchUncached(url, options, maxBytes) : Promise.reject(error);
       },
     );

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -168,7 +168,9 @@ function extractImageUrls(node: Node): string[] {
 /**
  * A cache of image fetches keyed by URL. Sharing one across renders deduplicates concurrent
  * requests for the same URL (single-flight) and reuses their bytes. Any object with `Map`-like
- * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in.
+ * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in. Each entry remembers the
+ * options of the call that created it, so later calls still run their own `allowUrl` and
+ * `maxBytes` against the shared bytes.
  */
 export interface ImageFetchCache {
   get(url: string): Promise<ArrayBuffer> | undefined;
@@ -176,10 +178,47 @@ export interface ImageFetchCache {
   delete(url: string): unknown;
 }
 
+/** Options recorded for entries this module created. Keyed by promise in a WeakMap, so cache
+ * values stay plain promises and the metadata dies with its entry. */
+const entryMeta = new WeakMap<Promise<ArrayBuffer>, { maxBytes: number; hops: string[] }>();
+
+function fetchUncached(
+  url: string,
+  options: FetchOptions,
+  maxBytes: number,
+  fetchCache?: ImageFetchCache,
+): Promise<ArrayBuffer> {
+  const { allowUrl } = options;
+  const hops: string[] = [];
+  // `fetchOk` calls `allowUrl` once per hop, so wrapping it records the full redirect chain.
+  const fetchOptions: FetchOptions = allowUrl
+    ? {
+        ...options,
+        allowUrl: (checked) => {
+          hops.push(checked);
+          return allowUrl(checked);
+        },
+      }
+    : options;
+
+  const promise = fetchOk(url, fetchOptions)
+    .then((response) => readBodyLimited(response, maxBytes))
+    .catch((error) => {
+      fetchCache?.delete(url);
+      throw error;
+    });
+
+  fetchCache?.set(url, promise);
+  entryMeta.set(promise, { maxBytes, hops });
+  return promise;
+}
+
 /** Fetches a URL's bytes, coalescing concurrent requests for the same URL through `cache`. A
- * rejected fetch is evicted so a later call can retry instead of replaying the failure. Cached
- * entries pass the current call's `allowUrl` and `maxBytes` too: a shared cache can hold bytes
- * fetched under another call's options. */
+ * rejected fetch is evicted so a later call can retry instead of replaying the failure.
+ *
+ * Cached entries serve under the current call's policy, not the creator's: `allowUrl` runs over
+ * the recorded redirect chain, `maxBytes` runs over the resolved bytes, and an entry capped
+ * tighter than this call allows refetches privately instead of failing this call too. */
 function fetchImageData(
   url: string,
   options: FetchOptions,
@@ -189,27 +228,38 @@ function fetchImageData(
 
   const cached = fetchCache?.get(url);
   if (cached) {
-    if (options.allowUrl && !options.allowUrl(url)) {
-      return Promise.reject(new Error(`URL blocked by allowUrl policy: ${url}`));
+    const meta = entryMeta.get(cached);
+
+    if (options.allowUrl) {
+      const checked = meta?.hops.length ? meta.hops : [url];
+      const blocked = checked.find((hop) => !options.allowUrl(hop));
+      if (blocked) {
+        return Promise.reject(new Error(`URL blocked by allowUrl policy: ${blocked}`));
+      }
     }
 
-    return cached.then((data) => {
-      if (data.byteLength > maxBytes) {
-        throw new Error(`Response exceeds ${maxBytes} bytes`);
-      }
-      return data;
-    });
+    return cached.then(
+      (data) => {
+        if (data.byteLength > maxBytes) {
+          throw new Error(`Response exceeds ${maxBytes} bytes`);
+        }
+        return data;
+      },
+      (error) => {
+        // The shared stream died under its creator's tighter cap; these bytes may still fit
+        // this call. Refetch privately rather than inherit that rejection. Match
+        // readBodyLimited's message, so unrelated failures keep propagating to every consumer.
+        const capped =
+          meta !== undefined &&
+          meta.maxBytes < maxBytes &&
+          error instanceof Error &&
+          error.message.startsWith(`Response exceeds ${meta.maxBytes} bytes`);
+        return capped ? fetchUncached(url, options, maxBytes) : Promise.reject(error);
+      },
+    );
   }
 
-  const promise = fetchOk(url, options)
-    .then((response) => readBodyLimited(response, maxBytes))
-    .catch((error) => {
-      fetchCache?.delete(url);
-      throw error;
-    });
-
-  fetchCache?.set(url, promise);
-  return promise;
+  return fetchUncached(url, options, maxBytes, fetchCache);
 }
 
 /** A fetched image entry: its source URL and raw bytes. */

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -239,15 +239,15 @@ function fetchImageData(
       return fetchUncached(url, options, maxBytes);
     }
 
-    if (allowUrl && meta) {
-      const blocked = meta.hops.find((hop) => !allowUrl(hop));
-      if (blocked) {
-        return Promise.reject(new Error(`URL blocked by allowUrl policy: ${blocked}`));
-      }
-    }
-
     return cached.then(
       (data) => {
+        if (allowUrl && meta) {
+          const blocked = meta.hops.find((hop) => !allowUrl(hop));
+          if (blocked) {
+            throw new Error(`URL blocked by allowUrl policy: ${blocked}`);
+          }
+        }
+
         if (data.byteLength > maxBytes) {
           throw new Error(`Response exceeds ${maxBytes} bytes`);
         }

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -55,6 +55,21 @@ describe("fetch byte caps", () => {
 
     expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
   });
+
+  test("a cache hit still respects a stricter maxBytes limit", async () => {
+    const payload = new Uint8Array(60);
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://example.com/cached.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 100 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await expect(
+      prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 50 }),
+    ).rejects.toThrow(/exceeds 50 bytes/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("allowUrl policy", () => {
@@ -150,6 +165,30 @@ describe("allowUrl policy", () => {
 
     expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a cache hit still respects a stricter allowUrl policy", async () => {
+    const payload = new TextEncoder().encode("pixels");
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://allowed.example.com/cached.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await expect(
+      prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => false }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const images = await prepareImages({
+      node,
+      fetchCache,
+      fetch: fetchMock,
+      allowUrl: () => true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
   });
 });
 

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -70,6 +70,38 @@ describe("fetch byte caps", () => {
     ).rejects.toThrow(/exceeds 50 bytes/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  test("concurrent cache consumers keep independent maxBytes limits", async () => {
+    const payload = new Uint8Array(60);
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://example.com/shared.png");
+
+    const [strict, loose] = await Promise.allSettled([
+      prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 50 }),
+      prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 100 }),
+    ]);
+
+    expect(strict.status).toBe("rejected");
+    expect(loose.status).toBe("fulfilled");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    if (loose.status === "fulfilled") {
+      expect(loose.value.map((image) => image.data.byteLength)).toEqual([60]);
+    }
+  });
+
+  test("a looser consumer reuses cached bytes that fit", async () => {
+    const payload = new Uint8Array(40);
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://example.com/small.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 50 });
+    const images = await prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 100 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(images.map((image) => image.data.byteLength)).toEqual([40]);
+  });
 });
 
 describe("allowUrl policy", () => {
@@ -189,6 +221,32 @@ describe("allowUrl policy", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
+  });
+
+  test("a cache hit rechecks every recorded redirect hop", async () => {
+    const redirectTo = (location: string) =>
+      new Response(null, { status: 302, headers: { location } });
+
+    const fetchMock = mock((url: string) =>
+      url === "https://allowed.example.com/a.png"
+        ? Promise.resolve(redirectTo("http://169.254.169.254/meta"))
+        : Promise.resolve(new Response(new Uint8Array(8))),
+    );
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://allowed.example.com/a.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await expect(
+      prepareImages({
+        node,
+        fetchCache,
+        fetch: fetchMock,
+        allowUrl: (url) => new URL(url).hostname === "allowed.example.com",
+      }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -248,6 +248,39 @@ describe("allowUrl policy", () => {
     ).rejects.toThrow(/blocked by allowUrl/);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  test("a strict caller does not trust cache created without allowUrl", async () => {
+    const payload = new TextEncoder().encode("pixels");
+    let call = 0;
+    const fetchMock = mock(() => {
+      call += 1;
+      // The first caller has no policy, so its fetch follows the redirect internally and only
+      // the internal host's 200 surfaces. The strict refetch exposes the redirect itself.
+      return Promise.resolve(
+        call === 1
+          ? new Response(streamOf(payload))
+          : new Response(null, {
+              status: 302,
+              headers: { location: "http://169.254.169.254/meta" },
+            }),
+      );
+    });
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://allowed.example.com/a.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await expect(
+      prepareImages({
+        node,
+        fetchCache,
+        fetch: fetchMock,
+        allowUrl: (url) => new URL(url).hostname === "allowed.example.com",
+      }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("default fetch timeout", () => {

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -56,7 +56,7 @@ describe("fetch byte caps", () => {
     expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
   });
 
-  test("a cache hit still respects a stricter maxBytes limit", async () => {
+  test("a stricter maxBytes rejection keeps the shared entry reusable", async () => {
     const payload = new Uint8Array(60);
     const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
     const fetchCache = new Map<string, Promise<ArrayBuffer>>();
@@ -69,6 +69,11 @@ describe("fetch byte caps", () => {
       prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 50 }),
     ).rejects.toThrow(/exceeds 50 bytes/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const images = await prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 100 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(images.map((image) => image.data.byteLength)).toEqual([60]);
   });
 
   test("concurrent cache consumers keep independent maxBytes limits", async () => {

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -249,6 +249,40 @@ describe("allowUrl policy", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test("an in-flight cache hit rechecks redirects discovered later", async () => {
+    let resolveEntry!: (response: Response) => void;
+    const entryResponse = new Promise<Response>((resolve) => {
+      resolveEntry = resolve;
+    });
+    const fetchMock = mock((url: string) =>
+      url === "https://allowed.example.com/a.png"
+        ? entryResponse
+        : Promise.resolve(new Response(new Uint8Array(8))),
+    );
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://allowed.example.com/a.png");
+
+    const permissive = prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const strict = prepareImages({
+      node,
+      fetchCache,
+      fetch: fetchMock,
+      allowUrl: (url) => new URL(url).hostname === "allowed.example.com",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const strictResult = strict.catch((error) => error);
+    resolveEntry(redirectTo("http://169.254.169.254/meta"));
+
+    expect(await permissive).toHaveLength(1);
+    const strictError = await strictResult;
+    expect(strictError).toBeInstanceOf(Error);
+    expect(strictError.message).toMatch(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   test("a strict caller does not trust cache created without allowUrl", async () => {
     const payload = new TextEncoder().encode("pixels");
     let call = 0;


### PR DESCRIPTION
Fixes #1390

## Problem

`fetchImageData` returned a `fetchCache` hit before running any policy. `allowUrl` (SSRF allowlist, enforced on every redirect hop) and `maxBytes` only ran on the fetch path. A cache shared across tenants, routes, or security levels let one call resolve bytes that another call's policy forbids.

Review of the first cut surfaced three deeper gaps in the same area:

1. Single-flight stores one promise, so a consumer with a looser `maxBytes` inherited the creator's tighter rejection.
2. A cache hit checked only the entry URL. Bytes fetched through a redirect into a blocked host still passed a strict hostname policy.
3. An in-flight entry's recorded redirect chain grows while the shared promise runs. Validating it before fulfillment missed redirects discovered later.

## Change

Entries now carry metadata recorded at creation time (the creator's byte cap and every URL its `allowUrl` checked, entry plus redirect hops). The metadata lives in a module-level `WeakMap` keyed by the entry promise, so `ImageFetchCache` values stay plain promises and the public interface is unchanged.

On a cache hit, the current call's policy runs in full:

- For trusted metadata, `allowUrl` runs once after the shared promise fulfills. At that point the redirect chain is complete. This blocks redirects discovered after an in-flight cache hit.
- Resolved bytes re-check against the current call's `maxBytes`.
- If the shared stream rejects under its creator's tighter cap while this call allows more, this call refetches privately instead of failing too; unrelated failures keep propagating to every consumer.
- An entry with no recorded chain — created without `allowUrl`, pre-seeded by hand, or produced by another module instance — is unprovenance. A caller carrying `allowUrl` does not trust it and refetches privately, because a miss under that policy would have checked every hop. Fail-closed: metadata present means revalidate after fulfillment, no metadata means no reuse.

Supporting internals:

- `readBodyLimited` now throws an internal `ResponseTooLargeError` carrying its cap, so cap-mismatch detection between cache consumers is type-based instead of message-text matching. The class is not exported; error messages are unchanged.

Constraints kept from earlier cuts:

- The miss path is untouched, so the network path still calls `allowUrl` exactly once per hop inside `fetchOk`.
- Policy rejections never evict the entry. Eviction stays fetch-failure-only.

## Tests

Regression tests in `takumi-helpers/tests/fetch-limits.test.ts`:

- a cache hit still respects a stricter `allowUrl` policy
- a cache hit rechecks every recorded redirect hop
- an in-flight cache hit rechecks redirects discovered later
- a strict caller does not trust cache created without `allowUrl`
- a stricter maxBytes rejection keeps the shared entry reusable
- concurrent cache consumers keep independent `maxBytes` limits
- a looser consumer reuses cached bytes that fit

Also adds `.tegami/fetch-cache-policy.md` (patch, `@takumi-rs/helpers`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image caching so cached results are revalidated against URL access rules and byte-size limits.
  * Prevented cached images from bypassing redirect and security policies.
  * Automatically refetches images when cached data lacks required policy information or exceeds the current request’s limits.
  * Preserved independent limits for concurrent image requests.
  * Ensured oversized image responses are handled consistently without invalidating reusable shared cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->