### PR TITLE
Core: expand @apply rules in stylesheets

### DIFF
--- a/.tegami/tw-apply-at-rule.md
+++ b/.tegami/tw-apply-at-rule.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Expand `@apply` inside stylesheet rules
+
+`.card { @apply mt-4 bg-brand-500; }` now expands through the `tw` parser at the spot it is written, `!` suffix included. Variants like `md:` are rejected; a static render has nothing for them to gate on.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -128,14 +128,20 @@ The `tw` prop runs a built-in parser with no build step. It won't cover every Ta
   `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`.
 </Callout>
 
-To reset those defaults, pass Preflight through `stylesheets`, wrapped in a layer so it stays below your utilities:
+To reset those defaults, put the same import line a Tailwind stylesheet starts with in `stylesheets`. It drops the UA margins, list markers and heading font tweaks; other `@import` targets stay unsupported.
 
 ```tsx
-import preflight from "tailwindcss/preflight.css?inline";
-
 const image = await render(node, {
-  stylesheets: [`@layer base { ${preflight} }`],
+  stylesheets: [`@import "tailwindcss";`],
 });
+```
+
+`@apply` works inside stylesheet rules and expands where it is written, `!` suffix included. Variants like `md:` are rejected.
+
+```css
+.card {
+  @apply mt-4 bg-brand-500;
+}
 ```
 
 **Unlayered stylesheet rules override `tw` utilities**, and rules in a named `@layer` lose to them. That is Tailwind's own order: utilities are the last declared layer. Prefix a utility with `!` to override an unlayered rule.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -128,7 +128,19 @@ The `tw` prop runs a built-in parser with no build step. It won't cover every Ta
   `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`.
 </Callout>
 
-To reset those defaults, put the same import line a Tailwind stylesheet starts with in `stylesheets`. It drops the UA margins, list markers and heading font tweaks; other `@import` targets stay unsupported.
+### Tailwind at-rules
+
+The engine parses Tailwind source stylesheets as-is. It reads these directives:
+
+| At-rule                 | Reads as                                                                                               | Rejected                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `@theme`                | its `:root` rule. Nested `@keyframes` register. Modifiers like `reference` and `inline` change nothing | `prefix()`              |
+| `@import "tailwindcss"` | Preflight: drops the UA margins, list markers and heading font tweaks                                  | any other import target |
+| `@apply`                | the utilities' declarations, expanded in place, `!` suffix included                                    | variants like `md:`     |
+
+Other Tailwind directives (`@utility`, `@custom-variant`, `@source`, `@plugin`, `@config`) do not parse. Compile those with Tailwind, then [bring the stylesheet](#bring-your-stylesheet).
+
+The import line goes through `stylesheets`:
 
 ```tsx
 const image = await render(node, {
@@ -136,7 +148,7 @@ const image = await render(node, {
 });
 ```
 
-`@apply` works inside stylesheet rules and expands where it is written, `!` suffix included. Variants like `md:` are rejected.
+`@apply` expands inside stylesheet rules:
 
 ```css
 .card {
@@ -156,7 +168,7 @@ const image = await render(node, {
 
 A utility reads a CSS custom property, the way Tailwind compiles it. `bg-red-500` resolves `var(--color-red-500)`, `p-4` resolves `calc(var(--spacing) * 4)`. The built-in scale sits behind them as the fallback.
 
-Declare tokens in a `:root` rule, in a Tailwind `@theme` block pasted as-is, or pass them as [the `cssVariables` option](#css-variables). `@theme` reads as the `:root` rule it compiles to, `@keyframes` inside it register, and `@theme reference` emits nothing.
+Declare tokens in a `:root` rule, in a [Tailwind `@theme` block](#tailwind-at-rules) pasted as-is, or pass them as [the `cssVariables` option](#css-variables).
 
 ```css
 :root {
@@ -206,6 +218,7 @@ Some things behave differently from Tailwind here:
 - `--color-red-500: initial` falls back to the built-in red instead of removing `bg-red-500`.
 - A bare `rounded` keeps its built-in value; `rounded-sm` and the rest read the variable.
 - `--spacing` needs a unit. A bare number makes `p-4` compute pixels here, where a browser rejects the declaration.
+- An aliased token stays live. `--color-brand: var(--background)` follows a subtree `--background` override. In a browser, `@theme inline` exists to arrange that.
 
 `tw` is a plain prop, so build it dynamically:
 

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -233,6 +233,10 @@ pub enum StyleSheetParseErrorKind {
   #[error("@supports cannot mix `and` and `or` without parentheses")]
   SupportsMixedAndOrWithoutParentheses,
 
+  /// `@apply` only takes plain utilities, without variants.
+  #[error("@apply expects plain utilities without variants")]
+  InvalidApplyUtility,
+
   /// `@property` names must be custom properties.
   #[error("@property name must be a custom property")]
   PropertyNameMustBeCustomProperty,
@@ -324,6 +328,11 @@ impl StyleSheetParseError {
   /// Error for an unsupported nested at-rule.
   pub(crate) fn unsupported_nested_at_rule() -> Self {
     Self::new(StyleSheetParseErrorKind::UnsupportedNestedAtRule)
+  }
+
+  /// Error for an `@apply` token that is not a plain utility.
+  pub(crate) fn invalid_apply_utility() -> Self {
+    Self::new(StyleSheetParseErrorKind::InvalidApplyUtility)
   }
 
   fn new(kind: StyleSheetParseErrorKind) -> Self {

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -2594,6 +2594,16 @@ mod tests {
   }
 
   #[test]
+  fn test_apply_treats_comments_as_separators() {
+    let sheet = parse_stylesheet(".card { @apply mt-4 /* note */ p-2; }");
+
+    assert_eq!(sheet.rules.len(), 1);
+    let computed = computed_style_from_declarations(&sheet.rules[0].normal_declarations);
+    assert_eq!(computed.margin_top, Length::Rem(1.0));
+    assert_eq!(computed.padding_top, Length::Rem(0.5));
+  }
+
+  #[test]
   fn test_apply_keeps_the_important_suffix() {
     let sheet = parse_stylesheet(".card { @apply mt-4!; }");
 

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -18,7 +18,7 @@ use crate::{
   keyframes::parse_keyframe_prelude,
   style::{
     BreakpointOverrides, FromCssStr, KeyframeRule, KeyframesRule, Length, StyleDeclaration,
-    StyleDeclarationBlock, supports::parse_supports_condition,
+    StyleDeclarationBlock, expand_apply, supports::parse_supports_condition,
   },
 };
 
@@ -456,6 +456,34 @@ impl<'i> AtRuleParser<'i> for NestedStyleRuleParser<'_> {
     )?;
     Ok(StyleRuleBodyItem::Rules(fragment))
   }
+
+  fn rule_without_block(
+    &mut self,
+    prelude: Self::Prelude,
+    _start: &ParserState,
+  ) -> Result<Self::AtRule, ()> {
+    match prelude {
+      // The expanded declarations become a rule on the parent's selectors, so
+      // a block with declarations before and after the `@apply` keeps its
+      // source order through the flush the nested-rules path already does.
+      AtRulePrelude::Apply(block) => {
+        let (normal_declarations, important_declarations) = block.split_importance();
+
+        Ok(StyleRuleBodyItem::Rules(StyleSheetFragment {
+          rules: vec![CssRule {
+            selectors: self.parent_selectors.clone(),
+            normal_declarations,
+            important_declarations,
+            media_queries: self.media_queries.to_vec(),
+            layer: self.layer.clone(),
+            layer_order: None,
+          }],
+          ..StyleSheetFragment::default()
+        }))
+      }
+      _ => Err(()),
+    }
+  }
 }
 
 impl<'i> RuleBodyItemParser<'i, StyleRuleBodyItem, StyleSheetParseError>
@@ -557,6 +585,8 @@ enum AtRulePrelude {
   /// `@import "tailwindcss"`, which here only turns Preflight on: the built-in
   /// scales already back every utility and `tw` is already the last layer.
   TailwindImport,
+  /// `@apply`, already expanded into the declarations its utilities stand for.
+  Apply(Box<StyleDeclarationBlock>),
 }
 
 fn parse_fragment_with_mode<'i, 't>(
@@ -881,6 +911,15 @@ fn parse_at_rule_prelude<'i, 't>(
     return Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name)));
   }
 
+  if name.eq_ignore_ascii_case("apply") {
+    let start = input.position();
+    while input.next_including_whitespace_and_comments().is_ok() {}
+    let block = expand_apply(input.slice_from(start))
+      .ok_or_else(|| input.new_custom_error(StyleSheetParseError::invalid_apply_utility()))?;
+
+    return Ok(AtRulePrelude::Apply(Box::new(block)));
+  }
+
   if name.eq_ignore_ascii_case("theme") {
     while !input.is_exhausted() {
       let location = input.current_source_location();
@@ -1069,7 +1108,10 @@ fn parse_nested_at_rule_block<'i, 't>(
       Ok(StyleSheetFragment::default())
     }
     AtRulePrelude::Theme => parse_theme_block(media_queries, current_layer, lossy, input),
-    AtRulePrelude::Keyframes(_) | AtRulePrelude::Property(_) | AtRulePrelude::TailwindImport => {
+    AtRulePrelude::Keyframes(_)
+    | AtRulePrelude::Property(_)
+    | AtRulePrelude::TailwindImport
+    | AtRulePrelude::Apply(_) => {
       Err(input.new_custom_error(StyleSheetParseError::unsupported_nested_at_rule()))
     }
   }
@@ -1151,8 +1193,8 @@ impl<'i> AtRuleParser<'i> for RuleParser {
       AtRulePrelude::Theme => {
         parse_theme_block(&[], self.current_layer.as_ref(), self.lossy, input)
       }
-      // `@import "tailwindcss"` ends at its semicolon; a block after it is invalid.
-      AtRulePrelude::TailwindImport => {
+      // `@import` and `@apply` end at their semicolon; a block after them is invalid.
+      AtRulePrelude::TailwindImport | AtRulePrelude::Apply(_) => {
         Err(input.new_custom_error(StyleSheetParseError::unsupported_nested_at_rule()))
       }
       AtRulePrelude::Media(media_query) => {
@@ -2535,6 +2577,44 @@ mod tests {
     let sheet = parse_stylesheet(":root { --breakpoint-md: 48em; }");
 
     assert_eq!(sheet.breakpoints.get("md"), None);
+  }
+
+  #[test]
+  fn test_apply_expands_utilities_in_place() {
+    let sheet = parse_stylesheet(".card { width: 100px; @apply mt-4; height: 50px; }");
+
+    assert_eq!(sheet.rules.len(), 3);
+    for rule in &sheet.rules {
+      assert_eq!(selector_text(rule), ".card");
+    }
+    assert_eq!(
+      computed_style_from_declarations(&sheet.rules[1].normal_declarations).margin_top,
+      Length::Rem(1.0)
+    );
+  }
+
+  #[test]
+  fn test_apply_keeps_the_important_suffix() {
+    let sheet = parse_stylesheet(".card { @apply mt-4!; }");
+
+    assert_eq!(sheet.rules.len(), 1);
+    assert!(sheet.rules[0].normal_declarations.declarations.is_empty());
+    assert!(
+      !sheet.rules[0]
+        .important_declarations
+        .declarations
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn test_apply_rejects_variants_and_unknown_utilities() {
+    for css in [
+      ".card { @apply md:mt-4; } .card { width: 100px; }",
+      ".card { @apply not-a-utility-#%; } .card { width: 100px; }",
+    ] {
+      assert_lossy_parse_keeps_single_valid_rule(css);
+    }
   }
 
   #[test]

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -81,10 +81,60 @@ fn blur_css(blur: &TwBlur) -> String {
   }
 }
 
+/// Blanks `/* … */` runs so comments separate utilities the way whitespace
+/// does. Quoted spans, as arbitrary values carry, pass through untouched.
+fn strip_css_comments(source: &str) -> Cow<'_, str> {
+  if !source.contains("/*") {
+    return Cow::Borrowed(source);
+  }
+
+  let bytes = source.as_bytes();
+  let mut out = String::with_capacity(source.len());
+  let mut segment_start = 0;
+  let mut quote: Option<u8> = None;
+  let mut index = 0;
+
+  while index < bytes.len() {
+    match quote {
+      Some(closing) => {
+        if bytes[index] == b'\\' {
+          index += 2;
+          continue;
+        }
+        if bytes[index] == closing {
+          quote = None;
+        }
+      }
+      None => match bytes[index] {
+        opening @ (b'\'' | b'"') => quote = Some(opening),
+        b'/' if bytes.get(index + 1) == Some(&b'*') => {
+          out.push_str(&source[segment_start..index]);
+          out.push(' ');
+          index += 2;
+          while index < bytes.len()
+            && !(bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/'))
+          {
+            index += 1;
+          }
+          index += 2;
+          segment_start = index.min(bytes.len());
+          continue;
+        }
+        _ => {}
+      },
+    }
+    index += 1;
+  }
+
+  out.push_str(&source[segment_start..]);
+  Cow::Owned(out)
+}
+
 /// Expands an `@apply` utility list into the declarations it stands for.
 /// `None` when a token is unknown or carries a variant, which `@apply` rejects.
 pub(crate) fn expand_apply(source: &str) -> Option<StyleDeclarationBlock> {
   let mut builder = TailwindDeclarationBuilder::default();
+  let source = strip_css_comments(source);
 
   for token in source.split_whitespace() {
     let value = TailwindValue::parse(token)?;

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -81,6 +81,24 @@ fn blur_css(blur: &TwBlur) -> String {
   }
 }
 
+/// Expands an `@apply` utility list into the declarations it stands for.
+/// `None` when a token is unknown or carries a variant, which `@apply` rejects.
+pub(crate) fn expand_apply(source: &str) -> Option<StyleDeclarationBlock> {
+  let mut builder = TailwindDeclarationBuilder::default();
+
+  for token in source.split_whitespace() {
+    let value = TailwindValue::parse(token)?;
+
+    if value.breakpoint.is_some() {
+      return None;
+    }
+
+    value.property.apply(&mut builder, value.important);
+  }
+
+  Some(builder.finish())
+}
+
 /// `var(--shadow-md, <built-in layers>)`: the variable overrides the whole
 /// shape, and the fallback keeps its per-layer colour slots. A custom shape
 /// carries its own colours, so `shadow-*` colour utilities only reach the


### PR DESCRIPTION
## Why
`@apply` is the most common Tailwind-ism in real stylesheets, and any rule using it failed to parse.

## What
`@apply` expands through the `tw` parser at the spot it is written, keeping source order and the `!` suffix, and lands on the rule's own selectors. Variants like `md:` are rejected; a static render has nothing for them to gate on.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tailwind `@apply` support within stylesheet rules.
  * Supports important utilities with the `!` suffix while preserving declaration order.
  * Direct `tailwindcss` imports enable Preflight browser-default resets.
  * Added support for Tailwind theme declarations, token aliases, and supported breakpoint overrides.

* **Bug Fixes**
  * Added clear errors for unsupported variants and invalid utilities.
  * Unsupported stylesheet imports are safely ignored.

* **Documentation**
  * Updated styling guidance for `@apply`, imports, themes, tokens, and supported directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->