### PR TITLE
Helpers: enforce policies on cached font CSS

### DIFF
--- a/.tegami/fetch-cache-policy.md
+++ b/.tegami/fetch-cache-policy.md
@@ -7,3 +7,5 @@ packages:
 ### Enforce fetch policies on shared image cache entries
 
 A shared `fetchCache` hit returned cached bytes without running the calling render's `allowUrl` or `maxBytes`. Cache hits now recheck both. `allowUrl` runs against the entry URL only, not the redirect hops the original fetch followed.
+
+Google Fonts CSS cache hits now apply the current caller's `allowUrl` and `maxBytes`. Policy rejection keeps the shared entry available.

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -72,7 +72,8 @@ export type GoogleFontsOptions = FetchOptions & {
    * Cache for the Google Fonts CSS, keyed by request URL, so the metadata is fetched once across
    * renders (e.g. a playground re-rendering on each edit). Holds the in-flight promise, so
    * concurrent calls share one request; failures evict themselves. Defaults to a process-wide
-   * cache; pass your own `Map` to scope it, or a fresh one per call to opt out.
+   * cache; pass your own `Map` to scope it, or a fresh one per call to opt out. Cache hits recheck
+   * the current caller's `allowUrl` and `maxBytes` policies.
    */
   cache?: Pick<Map<string, Promise<string>>, "get" | "set" | "delete">;
   /**
@@ -163,7 +164,18 @@ function fetchCssCached(url: string, options: GoogleFontsOptions) {
 
   const cached = cache.get(url);
   if (cached) {
-    return cached;
+    return cached.then((css) => {
+      if (options.allowUrl && !options.allowUrl(url)) {
+        throw new Error(`URL blocked by allowUrl policy: ${url}`);
+      }
+
+      const maxBytes = options.maxBytes ?? maxCssBytes;
+      const byteLength = new TextEncoder().encode(css).byteLength;
+      if (byteLength > maxBytes) {
+        throw new Error(`Response exceeds ${maxBytes} bytes`);
+      }
+      return css;
+    });
   }
 
   const pending = fetchCss(url, options);

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -309,7 +309,7 @@ describe("googleFonts", () => {
     const cache = new Map<string, Promise<string>>();
 
     await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
-    expect(
+    await expect(
       googleFonts({ families: ["Inter"], fetch: fetchMock, cache, allowUrl: () => false }),
     ).rejects.toThrow(/blocked by allowUrl/);
     await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
@@ -323,7 +323,7 @@ describe("googleFonts", () => {
     const cache = new Map<string, Promise<string>>();
 
     await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
-    expect(
+    await expect(
       googleFonts({ families: ["Inter"], fetch: fetchMock, cache, maxBytes: 1 }),
     ).rejects.toThrow("Response exceeds 1 bytes");
     await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
@@ -348,9 +348,10 @@ describe("googleFonts", () => {
     const families = ["Policy Cache Test"];
 
     await googleFonts({ families, fetch: fetchMock });
-    expect(googleFonts({ families, fetch: fetchMock, allowUrl: () => false })).rejects.toThrow(
-      /blocked by allowUrl/,
-    );
+    await expect(
+      googleFonts({ families, fetch: fetchMock, allowUrl: () => false }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    await expect(googleFonts({ families, fetch: fetchMock })).resolves.toBeDefined();
 
     const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
     expect(cssCalls).toHaveLength(1);

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -304,12 +304,53 @@ describe("googleFonts", () => {
     expect(cssCalls).toHaveLength(1);
   });
 
+  test("a CSS cache hit rechecks allowUrl and keeps the entry reusable", async () => {
+    const fetchMock = mockInter();
+    const cache = new Map<string, Promise<string>>();
+
+    await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
+    expect(
+      googleFonts({ families: ["Inter"], fetch: fetchMock, cache, allowUrl: () => false }),
+    ).rejects.toThrow(/blocked by allowUrl/);
+    await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
+
+    const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
+    expect(cssCalls).toHaveLength(1);
+  });
+
+  test("a CSS cache hit rechecks maxBytes and keeps the entry reusable", async () => {
+    const fetchMock = mockInter();
+    const cache = new Map<string, Promise<string>>();
+
+    await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
+    expect(
+      googleFonts({ families: ["Inter"], fetch: fetchMock, cache, maxBytes: 1 }),
+    ).rejects.toThrow("Response exceeds 1 bytes");
+    await googleFonts({ families: ["Inter"], fetch: fetchMock, cache });
+
+    const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
+    expect(cssCalls).toHaveLength(1);
+  });
+
   test("caches CSS process-wide when no cache is passed", async () => {
     const fetchMock = mockInter();
 
     // A unique family so no other test has warmed the shared default cache for its URL.
     await googleFonts({ families: ["Roboto Flex"], fetch: fetchMock });
     await googleFonts({ families: ["Roboto Flex"], fetch: fetchMock });
+
+    const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
+    expect(cssCalls).toHaveLength(1);
+  });
+
+  test("the process-wide CSS cache rechecks allowUrl", async () => {
+    const fetchMock = mockInter();
+    const families = ["Policy Cache Test"];
+
+    await googleFonts({ families, fetch: fetchMock });
+    expect(googleFonts({ families, fetch: fetchMock, allowUrl: () => false })).rejects.toThrow(
+      /blocked by allowUrl/,
+    );
 
     const cssCalls = fetchMock.mock.calls.filter(([url]) => (url as string).includes("/css2"));
     expect(cssCalls).toHaveLength(1);


### PR DESCRIPTION
Fixes #1402

## Why

A Google Fonts CSS cache hit skipped the current caller policies.
The process-wide cache could reuse CSS across different policy scopes.

## What

Cache hits now recheck `allowUrl` against the CSS request URL.
They also recheck `maxBytes` against the cached CSS UTF-8 size.
Policy rejection keeps the shared cache entry available.

The tests cover custom caches and the process-wide default cache.

## Validation

- `bun test takumi-helpers/tests` — 168 passed
- `bun run lint` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached Google Fonts CSS now respects the current request’s URL permissions and response-size limits.
  * Blocked or oversized cached responses are rejected without affecting reusable cache entries.
  * Cache hits continue to avoid unnecessary network requests.

* **Tests**
  * Added coverage for policy checks on cached font responses and cache reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->