### PR TITLE
Core: compose filters and transforms through custom properties

### DIFF
--- a/.tegami/tw-kill-builder.md
+++ b/.tegami/tw-kill-builder.md
@@ -10,4 +10,4 @@ packages:
 
 ### Compose filters and transforms through custom properties
 
-Filter, translate, scale and grid-line utilities merged in a parse-time builder instead of the cascade. Each one now writes its `--tw-*` variable and re-declares the property from Tailwind's fixed chain, so `blur-sm brightness-125` composes in the same order as Tailwind whichever way the classes are written. Stacked filters previously applied in class order; they now follow Tailwind's chain order, which can change the result when order matters.
+Filter, translate, scale and grid-line utilities now compose through `--tw-*` variables like Tailwind's compiled CSS. Stacked filters follow Tailwind's fixed chain order instead of class order.

--- a/.tegami/tw-kill-builder.md
+++ b/.tegami/tw-kill-builder.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Compose filters and transforms through custom properties
+
+Filter, translate, scale and grid-line utilities merged in a parse-time builder instead of the cascade. Each one now writes its `--tw-*` variable and re-declares the property from Tailwind's fixed chain, so `blur-sm brightness-125` composes in the same order as Tailwind whichever way the classes are written. Stacked filters previously applied in class order; they now follow Tailwind's chain order, which can change the result when order matters.

--- a/takumi-core/src/style/tw/builder.rs
+++ b/takumi-core/src/style/tw/builder.rs
@@ -3,53 +3,6 @@ use crate::style::*;
 #[derive(Debug, Default)]
 pub(super) struct TailwindDeclarationBuilder {
   pub(super) declarations: StyleDeclarationBlock,
-  pub(super) transform_state: TwTransformState,
-  pub(super) filter: Option<Filters>,
-  pub(super) filter_important: bool,
-  pub(super) backdrop_filter: Option<Filters>,
-  pub(super) backdrop_filter_important: bool,
-  pub(super) grid_column: TwGridLineState,
-  pub(super) grid_row: TwGridLineState,
-}
-
-#[derive(Debug, Default)]
-pub(super) struct TwGridLineState {
-  pub(super) start: Option<GridPlacement>,
-  pub(super) end: Option<GridPlacement>,
-  pub(super) start_important: bool,
-  pub(super) end_important: bool,
-}
-
-impl TwGridLineState {
-  fn set_line(&mut self, grid_line: GridLine, start_important: bool, end_important: bool) {
-    self.set_start(grid_line.start, start_important);
-    self.set_end(grid_line.end, end_important);
-  }
-
-  fn set_start(&mut self, grid_placement: GridPlacement, important: bool) {
-    self.start = Some(grid_placement);
-    self.start_important = important;
-  }
-
-  fn set_end(&mut self, grid_placement: GridPlacement, important: bool) {
-    self.end = Some(grid_placement);
-    self.end_important = important;
-  }
-
-  fn push_declarations(
-    self,
-    declarations: &mut StyleDeclarationBlock,
-    start_decl: fn(GridPlacement) -> StyleDeclaration,
-    end_decl: fn(GridPlacement) -> StyleDeclaration,
-  ) {
-    if let Some(start) = self.start {
-      declarations.push(start_decl(start), self.start_important);
-    }
-
-    if let Some(end) = self.end {
-      declarations.push(end_decl(end), self.end_important);
-    }
-  }
 }
 
 impl TailwindDeclarationBuilder {
@@ -57,68 +10,7 @@ impl TailwindDeclarationBuilder {
     self.declarations.push(declaration, important);
   }
 
-  pub(super) fn push_filter(&mut self, filter: Filter, important: bool) {
-    self
-      .filter
-      .get_or_insert_with(Filters::default)
-      .push(filter);
-    self.filter_important = important;
-  }
-
-  pub(super) fn push_backdrop_filter(&mut self, filter: Filter, important: bool) {
-    self
-      .backdrop_filter
-      .get_or_insert_with(Filters::default)
-      .push(filter);
-    self.backdrop_filter_important = important;
-  }
-
-  pub(super) fn set_filter_reset(&mut self, important: bool, use_backdrop: bool) {
-    let (filter, filter_important) = if use_backdrop {
-      (
-        &mut self.backdrop_filter,
-        &mut self.backdrop_filter_important,
-      )
-    } else {
-      (&mut self.filter, &mut self.filter_important)
-    };
-    *filter = Some(Filters::default());
-    *filter_important = important;
-  }
-
-  pub(super) fn set_grid_column(&mut self, grid_line: GridLine, important: bool) {
-    self.grid_column.set_line(grid_line, important, important);
-  }
-
-  pub(super) fn set_grid_row(&mut self, grid_line: GridLine, important: bool) {
-    self.grid_row.set_line(grid_line, important, important);
-  }
-
   pub(super) fn finish(mut self) -> StyleDeclarationBlock {
-    if let Some(filter) = self.filter.take() {
-      self.push(StyleDeclaration::filter(filter), self.filter_important);
-    }
-
-    if let Some(backdrop_filter) = self.backdrop_filter.take() {
-      self.push(
-        StyleDeclaration::backdrop_filter(backdrop_filter),
-        self.backdrop_filter_important,
-      );
-    }
-
-    self.transform_state.apply(&mut self.declarations);
-
-    self.grid_column.push_declarations(
-      &mut self.declarations,
-      StyleDeclaration::grid_column_start,
-      StyleDeclaration::grid_column_end,
-    );
-    self.grid_row.push_declarations(
-      &mut self.declarations,
-      StyleDeclaration::grid_row_start,
-      StyleDeclaration::grid_row_end,
-    );
-
     type BorderSide = (LonghandId, LonghandId, fn(BorderStyle) -> StyleDeclaration);
     let sides: [BorderSide; 4] = [
       (
@@ -159,52 +51,5 @@ impl TailwindDeclarationBuilder {
     }
 
     self.declarations
-  }
-}
-
-#[derive(Debug, Default)]
-pub(super) struct TwTransformState {
-  translate: Option<SpacePair<Length>>,
-  translate_important: bool,
-  scale: Option<SpacePair<PercentageNumber>>,
-  scale_important: bool,
-}
-
-impl TwTransformState {
-  pub(super) fn set_translate(&mut self, value: SpacePair<Length>, important: bool) {
-    self.translate = Some(value);
-    self.translate_important = important;
-  }
-
-  pub(super) fn translate_mut(&mut self, important: bool) -> &mut SpacePair<Length> {
-    self.translate_important = important;
-    self
-      .translate
-      .get_or_insert_with(SpacePair::<Length>::default)
-  }
-
-  pub(super) fn set_scale(&mut self, value: SpacePair<PercentageNumber>, important: bool) {
-    self.scale = Some(value);
-    self.scale_important = important;
-  }
-
-  pub(super) fn scale_mut(&mut self, important: bool) -> &mut SpacePair<PercentageNumber> {
-    self.scale_important = important;
-    self
-      .scale
-      .get_or_insert_with(SpacePair::<PercentageNumber>::default)
-  }
-
-  fn apply(self, declarations: &mut StyleDeclarationBlock) {
-    if let Some(translate) = self.translate {
-      declarations.push(
-        StyleDeclaration::translate(translate),
-        self.translate_important,
-      );
-    }
-
-    if let Some(scale) = self.scale {
-      declarations.push(StyleDeclaration::scale(scale), self.scale_important);
-    }
   }
 }

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -44,6 +44,34 @@ fn push_gradient_image(builder: &mut TailwindDeclarationBuilder, important: bool
   push_deferred(builder, important, LonghandId::BackgroundImage, image);
 }
 
+/// The filter chains Tailwind compiles, in its fixed order. An unset variable
+/// collapses to nothing through the empty fallback.
+const FILTER_CHAIN: &str = "var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,)";
+const BACKDROP_FILTER_CHAIN: &str = "var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,)";
+
+const TRANSLATE_PAIR: &str = "var(--tw-translate-x, 0px) var(--tw-translate-y, 0px)";
+const SCALE_PAIR: &str = "var(--tw-scale-x, 100%) var(--tw-scale-y, 100%)";
+
+fn push_tw_filter(
+  builder: &mut TailwindDeclarationBuilder,
+  important: bool,
+  backdrop: bool,
+  name: &str,
+  filter: &Filter,
+) {
+  let (prefix, longhand, chain) = match backdrop {
+    false => ("--tw-", LonghandId::Filter, FILTER_CHAIN),
+    true => (
+      "--tw-backdrop-",
+      LonghandId::BackdropFilter,
+      BACKDROP_FILTER_CHAIN,
+    ),
+  };
+
+  push_custom(builder, important, &format!("{prefix}{name}"), &css(filter));
+  push_deferred(builder, important, longhand, chain.to_owned());
+}
+
 /// One shadow layer with its colour behind `var()`, as Tailwind compiles it:
 /// the colour utility overrides through the variable, the layer's own colour
 /// stays as the fallback.
@@ -688,24 +716,31 @@ impl ThemeVar {
   /// One declaration per longhand, sharing the variable the prefix reads.
   /// `text-lg` spells its line height in a companion variable, so one token can
   /// set the size without dragging the leading with it.
+  /// `None` when a declaration has no single longhand to defer (it composes
+  /// through custom properties instead), leaving the utility unthemed.
   fn from_builtin(
     name: &Arc<str>,
     expression: &Arc<str>,
     declarations: impl IntoIterator<Item = StyleDeclaration>,
-  ) -> Self {
-    let targets = declarations
-      .into_iter()
-      .map(|declaration| {
-        var_ref(
-          name,
-          expression,
-          declaration.longhand_id(),
-          Some(declaration),
-        )
-      })
-      .collect();
+  ) -> Option<Self> {
+    let mut targets = SmallVec::new();
 
-    Self { targets }
+    for declaration in declarations {
+      if matches!(
+        declaration,
+        StyleDeclaration::CustomProperty(..)
+          | StyleDeclaration::Deferred(..)
+          | StyleDeclaration::VarRef(..)
+      ) {
+        return None;
+      }
+
+      let longhand = declaration.longhand_id();
+
+      targets.push(var_ref(name, expression, longhand, Some(declaration)));
+    }
+
+    Some(Self { targets })
   }
 
   #[cfg(test)]
@@ -919,18 +954,6 @@ macro_rules! try_neg {
 }
 
 impl TailwindProperty {
-  /// Whether this property merges with sibling utilities in the builder
-  /// (transforms), which a value that resolves at computed time cannot take
-  /// part in.
-  fn merges_in_builder(&self) -> bool {
-    matches!(
-      self,
-      TailwindProperty::Translate(..)
-        | TailwindProperty::TranslateX(..)
-        | TailwindProperty::TranslateY(..)
-    )
-  }
-
   fn try_neg(self) -> Option<Self> {
     try_neg!(self;
       try_negative:
@@ -1015,20 +1038,14 @@ impl TailwindProperty {
           property
         };
 
-        if property.merges_in_builder() {
-          return Some(property);
+        if let Some((name, expression)) = theme_expression(parser.namespaces(), suffix, negative)
+          && let Some(theme_var) =
+            ThemeVar::from_builtin(&name, &expression, property.clone().expand_targets())
+        {
+          return Some(TailwindProperty::ThemeVar(theme_var));
         }
 
-        return Some(
-          match theme_expression(parser.namespaces(), suffix, negative) {
-            Some((name, expression)) => TailwindProperty::ThemeVar(ThemeVar::from_builtin(
-              &name,
-              &expression,
-              property.expand_targets(),
-            )),
-            None => property,
-          },
-        );
+        return Some(property);
       }
 
       // No built-in value, but the prefix still names what the utility writes.
@@ -1546,27 +1563,46 @@ impl TailwindProperty {
         push_decl!(builder, important, line_height(line_height))
       }
       TailwindProperty::Translate(length) => {
-        builder
-          .transform_state
-          .set_translate(SpacePair::from_single(length), important);
+        push_custom(builder, important, "--tw-translate-x", &css(&length));
+        push_custom(builder, important, "--tw-translate-y", &css(&length));
+        push_deferred(
+          builder,
+          important,
+          LonghandId::Translate,
+          TRANSLATE_PAIR.to_owned(),
+        );
       }
       TailwindProperty::TranslateX(length) => {
-        builder.transform_state.translate_mut(important).x = length;
+        push_custom(builder, important, "--tw-translate-x", &css(&length));
+        push_deferred(
+          builder,
+          important,
+          LonghandId::Translate,
+          TRANSLATE_PAIR.to_owned(),
+        );
       }
       TailwindProperty::TranslateY(length) => {
-        builder.transform_state.translate_mut(important).y = length;
+        push_custom(builder, important, "--tw-translate-y", &css(&length));
+        push_deferred(
+          builder,
+          important,
+          LonghandId::Translate,
+          TRANSLATE_PAIR.to_owned(),
+        );
       }
       TailwindProperty::Rotate(angle) => push_decl!(builder, important, rotate(Some(angle))),
       TailwindProperty::Scale(percentage_number) => {
-        builder
-          .transform_state
-          .set_scale(SpacePair::from_single(percentage_number), important);
+        push_custom(builder, important, "--tw-scale-x", &css(&percentage_number));
+        push_custom(builder, important, "--tw-scale-y", &css(&percentage_number));
+        push_deferred(builder, important, LonghandId::Scale, SCALE_PAIR.to_owned());
       }
       TailwindProperty::ScaleX(percentage_number) => {
-        builder.transform_state.scale_mut(important).x = percentage_number;
+        push_custom(builder, important, "--tw-scale-x", &css(&percentage_number));
+        push_deferred(builder, important, LonghandId::Scale, SCALE_PAIR.to_owned());
       }
       TailwindProperty::ScaleY(percentage_number) => {
-        builder.transform_state.scale_mut(important).y = percentage_number;
+        push_custom(builder, important, "--tw-scale-y", &css(&percentage_number));
+        push_deferred(builder, important, LonghandId::Scale, SCALE_PAIR.to_owned());
       }
       TailwindProperty::TransformOrigin(background_position) => {
         push_decl!(builder, important, transform_origin(background_position))
@@ -1679,38 +1715,29 @@ impl TailwindProperty {
         important,
         grid_auto_rows(Some([grid_auto_size].into()))
       ),
-      TailwindProperty::GridColumn(tw_grid_span) => {
-        builder.set_grid_column(tw_grid_span, important)
-      }
-      TailwindProperty::GridRow(tw_grid_span) => builder.set_grid_row(tw_grid_span, important),
+      TailwindProperty::GridColumn(grid_line) => push_decl!(
+        builder,
+        important,
+        grid_column_start(grid_line.start),
+        grid_column_end(grid_line.end)
+      ),
+      TailwindProperty::GridRow(grid_line) => push_decl!(
+        builder,
+        important,
+        grid_row_start(grid_line.start),
+        grid_row_end(grid_line.end)
+      ),
       TailwindProperty::GridColumnStart(tw_grid_placement) => {
-        let start = builder
-          .grid_column
-          .start
-          .get_or_insert_with(GridPlacement::auto);
-        *start = tw_grid_placement;
-        builder.grid_column.start_important = important;
+        push_decl!(builder, important, grid_column_start(tw_grid_placement))
       }
       TailwindProperty::GridColumnEnd(tw_grid_placement) => {
-        let end = builder
-          .grid_column
-          .end
-          .get_or_insert_with(GridPlacement::auto);
-        *end = tw_grid_placement;
-        builder.grid_column.end_important = important;
+        push_decl!(builder, important, grid_column_end(tw_grid_placement))
       }
       TailwindProperty::GridRowStart(tw_grid_placement) => {
-        let start = builder
-          .grid_row
-          .start
-          .get_or_insert_with(GridPlacement::auto);
-        *start = tw_grid_placement;
-        builder.grid_row.start_important = important;
+        push_decl!(builder, important, grid_row_start(tw_grid_placement))
       }
       TailwindProperty::GridRowEnd(tw_grid_placement) => {
-        let end = builder.grid_row.end.get_or_insert_with(GridPlacement::auto);
-        *end = tw_grid_placement;
-        builder.grid_row.end_important = important;
+        push_decl!(builder, important, grid_row_end(tw_grid_placement))
       }
       TailwindProperty::GridTemplateColumns(tw_grid_template) => push_decl!(
         builder,
@@ -1729,79 +1756,192 @@ impl TailwindProperty {
         push_decl!(builder, important, grid_auto_flow(grid_auto_flow))
       }
       TailwindProperty::GridColumnSpan(grid_placement_span) => {
-        builder.set_grid_column(GridLine::span(grid_placement_span), important)
+        let line = GridLine::span(grid_placement_span);
+
+        push_decl!(
+          builder,
+          important,
+          grid_column_start(line.start),
+          grid_column_end(line.end)
+        )
       }
       TailwindProperty::GridRowSpan(grid_placement_span) => {
-        builder.set_grid_row(GridLine::span(grid_placement_span), important)
+        let line = GridLine::span(grid_placement_span);
+
+        push_decl!(
+          builder,
+          important,
+          grid_row_start(line.start),
+          grid_row_end(line.end)
+        )
       }
-      TailwindProperty::Blur(tw_blur) => builder.push_filter(Filter::Blur(tw_blur.0), important),
+      TailwindProperty::Blur(tw_blur) => {
+        push_tw_filter(builder, important, false, "blur", &Filter::Blur(tw_blur.0));
+      }
       TailwindProperty::Brightness(percentage_number) => {
-        builder.push_filter(Filter::Brightness(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "brightness",
+          &Filter::Brightness(percentage_number),
+        );
       }
       TailwindProperty::Contrast(percentage_number) => {
-        builder.push_filter(Filter::Contrast(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "contrast",
+          &Filter::Contrast(percentage_number),
+        );
       }
       TailwindProperty::DropShadow(text_shadow) => {
-        builder.push_filter(Filter::DropShadow(text_shadow), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "drop-shadow",
+          &Filter::DropShadow(text_shadow),
+        );
       }
       TailwindProperty::Grayscale(percentage_number) => {
-        builder.push_filter(Filter::Grayscale(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "grayscale",
+          &Filter::Grayscale(percentage_number),
+        );
       }
       TailwindProperty::HueRotate(angle) => {
-        builder.push_filter(Filter::HueRotate(angle), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "hue-rotate",
+          &Filter::HueRotate(angle),
+        );
       }
       TailwindProperty::Invert(percentage_number) => {
-        builder.push_filter(Filter::Invert(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "invert",
+          &Filter::Invert(percentage_number),
+        );
       }
       TailwindProperty::Saturate(percentage_number) => {
-        builder.push_filter(Filter::Saturate(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "saturate",
+          &Filter::Saturate(percentage_number),
+        );
       }
       TailwindProperty::Sepia(percentage_number) => {
-        builder.push_filter(Filter::Sepia(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          false,
+          "sepia",
+          &Filter::Sepia(percentage_number),
+        );
       }
       TailwindProperty::Filter(filters) => {
         if filters.is_empty() {
-          builder.set_filter_reset(important, false);
+          push_deferred(builder, important, LonghandId::Filter, "none".to_owned());
         } else {
-          for filter in filters {
-            builder.push_filter(filter, important);
-          }
+          push_decl!(builder, important, filter(filters));
         }
       }
       TailwindProperty::BackdropBlur(tw_blur) => {
-        builder.push_backdrop_filter(Filter::Blur(tw_blur.0), important)
+        push_tw_filter(builder, important, true, "blur", &Filter::Blur(tw_blur.0));
       }
       TailwindProperty::BackdropBrightness(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Brightness(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "brightness",
+          &Filter::Brightness(percentage_number),
+        );
       }
       TailwindProperty::BackdropContrast(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Contrast(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "contrast",
+          &Filter::Contrast(percentage_number),
+        );
       }
       TailwindProperty::BackdropGrayscale(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Grayscale(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "grayscale",
+          &Filter::Grayscale(percentage_number),
+        );
       }
       TailwindProperty::BackdropHueRotate(angle) => {
-        builder.push_backdrop_filter(Filter::HueRotate(angle), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "hue-rotate",
+          &Filter::HueRotate(angle),
+        );
       }
       TailwindProperty::BackdropInvert(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Invert(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "invert",
+          &Filter::Invert(percentage_number),
+        );
       }
       TailwindProperty::BackdropOpacity(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Opacity(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "opacity",
+          &Filter::Opacity(percentage_number),
+        );
       }
       TailwindProperty::BackdropSaturate(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Saturate(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "saturate",
+          &Filter::Saturate(percentage_number),
+        );
       }
       TailwindProperty::BackdropSepia(percentage_number) => {
-        builder.push_backdrop_filter(Filter::Sepia(percentage_number), important)
+        push_tw_filter(
+          builder,
+          important,
+          true,
+          "sepia",
+          &Filter::Sepia(percentage_number),
+        );
       }
       TailwindProperty::BackdropFilter(filters) => {
         if filters.is_empty() {
-          builder.set_filter_reset(important, true);
+          push_deferred(
+            builder,
+            important,
+            LonghandId::BackdropFilter,
+            "none".to_owned(),
+          );
         } else {
-          for filter in filters {
-            builder.push_backdrop_filter(filter, important);
-          }
+          push_decl!(builder, important, backdrop_filter(filters));
         }
       }
       TailwindProperty::TextShadow(text_shadow) => {

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -395,8 +395,8 @@ fn test_grid_longhand_importance_is_tracked_per_side() {
   assert_eq!(
     declarations.iter().collect::<Vec<_>>(),
     vec![
-      &StyleDeclaration::grid_column_start(GridPlacement::Line(2)),
       &StyleDeclaration::grid_column_end(GridPlacement::Line(3)),
+      &StyleDeclaration::grid_column_start(GridPlacement::Line(2)),
     ]
   );
   assert!(
@@ -1408,4 +1408,36 @@ fn test_shadow_color_reads_theme_variables() {
   for shadow in shadows {
     assert_eq!(shadow.color, ColorInput::Value(Color::from_rgb(0x5b21b6)));
   }
+}
+
+/// Filters compose through `--tw-*` variables in Tailwind's fixed chain
+/// order, whatever order the utilities appear in.
+#[test]
+fn test_filters_compose_through_variables() {
+  let compute = |classes: &str| {
+    let values = TailwindValues::from_str(classes).expect("tailwind values should parse");
+
+    Style::from(values.into_declaration_block(Viewport::new((100, 100))))
+      .inherit(&ComputedStyle::default())
+      .filter
+  };
+
+  let forward = compute("blur-sm brightness-125");
+
+  assert!(matches!(
+    &forward[..],
+    [Filter::Blur(..), Filter::Brightness(..)]
+  ));
+  assert_eq!(forward, compute("brightness-125 blur-sm"));
+}
+
+#[test]
+fn test_translate_composes_through_variables() {
+  let values =
+    TailwindValues::from_str("translate-x-4 -translate-y-2").expect("tailwind values should parse");
+  let computed = Style::from(values.into_declaration_block(Viewport::new((100, 100))))
+    .inherit(&ComputedStyle::default());
+
+  assert_eq!(computed.translate.x, Length::Rem(1.0));
+  assert_eq!(computed.translate.y, Length::Rem(-0.5));
 }


### PR DESCRIPTION
## Why

Filter, translate, scale and grid-line utilities merged in a parse-time builder the cascade never saw, so they were the last utilities organized unlike Tailwind's compiled CSS.

## What

Each utility writes its `--tw-*` variable and re-declares the property from Tailwind's fixed chain (`filter: var(--tw-blur,) var(--tw-brightness,) …` with empty fallbacks), grid lines push their longhands directly, and the builder shrinks to a declaration list plus the border post-pass that stands in for Preflight's `border: 0 solid`. One behaviour moves to match Tailwind: stacked filters follow the chain order instead of class order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tailwind-style filter, backdrop-filter, transform, and grid utilities now compose consistently, regardless of utility order.
  * Translation utilities correctly combine horizontal and vertical values, including negative translations.
  * Theme colors resolve more reliably in gradients and shadows.
  * Grid placement declarations follow consistent ordering for improved rendering reliability.
  * Borders receive a solid style automatically when a width is specified without an explicit style.
* **Documentation**
  * Added guidance on composing Tailwind-style custom properties for filters, transforms, and grid utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->