### PR TITLE
Core: turn on Preflight through the tailwindcss import

### DIFF
--- a/.tegami/tailwind-import-preflight.md
+++ b/.tegami/tailwind-import-preflight.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Turn on Preflight through `@import "tailwindcss"`
+
+The import line at the top of a Tailwind v4 stylesheet now works: it drops the UA preset cosmetics (element margins, list markers, heading font tweaks), the part of Preflight the renderer itself supplies. The theme defaults already back every utility, so nothing else needs importing. Other `@import` targets stay unsupported.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -29,10 +29,10 @@ use crate::{
   },
   matching::{MatchedDeclarationsView, NodeMatchedDeclarations, match_stylesheets_view},
   style::{
-    BackgroundImage, BackgroundImages, BlendMode, BoxSizing, BreakpointOverrides, Color,
-    ComputedStyle, ContentItem, ContentValue, Display, Filters, Float, Isolation, Length,
-    LineHeight, ListStylePosition, PercentageNumber, Position, SizingContext, Style as NodeStyle,
-    StyleDeclaration, StyleDeclarationBlock, StyleSheet, TextWrapMode, WhiteSpaceCollapse,
+    BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem,
+    ContentValue, Display, Filters, Float, Isolation, Length, LineHeight, ListStylePosition,
+    PercentageNumber, Position, SizingContext, Style as NodeStyle, StyleDeclaration,
+    StyleDeclarationBlock, StyleSheet, TextWrapMode, WhiteSpaceCollapse,
     apply_stylesheet_animations,
   },
   viewport::Viewport,
@@ -230,7 +230,7 @@ fn build_style_layers(
   node_layers: NodeStyleLayers,
   matched_declarations: &MatchedDeclarationsView<'_>,
   viewport: Viewport,
-  breakpoints: &BreakpointOverrides,
+  stylesheet: &StyleSheet,
 ) -> (NodeStyle, SmallVec<[StyleDeclarationBlock; 2]>) {
   let mut style = NodeStyle::default();
 
@@ -241,13 +241,13 @@ fn build_style_layers(
     .author_tw
     .map(|author_tw| {
       author_tw
-        .into_declaration_block(viewport, breakpoints)
+        .into_declaration_block(viewport, &stylesheet.breakpoints)
         .split_importance()
     })
     .unzip();
 
   if let Some(preset) = node_layers.preset {
-    style.merge_from(preset);
+    style.merge_preset(preset, stylesheet.preflight);
   }
 
   if let Some(dir) = node_layers.dir {
@@ -358,7 +358,7 @@ pub(super) fn pseudo_computed_style(
     NodeStyleLayers::default(),
     pseudo_matched,
     parent_context.sizing.viewport,
-    &parent_context.stylesheet.breakpoints,
+    parent_context.stylesheet.as_ref(),
   );
   let inherited_parent = registered_custom_property_parent_style(
     &parent_context.style,
@@ -1420,7 +1420,7 @@ impl RenderNode {
         layers,
         matched,
         parent_context.sizing.viewport,
-        &parent_context.stylesheet.breakpoints,
+        parent_context.stylesheet.as_ref(),
       );
       let inherited_parent = registered_custom_property_parent_style(
         &parent_context.style,

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -537,6 +537,9 @@ impl<'i> AtRuleParser<'i> for KeyframeRuleParser {
 struct RuleParser {
   current_layer: Option<LayerPath>,
   lossy: bool,
+  /// False inside `@media`, `@layer` and `@supports` blocks, where `@import`
+  /// is invalid and its preflight flag must not escape the gate.
+  top_level: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1138,6 +1141,7 @@ impl<'i> AtRuleParser<'i> for RuleParser {
           &mut RuleParser {
             current_layer: Some(nested_layer),
             lossy: self.lossy,
+            top_level: false,
           },
         )?;
         fragment.declared_layers.splice(0..0, declared_layers);
@@ -1157,6 +1161,7 @@ impl<'i> AtRuleParser<'i> for RuleParser {
           &mut RuleParser {
             current_layer: self.current_layer.clone(),
             lossy: self.lossy,
+            top_level: false,
           },
         )?;
 
@@ -1177,6 +1182,7 @@ impl<'i> AtRuleParser<'i> for RuleParser {
           let mut parser = RuleParser {
             current_layer: self.current_layer.clone(),
             lossy: self.lossy,
+            top_level: false,
           };
           for _ in StyleSheetParser::new(input, &mut parser) {}
           return Ok(StyleSheetFragment::default());
@@ -1187,6 +1193,7 @@ impl<'i> AtRuleParser<'i> for RuleParser {
           &mut RuleParser {
             current_layer: self.current_layer.clone(),
             lossy: self.lossy,
+            top_level: false,
           },
         )
       }
@@ -1210,10 +1217,16 @@ impl<'i> AtRuleParser<'i> for RuleParser {
           .collect(),
         ..StyleSheetFragment::default()
       }),
-      AtRulePrelude::TailwindImport => Ok(StyleSheetFragment {
-        preflight: true,
-        ..StyleSheetFragment::default()
-      }),
+      AtRulePrelude::TailwindImport => {
+        if !self.top_level {
+          return Err(());
+        }
+
+        Ok(StyleSheetFragment {
+          preflight: true,
+          ..StyleSheetFragment::default()
+        })
+      }
       _ => Err(()),
     }
   }
@@ -1336,6 +1349,7 @@ impl StyleSheet {
     let mut rule_parser = RuleParser {
       current_layer: None,
       lossy,
+      top_level: true,
     };
 
     let mut rules = Vec::new();
@@ -2528,6 +2542,24 @@ mod tests {
     let sheet = parse_stylesheet(r#"@import "tailwindcss"; .card { width: 100px; }"#);
     assert!(sheet.preflight);
     assert_eq!(sheet.rules.len(), 1);
+  }
+
+  /// `@import` is only valid at the top of a stylesheet; a nested one must
+  /// not switch Preflight on past its container's gate.
+  #[test]
+  fn test_nested_tailwind_import_is_rejected() {
+    let nested = [
+      r#"@media (min-width: 1px) { @import "tailwindcss"; }"#,
+      r#"@layer base { @import "tailwindcss"; }"#,
+      r#"@supports (display: flex) { @import "tailwindcss"; }"#,
+    ];
+
+    for css in nested {
+      assert!(StyleSheet::parse(css).is_err(), "{css}");
+
+      let sheet = parse_stylesheet_loosy(css);
+      assert!(!sheet.preflight, "{css}");
+    }
   }
 
   #[test]

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -871,7 +871,7 @@ fn parse_at_rule_prelude<'i, 't>(
       token => return Err(location.new_unexpected_token_error(token.clone())),
     };
 
-    if target.eq_ignore_ascii_case("tailwindcss") && input.is_exhausted() {
+    if &*target == "tailwindcss" && input.is_exhausted() {
       return Ok(AtRulePrelude::TailwindImport);
     }
 
@@ -2532,9 +2532,11 @@ mod tests {
 
   #[test]
   fn test_other_imports_are_dropped() {
-    let sheet = parse_stylesheet_loosy(r#"@import "./app.css"; .card { width: 100px; }"#);
-    assert!(!sheet.preflight);
-    assert_eq!(sheet.rules.len(), 1);
+    for import in [r#"@import "./app.css";"#, r#"@import "TAILWINDCSS";"#] {
+      let sheet = parse_stylesheet_loosy(&format!("{import} .card {{ width: 100px; }}"));
+      assert!(!sheet.preflight, "{import}");
+      assert_eq!(sheet.rules.len(), 1, "{import}");
+    }
   }
 
   #[test]

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -283,6 +283,7 @@ struct StyleSheetFragment {
   keyframes: Vec<KeyframesRule>,
   property_rules: Vec<PropertyRule>,
   declared_layers: Vec<LayerPath>,
+  preflight: bool,
 }
 
 impl StyleSheetFragment {
@@ -291,6 +292,7 @@ impl StyleSheetFragment {
     self.keyframes.extend(other.keyframes);
     self.property_rules.extend(other.property_rules);
     self.declared_layers.extend(other.declared_layers);
+    self.preflight |= other.preflight;
   }
 }
 
@@ -549,6 +551,9 @@ enum AtRulePrelude {
   /// cascade at computed time, so `reference` and `inline` collapse into the
   /// emitted rule.
   Theme,
+  /// `@import "tailwindcss"`, which here only turns Preflight on: the built-in
+  /// scales already back every utility and `tw` is already the last layer.
+  TailwindImport,
 }
 
 fn parse_fragment_with_mode<'i, 't>(
@@ -859,6 +864,20 @@ fn parse_at_rule_prelude<'i, 't>(
     return parse_supports_condition(input).map(AtRulePrelude::Supports);
   }
 
+  if name.eq_ignore_ascii_case("import") {
+    let location = input.current_source_location();
+    let target = match input.next()? {
+      Token::QuotedString(value) => value.clone(),
+      token => return Err(location.new_unexpected_token_error(token.clone())),
+    };
+
+    if target.eq_ignore_ascii_case("tailwindcss") && input.is_exhausted() {
+      return Ok(AtRulePrelude::TailwindImport);
+    }
+
+    return Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name)));
+  }
+
   if name.eq_ignore_ascii_case("theme") {
     while !input.is_exhausted() {
       let location = input.current_source_location();
@@ -1047,7 +1066,7 @@ fn parse_nested_at_rule_block<'i, 't>(
       Ok(StyleSheetFragment::default())
     }
     AtRulePrelude::Theme => parse_theme_block(media_queries, current_layer, lossy, input),
-    AtRulePrelude::Keyframes(_) | AtRulePrelude::Property(_) => {
+    AtRulePrelude::Keyframes(_) | AtRulePrelude::Property(_) | AtRulePrelude::TailwindImport => {
       Err(input.new_custom_error(StyleSheetParseError::unsupported_nested_at_rule()))
     }
   }
@@ -1128,6 +1147,10 @@ impl<'i> AtRuleParser<'i> for RuleParser {
       AtRulePrelude::Theme => {
         parse_theme_block(&[], self.current_layer.as_ref(), self.lossy, input)
       }
+      // `@import "tailwindcss"` ends at its semicolon; a block after it is invalid.
+      AtRulePrelude::TailwindImport => {
+        Err(input.new_custom_error(StyleSheetParseError::unsupported_nested_at_rule()))
+      }
       AtRulePrelude::Media(media_query) => {
         let mut fragment = parse_fragment_with_mode(
           input,
@@ -1187,6 +1210,10 @@ impl<'i> AtRuleParser<'i> for RuleParser {
           .collect(),
         ..StyleSheetFragment::default()
       }),
+      AtRulePrelude::TailwindImport => Ok(StyleSheetFragment {
+        preflight: true,
+        ..StyleSheetFragment::default()
+      }),
       _ => Err(()),
     }
   }
@@ -1206,6 +1233,9 @@ pub struct StyleSheet {
   /// Widths from unconditional `:root` `--breakpoint-*` declarations, which
   /// gate `tw` variants before the cascade runs and so resolve at parse time.
   pub(crate) breakpoints: BreakpointOverrides,
+  /// Whether `@import "tailwindcss"` turned Preflight on, dropping the UA
+  /// preset cosmetics.
+  pub(crate) preflight: bool,
 }
 
 impl From<Vec<KeyframesRule>> for StyleSheet {
@@ -1312,6 +1342,7 @@ impl StyleSheet {
     let mut keyframes = Vec::new();
     let mut property_rules = Vec::new();
     let mut declared_layers = Vec::new();
+    let mut preflight = false;
 
     for fragment in StyleSheetParser::new(&mut parser, &mut rule_parser) {
       match fragment {
@@ -1320,6 +1351,7 @@ impl StyleSheet {
           keyframes.extend(fragment.keyframes);
           property_rules.extend(fragment.property_rules);
           declared_layers.extend(fragment.declared_layers);
+          preflight |= fragment.preflight;
         }
         Err((error, context)) => {
           if lossy {
@@ -1362,6 +1394,7 @@ impl StyleSheet {
       keyframes,
       property_rules,
       layer_count: layer_order.len(),
+      preflight,
     })
   }
 }
@@ -2488,6 +2521,20 @@ mod tests {
     let sheet = parse_stylesheet(":root { --breakpoint-md: 48em; }");
 
     assert_eq!(sheet.breakpoints.get("md"), None);
+  }
+
+  #[test]
+  fn test_tailwind_import_turns_preflight_on() {
+    let sheet = parse_stylesheet(r#"@import "tailwindcss"; .card { width: 100px; }"#);
+    assert!(sheet.preflight);
+    assert_eq!(sheet.rules.len(), 1);
+  }
+
+  #[test]
+  fn test_other_imports_are_dropped() {
+    let sheet = parse_stylesheet_loosy(r#"@import "./app.css"; .card { width: 100px; }"#);
+    assert!(!sheet.preflight);
+    assert_eq!(sheet.rules.len(), 1);
   }
 
   #[test]

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -1906,23 +1906,35 @@ const PREFLIGHT_RESET: &[LonghandId] = &[
 
 impl Style {
   /// Merges a UA preset; with Preflight on, its cosmetic declarations drop.
+  /// A dropped `list-style-type` becomes `none` rather than the initial
+  /// `disc`, matching Preflight's `ol, ul, menu { list-style: none }`.
   pub(crate) fn merge_preset(&mut self, preset: Style, preflight: bool) {
     if !preflight {
       return self.merge_from(preset);
     }
 
     let block = preset.declarations;
+    let mut reset_list_marker = false;
 
     for (declaration, important) in block.declarations.into_iter().zip(block.important) {
-      if declaration
-        .affected_longhands()
+      let affected = declaration.affected_longhands();
+
+      if affected
         .iter()
         .any(|longhand| PREFLIGHT_RESET.contains(&longhand))
       {
+        reset_list_marker |= affected.contains(&LonghandId::ListStyleType);
         continue;
       }
 
       self.declarations.push(declaration, important);
+    }
+
+    if reset_list_marker {
+      self.declarations.push(
+        StyleDeclaration::list_style_type(ListStyleType::None),
+        false,
+      );
     }
   }
 }

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -1881,6 +1881,52 @@ impl FromStr for Style {
   }
 }
 
+/// The UA cosmetics Preflight clears: margins, paddings, list markers, and
+/// heading font tweaks. Structural declarations like `display` stay, matching
+/// what Tailwind's Preflight leaves to the UA.
+const PREFLIGHT_RESET: &[LonghandId] = &[
+  LonghandId::MarginTop,
+  LonghandId::MarginRight,
+  LonghandId::MarginBottom,
+  LonghandId::MarginLeft,
+  LonghandId::MarginInlineStart,
+  LonghandId::MarginInlineEnd,
+  LonghandId::PaddingTop,
+  LonghandId::PaddingRight,
+  LonghandId::PaddingBottom,
+  LonghandId::PaddingLeft,
+  LonghandId::PaddingInlineStart,
+  LonghandId::PaddingInlineEnd,
+  LonghandId::ListStyleType,
+  LonghandId::ListStylePosition,
+  LonghandId::ListStyleImage,
+  LonghandId::FontSize,
+  LonghandId::FontWeight,
+];
+
+impl Style {
+  /// Merges a UA preset; with Preflight on, its cosmetic declarations drop.
+  pub(crate) fn merge_preset(&mut self, preset: Style, preflight: bool) {
+    if !preflight {
+      return self.merge_from(preset);
+    }
+
+    let block = preset.declarations;
+
+    for (declaration, important) in block.declarations.into_iter().zip(block.important) {
+      if declaration
+        .affected_longhands()
+        .iter()
+        .any(|longhand| PREFLIGHT_RESET.contains(&longhand))
+      {
+        continue;
+      }
+
+      self.declarations.push(declaration, important);
+    }
+  }
+}
+
 #[cfg(test)]
 #[path = "stylesheets_tests.rs"]
 mod tests;

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1459,3 +1459,18 @@ fn preflight_drops_preset_cosmetics() {
   without_preflight.merge_preset(preset, false);
   assert_eq!(without_preflight.declarations.declarations.len(), 2);
 }
+
+/// Dropping `ol`'s `decimal` alone would fall back to the initial `disc`;
+/// Preflight removes markers, so the preset entry becomes `none`.
+#[test]
+fn preflight_resets_list_markers_to_none() {
+  let preset = Style::default().with(StyleDeclaration::list_style_type(ListStyleType::Decimal));
+
+  let mut style = Style::default();
+  style.merge_preset(preset, true);
+
+  assert_eq!(
+    style.declarations.declarations.as_slice(),
+    &[StyleDeclaration::list_style_type(ListStyleType::None)]
+  );
+}

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1441,3 +1441,21 @@ fn overflow_visible_paired_with_clip_stays_mixed() {
     SpacePair::from_pair(Overflow::Clip, Overflow::Visible)
   );
 }
+
+#[test]
+fn preflight_drops_preset_cosmetics() {
+  let preset = Style::default()
+    .with(StyleDeclaration::margin_top(Length::Em(0.67)))
+    .with(StyleDeclaration::display(Display::Block));
+
+  let mut with_preflight = Style::default();
+  with_preflight.merge_preset(preset.clone(), true);
+  assert_eq!(
+    with_preflight.declarations.declarations.as_slice(),
+    &[StyleDeclaration::display(Display::Block)]
+  );
+
+  let mut without_preflight = Style::default();
+  without_preflight.merge_preset(preset, false);
+  assert_eq!(without_preflight.declarations.declarations.len(), 2);
+}


### PR DESCRIPTION
## Why
A Tailwind v4 stylesheet opens with `@import "tailwindcss"`, which failed to parse, and there was no way to drop the renderer's UA cosmetics short of hand-passing Preflight CSS.

## What
The import line turns Preflight on: the preset merge drops UA cosmetics (element margins, list markers, heading font tweaks) and keeps structural declarations like `display`. No CSS is vendored; the reset is a filter over the presets the renderer itself supplies.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enabling Tailwind v4 Preflight with `@import "tailwindcss"`.
  * Added support for resolving responsive breakpoints from stylesheet theme values.
  * Added support for Tailwind theme declarations and additional layout shorthand properties.

* **Bug Fixes**
  * Preflight now resets cosmetic browser defaults while preserving structural styling.
  * Improved consistent Preflight behavior across responsive and pseudo-element styles.
  * Unsupported or nested Tailwind imports are safely rejected.

* **Documentation**
  * Documented Tailwind v4 Preflight support and supported import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->