### PR TITLE
Core: resolve animate utilities through CSS variables

### DIFF
--- a/.tegami/tw-animate-tokens.md
+++ b/.tegami/tw-animate-tokens.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Resolve `animate-*` through CSS variables
+
+`animate-spin` now reads `var(--animate-spin)` with the built-in animation as the fallback, and an unknown token like `animate-wiggle` reads `var(--animate-wiggle)` alone. Pair the variable with its `@keyframes` through `stylesheets` or the `keyframes` option.

--- a/takumi-core/src/style/tw/map.rs
+++ b/takumi-core/src/style/tw/map.rs
@@ -105,7 +105,7 @@ property_parsers! {
   FontStretch(FontStretch) => FontStretch,
   VerticalAlign(VerticalAlign) => VerticalAlign,
   DecorationThickness(TextDecorationThickness) => TextDecorationThickness,
-  Animation(Animations) => Animations,
+  Animation(TwAnimation) => TwAnimation,
 }
 
 /// What a prefix writes for a token the built-in scales do not know, as the

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -81,6 +81,24 @@ fn blur_css(blur: &TwBlur) -> String {
   }
 }
 
+/// The animation list as the shorthand text a `var()` fallback re-parses.
+fn animation_shorthand_css(animations: &Animations) -> String {
+  animations
+    .iter()
+    .filter_map(|animation| {
+      let name = animation.name.as_deref()?;
+
+      Some(format!(
+        "{} {} {} {name}",
+        css(&animation.duration),
+        css(&animation.timing_function),
+        css(&animation.iteration_count),
+      ))
+    })
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
 /// `drop-shadow(var(--drop-shadow-md, …))` for a preset; the bare `drop-shadow`
 /// utility reads `--drop-shadow` itself.
 fn drop_shadow_css(drop_shadow: &TwDropShadow) -> String {
@@ -706,7 +724,7 @@ pub(crate) enum TailwindProperty {
   /// `vertical-align` property.
   VerticalAlign(VerticalAlign),
   /// `animation` shorthand.
-  Animation(Animations),
+  Animation(TwAnimation),
   /// `bg-linear` property.
   BgLinearAngle(Angle),
   /// `bg-radial` property.
@@ -882,7 +900,7 @@ impl FnKind {
   }
 }
 
-fn is_ident_byte(byte: u8) -> bool {
+pub(crate) fn is_ident_byte(byte: u8) -> bool {
   byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'
 }
 
@@ -2001,7 +2019,27 @@ impl TailwindProperty {
       TailwindProperty::Visibility(visibility) => {
         push_decl!(builder, important, visibility(visibility))
       }
-      TailwindProperty::Animation(animations) => {
+      TailwindProperty::Animation(tw_animation) => {
+        let TwAnimation { animations, token } = tw_animation;
+
+        if let Some(token) = token {
+          let fallback = animation_shorthand_css(&animations);
+          let specified_value = if fallback.is_empty() {
+            format!("var(--animate-{token})")
+          } else {
+            format!("var(--animate-{token}, {fallback})")
+          };
+
+          builder.push(
+            StyleDeclaration::Deferred(DeferredDeclaration {
+              property: PropertyId::Shorthand(ShorthandId::Animation),
+              specified_value,
+            }),
+            important,
+          );
+          return;
+        }
+
         push_decl!(
           builder,
           important,

--- a/takumi-core/src/style/tw/parser.rs
+++ b/takumi-core/src/style/tw/parser.rs
@@ -5,7 +5,7 @@ use cssparser::{Parser, match_ignore_ascii_case};
 use crate::style::{
   CssToken,
   Length::{self, *},
-  tw::TailwindPropertyParser,
+  tw::{TailwindPropertyParser, is_ident_byte},
   *,
 };
 
@@ -312,6 +312,47 @@ impl<'i> FromCss<'i> for TwDropShadow {
 impl TailwindPropertyParser for TwDropShadow {
   fn parse_tw(_token: &str) -> Option<Self> {
     None
+  }
+}
+
+/// Tailwind `animate-*`, themable through `--animate-*`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TwAnimation {
+  /// The animation list the preset falls back to; empty for unknown tokens.
+  pub animations: Animations,
+  /// Token backing `var(--animate-<token>, …)`; `None` for arbitrary values
+  /// and `animate-none`.
+  pub token: Option<Arc<str>>,
+}
+
+impl<'i> FromCss<'i> for TwAnimation {
+  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
+    Ok(TwAnimation {
+      animations: Animations::from_css(input)?,
+      token: None,
+    })
+  }
+
+  const VALID_TOKENS: &'static [CssToken] = Animations::VALID_TOKENS;
+}
+
+impl TailwindPropertyParser for TwAnimation {
+  fn parse_tw(token: &str) -> Option<Self> {
+    if let Some(animations) = Animations::parse_tw(token) {
+      let themed = !token.eq_ignore_ascii_case("none");
+
+      return Some(TwAnimation {
+        animations,
+        token: themed.then(|| token.to_ascii_lowercase().into()),
+      });
+    }
+
+    // An unknown token reads `var(--animate-<token>)` alone: nothing runs
+    // until the variable and its keyframes exist, the way Tailwind pairs them.
+    (!token.is_empty() && token.bytes().all(is_ident_byte)).then(|| TwAnimation {
+      animations: Animations::default(),
+      token: Some(token.into()),
+    })
   }
 }
 

--- a/takumi-core/src/style/tw/tests.rs
+++ b/takumi-core/src/style/tw/tests.rs
@@ -213,14 +213,15 @@ fn test_parse_arbitrary_flex_with_spaces() {
 fn test_parse_tailwind_animation_preset() {
   assert_matches!(
     TailwindProperty::parse("animate-spin"),
-    Some(TailwindProperty::Animation(animations))
-      if animations.as_ref() == [Animation {
-        duration: AnimationTime::from_milliseconds(1000.0),
-        timing_function: AnimationTimingFunction::Linear,
-        iteration_count: AnimationIterationCount::Infinite,
-        name: Some("spin".to_string()),
-        ..Animation::default()
-      }]
+    Some(TailwindProperty::Animation(tw_animation))
+      if tw_animation.token.as_deref() == Some("spin")
+        && tw_animation.animations.as_ref() == [Animation {
+          duration: AnimationTime::from_milliseconds(1000.0),
+          timing_function: AnimationTimingFunction::Linear,
+          iteration_count: AnimationIterationCount::Infinite,
+          name: Some("spin".to_string()),
+          ..Animation::default()
+        }]
   );
 }
 
@@ -228,14 +229,15 @@ fn test_parse_tailwind_animation_preset() {
 fn test_parse_tailwind_animation_arbitrary_value() {
   assert_matches!(
     TailwindProperty::parse("animate-[wiggle_1s_ease-in-out_infinite]"),
-    Some(TailwindProperty::Animation(animations))
-      if animations.as_ref() == [Animation {
-        duration: AnimationTime::from_milliseconds(1000.0),
-        timing_function: AnimationTimingFunction::EaseInOut,
-        iteration_count: AnimationIterationCount::Infinite,
-        name: Some("wiggle".to_string()),
-        ..Animation::default()
-      }]
+    Some(TailwindProperty::Animation(tw_animation))
+      if tw_animation.token.is_none()
+        && tw_animation.animations.as_ref() == [Animation {
+          duration: AnimationTime::from_milliseconds(1000.0),
+          timing_function: AnimationTimingFunction::EaseInOut,
+          iteration_count: AnimationIterationCount::Infinite,
+          name: Some("wiggle".to_string()),
+          ..Animation::default()
+        }]
   );
 }
 
@@ -1184,6 +1186,58 @@ fn test_corner_radius_reads_a_css_variable() {
   let computed = style.inherit(&root_with(&[("--radius-card", "12px")]));
 
   assert_eq!(computed.border_top_left_radius.x, Length::Px(12.0));
+}
+
+#[test]
+fn test_animate_preset_reads_a_css_variable() {
+  let values = TailwindValues::from_str("animate-spin").expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let computed = style.inherit(&root_with(&[("--animate-spin", "wobble 2s ease-in 3")]));
+
+  assert_eq!(
+    computed.animation_name.as_ref(),
+    [Some("wobble".to_string())]
+  );
+  assert_eq!(
+    computed.animation_duration.as_ref(),
+    [AnimationTime::from_milliseconds(2000.0)]
+  );
+}
+
+#[test]
+fn test_animate_preset_falls_back_to_the_builtin_animation() {
+  let values = TailwindValues::from_str("animate-spin").expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let computed = style.inherit(&ComputedStyle::default());
+
+  assert_eq!(computed.animation_name.as_ref(), [Some("spin".to_string())]);
+  assert_eq!(
+    computed.animation_duration.as_ref(),
+    [AnimationTime::from_milliseconds(1000.0)]
+  );
+  assert_eq!(
+    computed.animation_iteration_count.as_ref(),
+    [AnimationIterationCount::Infinite]
+  );
+}
+
+#[test]
+fn test_unknown_animate_token_reads_a_css_variable() {
+  let values = TailwindValues::from_str("animate-wiggle").expect("tailwind values should parse");
+  let style = Style::from(values.into_declaration_block(Viewport::new((100, 100))));
+
+  let themed = style
+    .clone()
+    .inherit(&root_with(&[("--animate-wiggle", "wiggle 1s linear")]));
+  assert_eq!(themed.animation_name.as_ref(), [Some("wiggle".to_string())]);
+
+  let unthemed = style.inherit(&ComputedStyle::default());
+  assert_eq!(
+    unthemed.animation_name,
+    ComputedStyle::default().animation_name
+  );
 }
 
 #[test]


### PR DESCRIPTION
## Why
`animate-*` expanded straight to the built-in animation, so `--animate-*` tokens did nothing and unknown tokens were dropped.

## What
Presets compile to `animation: var(--animate-spin, …)` with the built-in as the fallback, and an unknown token like `animate-wiggle` reads `var(--animate-wiggle)` alone. The keyframes pair with the variable through `stylesheets` or the `keyframes` option.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for `animate-*` utilities through CSS variables.
  * Known animation tokens now use CSS-variable values with built-in fallbacks.
  * Custom animation tokens can resolve from CSS variables.
  * Keyframes can be paired through stylesheets or configuration options.

* **Documentation**
  * Added guidance for animation token behavior and customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->