### PR TITLE
Core: name tw variable internals after CSS variables

### DIFF
--- a/takumi-core/src/style/properties/aspect_ratio.rs
+++ b/takumi-core/src/style/properties/aspect_ratio.rs
@@ -59,7 +59,7 @@ impl Animatable for AspectRatio {
 impl TailwindPropertyParser for AspectRatio {
   const NAMESPACES: &'static [Namespace] = &[Namespace::Aspect];
 
-  /// `square` is a static ratio upstream, `video` a theme token whose built-in
+  /// `square` is a static ratio upstream, `video` a variable token whose built-in
   /// value this stands in for.
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -785,7 +785,7 @@ macro_rules! define_style {
         CustomProperty(String, String),
         /// A property value that must be resolved after `var()` substitution.
         Deferred(DeferredDeclaration),
-        /// A theme variable with the built-in utility scale as its fallback.
+        /// A CSS variable with the built-in utility scale as its fallback.
         VarRef(TwVarRef),
         /// A CSS-wide keyword targeting a longhand property.
         CssWideKeyword(LonghandId, CssWideKeyword),

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -32,7 +32,7 @@ macro_rules! property_parsers {
     }
 
     impl PropertyParser {
-      /// The theme namespaces this candidate's value type reads.
+      /// The variable namespaces this candidate's value type reads.
       pub fn namespaces(&self) -> &'static [Namespace] {
         match self {
           $(Self::$variant(..) => parser_namespaces!($parse $(, $($namespace),+)?),)+
@@ -85,7 +85,7 @@ property_parsers! {
   TextWrap(TextWrap) => TextWrap,
   ColorCurrent(ColorInput) => ColorInput,
   ColorTransparent(ColorInput) => ColorInput,
-  StopColor(TwThemeColor) => TwThemeColor,
+  StopColor(TwVarColor) => TwVarColor,
   Percentage(PercentageNumber) => PercentageNumber,
   FontFamily(FontFamily) => FontFamily,
   LineClamp(LineClamp) => LineClamp,
@@ -113,7 +113,7 @@ property_parsers! {
 /// has no built-in value to expand, so this is the only place its target is
 /// written down; a prefix reading two namespaces emits one variable per group,
 /// and the undefined ones leave their longhands unset.
-pub(crate) static THEME_TARGETS: phf::Map<&str, &[(Namespace, &[LonghandId])]> = phf_map! {
+pub(crate) static VAR_TARGETS: phf::Map<&str, &[(Namespace, &[LonghandId])]> = phf_map! {
   "aspect" => &[(Namespace::Aspect, &[LonghandId::AspectRatio])],
   "basis" => &[(Namespace::Spacing, &[LonghandId::FlexBasis])],
   "bg" => &[(Namespace::Color, &[LonghandId::BackgroundColor])],

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -17,7 +17,7 @@ use smallvec::SmallVec;
 use crate::{
   style::{
     tw::{
-      map::{FIXED_PROPERTIES, PREFIX_PARSERS, THEME_TARGETS},
+      map::{FIXED_PROPERTIES, PREFIX_PARSERS, VAR_TARGETS},
       parser::*,
     },
     *,
@@ -429,7 +429,7 @@ pub(crate) enum TailwindProperty {
   /// `box-shadow` property.
   Shadow(BoxShadow),
   /// `box-shadow` color override.
-  ShadowColor(TwThemeColor),
+  ShadowColor(TwVarColor),
   /// `display` property.
   Display(Display),
   /// `list-style-type` property.
@@ -665,7 +665,7 @@ pub(crate) enum TailwindProperty {
   /// `text-shadow` property.
   TextShadow(TextShadow),
   /// `text-shadow` color override.
-  TextShadowColor(TwThemeColor),
+  TextShadowColor(TwVarColor),
   /// `box-shadow` layer set.
   ShadowList(&'static [BoxShadow]),
   /// `text-shadow` layer set.
@@ -689,35 +689,35 @@ pub(crate) enum TailwindProperty {
   /// `bg-conic` property.
   BgConicAngle(Angle),
   /// `from` property.
-  GradientFrom(TwThemeColor),
+  GradientFrom(TwVarColor),
   /// `to` property.
-  GradientTo(TwThemeColor),
+  GradientTo(TwVarColor),
   /// `via` property.
-  GradientVia(TwThemeColor),
+  GradientVia(TwVarColor),
   /// Gradient `from` stop position.
   GradientFromPosition(Length),
   /// Gradient `via` stop position.
   GradientViaPosition(Length),
   /// Gradient `to` stop position.
   GradientToPosition(Length),
-  /// A theme variable standing in for the built-in value it falls back to.
+  /// A CSS variable standing in for the built-in value it falls back to.
   /// Tailwind compiles a utility to `var(--color-red-500)`, not to the colour.
-  ThemeVar(ThemeVar),
+  VarUtility(VarUtility),
 }
 
 /// A utility resolved from custom properties: one [`TwVarRef`] declaration per
 /// longhand it writes.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ThemeVar {
+pub(crate) struct VarUtility {
   targets: SmallVec<[StyleDeclaration; 2]>,
 }
 
-impl ThemeVar {
+impl VarUtility {
   /// One declaration per longhand, sharing the variable the prefix reads.
   /// `text-lg` spells its line height in a companion variable, so one token can
   /// set the size without dragging the leading with it.
   /// `None` when a declaration has no single longhand to defer (it composes
-  /// through custom properties instead), leaving the utility unthemed.
+  /// through custom properties instead), leaving the utility on its built-in value.
   fn from_builtin(
     name: &Arc<str>,
     expression: &Arc<str>,
@@ -787,7 +787,7 @@ fn companion_variable(name: &str, longhand: LonghandId) -> Option<Arc<str>> {
 /// The `var()` expression a utility suffix reads, or `None` when the value is
 /// spelled in the class itself. Numeric spacing multiplies the `--spacing` step
 /// the way Tailwind's own `calc(var(--spacing) * 4)` does.
-fn theme_expression(
+fn var_expression(
   namespaces: &[Namespace],
   suffix: &str,
   negative: bool,
@@ -923,7 +923,7 @@ pub(crate) trait TailwindPropertyParser: Sized + for<'i> FromCss<'i> {
     Self::from_css_str(token).ok()
   }
 
-  /// Theme namespaces this value type reads, tried in order. The utility keeps
+  /// Variable namespaces this value type reads, tried in order. The utility keeps
   /// the built-in value as the fallback behind `var()`, so this only decides
   /// which variable name the utility reads.
   const NAMESPACES: &'static [Namespace] = &[];
@@ -1038,22 +1038,22 @@ impl TailwindProperty {
           property
         };
 
-        if let Some((name, expression)) = theme_expression(parser.namespaces(), suffix, negative)
-          && let Some(theme_var) =
-            ThemeVar::from_builtin(&name, &expression, property.clone().expand_targets())
+        if let Some((name, expression)) = var_expression(parser.namespaces(), suffix, negative)
+          && let Some(var_utility) =
+            VarUtility::from_builtin(&name, &expression, property.clone().expand_targets())
         {
-          return Some(TailwindProperty::ThemeVar(theme_var));
+          return Some(TailwindProperty::VarUtility(var_utility));
         }
 
         return Some(property);
       }
 
       // No built-in value, but the prefix still names what the utility writes.
-      if let Some(groups) = THEME_TARGETS.get(prefix) {
+      if let Some(groups) = VAR_TARGETS.get(prefix) {
         let targets: SmallVec<[StyleDeclaration; 2]> = groups
           .iter()
           .filter_map(|(namespace, longhands)| {
-            let (name, expression) = theme_expression(&[*namespace], suffix, negative)?;
+            let (name, expression) = var_expression(&[*namespace], suffix, negative)?;
 
             Some(
               longhands
@@ -1065,7 +1065,7 @@ impl TailwindProperty {
           .collect();
 
         if !targets.is_empty() {
-          return Some(TailwindProperty::ThemeVar(ThemeVar { targets }));
+          return Some(TailwindProperty::VarUtility(VarUtility { targets }));
         }
       }
     }
@@ -1076,8 +1076,8 @@ impl TailwindProperty {
   #[inline(never)]
   fn apply(self, builder: &mut TailwindDeclarationBuilder, important: bool) {
     match self {
-      TailwindProperty::ThemeVar(theme_var) => {
-        for target in theme_var.targets {
+      TailwindProperty::VarUtility(var_utility) => {
+        for target in var_utility.targets {
           builder.push(target, important);
         }
       }

--- a/takumi-core/src/style/tw/namespace.rs
+++ b/takumi-core/src/style/tw/namespace.rs
@@ -1,4 +1,4 @@
-/// A theme namespace, spelled as the CSS custom-property prefix it reads.
+/// A variable namespace, spelled as the CSS custom-property prefix it reads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Namespace {
   /// `--color-*`

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -274,13 +274,13 @@ impl TailwindPropertyParser for TwBlur {
   }
 }
 
-/// A theme-backed colour expression for gradient stops and shadow colours:
+/// A variable-backed colour expression for gradient stops and shadow colours:
 /// `var(--color-*)`, with the built-in colour as the fallback when the token
 /// names one. `current` and `transparent` stay plain keywords.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct TwThemeColor(pub Arc<str>);
+pub(crate) struct TwVarColor(pub Arc<str>);
 
-impl<'i> FromCss<'i> for TwThemeColor {
+impl<'i> FromCss<'i> for TwVarColor {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
     let color = ColorInput::from_css(input)?;
     let mut css = String::new();
@@ -292,7 +292,7 @@ impl<'i> FromCss<'i> for TwThemeColor {
   const VALID_TOKENS: &'static [CssToken] = ColorInput::VALID_TOKENS;
 }
 
-impl TailwindPropertyParser for TwThemeColor {
+impl TailwindPropertyParser for TwVarColor {
   fn parse_tw(token: &str) -> Option<Self> {
     let (base, modifier) = match token.split_once('/') {
       Some((base, modifier)) => (base, Some(modifier)),

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -7,7 +7,7 @@ use crate::style::{ComputedStyle, LonghandId, Style, properties::BackgroundImage
 /// what these assertions are about.
 fn parse_property(token: &str) -> Option<Vec<StyleDeclaration>> {
   Some(match TailwindProperty::parse(token)? {
-    TailwindProperty::ThemeVar(theme_var) => theme_var.builtin_declarations(),
+    TailwindProperty::VarUtility(var_utility) => var_utility.builtin_declarations(),
     property => expand(property),
   })
 }
@@ -26,7 +26,7 @@ fn parse_value(token: &str) -> Option<(Vec<StyleDeclaration>, Option<Breakpoint>
 
   Some((
     match value.property {
-      TailwindProperty::ThemeVar(theme_var) => theme_var.builtin_declarations(),
+      TailwindProperty::VarUtility(var_utility) => var_utility.builtin_declarations(),
       property => expand(property),
     },
     value.breakpoint,
@@ -76,11 +76,11 @@ fn test_parse_red_500_color_utilities() {
   let cases: &[(&str, TailwindProperty)] = &[
     (
       "shadow-red-500",
-      TailwindProperty::ShadowColor(TwThemeColor::parse_tw("red-500").expect("palette colour")),
+      TailwindProperty::ShadowColor(TwVarColor::parse_tw("red-500").expect("palette colour")),
     ),
     (
       "text-shadow-red-500",
-      TailwindProperty::TextShadowColor(TwThemeColor::parse_tw("red-500").expect("palette colour")),
+      TailwindProperty::TextShadowColor(TwVarColor::parse_tw("red-500").expect("palette colour")),
     ),
     (
       "decoration-red-500",
@@ -569,7 +569,7 @@ fn test_values_sorting() {
     .iter()
     .map(|value| {
       let declarations = match &value.property {
-        TailwindProperty::ThemeVar(theme_var) => theme_var.builtin_declarations(),
+        TailwindProperty::VarUtility(var_utility) => var_utility.builtin_declarations(),
         property => expand(property.clone()),
       };
 
@@ -1165,7 +1165,7 @@ fn root_with(variables: &[(&str, &str)]) -> ComputedStyle {
 
 /// Logical sides resolve to a physical one at apply time, after substitution.
 #[test]
-fn test_logical_side_reads_a_theme_variable() {
+fn test_logical_side_reads_a_css_variable() {
   let values =
     TailwindValues::from_str("ms-gutter ps-gutter").expect("tailwind values should parse");
   let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
@@ -1177,7 +1177,7 @@ fn test_logical_side_reads_a_theme_variable() {
 }
 
 #[test]
-fn test_corner_radius_reads_a_theme_variable() {
+fn test_corner_radius_reads_a_css_variable() {
   let values = TailwindValues::from_str("rounded-t-card").expect("tailwind values should parse");
   let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
 
@@ -1250,11 +1250,11 @@ fn test_aspect_keywords_survive_the_move_out_of_the_fixed_table() {
 
   let square = Style::from(square.into_declaration_block(Viewport::new((100, 100))))
     .inherit(&ComputedStyle::default());
-  let themed = Style::from(video.into_declaration_block(Viewport::new((100, 100))))
+  let styled = Style::from(video.into_declaration_block(Viewport::new((100, 100))))
     .inherit(&root_with(&[("--aspect-video", "4/3")]));
 
   assert_eq!(square.aspect_ratio, AspectRatio::Ratio(1.0));
-  assert_eq!(themed.aspect_ratio, AspectRatio::Ratio(4.0 / 3.0));
+  assert_eq!(styled.aspect_ratio, AspectRatio::Ratio(4.0 / 3.0));
 }
 
 /// A custom `--text-*` token spells its line height in the companion variable,
@@ -1312,7 +1312,7 @@ fn test_numeric_leading_scales_with_spacing() {
 }
 
 #[test]
-fn test_gradient_reads_theme_variables() {
+fn test_gradient_reads_css_variables() {
   let values = TailwindValues::from_str("bg-linear-to-r from-brand-500 to-red-500")
     .expect("tailwind values should parse");
   let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
@@ -1393,9 +1393,9 @@ fn test_gradient_state_does_not_inherit() {
 }
 
 /// The shadow colour utility overrides every layer through the variable it
-/// sets, and reads the theme like any colour utility.
+/// sets, and reads its variable like any colour utility.
 #[test]
-fn test_shadow_color_reads_theme_variables() {
+fn test_shadow_color_reads_css_variables() {
   let values =
     TailwindValues::from_str("shadow-md shadow-brand-500").expect("tailwind values should parse");
   let computed = Style::from(values.into_declaration_block(Viewport::new((100, 100))))


### PR DESCRIPTION
## Why
The tw internals called the CSS-variable machinery "theme" (`ThemeVar`, `THEME_TARGETS`, `theme_expression`), a Tailwind noun the engine has no concept for.

## What
Renames them after what they are (`VarUtility`, `VAR_TARGETS`, `var_expression`, `TwVarColor`) and rewords the docs. Behavior and goldens are untouched.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified terminology throughout styling documentation, replacing “theme” references with “variable” or “CSS variable.”

* **Refactor**
  * Renamed internal variable-resolution concepts to use consistent CSS variable terminology.
  * Updated color, gradient, shadow, and text-shadow handling to use the revised variable-based naming.

* **Tests**
  * Updated styling tests and expectations to reflect the revised terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->