### PR TITLE
Core: resolve gradient stops through theme variables

### DIFF
--- a/.tegami/tw-gradient-vars.md
+++ b/.tegami/tw-gradient-vars.md
@@ -10,6 +10,4 @@ packages:
 
 ### Resolve gradient stops through theme variables
 
-Gradient utilities merged into a finished gradient while parsing, so their colours could not come from the theme. They now compose through `--tw-gradient-*` custom properties, the way Tailwind compiles them: `from-brand-500` reads `var(--color-brand-500)`, `from-red-500` keeps the built-in red as its fallback, and an opacity modifier mixes the variable. The `--tw-*` state does not inherit, matching Tailwind's `@property` registrations.
-
-Two behaviours move to match Tailwind. Stops alone no longer paint: `from-red-500` needs `bg-linear-*`, `bg-radial` or `bg-conic` to declare the gradient. And a missing `to` stop now fades to `transparent` instead of a transparent copy of the `from` colour, which interpolates the same way in the engine's Oklab default.
+`from-brand-500` reads `var(--color-brand-500)`; built-in colours stay as fallbacks. Two behaviours move to match Tailwind: stops alone no longer paint without `bg-linear-*`, `bg-radial` or `bg-conic`, and a missing `to` stop fades to `transparent`.

--- a/.tegami/tw-gradient-vars.md
+++ b/.tegami/tw-gradient-vars.md
@@ -1,0 +1,15 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Resolve gradient stops through theme variables
+
+Gradient utilities merged into a finished gradient while parsing, so their colours could not come from the theme. They now compose through `--tw-gradient-*` custom properties, the way Tailwind compiles them: `from-brand-500` reads `var(--color-brand-500)`, `from-red-500` keeps the built-in red as its fallback, and an opacity modifier mixes the variable. The `--tw-*` state does not inherit, matching Tailwind's `@property` registrations.
+
+Two behaviours move to match Tailwind. Stops alone no longer paint: `from-red-500` needs `bg-linear-*`, `bg-radial` or `bg-conic` to declare the gradient. And a missing `to` stop now fades to `transparent` instead of a transparent copy of the `from` colour, which interpolates the same way in the engine's Oklab default.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -180,7 +180,8 @@ The namespace picks which utilities a token reaches:
 
 Some things behave differently from Tailwind here:
 
-- Gradients, shadows, filters, transforms and animations merge across utilities before the cascade runs, so `--shadow-*`, `--drop-shadow-*`, `--text-shadow-*`, `--blur-*` and `--animate-*` are not read.
+- Shadows, filters, transforms and animations merge across utilities before the cascade runs, so `--shadow-*`, `--drop-shadow-*`, `--text-shadow-*`, `--blur-*` and `--animate-*` are not read. Gradient stops do read `--color-*`: `from-brand-500` works like `bg-brand-500`.
+- A gradient needs `bg-linear-*`, `bg-radial` or `bg-conic`. Stops alone paint nothing, as in Tailwind.
 - `--color-red-500: initial` falls back to the built-in red instead of removing `bg-red-500`.
 - A bare `rounded` keeps its built-in value; `rounded-sm` and the rest read the variable.
 - `--spacing` needs a unit. A bare number makes `p-4` compute pixels here, where a browser rejects the declaration.

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -50,6 +50,24 @@ pub(crate) struct DeferredDeclaration {
   pub(crate) specified_value: String,
 }
 
+/// `--tw-*` holds per-element composition state (gradient stops), registered
+/// `inherits: false` by Tailwind's own `@property` rules.
+fn inherited_custom_properties(
+  parent: &Arc<HashMap<String, String>>,
+) -> Arc<HashMap<String, String>> {
+  if !parent.keys().any(|name| name.starts_with("--tw-")) {
+    return parent.clone();
+  }
+
+  Arc::new(
+    parent
+      .iter()
+      .filter(|(name, _)| !name.starts_with("--tw-"))
+      .map(|(name, value)| (name.clone(), value.clone()))
+      .collect(),
+  )
+}
+
 /// A utility value read from a custom property, with the built-in scale as its
 /// fallback. Tailwind compiles `bg-red-500` to `var(--color-red-500)`.
 #[derive(Debug, Clone, PartialEq)]
@@ -777,7 +795,7 @@ macro_rules! define_style {
         /// Builds a child computed style inheriting from a parent.
         pub(crate) fn from_parent(parent: &Self) -> Self {
           Self {
-            custom_properties: parent.custom_properties.clone(),
+            custom_properties: inherited_custom_properties(&parent.custom_properties),
             registered_custom_properties: parent.registered_custom_properties.clone(),
             lang: parent.lang,
             $($longhand: define_inherited_default!(parent.$longhand, define_style!(@default $($longhand_default)?) $(, $longhand_inherit)?),)*

--- a/takumi-core/src/style/tw/builder.rs
+++ b/takumi-core/src/style/tw/builder.rs
@@ -1,9 +1,8 @@
-use crate::style::{LinearGradientDirection, *};
+use crate::style::*;
 
 #[derive(Debug, Default)]
 pub(super) struct TailwindDeclarationBuilder {
   pub(super) declarations: StyleDeclarationBlock,
-  pub(super) gradient_state: TwGradientState,
   pub(super) transform_state: TwTransformState,
   pub(super) shadow: Option<Vec<BoxShadow>>,
   pub(super) shadow_important: bool,
@@ -194,7 +193,6 @@ impl TailwindDeclarationBuilder {
     }
 
     self.transform_state.apply(&mut self.declarations);
-    self.gradient_state.apply(&mut self.declarations);
 
     self.grid_column.push_declarations(
       &mut self.declarations,
@@ -293,132 +291,6 @@ impl TwTransformState {
 
     if let Some(scale) = self.scale {
       declarations.push(StyleDeclaration::scale(scale), self.scale_important);
-    }
-  }
-}
-
-/// Accumulated Tailwind gradient utilities pending synthesis into a `background-image`.
-#[derive(Debug, Default)]
-pub(crate) struct TwGradientState {
-  /// Gradient kind (linear, radial, conic).
-  pub gradient_type: TwGradientType,
-  /// Linear/conic angle, if set.
-  pub angle: Option<Angle>,
-  /// Starting color stop.
-  pub from: Option<ColorInput>,
-  /// Ending color stop.
-  pub to: Option<ColorInput>,
-  /// Middle color stop.
-  pub via: Option<ColorInput>,
-  /// Position of the `from` stop.
-  pub from_position: Option<Length>,
-  /// Position of the `via` stop.
-  pub via_position: Option<Length>,
-  /// Position of the `to` stop.
-  pub to_position: Option<Length>,
-  /// Whether the gradient is `!important`.
-  pub important: bool,
-}
-
-/// Gradient kind.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub(crate) enum TwGradientType {
-  /// Linear gradient.
-  #[default]
-  Linear,
-  /// Radial gradient.
-  Radial,
-  /// Conic gradient.
-  Conic,
-}
-
-impl TwGradientState {
-  /// Synthesizes the accumulated gradient into a `background-image` declaration.
-  pub fn apply(self, declarations: &mut StyleDeclarationBlock) {
-    // Stop positions alone (`from-50%` etc.) must not synthesise a gradient —
-    // a color or angle has to be present.
-    if self.from.is_none() && self.to.is_none() && self.via.is_none() && self.angle.is_none() {
-      return;
-    }
-
-    let angle = self.angle.unwrap_or_else(|| Angle::new(180.0));
-
-    let from_color = self.from.unwrap_or(ColorInput::Value(Color([0, 0, 0, 0])));
-    let to_color = self.to.unwrap_or_else(|| {
-      if let ColorInput::Value(from_c) = from_color {
-        ColorInput::Value(Color([from_c.0[0], from_c.0[1], from_c.0[2], 0]))
-      } else {
-        ColorInput::Value(Color([0, 0, 0, 0]))
-      }
-    });
-
-    let mut stops = Vec::new();
-    stops.push(GradientStop::ColorHint {
-      color: from_color,
-      hint: Some(StopPosition(
-        self.from_position.unwrap_or(Length::Percentage(0.0)),
-      )),
-    });
-
-    if let Some(via_color) = self.via {
-      stops.push(GradientStop::ColorHint {
-        color: via_color,
-        hint: Some(StopPosition(
-          self.via_position.unwrap_or(Length::Percentage(50.0)),
-        )),
-      });
-    }
-
-    stops.push(GradientStop::ColorHint {
-      color: to_color,
-      hint: Some(StopPosition(
-        self.to_position.unwrap_or(Length::Percentage(100.0)),
-      )),
-    });
-
-    match self.gradient_type {
-      TwGradientType::Linear => {
-        let gradient = LinearGradient {
-          repeating: false,
-          direction: LinearGradientDirection::Angle(angle),
-          interpolation: ColorInterpolationMethod::default(),
-          stops: stops.into_boxed_slice(),
-        };
-
-        declarations.push(
-          StyleDeclaration::background_image(Some([BackgroundImage::Linear(gradient)].into())),
-          self.important,
-        );
-      }
-      TwGradientType::Radial => {
-        let gradient = RadialGradient {
-          repeating: false,
-          shape: RadialShape::Ellipse,
-          size: RadialSize::FarthestCorner,
-          center: PositionValue::center(),
-          interpolation: ColorInterpolationMethod::default(),
-          stops: stops.into_boxed_slice(),
-        };
-
-        declarations.push(
-          StyleDeclaration::background_image(Some([BackgroundImage::Radial(gradient)].into())),
-          self.important,
-        );
-      }
-      TwGradientType::Conic => {
-        let gradient = ConicGradient {
-          repeating: false,
-          from_angle: angle,
-          center: PositionValue::center(),
-          interpolation: ColorInterpolationMethod::default(),
-          stops: stops.into_boxed_slice(),
-        };
-
-        declarations.push(
-          StyleDeclaration::background_image(Some([BackgroundImage::Conic(gradient)].into())),
-          self.important,
-        );
-      }
     }
   }
 }

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -85,6 +85,7 @@ property_parsers! {
   TextWrap(TextWrap) => TextWrap,
   ColorCurrent(ColorInput) => ColorInput,
   ColorTransparent(ColorInput) => ColorInput,
+  StopColor(TwStopColor) => TwStopColor,
   Percentage(PercentageNumber) => PercentageNumber,
   FontFamily(FontFamily) => FontFamily,
   LineClamp(LineClamp) => LineClamp,
@@ -199,16 +200,16 @@ pub(crate) static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
   "bg-linear" => &[PropertyParser::Angle(TailwindProperty::BgLinearAngle)],
   "bg-conic" => &[PropertyParser::Angle(TailwindProperty::BgConicAngle)],
   "from" => &[
-    PropertyParser::ColorCurrent(TailwindProperty::GradientFrom),
     PropertyParser::GradientPosition(TailwindProperty::GradientFromPosition),
+    PropertyParser::StopColor(TailwindProperty::GradientFrom),
   ],
   "to" => &[
-    PropertyParser::ColorCurrent(TailwindProperty::GradientTo),
     PropertyParser::GradientPosition(TailwindProperty::GradientToPosition),
+    PropertyParser::StopColor(TailwindProperty::GradientTo),
   ],
   "via" => &[
-    PropertyParser::ColorCurrent(TailwindProperty::GradientVia),
     PropertyParser::GradientPosition(TailwindProperty::GradientViaPosition),
+    PropertyParser::StopColor(TailwindProperty::GradientVia),
   ],
   "bg-size" => &[PropertyParser::BgSize(TailwindProperty::BackgroundSize)],
   "bg-position" => &[PropertyParser::BgPosition(TailwindProperty::BackgroundPosition)],

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -9,7 +9,6 @@ mod parser;
 use std::{borrow::Cow, cmp::Ordering, str::FromStr, sync::Arc};
 
 use builder::TailwindDeclarationBuilder;
-pub(crate) use builder::TwGradientType;
 use cssparser::match_ignore_ascii_case;
 pub(crate) use namespace::Namespace;
 use serde::{Deserialize, Deserializer, de::Error as DeError};
@@ -28,6 +27,35 @@ use crate::{
 
 /// Tailwind v4 `--spacing` (rem per unit). Prefer [`Length::from_spacing`].
 pub(crate) const TW_VAR_SPACING: f32 = 0.25;
+
+/// The stop list Tailwind compiles gradients to, with each variable's
+/// `@property` initial value inlined as its fallback.
+const GRADIENT_STOPS: &str = "var(--tw-gradient-via-stops, var(--tw-gradient-from, transparent) var(--tw-gradient-from-position, 0%), var(--tw-gradient-to, transparent) var(--tw-gradient-to-position, 100%))";
+const GRADIENT_VIA_STOPS: &str = "var(--tw-gradient-from, transparent) var(--tw-gradient-from-position, 0%), var(--tw-gradient-via) var(--tw-gradient-via-position, 50%), var(--tw-gradient-to, transparent) var(--tw-gradient-to-position, 100%)";
+
+fn push_custom(builder: &mut TailwindDeclarationBuilder, important: bool, name: &str, value: &str) {
+  builder.push(
+    StyleDeclaration::CustomProperty(name.to_owned(), value.to_owned()),
+    important,
+  );
+}
+
+fn push_gradient_image(builder: &mut TailwindDeclarationBuilder, important: bool, image: String) {
+  builder.push(
+    StyleDeclaration::Deferred(DeferredDeclaration {
+      property: PropertyId::Longhand(LonghandId::BackgroundImage),
+      specified_value: image,
+    }),
+    important,
+  );
+}
+
+fn css<T: ToCss>(value: &T) -> String {
+  let mut output = String::new();
+
+  let _ = value.to_css(&mut output);
+  output
+}
 
 /// Represents a collection of tailwind properties.
 #[derive(Debug, Clone, PartialEq)]
@@ -581,11 +609,11 @@ pub(crate) enum TailwindProperty {
   /// `bg-conic` property.
   BgConicAngle(Angle),
   /// `from` property.
-  GradientFrom(ColorInput),
+  GradientFrom(TwStopColor),
   /// `to` property.
-  GradientTo(ColorInput),
+  GradientTo(TwStopColor),
   /// `via` property.
-  GradientVia(ColorInput),
+  GradientVia(TwStopColor),
   /// Gradient `from` stop position.
   GradientFromPosition(Length),
   /// Gradient `via` stop position.
@@ -840,17 +868,14 @@ macro_rules! try_neg {
 
 impl TailwindProperty {
   /// Whether this property merges with sibling utilities in the builder
-  /// (gradients, transforms, shadow colour halves), which a value that
-  /// resolves at computed time cannot take part in.
+  /// (transforms, shadow colour halves), which a value that resolves at
+  /// computed time cannot take part in.
   fn merges_in_builder(&self) -> bool {
     matches!(
       self,
       TailwindProperty::Translate(..)
         | TailwindProperty::TranslateX(..)
         | TailwindProperty::TranslateY(..)
-        | TailwindProperty::GradientFrom(..)
-        | TailwindProperty::GradientVia(..)
-        | TailwindProperty::GradientTo(..)
         | TailwindProperty::ShadowColor(..)
         | TailwindProperty::TextShadowColor(..)
     )
@@ -990,42 +1015,67 @@ impl TailwindProperty {
         }
       }
       TailwindProperty::BgLinearAngle(angle) => {
-        builder.gradient_state.gradient_type = TwGradientType::Linear;
-        builder.gradient_state.angle = Some(angle);
-        builder.gradient_state.important = important;
+        push_gradient_image(
+          builder,
+          important,
+          format!("linear-gradient({}deg, var(--tw-gradient-stops))", *angle),
+        );
       }
       TailwindProperty::BgRadial => {
-        builder.gradient_state.gradient_type = TwGradientType::Radial;
-        builder.gradient_state.important = important;
+        push_gradient_image(
+          builder,
+          important,
+          "radial-gradient(var(--tw-gradient-stops))".to_owned(),
+        );
       }
       TailwindProperty::BgConicAngle(angle) => {
-        builder.gradient_state.gradient_type = TwGradientType::Conic;
-        builder.gradient_state.angle = Some(angle);
-        builder.gradient_state.important = important;
+        let image = if *angle == 0.0 {
+          "conic-gradient(var(--tw-gradient-stops))".to_owned()
+        } else {
+          format!(
+            "conic-gradient(from {}deg, var(--tw-gradient-stops))",
+            *angle
+          )
+        };
+
+        push_gradient_image(builder, important, image);
       }
       TailwindProperty::GradientFrom(color) => {
-        builder.gradient_state.from = Some(color);
-        builder.gradient_state.important = important;
+        push_custom(builder, important, "--tw-gradient-from", &color.0);
+        push_custom(builder, important, "--tw-gradient-stops", GRADIENT_STOPS);
       }
       TailwindProperty::GradientTo(color) => {
-        builder.gradient_state.to = Some(color);
-        builder.gradient_state.important = important;
+        push_custom(builder, important, "--tw-gradient-to", &color.0);
+        push_custom(builder, important, "--tw-gradient-stops", GRADIENT_STOPS);
       }
       TailwindProperty::GradientVia(color) => {
-        builder.gradient_state.via = Some(color);
-        builder.gradient_state.important = important;
+        push_custom(builder, important, "--tw-gradient-via", &color.0);
+        push_custom(
+          builder,
+          important,
+          "--tw-gradient-via-stops",
+          GRADIENT_VIA_STOPS,
+        );
+        push_custom(
+          builder,
+          important,
+          "--tw-gradient-stops",
+          "var(--tw-gradient-via-stops)",
+        );
       }
       TailwindProperty::GradientFromPosition(pos) => {
-        builder.gradient_state.from_position = Some(pos);
-        builder.gradient_state.important = important;
+        push_custom(
+          builder,
+          important,
+          "--tw-gradient-from-position",
+          &css(&pos),
+        );
       }
       TailwindProperty::GradientViaPosition(pos) => {
-        builder.gradient_state.via_position = Some(pos);
-        builder.gradient_state.important = important;
+        push_custom(builder, important, "--tw-gradient-via-position", &css(&pos));
       }
       TailwindProperty::GradientToPosition(pos) => {
-        builder.gradient_state.to_position = Some(pos);
-        builder.gradient_state.important = important;
+        push_custom(builder, important, "--tw-gradient-to-position", &css(&pos));
       }
       TailwindProperty::BackgroundClip(background_clip) => {
         push_decl!(builder, important, background_clip(background_clip));

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -273,3 +273,69 @@ impl TailwindPropertyParser for TwBlur {
     }
   }
 }
+
+/// A gradient stop colour as the expression Tailwind compiles it to: the
+/// `--color-*` variable with the built-in colour as its inline fallback.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TwStopColor(pub std::sync::Arc<str>);
+
+impl<'i> FromCss<'i> for TwStopColor {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    let color = ColorInput::from_css(input)?;
+    let mut css = String::new();
+
+    let _ = color.to_css(&mut css);
+    Ok(Self(css.into()))
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = ColorInput::VALID_TOKENS;
+}
+
+impl TailwindPropertyParser for TwStopColor {
+  fn parse_tw(token: &str) -> Option<Self> {
+    let (base, modifier) = match token.split_once('/') {
+      Some((base, modifier)) => (base, Some(modifier)),
+      None => (token, None),
+    };
+
+    let percentage = match modifier {
+      Some(modifier) => {
+        let percentage = modifier.parse::<f32>().ok()?;
+
+        if !(0.0..=100.0).contains(&percentage) {
+          return None;
+        }
+
+        Some(percentage)
+      }
+      None => None,
+    };
+
+    let expression = if base.eq_ignore_ascii_case("current") {
+      "currentcolor".to_owned()
+    } else if base.eq_ignore_ascii_case("transparent") {
+      "transparent".to_owned()
+    } else {
+      if base.is_empty() || !base.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return None;
+      }
+
+      match Color::parse_tw(base) {
+        Some(color) => {
+          let mut css = String::new();
+
+          let _ = color.to_css(&mut css);
+          format!("var(--color-{base}, {css})")
+        }
+        None => format!("var(--color-{base})"),
+      }
+    };
+
+    Some(Self(match percentage {
+      Some(percentage) => {
+        format!("color-mix(in oklab, {expression} {percentage}%, transparent)").into()
+      }
+      None => expression.into(),
+    }))
+  }
+}

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use std::{ops::Neg, sync::Arc};
 
 use cssparser::{Parser, match_ignore_ascii_case};
 

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -277,7 +277,7 @@ impl TailwindPropertyParser for TwBlur {
 /// A gradient stop colour as the expression Tailwind compiles it to: the
 /// `--color-*` variable with the built-in colour as its inline fallback.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct TwStopColor(pub std::sync::Arc<str>);
+pub(crate) struct TwStopColor(pub Arc<str>);
 
 impl<'i> FromCss<'i> for TwStopColor {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -1310,3 +1310,84 @@ fn test_numeric_leading_scales_with_spacing() {
 
   assert_eq!(line_height.to_px(&sizing, 0.0), 56.0);
 }
+
+#[test]
+fn test_gradient_reads_theme_variables() {
+  let values = TailwindValues::from_str("bg-linear-to-r from-brand-500 to-red-500")
+    .expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let computed = style.inherit(&root_with(&[
+    ("--color-brand-500", "#5b21b6"),
+    ("--color-red-500", "#00a63e"),
+  ]));
+
+  let images = computed.background_image.as_deref().expect("gradient");
+  let [BackgroundImage::Linear(gradient)] = images else {
+    panic!("expected a single linear gradient");
+  };
+
+  let colors: Vec<ColorInput> = gradient
+    .stops
+    .iter()
+    .map(|stop| match stop {
+      GradientStop::ColorHint { color, .. } => *color,
+      GradientStop::Hint(..) => panic!("expected color stops"),
+    })
+    .collect();
+
+  assert_eq!(
+    colors,
+    vec![
+      ColorInput::Value(Color::from_rgb(0x5b21b6)),
+      ColorInput::Value(Color::from_rgb(0x00a63e)),
+    ]
+  );
+}
+
+/// Stops and the gradient shape compose through custom properties, so utility
+/// order cannot matter.
+#[test]
+fn test_gradient_utility_order_does_not_matter() {
+  let compute = |classes: &str| {
+    let values = TailwindValues::from_str(classes).expect("tailwind values should parse");
+
+    Style::from(values.into_declaration_block(Viewport::new((100, 100))))
+      .inherit(&ComputedStyle::default())
+      .background_image
+  };
+
+  let forward = compute("bg-linear-to-r from-red-500 to-blue-500");
+
+  assert!(forward.is_some());
+  assert_eq!(forward, compute("from-red-500 to-blue-500 bg-linear-to-r"));
+}
+
+/// Stops alone declare no `background-image`, as Tailwind compiles them.
+#[test]
+fn test_stops_without_a_gradient_paint_nothing() {
+  let values =
+    TailwindValues::from_str("from-red-500 to-blue-500").expect("tailwind values should parse");
+  let computed = Style::from(values.into_declaration_block(Viewport::new((100, 100))))
+    .inherit(&ComputedStyle::default());
+
+  assert_eq!(computed.background_image, None);
+}
+
+/// `--tw-*` state is `inherits: false`, so a child gradient starts from its
+/// own stops, not the parent's.
+#[test]
+fn test_gradient_state_does_not_inherit() {
+  let parent_values = TailwindValues::from_str("bg-linear-to-r from-red-500 to-blue-500")
+    .expect("tailwind values should parse");
+  let parent = Style::from(parent_values.into_declaration_block(Viewport::new((100, 100))))
+    .inherit(&ComputedStyle::default());
+
+  let child_values = TailwindValues::from_str("bg-radial").expect("tailwind values should parse");
+  let child =
+    Style::from(child_values.into_declaration_block(Viewport::new((100, 100)))).inherit(&parent);
+
+  // With the parent's stops out of reach, `var(--tw-gradient-stops)` fails to
+  // substitute and the child paints no gradient, as a browser would.
+  assert_eq!(child.background_image, None);
+}


### PR DESCRIPTION
## Why

Gradient utilities merged into a finished gradient at parse time, so their colours sat outside the cascade: `from-brand-500` could not read `--color-brand-500`, and a dark-mode token change never reached a gradient.

## What

Stops compose through `--tw-gradient-*` custom properties the way Tailwind v4 compiles them: `from-red-500` sets `--tw-gradient-from: var(--color-red-500, …)` and `bg-linear-*` declares the `background-image` that reads the stops, so utility order stays irrelevant and the parse-time gradient state machine is deleted. Two behaviours move to match Tailwind: stops alone no longer paint without `bg-linear-*`/`bg-radial`/`bg-conic`, and a missing `to` stop fades to `transparent`. `--tw-*` state does not inherit, mirroring Tailwind's `@property inherits: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gradient stops support Tailwind theme color variables, arbitrary colors, opacity modifiers, and transparent fallbacks.
  - Built-in color fallbacks improve gradient compatibility.
  - Missing `to` stops now fade smoothly to transparent.

- **Bug Fixes**
  - Gradients no longer render without a gradient background utility.
  - Gradient styling no longer incorrectly carries from parent elements to children.
  - Gradients render consistently regardless of utility order.
  - Improved gradient color fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->