### PR TITLE
Helpers: flatten nested palettes into cssVariables

### DIFF
--- a/.tegami/css-variables-helper.md
+++ b/.tegami/css-variables-helper.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: minor
+---
+
+### Add the `cssVariables` helper
+
+Flattens a nested tree into the flat map the `cssVariables` option takes: `{ color: { brand: { 500: "#5b21b6" } } }` becomes `{ "--color-brand-500": "#5b21b6" }`.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -71,6 +71,15 @@ The generated rule comes after every stylesheet, so a media query at equal speci
 
 **Values containing `;`, `{`, `}`, `/*` or `!important` are dropped.** They could escape the generated rule.
 
+A nested palette flattens with the `cssVariables` helper. Keys join with `-` into one variable name.
+
+```tsx twoslash
+import { cssVariables } from "takumi-js/helpers";
+
+const flat = cssVariables({ color: { brand: { 500: "#5b21b6" } } });
+// { "--color-brand-500": "#5b21b6" }
+```
+
 ## Tailwind
 
 ### Bring your stylesheet

--- a/takumi-helpers/src/css-variables.ts
+++ b/takumi-helpers/src/css-variables.ts
@@ -1,0 +1,25 @@
+/** A nested tree of variable values; keys join with `-` into one variable name. */
+export type CssVariableTree = { [key: string]: string | number | CssVariableTree };
+
+/**
+ * Flattens a nested tree into the flat map the `cssVariables` option takes:
+ * `{ color: { brand: { 500: "#5b21b6" } } }` becomes `{ "--color-brand-500": "#5b21b6" }`.
+ */
+export function cssVariables(tree: CssVariableTree): Record<string, string> {
+  const flat: Record<string, string> = {};
+
+  flatten(tree, "-", flat);
+  return flat;
+}
+
+function flatten(tree: CssVariableTree, prefix: string, into: Record<string, string>) {
+  for (const [key, value] of Object.entries(tree)) {
+    const name = `${prefix}-${key}`;
+
+    if (typeof value === "object") {
+      flatten(value, name, into);
+    } else {
+      into[name] = String(value);
+    }
+  }
+}

--- a/takumi-helpers/src/css-variables.ts
+++ b/takumi-helpers/src/css-variables.ts
@@ -14,7 +14,8 @@ export function cssVariables(tree: CssVariableTree): Record<string, string> {
 
 function flatten(tree: CssVariableTree, prefix: string, into: Record<string, string>) {
   for (const [key, value] of Object.entries(tree)) {
-    const name = `${prefix}-${key}`;
+    // Tailwind v3 configs spell a scale's bare value as `DEFAULT`.
+    const name = key === "DEFAULT" ? prefix : `${prefix}-${key}`;
 
     if (typeof value === "object") {
       flatten(value, name, into);

--- a/takumi-helpers/src/css-variables.ts
+++ b/takumi-helpers/src/css-variables.ts
@@ -14,7 +14,10 @@ export function cssVariables(tree: CssVariableTree): Record<string, string> {
 
 function flatten(tree: CssVariableTree, prefix: string, into: Record<string, string>) {
   for (const [key, value] of Object.entries(tree)) {
-    // Tailwind v3 configs spell a scale's bare value as `DEFAULT`.
+    // Tailwind v3 configs spell a scale's bare value as `DEFAULT`. At the root
+    // there is no scale to name, so the entry is dropped.
+    if (key === "DEFAULT" && prefix === "-") continue;
+
     const name = key === "DEFAULT" ? prefix : `${prefix}-${key}`;
 
     if (typeof value === "object") {

--- a/takumi-helpers/src/index.ts
+++ b/takumi-helpers/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./css-variables";
 export * from "./fonts";
 export * from "./helpers";
 export * from "./types";

--- a/takumi-helpers/tests/css-variables.test.ts
+++ b/takumi-helpers/tests/css-variables.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { cssVariables } from "../src/css-variables";
+
+test("joins nested keys into one variable name", () => {
+  expect(cssVariables({ color: { brand: { 500: "#5b21b6" } }, spacing: "0.25rem" })).toEqual({
+    "--color-brand-500": "#5b21b6",
+    "--spacing": "0.25rem",
+  });
+});
+
+test("stringifies numeric leaves", () => {
+  expect(cssVariables({ leading: { tight: 1.25 } })).toEqual({ "--leading-tight": "1.25" });
+});

--- a/takumi-helpers/tests/css-variables.test.ts
+++ b/takumi-helpers/tests/css-variables.test.ts
@@ -15,6 +15,10 @@ test("DEFAULT names the parent scale", () => {
   });
 });
 
+test("a root-level DEFAULT names nothing and is dropped", () => {
+  expect(cssVariables({ DEFAULT: "#5b21b6" })).toEqual({});
+});
+
 test("stringifies numeric leaves", () => {
   expect(cssVariables({ leading: { tight: 1.25 } })).toEqual({ "--leading-tight": "1.25" });
 });

--- a/takumi-helpers/tests/css-variables.test.ts
+++ b/takumi-helpers/tests/css-variables.test.ts
@@ -8,6 +8,13 @@ test("joins nested keys into one variable name", () => {
   });
 });
 
+test("DEFAULT names the parent scale", () => {
+  expect(cssVariables({ color: { brand: { DEFAULT: "#5b21b6", 300: "#c4b5fd" } } })).toEqual({
+    "--color-brand": "#5b21b6",
+    "--color-brand-300": "#c4b5fd",
+  });
+});
+
 test("stringifies numeric leaves", () => {
   expect(cssVariables({ leading: { tight: 1.25 } })).toEqual({ "--leading-tight": "1.25" });
 });


### PR DESCRIPTION
## Why
`cssVariables` takes a flat map, while palettes are naturally nested and Tailwind v3 configs spell them that way.

## What
Adds a `cssVariables()` helper that joins nested keys with `-` and maps a v3 `DEFAULT` key onto the parent scale.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper for converting nested theme values into flat CSS custom properties.
  * Supports nested names, default values, and numeric values.

* **Documentation**
  * Added usage guidance for generating CSS variables from nested palettes.

* **Tests**
  * Added coverage for nested keys, default naming, and numeric value conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->