### PR TITLE
Core: resolve shadow colours through theme variables

### DIFF
--- a/.tegami/tw-shadow-vars.md
+++ b/.tegami/tw-shadow-vars.md
@@ -10,4 +10,4 @@ packages:
 
 ### Resolve shadow colours through theme variables
 
-`shadow-*` and `text-shadow-*` colour utilities recoloured the shadow while parsing, so the colour could not come from the theme. They now set `--tw-shadow-color` and `--tw-text-shadow-color`, and every shadow layer reads the variable with its own colour as the fallback, the way Tailwind compiles it. `shadow-brand-500` reads `--color-brand-500`; the preset shapes (`--shadow-*`, `--text-shadow-*`) still come from the built-in scale.
+`shadow-brand-500` and `text-shadow-brand-500` read `--color-brand-500` through `--tw-shadow-color` and `--tw-text-shadow-color`, with each layer's own colour as the fallback.

--- a/.tegami/tw-shadow-vars.md
+++ b/.tegami/tw-shadow-vars.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Resolve shadow colours through theme variables
+
+`shadow-*` and `text-shadow-*` colour utilities recoloured the shadow while parsing, so the colour could not come from the theme. They now set `--tw-shadow-color` and `--tw-text-shadow-color`, and every shadow layer reads the variable with its own colour as the fallback, the way Tailwind compiles it. `shadow-brand-500` reads `--color-brand-500`; the preset shapes (`--shadow-*`, `--text-shadow-*`) still come from the built-in scale.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -180,7 +180,7 @@ The namespace picks which utilities a token reaches:
 
 Some things behave differently from Tailwind here:
 
-- Shadows, filters, transforms and animations merge across utilities before the cascade runs, so `--shadow-*`, `--drop-shadow-*`, `--text-shadow-*`, `--blur-*` and `--animate-*` are not read. Gradient stops do read `--color-*`: `from-brand-500` works like `bg-brand-500`.
+- Filters, transforms and animations merge across utilities before the cascade runs, so `--shadow-*`, `--drop-shadow-*`, `--text-shadow-*`, `--blur-*` and `--animate-*` are not read. Colours do reach gradients and shadows: `from-brand-500` and `shadow-brand-500` read `--color-brand-500` like `bg-brand-500` does.
 - A gradient needs `bg-linear-*`, `bg-radial` or `bg-conic`. Stops alone paint nothing, as in Tailwind.
 - `--color-red-500: initial` falls back to the built-in red instead of removing `bg-red-500`.
 - A bare `rounded` keeps its built-in value; `rounded-sm` and the rest read the variable.

--- a/takumi-core/src/style/tw/builder.rs
+++ b/takumi-core/src/style/tw/builder.rs
@@ -4,12 +4,6 @@ use crate::style::*;
 pub(super) struct TailwindDeclarationBuilder {
   pub(super) declarations: StyleDeclarationBlock,
   pub(super) transform_state: TwTransformState,
-  pub(super) shadow: Option<Vec<BoxShadow>>,
-  pub(super) shadow_important: bool,
-  pub(super) shadow_color: Option<ColorInput>,
-  pub(super) text_shadow: Option<Vec<TextShadow>>,
-  pub(super) text_shadow_important: bool,
-  pub(super) text_shadow_color: Option<ColorInput>,
   pub(super) filter: Option<Filters>,
   pub(super) filter_important: bool,
   pub(super) backdrop_filter: Option<Filters>,
@@ -63,72 +57,6 @@ impl TailwindDeclarationBuilder {
     self.declarations.push(declaration, important);
   }
 
-  pub(super) fn set_shadow_layers<I: IntoIterator<Item = BoxShadow>>(
-    &mut self,
-    layers: I,
-    important: bool,
-  ) {
-    let mut shadows: Vec<BoxShadow> = layers.into_iter().collect();
-    if let Some(color) = self.shadow_color {
-      for shadow in &mut shadows {
-        shadow.color = color;
-      }
-    }
-
-    self.shadow = Some(shadows);
-    self.shadow_important = important;
-  }
-
-  pub(super) fn reset_shadow(&mut self, important: bool) {
-    self.shadow = None;
-    self.shadow_color = None;
-    self.shadow_important = important;
-  }
-
-  pub(super) fn reset_text_shadow(&mut self, important: bool) {
-    self.text_shadow = None;
-    self.text_shadow_color = None;
-    self.text_shadow_important = important;
-  }
-
-  pub(super) fn set_shadow_color(&mut self, color: ColorInput, important: bool) {
-    self.shadow_color = Some(color);
-    self.shadow_important = important;
-
-    if let Some(shadows) = self.shadow.as_mut() {
-      for shadow in shadows {
-        shadow.color = color;
-      }
-    }
-  }
-
-  pub(super) fn set_text_shadow_layers<I: IntoIterator<Item = TextShadow>>(
-    &mut self,
-    layers: I,
-    important: bool,
-  ) {
-    let mut shadows: Vec<TextShadow> = layers.into_iter().collect();
-    if let Some(color) = self.text_shadow_color {
-      for shadow in &mut shadows {
-        shadow.color = color;
-      }
-    }
-
-    self.text_shadow = Some(shadows);
-    self.text_shadow_important = important;
-  }
-
-  pub(super) fn set_text_shadow_color(&mut self, color: ColorInput, important: bool) {
-    self.text_shadow_color = Some(color);
-    self.text_shadow_important = important;
-
-    if let Some(shadows) = self.text_shadow.as_mut() {
-      for shadow in shadows {
-        shadow.color = color;
-      }
-    }
-  }
-
   pub(super) fn push_filter(&mut self, filter: Filter, important: bool) {
     self
       .filter
@@ -167,20 +95,6 @@ impl TailwindDeclarationBuilder {
   }
 
   pub(super) fn finish(mut self) -> StyleDeclarationBlock {
-    if let Some(shadows) = self.shadow.take() {
-      self.push(
-        StyleDeclaration::box_shadow(Some(shadows.into_boxed_slice())),
-        self.shadow_important,
-      );
-    }
-
-    if let Some(shadows) = self.text_shadow.take() {
-      self.push(
-        StyleDeclaration::text_shadow(Some(shadows.into_boxed_slice())),
-        self.text_shadow_important,
-      );
-    }
-
     if let Some(filter) = self.filter.take() {
       self.push(StyleDeclaration::filter(filter), self.filter_important);
     }

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -85,7 +85,7 @@ property_parsers! {
   TextWrap(TextWrap) => TextWrap,
   ColorCurrent(ColorInput) => ColorInput,
   ColorTransparent(ColorInput) => ColorInput,
-  StopColor(TwStopColor) => TwStopColor,
+  StopColor(TwThemeColor) => TwThemeColor,
   Percentage(PercentageNumber) => PercentageNumber,
   FontFamily(FontFamily) => FontFamily,
   LineClamp(LineClamp) => LineClamp,
@@ -272,7 +272,7 @@ pub(crate) static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
     PropertyParser::BorderWidth(TailwindProperty::OutlineWidth),
   ],
   "shadow" => &[
-    PropertyParser::ColorCurrent(TailwindProperty::ShadowColor),
+    PropertyParser::StopColor(TailwindProperty::ShadowColor),
     PropertyParser::BoxShadow(TailwindProperty::Shadow),
   ],
   "outline-offset" => &[PropertyParser::BorderWidth(TailwindProperty::OutlineOffset)],
@@ -372,7 +372,7 @@ pub(crate) static PREFIX_PARSERS: phf::Map<&str, &[PropertyParser]> = phf_map! {
   "backdrop-filter" => &[PropertyParser::Filter(TailwindProperty::BackdropFilter)],
   "drop-shadow" => &[PropertyParser::DropShadow(TailwindProperty::DropShadow)],
   "text-shadow" => &[
-    PropertyParser::ColorCurrent(TailwindProperty::TextShadowColor),
+    PropertyParser::StopColor(TailwindProperty::TextShadowColor),
     PropertyParser::TextShadow(TailwindProperty::TextShadow),
   ],
   "mix-blend" => &[PropertyParser::BlendMode(TailwindProperty::MixBlendMode)],

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -41,10 +41,62 @@ fn push_custom(builder: &mut TailwindDeclarationBuilder, important: bool, name: 
 }
 
 fn push_gradient_image(builder: &mut TailwindDeclarationBuilder, important: bool, image: String) {
+  push_deferred(builder, important, LonghandId::BackgroundImage, image);
+}
+
+/// One shadow layer with its colour behind `var()`, as Tailwind compiles it:
+/// the colour utility overrides through the variable, the layer's own colour
+/// stays as the fallback.
+fn shadow_layer_css(
+  prefix: &str,
+  offsets: [&Length; 3],
+  color: &ColorInput,
+  variable: &str,
+) -> String {
+  let mut out = String::from(prefix);
+
+  for length in offsets {
+    out.push_str(&css(length));
+    out.push(' ');
+  }
+
+  out.push_str(&format!("var({variable}, {})", css(color)));
+  out
+}
+
+fn box_shadow_css(shadow: &BoxShadow) -> String {
+  let mut layer = shadow_layer_css(
+    if shadow.inset { "inset " } else { "" },
+    [&shadow.offset_x, &shadow.offset_y, &shadow.blur_radius],
+    &shadow.color,
+    "--tw-shadow-color",
+  );
+
+  let spread = format!("{} ", css(&shadow.spread_radius));
+
+  layer.insert_str(layer.rfind("var(").unwrap_or(0), &spread);
+  layer
+}
+
+fn text_shadow_css(shadow: &TextShadow) -> String {
+  shadow_layer_css(
+    "",
+    [&shadow.offset_x, &shadow.offset_y, &shadow.blur_radius],
+    &shadow.color,
+    "--tw-text-shadow-color",
+  )
+}
+
+fn push_deferred(
+  builder: &mut TailwindDeclarationBuilder,
+  important: bool,
+  longhand: LonghandId,
+  specified_value: String,
+) {
   builder.push(
     StyleDeclaration::Deferred(DeferredDeclaration {
-      property: PropertyId::Longhand(LonghandId::BackgroundImage),
-      specified_value: image,
+      property: PropertyId::Longhand(longhand),
+      specified_value,
     }),
     important,
   );
@@ -349,7 +401,7 @@ pub(crate) enum TailwindProperty {
   /// `box-shadow` property.
   Shadow(BoxShadow),
   /// `box-shadow` color override.
-  ShadowColor(ColorInput),
+  ShadowColor(TwThemeColor),
   /// `display` property.
   Display(Display),
   /// `list-style-type` property.
@@ -585,7 +637,7 @@ pub(crate) enum TailwindProperty {
   /// `text-shadow` property.
   TextShadow(TextShadow),
   /// `text-shadow` color override.
-  TextShadowColor(ColorInput),
+  TextShadowColor(TwThemeColor),
   /// `box-shadow` layer set.
   ShadowList(&'static [BoxShadow]),
   /// `text-shadow` layer set.
@@ -609,11 +661,11 @@ pub(crate) enum TailwindProperty {
   /// `bg-conic` property.
   BgConicAngle(Angle),
   /// `from` property.
-  GradientFrom(TwStopColor),
+  GradientFrom(TwThemeColor),
   /// `to` property.
-  GradientTo(TwStopColor),
+  GradientTo(TwThemeColor),
   /// `via` property.
-  GradientVia(TwStopColor),
+  GradientVia(TwThemeColor),
   /// Gradient `from` stop position.
   GradientFromPosition(Length),
   /// Gradient `via` stop position.
@@ -868,16 +920,14 @@ macro_rules! try_neg {
 
 impl TailwindProperty {
   /// Whether this property merges with sibling utilities in the builder
-  /// (transforms, shadow colour halves), which a value that resolves at
-  /// computed time cannot take part in.
+  /// (transforms), which a value that resolves at computed time cannot take
+  /// part in.
   fn merges_in_builder(&self) -> bool {
     matches!(
       self,
       TailwindProperty::Translate(..)
         | TailwindProperty::TranslateX(..)
         | TailwindProperty::TranslateY(..)
-        | TailwindProperty::ShadowColor(..)
-        | TailwindProperty::TextShadowColor(..)
     )
   }
 
@@ -1192,12 +1242,25 @@ impl TailwindProperty {
       TailwindProperty::MaxHeight(max_height) => {
         push_decl!(builder, important, max_height(max_height.into()))
       }
-      TailwindProperty::Shadow(box_shadow) => builder.set_shadow_layers([box_shadow], important),
-      TailwindProperty::ShadowList(&[]) => builder.reset_shadow(important),
-      TailwindProperty::ShadowList(layers) => {
-        builder.set_shadow_layers(layers.iter().copied(), important)
+      TailwindProperty::Shadow(box_shadow) => {
+        push_deferred(
+          builder,
+          important,
+          LonghandId::BoxShadow,
+          box_shadow_css(&box_shadow),
+        );
       }
-      TailwindProperty::ShadowColor(color) => builder.set_shadow_color(color, important),
+      TailwindProperty::ShadowList(&[]) => {
+        push_deferred(builder, important, LonghandId::BoxShadow, "none".to_owned());
+      }
+      TailwindProperty::ShadowList(layers) => {
+        let layers: Vec<String> = layers.iter().map(box_shadow_css).collect();
+
+        push_deferred(builder, important, LonghandId::BoxShadow, layers.join(", "));
+      }
+      TailwindProperty::ShadowColor(color) => {
+        push_custom(builder, important, "--tw-shadow-color", &color.0);
+      }
       TailwindProperty::Display(display) => {
         push_decl!(builder, important, display(display));
       }
@@ -1742,13 +1805,34 @@ impl TailwindProperty {
         }
       }
       TailwindProperty::TextShadow(text_shadow) => {
-        builder.set_text_shadow_layers([text_shadow], important)
+        push_deferred(
+          builder,
+          important,
+          LonghandId::TextShadow,
+          text_shadow_css(&text_shadow),
+        );
       }
-      TailwindProperty::TextShadowList(&[]) => builder.reset_text_shadow(important),
+      TailwindProperty::TextShadowList(&[]) => {
+        push_deferred(
+          builder,
+          important,
+          LonghandId::TextShadow,
+          "none".to_owned(),
+        );
+      }
       TailwindProperty::TextShadowList(layers) => {
-        builder.set_text_shadow_layers(layers.iter().copied(), important)
+        let layers: Vec<String> = layers.iter().map(text_shadow_css).collect();
+
+        push_deferred(
+          builder,
+          important,
+          LonghandId::TextShadow,
+          layers.join(", "),
+        );
       }
-      TailwindProperty::TextShadowColor(color) => builder.set_text_shadow_color(color, important),
+      TailwindProperty::TextShadowColor(color) => {
+        push_custom(builder, important, "--tw-text-shadow-color", &color.0);
+      }
       TailwindProperty::Visibility(visibility) => {
         push_decl!(builder, important, visibility(visibility))
       }

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -274,8 +274,9 @@ impl TailwindPropertyParser for TwBlur {
   }
 }
 
-/// A gradient stop colour as the expression Tailwind compiles it to: the
-/// `--color-*` variable with the built-in colour as its inline fallback.
+/// A theme-backed colour expression for gradient stops and shadow colours:
+/// `var(--color-*)`, with the built-in colour as the fallback when the token
+/// names one. `current` and `transparent` stay plain keywords.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct TwThemeColor(pub Arc<str>);
 

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -277,9 +277,9 @@ impl TailwindPropertyParser for TwBlur {
 /// A gradient stop colour as the expression Tailwind compiles it to: the
 /// `--color-*` variable with the built-in colour as its inline fallback.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct TwStopColor(pub Arc<str>);
+pub(crate) struct TwThemeColor(pub Arc<str>);
 
-impl<'i> FromCss<'i> for TwStopColor {
+impl<'i> FromCss<'i> for TwThemeColor {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     let color = ColorInput::from_css(input)?;
     let mut css = String::new();
@@ -291,7 +291,7 @@ impl<'i> FromCss<'i> for TwStopColor {
   const VALID_TOKENS: &'static [CssToken] = ColorInput::VALID_TOKENS;
 }
 
-impl TailwindPropertyParser for TwStopColor {
+impl TailwindPropertyParser for TwThemeColor {
   fn parse_tw(token: &str) -> Option<Self> {
     let (base, modifier) = match token.split_once('/') {
       Some((base, modifier)) => (base, Some(modifier)),

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -76,11 +76,11 @@ fn test_parse_red_500_color_utilities() {
   let cases: &[(&str, TailwindProperty)] = &[
     (
       "shadow-red-500",
-      TailwindProperty::ShadowColor(ColorInput::Value(Color([251, 44, 54, 255]))),
+      TailwindProperty::ShadowColor(TwThemeColor::parse_tw("red-500").expect("palette colour")),
     ),
     (
       "text-shadow-red-500",
-      TailwindProperty::TextShadowColor(ColorInput::Value(Color([251, 44, 54, 255]))),
+      TailwindProperty::TextShadowColor(TwThemeColor::parse_tw("red-500").expect("palette colour")),
     ),
     (
       "decoration-red-500",
@@ -1390,4 +1390,22 @@ fn test_gradient_state_does_not_inherit() {
   // With the parent's stops out of reach, `var(--tw-gradient-stops)` fails to
   // substitute and the child paints no gradient, as a browser would.
   assert_eq!(child.background_image, None);
+}
+
+/// The shadow colour utility overrides every layer through the variable it
+/// sets, and reads the theme like any colour utility.
+#[test]
+fn test_shadow_color_reads_theme_variables() {
+  let values =
+    TailwindValues::from_str("shadow-md shadow-brand-500").expect("tailwind values should parse");
+  let computed = Style::from(values.into_declaration_block(Viewport::new((100, 100))))
+    .inherit(&root_with(&[("--color-brand-500", "#5b21b6")]));
+
+  let shadows = computed.box_shadow.as_deref().expect("shadows");
+
+  assert_eq!(shadows.len(), 2);
+
+  for shadow in shadows {
+    assert_eq!(shadow.color, ColorInput::Value(Color::from_rgb(0x5b21b6)));
+  }
 }


### PR DESCRIPTION
## Why

The colour half of `shadow-*` and `text-shadow-*` recoloured shadow layers at parse time, outside the cascade, so `shadow-brand-500` could not read `--color-brand-500`.

## What

Colour utilities now set `--tw-shadow-color` / `--tw-text-shadow-color`, and every shadow layer reads the variable with its own colour as the inline fallback, the way Tailwind compiles it. The builder loses its shadow merge state; preset shapes (`--shadow-*`, `--text-shadow-*`) still come from the built-in scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shadow and text-shadow utilities now support theme color variables.
  * Composite shadows apply theme-defined colors consistently across all layers.
  * Gradient and shadow colors can reference shared theme color tokens.
  * Shadow layers include fallbacks for reliable rendering, while preset shadow shapes retain the existing scale.
  * Empty shadow definitions now render as `none`.

* **Documentation**
  * Clarified theme color behavior for gradients and shadows.
  * Added release metadata for affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->