### PR TITLE
Docs: support the variables option in the playground

### DIFF
--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -20,9 +20,9 @@ const INPUT = `@layer theme, base, utilities;
 @layer base{*,::after,::before,::backdrop,::file-selector-button{box-sizing:border-box;border:0 solid}}
 @import "tailwindcss/utilities.css" layer(utilities);`;
 
-// Mirrors the binding's `variables_stylesheet`: the `--` prefix is optional,
+// Mirrors the binding's `css_variables_stylesheet`: the `--` prefix is optional,
 // and an entry that would escape the `:root` rule is dropped.
-function variableDeclarations(variables: Record<string, string> | undefined) {
+function cssVariableDeclarations(variables: Record<string, string> | undefined) {
   return Object.entries(variables ?? {})
     .map(([name, value]): [string, string] => [name.startsWith("--") ? name : `--${name}`, value])
     .filter(
@@ -211,7 +211,7 @@ export default function BrowserPreview({
   height,
   padding,
   cssContents,
-  variables,
+  cssVariables,
 }: {
   html: string | undefined;
   width?: number;
@@ -219,7 +219,7 @@ export default function BrowserPreview({
   height?: number;
   padding?: string;
   cssContents?: string[];
-  variables?: Record<string, string>;
+  cssVariables?: Record<string, string>;
 }) {
   const { ref, scale } = useFitScale(width, height);
   const [paint, setPaint] = useState<Paint>();
@@ -229,7 +229,7 @@ export default function BrowserPreview({
     if (!html) return;
 
     let cancelled = false;
-    const declarations = variableDeclarations(variables);
+    const declarations = cssVariableDeclarations(cssVariables);
 
     // The unlayered `:root` sheet comes after everything the compiler built, the
     // position the binding gives it, so a variable overriding a builtin token
@@ -253,7 +253,7 @@ export default function BrowserPreview({
     return () => {
       cancelled = true;
     };
-  }, [html, cssContents, variables, height, padding]);
+  }, [html, cssContents, cssVariables, height, padding]);
 
   // `border-0` overrides the border an iframe carries by default, which paints
   // a light ring around the preview.

--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -20,18 +20,40 @@ const INPUT = `@layer theme, base, utilities;
 @layer base{*,::after,::before,::backdrop,::file-selector-button{box-sizing:border-box;border:0 solid}}
 @import "tailwindcss/utilities.css" layer(utilities);`;
 
-// Cache the resolved compiler so a remount (e.g. mobile tab switch) can paint
-// the frame without flashing through an async load.
-let compiler: { build(candidates: string[]): string } | undefined;
-let compilerPromise: Promise<void> | undefined;
-function loadCompiler() {
-  compilerPromise ??= compile(INPUT, {
-    base: "/",
-    loadStylesheet: async (id, base) => ({ path: id, base, content: SOURCES[id] ?? "" }),
-  }).then((c) => {
-    compiler = c;
-  });
-  return compilerPromise;
+// Mirrors the binding's `variables_stylesheet`: the `--` prefix is optional,
+// and an entry that would escape the `:root` rule is dropped.
+function variableDeclarations(variables: Record<string, string> | undefined) {
+  return Object.entries(variables ?? {})
+    .map(([name, value]): [string, string] => [name.startsWith("--") ? name : `--${name}`, value])
+    .filter(
+      ([name, value]) =>
+        !/[:;{}]/.test(name) &&
+        !/[;{}]/.test(value) &&
+        !value.includes("/*") &&
+        !value.toLowerCase().includes("!important"),
+    )
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `${name}:${value};`)
+    .join("");
+}
+
+// One compiler per variables set: `@theme` is what lets a custom token like
+// `bg-brand` compile at all. Cached so a remount (e.g. mobile tab switch) can
+// paint the frame without flashing through a fresh compile.
+const compilers = new Map<string, Promise<{ build(candidates: string[]): string }>>();
+function loadCompiler(declarations: string): Promise<{ build(candidates: string[]): string }> {
+  let promise = compilers.get(declarations);
+  if (!promise) {
+    const input = declarations ? `${INPUT}\n@theme{${declarations}}` : INPUT;
+    promise = compile(input, {
+      base: "/",
+      loadStylesheet: async (id, base) => ({ path: id, base, content: SOURCES[id] ?? "" }),
+    });
+    // Variables the theme parser rejects should not blank the preview.
+    if (declarations) promise = promise.catch(() => loadCompiler(""));
+    compilers.set(declarations, promise);
+  }
+  return promise;
 }
 
 // Mirror the worker's font stack so the pane routes text to the same faces: one
@@ -189,6 +211,7 @@ export default function BrowserPreview({
   height,
   padding,
   cssContents,
+  variables,
 }: {
   html: string | undefined;
   width?: number;
@@ -196,6 +219,7 @@ export default function BrowserPreview({
   height?: number;
   padding?: string;
   cssContents?: string[];
+  variables?: Record<string, string>;
 }) {
   const { ref, scale } = useFitScale(width, height);
   const [paint, setPaint] = useState<Paint>();
@@ -205,27 +229,31 @@ export default function BrowserPreview({
     if (!html) return;
 
     let cancelled = false;
-    const build = () => {
-      if (cancelled || !compiler) return;
+    const declarations = variableDeclarations(variables);
+
+    // The unlayered `:root` sheet comes after everything the compiler built, the
+    // position the binding gives it, so a variable overriding a builtin token
+    // (`--color-red-500`) wins in the pane the way it wins in the render.
+    void loadCompiler(declarations).then((compiler) => {
+      if (cancelled) return;
 
       setPaint({
         type: "paint",
-        css: [ROOT_CSS, compiler.build(extractClasses(html)), ...(cssContents ?? [])].join("\n\n"),
+        css: [
+          ROOT_CSS,
+          compiler.build(extractClasses(html)),
+          ...(cssContents ?? []),
+          ...(declarations ? [`:root{${declarations}}`] : []),
+        ].join("\n\n"),
         html,
         mountStyle: `display:flex;width:100%;height:${height ? "100%" : "auto"};padding:${padding ?? "0"}`,
       });
-    };
-
-    if (compiler) {
-      build();
-    } else {
-      void loadCompiler().then(build);
-    }
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [html, cssContents, height, padding]);
+  }, [html, cssContents, variables, height, padding]);
 
   // `border-0` overrides the border an iframe carries by default, which paints
   // a light ring around the preview.

--- a/docs/app/components/playground/playground.tsx
+++ b/docs/app/components/playground/playground.tsx
@@ -164,7 +164,7 @@ export default function Playground() {
         height={browserPreview?.height}
         padding={browserPreview?.padding}
         cssContents={browserPreview?.cssContents}
-        variables={browserPreview?.variables}
+        cssVariables={browserPreview?.cssVariables}
       />
     </Suspense>
   );

--- a/docs/app/components/playground/playground.tsx
+++ b/docs/app/components/playground/playground.tsx
@@ -164,6 +164,7 @@ export default function Playground() {
         height={browserPreview?.height}
         padding={browserPreview?.padding}
         cssContents={browserPreview?.cssContents}
+        variables={browserPreview?.variables}
       />
     </Suspense>
   );

--- a/docs/app/components/playground/use-render-worker.ts
+++ b/docs/app/components/playground/use-render-worker.ts
@@ -17,6 +17,7 @@ export type BrowserPreviewData = {
   height?: number;
   padding?: string;
   cssContents?: string[];
+  variables?: Record<string, string>;
 };
 
 function isBlobUrl(url: string | undefined): url is string {
@@ -36,9 +37,18 @@ const LIVENESS_TIMEOUT_MS = 2_000;
 /** Bounds what the worker can hand the page to hold, forged or not, in UTF-16 code units. */
 const MAX_PREVIEW_LENGTH = 4 * 1024 * 1024;
 
-function previewLength(message: { html: string; cssContents?: string[] }) {
+function previewLength(message: {
+  html: string;
+  cssContents?: string[];
+  variables?: Record<string, string>;
+}) {
   return (
-    message.html.length + (message.cssContents ?? []).reduce((sum, css) => sum + css.length, 0)
+    message.html.length +
+    (message.cssContents ?? []).reduce((sum, css) => sum + css.length, 0) +
+    Object.entries(message.variables ?? {}).reduce(
+      (sum, [name, value]) => sum + name.length + value.length,
+      0,
+    )
   );
 }
 
@@ -88,6 +98,7 @@ export function useRenderWorker(ranCode: string | undefined) {
               height: message.height,
               padding: message.padding,
               cssContents: message.cssContents,
+              variables: message.variables,
             });
           }
           break;

--- a/docs/app/components/playground/use-render-worker.ts
+++ b/docs/app/components/playground/use-render-worker.ts
@@ -17,7 +17,7 @@ export type BrowserPreviewData = {
   height?: number;
   padding?: string;
   cssContents?: string[];
-  variables?: Record<string, string>;
+  cssVariables?: Record<string, string>;
 };
 
 function isBlobUrl(url: string | undefined): url is string {
@@ -40,12 +40,12 @@ const MAX_PREVIEW_LENGTH = 4 * 1024 * 1024;
 function previewLength(message: {
   html: string;
   cssContents?: string[];
-  variables?: Record<string, string>;
+  cssVariables?: Record<string, string>;
 }) {
   return (
     message.html.length +
     (message.cssContents ?? []).reduce((sum, css) => sum + css.length, 0) +
-    Object.entries(message.variables ?? {}).reduce(
+    Object.entries(message.cssVariables ?? {}).reduce(
       (sum, [name, value]) => sum + name.length + value.length,
       0,
     )
@@ -98,7 +98,7 @@ export function useRenderWorker(ranCode: string | undefined) {
               height: message.height,
               padding: message.padding,
               cssContents: message.cssContents,
-              variables: message.variables,
+              cssVariables: message.cssVariables,
             });
           }
           break;

--- a/docs/app/playground/options.ts
+++ b/docs/app/playground/options.ts
@@ -42,9 +42,9 @@ declare global {
      */
     stylesheets?: string[];
     /**
-     * @description theme variables set on `:root`. `{ "--color-brand": "#7c3aed" }` makes `bg-brand` resolve; the `--` prefix is optional.
+     * @description theme cssVariables set on `:root`. `{ "--color-brand": "#7c3aed" }` makes `bg-brand` resolve; the `--` prefix is optional.
      */
-    variables?: Record<string, string>;
+    cssVariables?: Record<string, string>;
     /**
      * @description structured keyframes registered alongside the stylesheets.
      */

--- a/docs/app/playground/options.ts
+++ b/docs/app/playground/options.ts
@@ -42,6 +42,10 @@ declare global {
      */
     stylesheets?: string[];
     /**
+     * @description theme variables set on `:root`. `{ "--color-brand": "#7c3aed" }` makes `bg-brand` resolve; the `--` prefix is optional.
+     */
+    variables?: Record<string, string>;
+    /**
      * @description structured keyframes registered alongside the stylesheets.
      */
     keyframes?: Keyframes;

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -10,6 +10,7 @@ export const optionsSchema = z.object({
   format: z.optional(z.enum(["png", "jpeg", "webp"])),
   devicePixelRatio: z.optional(z.number().check(z.positive(), z.minimum(0.1), z.maximum(10.0))),
   stylesheets: z.optional(z.array(z.string())),
+  variables: z.optional(z.record(z.string(), z.string())),
   keyframes: z.optional(z.custom<Keyframes>()),
   animation: z.optional(
     z.object({
@@ -84,6 +85,7 @@ const previewResultSchema = z.object({
   /** CSS `padding` shorthand mirroring the PDF page margin. */
   padding: z.optional(z.string()),
   cssContents: z.optional(z.array(z.string())),
+  variables: z.optional(z.record(z.string(), z.string())),
 });
 
 export const messageSchema = z.discriminatedUnion("type", [

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -10,7 +10,7 @@ export const optionsSchema = z.object({
   format: z.optional(z.enum(["png", "jpeg", "webp"])),
   devicePixelRatio: z.optional(z.number().check(z.positive(), z.minimum(0.1), z.maximum(10.0))),
   stylesheets: z.optional(z.array(z.string())),
-  variables: z.optional(z.record(z.string(), z.string())),
+  cssVariables: z.optional(z.record(z.string(), z.string())),
   keyframes: z.optional(z.custom<Keyframes>()),
   animation: z.optional(
     z.object({
@@ -85,7 +85,7 @@ const previewResultSchema = z.object({
   /** CSS `padding` shorthand mirroring the PDF page margin. */
   padding: z.optional(z.string()),
   cssContents: z.optional(z.array(z.string())),
-  variables: z.optional(z.record(z.string(), z.string())),
+  cssVariables: z.optional(z.record(z.string(), z.string())),
 });
 
 export const messageSchema = z.discriminatedUnion("type", [

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -131,7 +131,13 @@ async function renderOutput({
     const pdf = await loadPdfRenderer();
 
     return {
-      buffer: await pdf.render(node, { ...options.pdf, stylesheets, images, fonts }),
+      buffer: await pdf.render(node, {
+        variables: options.variables,
+        ...options.pdf,
+        stylesheets,
+        images,
+        fonts,
+      }),
       kind: "pdf",
       format: "pdf",
     };
@@ -150,6 +156,7 @@ async function renderOutput({
         quality: options.quality,
         devicePixelRatio: options.devicePixelRatio,
         keyframes: options.keyframes,
+        variables: options.variables,
         images,
         fonts,
         stylesheets,
@@ -186,6 +193,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
       cssContents: options.keyframes
         ? [...effectiveStylesheets, keyframesToCss(options.keyframes)]
         : effectiveStylesheets,
+      variables: options.variables,
     });
   }
 

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -132,7 +132,7 @@ async function renderOutput({
 
     return {
       buffer: await pdf.render(node, {
-        variables: options.variables,
+        cssVariables: options.cssVariables,
         ...options.pdf,
         stylesheets,
         images,
@@ -156,7 +156,7 @@ async function renderOutput({
         quality: options.quality,
         devicePixelRatio: options.devicePixelRatio,
         keyframes: options.keyframes,
-        variables: options.variables,
+        cssVariables: options.cssVariables,
         images,
         fonts,
         stylesheets,
@@ -193,7 +193,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
       cssContents: options.keyframes
         ? [...effectiveStylesheets, keyframesToCss(options.keyframes)]
         : effectiveStylesheets,
-      variables: options.variables,
+      cssVariables: options.cssVariables,
     });
   }
 


### PR DESCRIPTION
## Why
The playground had no way to pass the new `cssVariables` option. The browser pane's Tailwind compiler also cannot emit a class for an unknown token like `bg-brand`.

## What
The worker forwards `cssVariables` to every backend and into the preview message. The pane compiles its Tailwind with an `@theme` block and appends the same unlayered `:root` sheet the binding synthesizes, so both sides resolve identical tokens.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring CSS variables in playground previews.
  - CSS variables now apply consistently across browser previews, PDF output, animations, and rendered results.
  - Custom variables can be defined with or without the `--` prefix.
  - Preview rendering validates variable names and values and preserves them in results.
  - Custom variables are integrated with theme styling and custom CSS output.
- **Bug Fixes**
  - Improved preview updates when CSS variable settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

