### PR TITLE
Core: resolve blur and drop-shadow presets through CSS variables

### DIFF
--- a/.tegami/tw-filter-shape-tokens.md
+++ b/.tegami/tw-filter-shape-tokens.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Resolve blur and drop-shadow presets through CSS variables
+
+`blur-md` now reads `var(--blur-md)` and `drop-shadow-md` reads `var(--drop-shadow-md)`, with the built-in shape as the fallback. Only the preset scale is themable; a token outside it stays unrecognized.

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -99,7 +99,7 @@ property_parsers! {
   Blur(TwBlur) => TwBlur,
   Filter(Filters) => Filters,
   BoxShadow(BoxShadow) => BoxShadow,
-  DropShadow(TextShadow) => TextShadow,
+  DropShadow(TwDropShadow) => TwDropShadow,
   TextShadow(TextShadow) => TextShadow,
   BlendMode(BlendMode) => BlendMode,
   FontStretch(FontStretch) => FontStretch,
@@ -392,6 +392,12 @@ const fn bs(inset: bool, oy: f32, blur: f32, spread: f32, alpha: u8) -> BoxShado
     color: ColorInput::Value(Color([0, 0, 0, alpha])),
   }
 }
+const fn dsp(token: &'static str, shadow: TextShadow) -> TwDropShadow {
+  TwDropShadow {
+    shadow,
+    token: Some(token),
+  }
+}
 const fn ts(oy: f32, blur: f32, alpha: u8) -> TextShadow {
   TextShadow {
     offset_x: Length::Px(0.0),
@@ -515,14 +521,14 @@ pub(crate) static FIXED_PROPERTIES: phf::Map<&str, TailwindProperty> = phf_map! 
   "backdrop-grayscale" => TailwindProperty::BackdropGrayscale(PercentageNumber(1.0)),
   "backdrop-invert" => TailwindProperty::BackdropInvert(PercentageNumber(1.0)),
   "backdrop-sepia" => TailwindProperty::BackdropSepia(PercentageNumber(1.0)),
-  "drop-shadow-xs" => TailwindProperty::DropShadow(ts(1.0, 1.0, 13)),
-  "drop-shadow-sm" => TailwindProperty::DropShadow(ts(1.0, 2.0, 38)),
-  "drop-shadow" => TailwindProperty::DropShadow(ts(1.0, 2.0, 26)),
-  "drop-shadow-md" => TailwindProperty::DropShadow(ts(3.0, 3.0, 31)),
-  "drop-shadow-lg" => TailwindProperty::DropShadow(ts(4.0, 4.0, 38)),
-  "drop-shadow-xl" => TailwindProperty::DropShadow(ts(9.0, 7.0, 26)),
-  "drop-shadow-2xl" => TailwindProperty::DropShadow(ts(25.0, 25.0, 38)),
-  "drop-shadow-none" => TailwindProperty::DropShadow(ts(0.0, 0.0, 0)),
+  "drop-shadow-xs" => TailwindProperty::DropShadow(dsp("xs", ts(1.0, 1.0, 13))),
+  "drop-shadow-sm" => TailwindProperty::DropShadow(dsp("sm", ts(1.0, 2.0, 38))),
+  "drop-shadow" => TailwindProperty::DropShadow(dsp("", ts(1.0, 2.0, 26))),
+  "drop-shadow-md" => TailwindProperty::DropShadow(dsp("md", ts(3.0, 3.0, 31))),
+  "drop-shadow-lg" => TailwindProperty::DropShadow(dsp("lg", ts(4.0, 4.0, 38))),
+  "drop-shadow-xl" => TailwindProperty::DropShadow(dsp("xl", ts(9.0, 7.0, 26))),
+  "drop-shadow-2xl" => TailwindProperty::DropShadow(dsp("2xl", ts(25.0, 25.0, 38))),
+  "drop-shadow-none" => TailwindProperty::DropShadow(TwDropShadow { shadow: ts(0.0, 0.0, 0), token: None }),
   // Inset shadows (--inset-shadow-*)
   "inset-shadow-2xs" => TailwindProperty::Shadow(bs(true, 1.0, 0.0, 0.0, 13)),
   "inset-shadow-xs" => TailwindProperty::Shadow(bs(true, 1.0, 1.0, 0.0, 13)),

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -57,7 +57,7 @@ fn push_tw_filter(
   important: bool,
   backdrop: bool,
   name: &str,
-  filter: &Filter,
+  value: &str,
 ) {
   let (prefix, longhand, chain) = match backdrop {
     false => ("--tw-", LonghandId::Filter, FILTER_CHAIN),
@@ -68,8 +68,33 @@ fn push_tw_filter(
     ),
   };
 
-  push_custom(builder, important, &format!("{prefix}{name}"), &css(filter));
+  push_custom(builder, important, &format!("{prefix}{name}"), value);
   push_deferred(builder, important, longhand, chain.to_owned());
+}
+
+/// `blur(var(--blur-md, 12px))` for a preset, `blur(2px)` for the rest, so a
+/// `--blur-*` variable re-shapes the preset the way Tailwind's theme does.
+fn blur_css(blur: &TwBlur) -> String {
+  match blur.token {
+    Some(token) => format!("blur(var(--blur-{token}, {}))", css(&blur.radius)),
+    None => css(&Filter::Blur(blur.radius)),
+  }
+}
+
+/// `drop-shadow(var(--drop-shadow-md, …))` for a preset; the bare `drop-shadow`
+/// utility reads `--drop-shadow` itself.
+fn drop_shadow_css(drop_shadow: &TwDropShadow) -> String {
+  match drop_shadow.token {
+    Some("") => format!(
+      "drop-shadow(var(--drop-shadow, {}))",
+      css(&drop_shadow.shadow)
+    ),
+    Some(token) => format!(
+      "drop-shadow(var(--drop-shadow-{token}, {}))",
+      css(&drop_shadow.shadow)
+    ),
+    None => css(&Filter::DropShadow(drop_shadow.shadow)),
+  }
 }
 
 /// One shadow layer with its colour behind `var()`, as Tailwind compiles it:
@@ -629,7 +654,7 @@ pub(crate) enum TailwindProperty {
   /// `filter: contrast()` property.
   Contrast(PercentageNumber),
   /// `filter: drop-shadow()` property.
-  DropShadow(TextShadow),
+  DropShadow(TwDropShadow),
   /// `filter: grayscale()` property.
   Grayscale(PercentageNumber),
   /// `filter: hue-rotate()` property.
@@ -1776,7 +1801,7 @@ impl TailwindProperty {
         )
       }
       TailwindProperty::Blur(tw_blur) => {
-        push_tw_filter(builder, important, false, "blur", &Filter::Blur(tw_blur.0));
+        push_tw_filter(builder, important, false, "blur", &blur_css(&tw_blur));
       }
       TailwindProperty::Brightness(percentage_number) => {
         push_tw_filter(
@@ -1784,7 +1809,7 @@ impl TailwindProperty {
           important,
           false,
           "brightness",
-          &Filter::Brightness(percentage_number),
+          &css(&Filter::Brightness(percentage_number)),
         );
       }
       TailwindProperty::Contrast(percentage_number) => {
@@ -1793,16 +1818,16 @@ impl TailwindProperty {
           important,
           false,
           "contrast",
-          &Filter::Contrast(percentage_number),
+          &css(&Filter::Contrast(percentage_number)),
         );
       }
-      TailwindProperty::DropShadow(text_shadow) => {
+      TailwindProperty::DropShadow(drop_shadow) => {
         push_tw_filter(
           builder,
           important,
           false,
           "drop-shadow",
-          &Filter::DropShadow(text_shadow),
+          &drop_shadow_css(&drop_shadow),
         );
       }
       TailwindProperty::Grayscale(percentage_number) => {
@@ -1811,7 +1836,7 @@ impl TailwindProperty {
           important,
           false,
           "grayscale",
-          &Filter::Grayscale(percentage_number),
+          &css(&Filter::Grayscale(percentage_number)),
         );
       }
       TailwindProperty::HueRotate(angle) => {
@@ -1820,7 +1845,7 @@ impl TailwindProperty {
           important,
           false,
           "hue-rotate",
-          &Filter::HueRotate(angle),
+          &css(&Filter::HueRotate(angle)),
         );
       }
       TailwindProperty::Invert(percentage_number) => {
@@ -1829,7 +1854,7 @@ impl TailwindProperty {
           important,
           false,
           "invert",
-          &Filter::Invert(percentage_number),
+          &css(&Filter::Invert(percentage_number)),
         );
       }
       TailwindProperty::Saturate(percentage_number) => {
@@ -1838,7 +1863,7 @@ impl TailwindProperty {
           important,
           false,
           "saturate",
-          &Filter::Saturate(percentage_number),
+          &css(&Filter::Saturate(percentage_number)),
         );
       }
       TailwindProperty::Sepia(percentage_number) => {
@@ -1847,7 +1872,7 @@ impl TailwindProperty {
           important,
           false,
           "sepia",
-          &Filter::Sepia(percentage_number),
+          &css(&Filter::Sepia(percentage_number)),
         );
       }
       TailwindProperty::Filter(filters) => {
@@ -1858,7 +1883,7 @@ impl TailwindProperty {
         }
       }
       TailwindProperty::BackdropBlur(tw_blur) => {
-        push_tw_filter(builder, important, true, "blur", &Filter::Blur(tw_blur.0));
+        push_tw_filter(builder, important, true, "blur", &blur_css(&tw_blur));
       }
       TailwindProperty::BackdropBrightness(percentage_number) => {
         push_tw_filter(
@@ -1866,7 +1891,7 @@ impl TailwindProperty {
           important,
           true,
           "brightness",
-          &Filter::Brightness(percentage_number),
+          &css(&Filter::Brightness(percentage_number)),
         );
       }
       TailwindProperty::BackdropContrast(percentage_number) => {
@@ -1875,7 +1900,7 @@ impl TailwindProperty {
           important,
           true,
           "contrast",
-          &Filter::Contrast(percentage_number),
+          &css(&Filter::Contrast(percentage_number)),
         );
       }
       TailwindProperty::BackdropGrayscale(percentage_number) => {
@@ -1884,7 +1909,7 @@ impl TailwindProperty {
           important,
           true,
           "grayscale",
-          &Filter::Grayscale(percentage_number),
+          &css(&Filter::Grayscale(percentage_number)),
         );
       }
       TailwindProperty::BackdropHueRotate(angle) => {
@@ -1893,7 +1918,7 @@ impl TailwindProperty {
           important,
           true,
           "hue-rotate",
-          &Filter::HueRotate(angle),
+          &css(&Filter::HueRotate(angle)),
         );
       }
       TailwindProperty::BackdropInvert(percentage_number) => {
@@ -1902,7 +1927,7 @@ impl TailwindProperty {
           important,
           true,
           "invert",
-          &Filter::Invert(percentage_number),
+          &css(&Filter::Invert(percentage_number)),
         );
       }
       TailwindProperty::BackdropOpacity(percentage_number) => {
@@ -1911,7 +1936,7 @@ impl TailwindProperty {
           important,
           true,
           "opacity",
-          &Filter::Opacity(percentage_number),
+          &css(&Filter::Opacity(percentage_number)),
         );
       }
       TailwindProperty::BackdropSaturate(percentage_number) => {
@@ -1920,7 +1945,7 @@ impl TailwindProperty {
           important,
           true,
           "saturate",
-          &Filter::Saturate(percentage_number),
+          &css(&Filter::Saturate(percentage_number)),
         );
       }
       TailwindProperty::BackdropSepia(percentage_number) => {
@@ -1929,7 +1954,7 @@ impl TailwindProperty {
           important,
           true,
           "sepia",
-          &Filter::Sepia(percentage_number),
+          &css(&Filter::Sepia(percentage_number)),
         );
       }
       TailwindProperty::BackdropFilter(filters) => {

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -243,16 +243,30 @@ impl TailwindPropertyParser for TwGradientPosition {
   }
 }
 
-/// Tailwind `blur-*` radius.
+/// Tailwind `blur-*` radius, themable through `--blur-*`.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct TwBlur(
+pub(crate) struct TwBlur {
   /// Blur radius.
-  pub Length,
-);
+  pub radius: Length,
+  /// Preset backing `var(--blur-<token>, radius)`; `None` for arbitrary values.
+  pub token: Option<&'static str>,
+}
+
+impl TwBlur {
+  const fn preset(token: &'static str, radius: f32) -> Self {
+    Self {
+      radius: Length::Px(radius),
+      token: Some(token),
+    }
+  }
+}
 
 impl<'i> FromCss<'i> for TwBlur {
   fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    Ok(TwBlur(Length::from_css(input)?))
+    Ok(TwBlur {
+      radius: Length::from_css(input)?,
+      token: None,
+    })
   }
 
   const VALID_TOKENS: &'static [CssToken] = Length::VALID_TOKENS;
@@ -261,16 +275,43 @@ impl<'i> FromCss<'i> for TwBlur {
 impl TailwindPropertyParser for TwBlur {
   fn parse_tw(token: &str) -> Option<Self> {
     match_ignore_ascii_case! {token,
-      "none" => Some(TwBlur(Length::Px(0.0))),
-      "xs" => Some(TwBlur(Length::Px(4.0))),
-      "sm" => Some(TwBlur(Length::Px(8.0))),
-      "md" => Some(TwBlur(Length::Px(12.0))),
-      "lg" => Some(TwBlur(Length::Px(16.0))),
-      "xl" => Some(TwBlur(Length::Px(24.0))),
-      "2xl" => Some(TwBlur(Length::Px(40.0))),
-      "3xl" => Some(TwBlur(Length::Px(64.0))),
+      "none" => Some(TwBlur { radius: Length::Px(0.0), token: None }),
+      "xs" => Some(TwBlur::preset("xs", 4.0)),
+      "sm" => Some(TwBlur::preset("sm", 8.0)),
+      "md" => Some(TwBlur::preset("md", 12.0)),
+      "lg" => Some(TwBlur::preset("lg", 16.0)),
+      "xl" => Some(TwBlur::preset("xl", 24.0)),
+      "2xl" => Some(TwBlur::preset("2xl", 40.0)),
+      "3xl" => Some(TwBlur::preset("3xl", 64.0)),
       _ => None,
     }
+  }
+}
+
+/// Tailwind `drop-shadow-*`, themable through `--drop-shadow-*`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct TwDropShadow {
+  /// The shadow the preset falls back to.
+  pub shadow: TextShadow,
+  /// Preset backing `var(--drop-shadow-<token>, shadow)`; `None` for
+  /// arbitrary values and `drop-shadow-none`, empty for bare `drop-shadow`.
+  pub token: Option<&'static str>,
+}
+
+impl<'i> FromCss<'i> for TwDropShadow {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    Ok(TwDropShadow {
+      shadow: TextShadow::from_css(input)?,
+      token: None,
+    })
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = TextShadow::VALID_TOKENS;
+}
+
+impl TailwindPropertyParser for TwDropShadow {
+  fn parse_tw(_token: &str) -> Option<Self> {
+    None
   }
 }
 

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -1186,6 +1186,55 @@ fn test_corner_radius_reads_a_css_variable() {
   assert_eq!(computed.border_top_left_radius.x, Length::Px(12.0));
 }
 
+#[test]
+fn test_blur_preset_reads_a_css_variable() {
+  use crate::style::properties::Filter;
+
+  let values =
+    TailwindValues::from_str("blur-md backdrop-blur-md").expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let computed = style.inherit(&root_with(&[("--blur-md", "20px")]));
+
+  assert_eq!(computed.filter, vec![Filter::Blur(Length::Px(20.0))]);
+  assert_eq!(
+    computed.backdrop_filter,
+    vec![Filter::Blur(Length::Px(20.0))]
+  );
+}
+
+#[test]
+fn test_blur_preset_falls_back_to_the_builtin_radius() {
+  use crate::style::properties::Filter;
+
+  let values = TailwindValues::from_str("blur-md").expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let computed = style.inherit(&ComputedStyle::default());
+
+  assert_eq!(computed.filter, vec![Filter::Blur(Length::Px(12.0))]);
+}
+
+#[test]
+fn test_drop_shadow_preset_reads_a_css_variable() {
+  use crate::style::properties::{Filter, TextShadow};
+
+  let values = TailwindValues::from_str("drop-shadow-md").expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let computed = style.inherit(&root_with(&[("--drop-shadow-md", "0 5px 5px #ff0000")]));
+
+  assert_eq!(
+    computed.filter,
+    vec![Filter::DropShadow(TextShadow {
+      offset_x: Length::Px(0.0),
+      offset_y: Length::Px(5.0),
+      blur_radius: Length::Px(5.0),
+      color: ColorInput::Value(Color::from_rgb(0xff0000)),
+    })]
+  );
+}
+
 /// The built-in scale has to stay reachable as a variable, not just as a value
 /// baked into the utility.
 #[test]


### PR DESCRIPTION
## Why
`blur-md` and `drop-shadow-md` baked their shapes into the utility, so `--blur-*` and `--drop-shadow-*` tokens did nothing.

## What
Presets now compile to `blur(var(--blur-md, 12px))` and `drop-shadow(var(--drop-shadow-md, …))`, with the built-in shape as the fallback. Tokens outside the preset scale stay unrecognized.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blur and drop-shadow presets now support theming through CSS variables.
  - `blur-md` and `drop-shadow-md` use built-in values as fallbacks when variables are unavailable.
  - Themed blur presets work consistently for regular and backdrop filters.

- **Bug Fixes**
  - Improved preservation and handling of preset values for drop-shadow utilities.

- **Tests**
  - Added coverage for themed presets and built-in fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->