### PR TITLE
Helpers: enforce fetch policy on cached images

### DIFF
--- a/.tegami/fetch-cache-policy.md
+++ b/.tegami/fetch-cache-policy.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Enforce fetch policies on shared image cache entries
+
+A shared `fetchCache` hit returned cached bytes without running the calling render's `allowUrl` or `maxBytes`. Cache hits now check both, including every recorded redirect hop. Entries fetched without `allowUrl` have no recorded chain, so a later `allowUrl` only checks their entry URL.

--- a/.tegami/fetch-cache-policy.md
+++ b/.tegami/fetch-cache-policy.md
@@ -6,4 +6,4 @@ packages:
 
 ### Enforce fetch policies on shared image cache entries
 
-A shared `fetchCache` hit returned cached bytes without running the calling render's `allowUrl` or `maxBytes`. Cache hits now check both, including every recorded redirect hop. Entries fetched without `allowUrl` have no recorded chain, so a later `allowUrl` only checks their entry URL.
+A shared `fetchCache` hit returned cached bytes without running the calling render's `allowUrl` or `maxBytes`. Cache hits now recheck both. `allowUrl` runs against the entry URL only, not the redirect hops the original fetch followed.

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -168,7 +168,8 @@ function extractImageUrls(node: Node): string[] {
 /**
  * A cache of image fetches keyed by URL. Sharing one across renders deduplicates concurrent
  * requests for the same URL (single-flight) and reuses their bytes. Any object with `Map`-like
- * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in.
+ * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in. Cache hits still run the
+ * calling render's `allowUrl` and `maxBytes` against the shared bytes.
  */
 export interface ImageFetchCache {
   get(url: string): Promise<ArrayBuffer> | undefined;
@@ -176,26 +177,62 @@ export interface ImageFetchCache {
   delete(url: string): unknown;
 }
 
+/** Redirect chains of entries fetched under an `allowUrl` policy, keyed by cache promise. */
+const entryHops = new WeakMap<Promise<ArrayBuffer>, string[]>();
+
 /** Fetches a URL's bytes, coalescing concurrent requests for the same URL through `cache`. A
- * rejected fetch is evicted so a later call can retry instead of replaying the failure. */
+ * rejected fetch is evicted so a later call can retry instead of replaying the failure.
+ *
+ * A cache hit re-runs the current call's `allowUrl` and `maxBytes` instead of trusting the
+ * creator's. Entries fetched without `allowUrl` have no recorded redirect chain, so a later
+ * `allowUrl` only checks the entry URL for them. */
 function fetchImageData(
   url: string,
   options: FetchOptions,
   fetchCache?: ImageFetchCache,
 ): Promise<ArrayBuffer> {
+  const maxBytes = options.maxBytes ?? defaultMaxFetchBytes;
+  const { allowUrl } = options;
+
   const cached = fetchCache?.get(url);
   if (cached) {
-    return cached;
+    return cached.then((data) => {
+      if (allowUrl) {
+        const blocked = (entryHops.get(cached) ?? [url]).find((hop) => !allowUrl(hop));
+        if (blocked) {
+          throw new Error(`URL blocked by allowUrl policy: ${blocked}`);
+        }
+      }
+
+      if (data.byteLength > maxBytes) {
+        throw new Error(`Response exceeds ${maxBytes} bytes`);
+      }
+      return data;
+    });
   }
 
-  const promise = fetchOk(url, options)
-    .then((response) => readBodyLimited(response, options.maxBytes ?? defaultMaxFetchBytes))
+  const hops: string[] = [];
+  const fetchOptions: FetchOptions = allowUrl
+    ? {
+        ...options,
+        allowUrl: (checked) => {
+          hops.push(checked);
+          return allowUrl(checked);
+        },
+      }
+    : options;
+
+  const promise = fetchOk(url, fetchOptions)
+    .then((response) => readBodyLimited(response, maxBytes))
     .catch((error) => {
       fetchCache?.delete(url);
       throw error;
     });
 
   fetchCache?.set(url, promise);
+  if (allowUrl) {
+    entryHops.set(promise, hops);
+  }
   return promise;
 }
 

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -168,8 +168,7 @@ function extractImageUrls(node: Node): string[] {
 /**
  * A cache of image fetches keyed by URL. Sharing one across renders deduplicates concurrent
  * requests for the same URL (single-flight) and reuses their bytes. Any object with `Map`-like
- * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in. Cache hits still run the
- * calling render's `allowUrl` and `maxBytes` against the shared bytes.
+ * `get`/`set`/`delete` works, so LRU/TTL policies can be plugged in.
  */
 export interface ImageFetchCache {
   get(url: string): Promise<ArrayBuffer> | undefined;
@@ -177,15 +176,9 @@ export interface ImageFetchCache {
   delete(url: string): unknown;
 }
 
-/** Redirect chains of entries fetched under an `allowUrl` policy, keyed by cache promise. */
-const entryHops = new WeakMap<Promise<ArrayBuffer>, string[]>();
-
 /** Fetches a URL's bytes, coalescing concurrent requests for the same URL through `cache`. A
- * rejected fetch is evicted so a later call can retry instead of replaying the failure.
- *
- * A cache hit re-runs the current call's `allowUrl` and `maxBytes` instead of trusting the
- * creator's. Entries fetched without `allowUrl` have no recorded redirect chain, so a later
- * `allowUrl` only checks the entry URL for them. */
+ * rejected fetch is evicted so a later call can retry instead of replaying the failure. A cache
+ * hit rechecks the caller's `allowUrl` (entry URL only, not redirect hops) and `maxBytes`. */
 function fetchImageData(
   url: string,
   options: FetchOptions,
@@ -197,11 +190,8 @@ function fetchImageData(
   const cached = fetchCache?.get(url);
   if (cached) {
     return cached.then((data) => {
-      if (allowUrl) {
-        const blocked = (entryHops.get(cached) ?? [url]).find((hop) => !allowUrl(hop));
-        if (blocked) {
-          throw new Error(`URL blocked by allowUrl policy: ${blocked}`);
-        }
+      if (allowUrl && !allowUrl(url)) {
+        throw new Error(`URL blocked by allowUrl policy: ${url}`);
       }
 
       if (data.byteLength > maxBytes) {
@@ -211,18 +201,7 @@ function fetchImageData(
     });
   }
 
-  const hops: string[] = [];
-  const fetchOptions: FetchOptions = allowUrl
-    ? {
-        ...options,
-        allowUrl: (checked) => {
-          hops.push(checked);
-          return allowUrl(checked);
-        },
-      }
-    : options;
-
-  const promise = fetchOk(url, fetchOptions)
+  const promise = fetchOk(url, options)
     .then((response) => readBodyLimited(response, maxBytes))
     .catch((error) => {
       fetchCache?.delete(url);
@@ -230,9 +209,6 @@ function fetchImageData(
     });
 
   fetchCache?.set(url, promise);
-  if (allowUrl) {
-    entryHops.set(promise, hops);
-  }
   return promise;
 }
 

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -153,6 +153,94 @@ describe("allowUrl policy", () => {
   });
 });
 
+describe("shared fetchCache policy enforcement", () => {
+  test("a cache hit re-runs a stricter maxBytes and keeps the entry reusable", async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(new Uint8Array(60)))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://example.com/cached.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 100 });
+
+    await expect(
+      prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 50 }),
+    ).rejects.toThrow(/exceeds 50 bytes/);
+
+    const images = await prepareImages({ node, fetchCache, fetch: fetchMock, maxBytes: 100 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(images.map((image) => image.data.byteLength)).toEqual([60]);
+  });
+
+  test("a cache hit re-runs a stricter allowUrl and keeps the entry reusable", async () => {
+    const payload = new TextEncoder().encode("pixels");
+    const fetchMock = mock(() => Promise.resolve(new Response(streamOf(payload))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://allowed.example.com/cached.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
+
+    await expect(
+      prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => false }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+
+    const images = await prepareImages({
+      node,
+      fetchCache,
+      fetch: fetchMock,
+      allowUrl: () => true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
+  });
+
+  test("a cache hit rechecks every recorded redirect hop", async () => {
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(
+        url === "https://allowed.example.com/a.png"
+          ? new Response(null, {
+              status: 302,
+              headers: { location: "http://169.254.169.254/meta" },
+            })
+          : new Response(new Uint8Array(8)),
+      ),
+    );
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("https://allowed.example.com/a.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await expect(
+      prepareImages({
+        node,
+        fetchCache,
+        fetch: fetchMock,
+        allowUrl: (url) => new URL(url).hostname === "allowed.example.com",
+      }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("an entry fetched without allowUrl is still checked against its entry url", async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(new Uint8Array(8))));
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const node = tree("http://169.254.169.254/meta.png");
+
+    await prepareImages({ node, fetchCache, fetch: fetchMock });
+
+    await expect(
+      prepareImages({
+        node,
+        fetchCache,
+        fetch: fetchMock,
+        allowUrl: (url) => new URL(url).hostname === "allowed.example.com",
+      }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("default fetch timeout", () => {
   test("fontFromUrl rejects a hanging host within the timeout", async () => {
     const fetchMock = mock(

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -194,34 +194,6 @@ describe("shared fetchCache policy enforcement", () => {
     expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
   });
 
-  test("a cache hit rechecks every recorded redirect hop", async () => {
-    const fetchMock = mock((url: string) =>
-      Promise.resolve(
-        url === "https://allowed.example.com/a.png"
-          ? new Response(null, {
-              status: 302,
-              headers: { location: "http://169.254.169.254/meta" },
-            })
-          : new Response(new Uint8Array(8)),
-      ),
-    );
-    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
-    const node = tree("https://allowed.example.com/a.png");
-
-    await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    await expect(
-      prepareImages({
-        node,
-        fetchCache,
-        fetch: fetchMock,
-        allowUrl: (url) => new URL(url).hostname === "allowed.example.com",
-      }),
-    ).rejects.toThrow(/blocked by allowUrl/);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
   test("an entry fetched without allowUrl is still checked against its entry url", async () => {
     const fetchMock = mock(() => Promise.resolve(new Response(new Uint8Array(8))));
     const fetchCache = new Map<string, Promise<ArrayBuffer>>();


### PR DESCRIPTION
Fixes #1390

## Why
A shared `fetchCache` hit returned bytes without running the calling render's `allowUrl` or `maxBytes`, so bytes fetched under one policy could serve a render whose policy forbids them.

## What
Cache hits now re-run the current call's `allowUrl` against the entry URL and re-check `maxBytes` against the resolved bytes; a policy rejection never evicts the entry. Redirect hops the original fetch followed are not rechecked — that is documented on `fetchImageData`.