### PR TITLE
Docs: theme the playground templates with variables

### DIFF
--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -22,7 +22,7 @@ export const templates: Template[] = [
   {
     id: "welcome",
     name: "Welcome",
-    description: "Edit the code, press Run — the palette lives in options.cssVariables",
+    description: "Edit the code, press Run. The palette lives in options.cssVariables",
     kind: "image",
     code: welcome,
   },

--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -22,7 +22,7 @@ export const templates: Template[] = [
   {
     id: "welcome",
     name: "Welcome",
-    description: "Edit the code, press Run — the palette lives in options.variables",
+    description: "Edit the code, press Run — the palette lives in options.cssVariables",
     kind: "image",
     code: welcome,
   },

--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -22,7 +22,7 @@ export const templates: Template[] = [
   {
     id: "welcome",
     name: "Welcome",
-    description: "Edit the code, press Run, watch it render",
+    description: "Edit the code, press Run — the palette lives in options.variables",
     kind: "image",
     code: welcome,
   },
@@ -36,14 +36,14 @@ export const templates: Template[] = [
   {
     id: "twitter-profile-card",
     name: "Profile card",
-    description: "Remote avatar, rounded borders, stats row",
+    description: "One accent variable skins the border, handle and avatar ring",
     kind: "image",
     code: twitterProfileCard,
   },
   {
     id: "article-cover",
     name: "Article cover",
-    description: "Blog header with a gradient background and a byline",
+    description: "Blog header with a gradient background, themed by a brand scale",
     kind: "image",
     code: articleCover,
   },

--- a/docs/app/playground/templates/article-cover.tsx
+++ b/docs/app/playground/templates/article-cover.tsx
@@ -1,25 +1,25 @@
 export default function ArticleCover() {
   return (
-    <div tw="flex h-full w-full flex-col justify-between bg-linear-to-br from-zinc-900 to-black p-14 text-zinc-100">
+    <div tw="flex h-full w-full flex-col justify-between bg-linear-to-br from-night-900 to-night-950 p-14 text-night-100">
       <div tw="flex items-center">
-        <span tw="rounded-full bg-indigo-500/15 px-5 py-2 text-xl font-bold tracking-widest text-indigo-300 uppercase">
+        <span tw="rounded-full bg-brand-500/15 px-5 py-2 text-xl font-bold tracking-widest text-brand-300 uppercase">
           Engineering
         </span>
-        <span tw="ml-6 text-2xl text-zinc-500">Oct 24, 2026 · 8 min read</span>
+        <span tw="ml-6 text-2xl text-night-500">Oct 24, 2026 · 8 min read</span>
       </div>
 
       <h1 tw="m-0 text-7xl font-black leading-none tracking-tighter">
-        Building a renderer <span tw="text-indigo-400">without a browser</span>
+        Building a renderer <span tw="text-brand-400">without a browser</span>
       </h1>
 
       <div tw="flex items-center">
         <img
           src="https://avatars.githubusercontent.com/u/10137?v=4"
           alt=""
-          tw="h-16 w-16 rounded-xl"
+          tw="h-16 w-16 rounded-xl border-2 border-brand-500/40"
         />
         <div tw="ml-5 flex flex-col">
-          <span tw="text-lg text-zinc-400">Published by</span>
+          <span tw="text-lg text-night-500">Published by</span>
           <span tw="text-2xl font-bold">The Engineering Team</span>
         </div>
       </div>
@@ -27,8 +27,18 @@ export default function ArticleCover() {
   );
 }
 
+// Swap this block for a teal or amber scale and the whole cover re-skins.
 export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
+  variables: {
+    "--color-brand-300": "#c4b5fd",
+    "--color-brand-400": "#a78bfa",
+    "--color-brand-500": "#7c3aed",
+    "--color-night-100": "#f4f4f5",
+    "--color-night-500": "#71717b",
+    "--color-night-900": "#1c1825",
+    "--color-night-950": "#0e0c14",
+  },
 };

--- a/docs/app/playground/templates/article-cover.tsx
+++ b/docs/app/playground/templates/article-cover.tsx
@@ -32,7 +32,7 @@ export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
-  variables: {
+  cssVariables: {
     "--color-brand-300": "#c4b5fd",
     "--color-brand-400": "#a78bfa",
     "--color-brand-500": "#7c3aed",

--- a/docs/app/playground/templates/article-cover.tsx
+++ b/docs/app/playground/templates/article-cover.tsx
@@ -27,7 +27,6 @@ export default function ArticleCover() {
   );
 }
 
-// Swap this block for a teal or amber scale and the whole cover re-skins.
 export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,

--- a/docs/app/playground/templates/gradient-poster.tsx
+++ b/docs/app/playground/templates/gradient-poster.tsx
@@ -26,7 +26,7 @@ export const options: PlaygroundOptions = {
   width: 1080,
   height: 1080,
   format: "png",
-  variables: {
+  cssVariables: {
     "--color-dawn": "#ff6b6b",
     "--color-dusk": "#556270",
     "--color-noon": "#ffd93d",

--- a/docs/app/playground/templates/gradient-poster.tsx
+++ b/docs/app/playground/templates/gradient-poster.tsx
@@ -21,7 +21,6 @@ export default function Poster() {
   );
 }
 
-// The inline `var()` calls read the same tokens tw classes would.
 export const options: PlaygroundOptions = {
   width: 1080,
   height: 1080,

--- a/docs/app/playground/templates/gradient-poster.tsx
+++ b/docs/app/playground/templates/gradient-poster.tsx
@@ -2,7 +2,10 @@ export default function Poster() {
   return (
     <div
       tw="flex h-full w-full items-center justify-center"
-      style={{ backgroundImage: "conic-gradient(from 210deg, #ff6b6b, #556270, #ffd93d, #ff6b6b)" }}
+      style={{
+        backgroundImage:
+          "conic-gradient(from 210deg, var(--color-dawn), var(--color-dusk), var(--color-noon), var(--color-dawn))",
+      }}
     >
       <div
         tw="flex h-[560px] w-[560px] flex-col items-center justify-center rounded-full bg-white/10 text-white"
@@ -18,8 +21,14 @@ export default function Poster() {
   );
 }
 
+// The inline `var()` calls read the same tokens tw classes would.
 export const options: PlaygroundOptions = {
   width: 1080,
   height: 1080,
   format: "png",
+  variables: {
+    "--color-dawn": "#ff6b6b",
+    "--color-dusk": "#556270",
+    "--color-noon": "#ffd93d",
+  },
 };

--- a/docs/app/playground/templates/multilingual.tsx
+++ b/docs/app/playground/templates/multilingual.tsx
@@ -48,7 +48,7 @@ export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
-  variables: {
+  cssVariables: {
     "--color-canvas": "#0b1020",
     "--color-subtle": "#94a3b8",
     "--color-coral": "#fb7185",

--- a/docs/app/playground/templates/multilingual.tsx
+++ b/docs/app/playground/templates/multilingual.tsx
@@ -1,3 +1,5 @@
+const accents = ["coral", "honey", "mint", "sky"];
+
 const greetings = [
   { lang: "en", label: "English", text: "Hello, world" },
   { lang: "zh-Hant", label: "繁體中文", text: "你好,世界" },
@@ -11,28 +13,32 @@ const greetings = [
 
 export default function Multilingual() {
   return (
-    <div tw="flex h-full w-full flex-col bg-[#0b1020] p-16 text-white">
+    <div tw="flex h-full w-full flex-col bg-canvas p-16 text-white">
       <h1 tw="m-0 text-5xl font-bold tracking-tight">One font stack, every script 🌏</h1>
-      <p tw="mt-3 mb-10 text-2xl text-[#94a3b8]">
+      <p tw="mt-3 mb-10 text-2xl text-subtle">
         Each line picks the face that covers it, and Arabic and Hebrew lay out right to left.
       </p>
 
       <div tw="flex flex-wrap">
-        {greetings.map((greeting) => (
-          <div
-            key={greeting.lang}
-            tw="mr-4 mb-4 flex w-[330px] flex-col rounded-2xl bg-white/5 px-6 py-4"
-          >
-            <span tw="text-lg text-[#64748b]">{greeting.label}</span>
-            <span
-              lang={greeting.lang}
-              dir={greeting.rtl ? "rtl" : undefined}
-              tw="mt-1 text-4xl font-semibold"
+        {greetings.map((greeting, index) => {
+          const accent = accents[index % accents.length];
+
+          return (
+            <div
+              key={greeting.lang}
+              tw={`mr-4 mb-4 flex w-[330px] flex-col rounded-2xl border-l-4 border-${accent} bg-white/5 px-6 py-4`}
             >
-              {greeting.text}
-            </span>
-          </div>
-        ))}
+              <span tw={`text-lg text-${accent}`}>{greeting.label}</span>
+              <span
+                lang={greeting.lang}
+                dir={greeting.rtl ? "rtl" : undefined}
+                tw="mt-1 text-4xl font-semibold"
+              >
+                {greeting.text}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -42,4 +48,12 @@ export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
+  variables: {
+    "--color-canvas": "#0b1020",
+    "--color-subtle": "#94a3b8",
+    "--color-coral": "#fb7185",
+    "--color-honey": "#fbbf24",
+    "--color-mint": "#34d399",
+    "--color-sky": "#38bdf8",
+  },
 };

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -36,42 +36,44 @@ const days = Array.from({ length: 90 }, (_, index) => ({
 
 export default function Report() {
   return (
-    <div tw="flex w-full flex-col text-[#1f2430]">
+    <div tw="flex w-full flex-col text-ink">
       <h1 tw="m-0 text-3xl font-semibold">Rendering report</h1>
-      <p tw="mt-2 mb-0 text-xs text-[#6b7280]">Q1 2026 · 匠 Werkstatt</p>
+      <p tw="mt-2 mb-0 text-xs text-faint">
+        Q1 2026 · <span tw="text-brand">匠 Werkstatt</span>
+      </p>
 
       {sections.map((section) => (
         <div key={section.title} tw="mt-8 flex flex-col">
-          <h2 lang={section.lang} tw="m-0 text-lg font-semibold">
+          <h2 lang={section.lang} tw="m-0 border-l-4 border-brand pl-3 text-lg font-semibold">
             {section.title}
           </h2>
           <p
             lang={section.lang}
             dir={section.rtl ? "rtl" : undefined}
-            tw="mt-2 mb-0 text-sm leading-6 text-[#374151]"
+            tw="mt-2 mb-0 text-sm leading-6 text-body"
           >
             {section.body}
           </p>
         </div>
       ))}
 
-      <h2 tw="mt-8 mb-0 text-lg font-semibold">Daily measurements</h2>
+      <h2 tw="mt-8 mb-0 border-l-4 border-brand pl-3 text-lg font-semibold">Daily measurements</h2>
       <table tw="mt-3 w-full text-xs">
         <thead>
-          <tr tw="text-[11px] font-semibold text-[#6b7280]">
-            <th tw="border-b border-[#e5e7eb] pb-2 text-left">Day</th>
-            <th tw="w-[110px] border-b border-[#e5e7eb] pb-2 text-right">Median (ms)</th>
-            <th tw="w-[110px] border-b border-[#e5e7eb] pb-2 text-right">p95 (ms)</th>
-            <th tw="w-[110px] border-b border-[#e5e7eb] pb-2 text-right">Size (KB)</th>
+          <tr tw="text-[11px] font-semibold text-faint">
+            <th tw="border-b-2 border-brand/40 pb-2 text-left">Day</th>
+            <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">Median (ms)</th>
+            <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">p95 (ms)</th>
+            <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">Size (KB)</th>
           </tr>
         </thead>
         <tbody>
           {days.map((row) => (
             <tr key={row.day}>
               <td tw="pt-2">{row.day}</td>
-              <td tw="pt-2 text-right text-[#374151]">{row.median}</td>
-              <td tw="pt-2 text-right text-[#374151]">{row.p95}</td>
-              <td tw="pt-2 text-right text-[#374151]">{row.size.toFixed(1)}</td>
+              <td tw="pt-2 text-right text-body">{row.median}</td>
+              <td tw="pt-2 text-right text-body">{row.p95}</td>
+              <td tw="pt-2 text-right text-body">{row.size.toFixed(1)}</td>
             </tr>
           ))}
         </tbody>
@@ -81,26 +83,32 @@ export default function Report() {
 }
 
 export const options: PlaygroundOptions = {
+  // Set on the render, the tokens reach the header and footer bands too.
+  variables: {
+    "--color-brand": "#0d9488",
+    "--color-ink": "#1f2430",
+    "--color-body": "#374151",
+    "--color-faint": "#6b7280",
+    "--color-hairline": "#e5e7eb",
+  },
   pdf: {
     size: "a4",
     margin: { right: 56, left: 56 },
     header: (
       <div tw="flex w-full flex-col px-14 py-6">
         <div tw="flex w-full items-end justify-between">
-          <span tw="text-lg font-semibold text-[#1f2430]">匠 Werkstatt</span>
-          <span tw="text-[10px] text-[#9ca3af]">Rendering report · Q1 2026</span>
+          <span tw="text-lg font-semibold text-ink">匠 Werkstatt</span>
+          <span tw="text-[10px] text-faint">Rendering report · Q1 2026</span>
         </div>
-        <div tw="mt-3 flex h-[3px] w-full bg-[#1f2430]" />
-        <span tw="mt-2 text-[10px] text-[#9ca3af]">Prepared for the platform team</span>
+        <div tw="mt-3 flex h-[3px] w-full bg-brand" />
+        <span tw="mt-2 text-[10px] text-faint">Prepared for the platform team</span>
       </div>
     ),
     footer: (
       <div tw="flex w-full flex-col items-center pb-6">
-        <div tw="mb-2 flex h-[1px] w-[420px] bg-[#e5e7eb]" />
-        <span tw="text-[10px] text-[#9ca3af]">
-          匠 Werkstatt · Kawagoe, Saitama · werkstatt.example
-        </span>
-        <span tw="mt-1 text-[10px] text-[#9ca3af]">
+        <div tw="mb-2 flex h-[1px] w-[420px] bg-hairline" />
+        <span tw="text-[10px] text-faint">匠 Werkstatt · Kawagoe, Saitama · werkstatt.example</span>
+        <span tw="mt-1 text-[10px] text-faint">
           第 <PageNumber format="trad-chinese-informal" /> 頁,共{" "}
           <TotalPages format="trad-chinese-informal" /> 頁
         </span>

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -84,7 +84,7 @@ export default function Report() {
 
 export const options: PlaygroundOptions = {
   // Set on the render, the tokens reach the header and footer bands too.
-  variables: {
+  cssVariables: {
     "--color-brand": "#0d9488",
     "--color-ink": "#1f2430",
     "--color-body": "#374151",

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -83,7 +83,6 @@ export default function Report() {
 }
 
 export const options: PlaygroundOptions = {
-  // Set on the render, the tokens reach the header and footer bands too.
   cssVariables: {
     "--color-brand": "#0d9488",
     "--color-ink": "#1f2430",

--- a/docs/app/playground/templates/twitter-profile-card.tsx
+++ b/docs/app/playground/templates/twitter-profile-card.tsx
@@ -39,7 +39,7 @@ export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
-  variables: {
+  cssVariables: {
     "--color-accent": "#2dd4bf",
     "--color-surface": "#0f172b",
     "--color-bright": "#f8fafc",

--- a/docs/app/playground/templates/twitter-profile-card.tsx
+++ b/docs/app/playground/templates/twitter-profile-card.tsx
@@ -34,7 +34,6 @@ export default function Profile() {
   );
 }
 
-// One accent token re-skins the border, the handle and the avatar ring together.
 export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,

--- a/docs/app/playground/templates/twitter-profile-card.tsx
+++ b/docs/app/playground/templates/twitter-profile-card.tsx
@@ -5,27 +5,27 @@ const stats = [
 
 export default function Profile() {
   return (
-    <div tw="flex h-full w-full flex-col border-t-8 border-t-blue-500 bg-slate-900 px-16 py-12 text-white">
+    <div tw="flex h-full w-full flex-col border-t-8 border-t-accent bg-surface px-16 py-12 text-bright">
       <div tw="flex items-center">
         <img
           src="https://avatars.githubusercontent.com/u/1024025"
           alt=""
-          tw="h-32 w-32 rounded-full border-4 border-slate-700"
+          tw="h-32 w-32 rounded-full border-4 border-accent/40"
         />
         <div tw="ml-8 flex flex-col">
           <span tw="text-5xl font-bold">Linus Torvalds</span>
-          <span tw="mt-2 text-3xl text-slate-400">@torvalds</span>
+          <span tw="mt-2 text-3xl text-accent">@torvalds</span>
         </div>
       </div>
 
-      <p tw="mt-8 mb-0 max-w-[820px] text-4xl leading-tight text-slate-200">
+      <p tw="mt-8 mb-0 max-w-[820px] text-4xl leading-tight text-body">
         Wrote Linux in 1991 and Git in 2005. Still reviews patches on the mailing list.
       </p>
 
       <div tw="mt-auto flex text-3xl">
         {stats.map((stat) => (
-          <div key={stat.label} tw="mr-12 flex text-slate-400">
-            <strong tw="mr-3 font-bold text-white">{stat.value}</strong>
+          <div key={stat.label} tw="mr-12 flex text-dim">
+            <strong tw="mr-3 font-bold text-bright">{stat.value}</strong>
             {stat.label}
           </div>
         ))}
@@ -34,8 +34,16 @@ export default function Profile() {
   );
 }
 
+// One accent token re-skins the border, the handle and the avatar ring together.
 export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
+  variables: {
+    "--color-accent": "#2dd4bf",
+    "--color-surface": "#0f172b",
+    "--color-bright": "#f8fafc",
+    "--color-body": "#e2e8f0",
+    "--color-dim": "#90a1b9",
+  },
 };

--- a/docs/app/playground/templates/welcome.tsx
+++ b/docs/app/playground/templates/welcome.tsx
@@ -17,7 +17,7 @@ export default function Welcome() {
       <h1 tw="m-0 mt-2 text-8xl font-bold leading-none tracking-tighter text-coral">Press Run.</h1>
       <p tw="mt-10 mb-0 text-3xl leading-snug text-faded">
         The exported options decide what comes out: an image, an animation, or a PDF. The colours
-        here come from <span tw="text-honey">options.variables</span> — rename a token and every
+        here come from <span tw="text-honey">options.cssVariables</span> — rename a token and every
         class reading it follows.
       </p>
     </div>
@@ -28,7 +28,7 @@ export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
-  variables: {
+  cssVariables: {
     "--color-ink": "#16130f",
     "--color-paper": "#fdfaf4",
     "--color-faded": "#a8a29a",

--- a/docs/app/playground/templates/welcome.tsx
+++ b/docs/app/playground/templates/welcome.tsx
@@ -17,8 +17,8 @@ export default function Welcome() {
       <h1 tw="m-0 mt-2 text-8xl font-bold leading-none tracking-tighter text-coral">Press Run.</h1>
       <p tw="mt-10 mb-0 text-3xl leading-snug text-faded">
         The exported options decide what comes out: an image, an animation, or a PDF. The colours
-        here come from <span tw="text-honey">options.cssVariables</span> — rename a token and every
-        class reading it follows.
+        come from <span tw="text-honey">options.cssVariables</span>. Rename a token and every class
+        reading it follows.
       </p>
     </div>
   );

--- a/docs/app/playground/templates/welcome.tsx
+++ b/docs/app/playground/templates/welcome.tsx
@@ -1,12 +1,24 @@
+const swatches = ["bg-coral", "bg-honey", "bg-mint", "bg-sky"];
+
 export default function Welcome() {
   return (
-    <div tw="flex h-full w-full flex-col justify-end bg-[#16130f] p-20">
-      <h1 tw="m-0 text-8xl font-bold leading-none tracking-tighter text-white">Edit the code.</h1>
-      <h1 tw="m-0 mt-2 text-8xl font-bold leading-none tracking-tighter text-[#ff4d4d]">
-        Press Run.
+    <div tw="flex h-full w-full flex-col justify-end bg-ink p-20">
+      <div tw="flex">
+        {swatches.map((swatch, index) => (
+          <div
+            key={swatch}
+            tw={`h-6 w-${24 - index * 6} rounded-full ${swatch} ${index ? "ml-3" : ""}`}
+          />
+        ))}
+      </div>
+      <h1 tw="m-0 mt-10 text-8xl font-bold leading-none tracking-tighter text-paper">
+        Edit the code.
       </h1>
-      <p tw="mt-10 mb-0 text-3xl text-[#a8a29a]">
-        The exported options decide what comes out: an image, an animation, or a PDF.
+      <h1 tw="m-0 mt-2 text-8xl font-bold leading-none tracking-tighter text-coral">Press Run.</h1>
+      <p tw="mt-10 mb-0 text-3xl leading-snug text-faded">
+        The exported options decide what comes out: an image, an animation, or a PDF. The colours
+        here come from <span tw="text-honey">options.variables</span> — rename a token and every
+        class reading it follows.
       </p>
     </div>
   );
@@ -16,4 +28,13 @@ export const options: PlaygroundOptions = {
   width: 1200,
   height: 630,
   format: "png",
+  variables: {
+    "--color-ink": "#16130f",
+    "--color-paper": "#fdfaf4",
+    "--color-faded": "#a8a29a",
+    "--color-coral": "#ff4d4d",
+    "--color-honey": "#fbbf24",
+    "--color-mint": "#34d399",
+    "--color-sky": "#38bdf8",
+  },
 };


### PR DESCRIPTION
## Why
Every template spelled its colours as hex literals, so none of them showed what the new `cssVariables` option does.

## What
Six templates now define their palette in `options.cssVariables`, covering custom tw tokens, opacity modifiers, inline `var()` gradient stops, and a PDF whose header and footer bands read the same tokens.

## Screenshots

| Welcome | Every script |
| --- | --- |
| ![Welcome template with a token palette](https://github.com/user-attachments/assets/6833498a-2acf-45bd-92c8-17a6dd545eac) | ![Multilingual cards with cycling accents](https://github.com/user-attachments/assets/f133bd0c-fc81-4c24-a159-b75d59e08c1a) |

| Profile card | Article cover |
| --- | --- |
| ![Profile card with a teal accent token](https://github.com/user-attachments/assets/ea8fe1b3-3d93-4df0-8c13-2b6f9b6cb36f) | ![Article cover with a violet brand scale](https://github.com/user-attachments/assets/e1de32e1-c41d-4565-8f7a-0faee8ebad4d) |

| Gradient poster |
| --- |
| ![Poster with var() gradient stops](https://github.com/user-attachments/assets/9657f5b5-3ab5-4f84-bfb6-8bddbfc13fbe) |

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable color themes to playground templates through reusable color settings.
  * Refreshed the Welcome, Profile Card, Article Cover, Gradient Poster, Multilingual, Report, and social profile examples with updated palettes, accents, gradients, borders, and highlights.
  * Added color swatches and clearer customization descriptions.
  * Improved visual consistency across template elements, including labels, headings, avatars, and table cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


