### PR TITLE
Core: parse class names as utilities behind a future flag

### DIFF
--- a/.tegami/classname-utilities.md
+++ b/.tegami/classname-utilities.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+---
+
+### Parse `className` as Tailwind utilities behind `future.classNameUtilities`
+
+The flag feeds `className` tokens to the `tw` parser, so Tailwind JSX pasted from an app renders without a build step. A token that is not a utility still matches stylesheet selectors, and `tw` wins a tie on the same node. The flag becomes the default in the next major.

--- a/docs/content/docs/future.mdx
+++ b/docs/content/docs/future.mdx
@@ -1,0 +1,35 @@
+---
+title: Future flags
+description: Opt into behavior that becomes the default in the next major.
+icon: FlaskConical
+---
+
+The `future` render option holds opt-in flags for behavior planned as the next major release's default. Enable them now and the upgrade changes nothing.
+
+```tsx
+const image = await render(node, {
+  width: 1200,
+  height: 630,
+  future: { classNameUtilities: true },
+});
+```
+
+## classNameUtilities
+
+`className` tokens use the same parser as [the `tw` prop](/docs/styling#native-parser). JSX pasted from your app renders without a build step.
+
+```tsx twoslash
+import { render } from "takumi-js";
+
+const image = await render(<div className="flex p-4 bg-brand-500">Hello</div>, {
+  width: 1200,
+  height: 630,
+  future: { classNameUtilities: true },
+});
+```
+
+- A token that is not a utility still matches stylesheet selectors.
+- A stylesheet rule and a utility for the same token both apply. [The cascade resolves conflicts as it does for `tw`](/docs/styling#native-parser).
+- `tw` wins a tie against a `className` utility on the same node.
+
+The flag is off by default because a class name can match utility syntax by accident. A plain `hidden` class with no matching rule would hide the node.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -18,6 +18,7 @@
     "keyframe-animation",
     "visual-effects",
     "performance-and-optimization",
+    "future",
     "upgrade",
     "--- Reference ---",
     "reference",

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -128,6 +128,8 @@ The `tw` prop runs a built-in parser with no build step. It won't cover every Ta
   `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`.
 </Callout>
 
+The [`classNameUtilities` future flag](/docs/future#classnameutilities) feeds `className` tokens to this parser too.
+
 ### Tailwind at-rules
 
 The engine parses Tailwind source stylesheets as-is. It reads these directives:

--- a/takumi-core/src/context.rs
+++ b/takumi-core/src/context.rs
@@ -30,6 +30,9 @@ pub struct RenderContext {
   /// Whether to draw debug borders.
   #[builder(default = false)]
   pub draw_debug_border: bool,
+  /// Whether `class` names also parse as Tailwind utilities.
+  #[builder(default = false)]
+  pub class_name_utilities: bool,
   /// Whether this box is a cell of a table that collapses its borders. Set
   /// during lowering, which is the last place a table cell is still one.
   #[builder(default = false)]
@@ -63,6 +66,7 @@ impl RenderContext {
       current_color,
       time_ms: parent.time_ms,
       draw_debug_border: parent.draw_debug_border,
+      class_name_utilities: parent.class_name_utilities,
       collapsed_borders: false,
       images: parent.images.clone(),
       sizing,

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -32,7 +32,7 @@ use crate::{
     BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem,
     ContentValue, Display, Filters, Float, Isolation, Length, LineHeight, ListStylePosition,
     PercentageNumber, Position, SizingContext, Style as NodeStyle, StyleDeclaration,
-    StyleDeclarationBlock, StyleSheet, TextWrapMode, WhiteSpaceCollapse,
+    StyleDeclarationBlock, StyleSheet, TailwindValues, TextWrapMode, WhiteSpaceCollapse,
     apply_stylesheet_animations,
   },
   viewport::Viewport,
@@ -1413,8 +1413,21 @@ impl RenderNode {
         .get(source_order)
         .map(NodeMatchedDeclarations::element)
         .unwrap_or(&default_matched);
-      let layers = node.take_style_layers();
+      let mut layers = node.take_style_layers();
       let lang = layers.lang;
+
+      if parent_context.class_name_utilities
+        && let Some(class_tw) = node
+          .class_name()
+          .and_then(|class_name| class_name.parse::<TailwindValues>().ok())
+        && !class_tw.is_empty()
+      {
+        // The `tw` prop reads as coming after the class list, so it wins ties.
+        layers.author_tw = Some(match layers.author_tw {
+          Some(author_tw) => class_tw.merge(author_tw),
+          None => class_tw,
+        });
+      }
 
       let (style_layers, element_important) = build_style_layers(
         layers,
@@ -2327,6 +2340,41 @@ mod tests {
     let result = StyleSheet::parse(css);
     assert!(result.is_ok(), "expected stylesheet to parse: {result:?}");
     result.unwrap_or_default()
+  }
+
+  fn render_with_class_utilities(node: crate::layout::node::Node, enabled: bool) -> RenderNode {
+    let context = RenderContext::builder()
+      .fonts(Fonts::default().snapshot())
+      .sizing(
+        SizingContext::builder()
+          .viewport(Viewport::default())
+          .build(),
+      )
+      .class_name_utilities(enabled)
+      .build();
+
+    RenderNode::from_node(&context, node)
+  }
+
+  #[test]
+  fn class_names_parse_as_utilities_behind_the_flag() {
+    let node = crate::layout::node::Node::container([]).with_class_name("p-[10px] custom-card");
+
+    let on = render_with_class_utilities(node.clone(), true);
+    assert_eq!(on.context.style.padding_left, Length::Px(10.0));
+
+    let off = render_with_class_utilities(node, false);
+    assert_eq!(off.context.style.padding_left, Length::zero());
+  }
+
+  #[test]
+  fn tw_prop_wins_over_class_name_utilities() {
+    let node = crate::layout::node::Node::container([])
+      .with_class_name("p-[10px]")
+      .with_tw("p-[20px]".parse().expect("tw parses"));
+
+    let rendered = render_with_class_utilities(node, true);
+    assert_eq!(rendered.context.style.padding_left, Length::Px(20.0));
   }
 
   #[test]

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -268,36 +268,55 @@ impl FromStr for TailwindValues {
   type Err = String;
 
   fn from_str(source: &str) -> Result<Self, Self::Err> {
-    let mut collected = source
+    let collected = source
       .split_whitespace()
       .filter_map(TailwindValue::parse)
       .collect::<Vec<_>>();
 
-    // sort in reverse order by is important, then has breakpoint, then rest is last.
-    // Stable sort so equal-priority utilities keep source order (later one wins).
-    collected.sort_by(|a, b| {
-      // Not important comes before important
-      if !a.important && b.important {
-        return Ordering::Less;
-      }
-
-      if a.important && !b.important {
-        return Ordering::Greater;
-      }
-
-      // No breakpoint comes before breakpoint
-      match (&a.breakpoint, &b.breakpoint) {
-        (None, Some(_)) => Ordering::Less,
-        (Some(_), None) => Ordering::Greater,
-        _ => Ordering::Equal,
-      }
-    });
-
-    Ok(TailwindValues { inner: collected })
+    Ok(TailwindValues::from_sorted(collected))
   }
 }
 
+// sort in reverse order by is important, then has breakpoint, then rest is last.
+// Stable sort so equal-priority utilities keep source order (later one wins).
+fn sort_by_priority(values: &mut [TailwindValue]) {
+  values.sort_by(|a, b| {
+    // Not important comes before important
+    if !a.important && b.important {
+      return Ordering::Less;
+    }
+
+    if a.important && !b.important {
+      return Ordering::Greater;
+    }
+
+    // No breakpoint comes before breakpoint
+    match (&a.breakpoint, &b.breakpoint) {
+      (None, Some(_)) => Ordering::Less,
+      (Some(_), None) => Ordering::Greater,
+      _ => Ordering::Equal,
+    }
+  });
+}
+
 impl TailwindValues {
+  fn from_sorted(mut values: Vec<TailwindValue>) -> Self {
+    sort_by_priority(&mut values);
+    TailwindValues { inner: values }
+  }
+
+  /// Whether no utility parsed.
+  pub fn is_empty(&self) -> bool {
+    self.inner.is_empty()
+  }
+
+  /// Merges two utility sets; `other`'s utilities win ties, as if its source
+  /// text came after this one's.
+  pub fn merge(mut self, other: Self) -> Self {
+    self.inner.extend(other.inner);
+    Self::from_sorted(self.inner)
+  }
+
   /// Collects resource URLs referenced by active Tailwind utilities for the given viewport.
   pub(crate) fn image_urls(
     &self,

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -12,13 +12,14 @@ use takumi_raster::measure;
 use crate::{
   JsBytes, map_error,
   renderer::{
-    ImageCacheMode, MeasuredNode, RenderOptions, RendererState, collect_images, decode_images,
-    deserialize_keyframes, device_pixel_ratio, parse_lang,
+    ImageCacheMode, MeasuredNode, RenderOptions, RendererState, class_name_utilities,
+    collect_images, decode_images, deserialize_keyframes, device_pixel_ratio, parse_lang,
   },
 };
 
 pub struct MeasureTask {
   pub(crate) node: Option<Node>,
+  pub(crate) class_name_utilities: bool,
   pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
@@ -44,6 +45,7 @@ impl MeasureTask {
 
     Ok(MeasureTask {
       node: Some(node),
+      class_name_utilities: class_name_utilities(options.future),
       state,
       viewport: Viewport::new((options.width, options.height))
         .with_device_pixel_ratio(device_pixel_ratio(options.device_pixel_ratio)),
@@ -78,6 +80,7 @@ impl Task for MeasureTask {
       .fonts(&fonts)
       .font_families(take(&mut self.font_families))
       .lang(take(&mut self.lang))
+      .class_name_utilities(self.class_name_utilities)
       .build();
 
     measure(options).map_err(map_error)

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -15,8 +15,9 @@ use takumi_raster::{
 use crate::{
   JsBytes, deserialize_with_tracing,
   renderer::{
-    AnimationOutputFormat, ImageCacheMode, RenderAnimationOptions, RendererState, collect_images,
-    decode_images, deserialize_keyframes, device_pixel_ratio, parse_lang, webp_lossless,
+    AnimationOutputFormat, ImageCacheMode, RenderAnimationOptions, RendererState,
+    class_name_utilities, collect_images, decode_images, deserialize_keyframes, device_pixel_ratio,
+    parse_lang, webp_lossless,
   },
 };
 
@@ -28,6 +29,7 @@ pub struct RenderAnimationTask {
   pub(crate) quality: Option<u8>,
   pub(crate) lossless: Option<bool>,
   pub(crate) draw_debug_border: bool,
+  pub(crate) class_name_utilities: bool,
   pub(crate) stylesheets: Option<Vec<String>>,
   pub(crate) keyframes: Vec<KeyframesRule>,
   pub(crate) css_variables: Option<HashMap<String, String>>,
@@ -59,6 +61,7 @@ impl RenderAnimationTask {
       device_pixel_ratio: dpr,
       font_families,
       lang,
+      future,
     } = options;
     let scenes = scenes
       .into_iter()
@@ -87,6 +90,7 @@ impl RenderAnimationTask {
       quality,
       lossless,
       draw_debug_border: draw_debug_border.unwrap_or_default(),
+      class_name_utilities: class_name_utilities(future),
       stylesheets,
       keyframes: deserialize_keyframes(keyframes)?,
       css_variables,
@@ -130,6 +134,7 @@ impl Task for RenderAnimationTask {
                 .font_families(self.font_families.clone())
                 .lang(self.lang)
                 .draw_debug_border(self.draw_debug_border)
+                .class_name_utilities(self.class_name_utilities)
                 .build(),
             )
             .build()

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -12,13 +12,14 @@ use takumi_raster::{DitheringAlgorithm, render, write_image};
 use crate::{
   JsBytes, map_error,
   renderer::{
-    ImageCacheMode, OutputFormat, RenderOptions, RendererState, collect_images, decode_images,
-    deserialize_keyframes, device_pixel_ratio, parse_lang,
+    ImageCacheMode, OutputFormat, RenderOptions, RendererState, class_name_utilities,
+    collect_images, decode_images, deserialize_keyframes, device_pixel_ratio, parse_lang,
   },
 };
 
 pub struct RenderTask {
   pub(crate) draw_debug_border: bool,
+  pub(crate) class_name_utilities: bool,
   pub(crate) node: Option<Node>,
   pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
@@ -58,6 +59,7 @@ impl RenderTask {
       dithering: options.dithering.map(Into::into).unwrap_or_default(),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
       draw_debug_border: options.draw_debug_border.unwrap_or_default(),
+      class_name_utilities: class_name_utilities(options.future),
       stylesheet,
       images: collect_images(env, options.images)?,
       font_families: options.font_families.map(FontFamily::from_names),
@@ -91,6 +93,7 @@ impl Task for RenderTask {
         .font_families(take(&mut self.font_families))
         .lang(take(&mut self.lang))
         .draw_debug_border(self.draw_debug_border)
+        .class_name_utilities(self.class_name_utilities)
         .build(),
     )
     .map_err(map_error)?;

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -157,6 +157,20 @@ pub(crate) fn deserialize_keyframes(keyframes: Option<Object>) -> Result<Vec<Cor
   }
 }
 
+/// Opt-in flags for behavior that becomes the default in a future major.
+#[napi(object)]
+#[derive(Default, Clone, Copy)]
+pub struct FutureFlags {
+  /// Parse `className` tokens as Tailwind utilities, the way `tw` does.
+  pub class_name_utilities: Option<bool>,
+}
+
+pub(crate) fn class_name_utilities(future: Option<FutureFlags>) -> bool {
+  future
+    .and_then(|flags| flags.class_name_utilities)
+    .unwrap_or_default()
+}
+
 /// Options for rendering an image.
 #[napi(object)]
 #[derive(Default)]
@@ -196,6 +210,8 @@ pub struct RenderOptions<'env> {
   pub font_families: Option<Vec<String>>,
   /// Default BCP-47 language applied to the root, inherited by nodes without their own lang.
   pub lang: Option<String>,
+  /// Opt-in future behavior flags.
+  pub future: Option<FutureFlags>,
 }
 
 /// Options for rendering a node tree to an SVG document. SVG is a vector
@@ -224,6 +240,8 @@ pub struct SvgRenderOptions<'env> {
   pub font_families: Option<Vec<String>>,
   /// Default BCP-47 language applied to the root, inherited by nodes without their own lang.
   pub lang: Option<String>,
+  /// Opt-in future behavior flags.
+  pub future: Option<FutureFlags>,
 }
 
 #[napi(string_enum)]
@@ -295,6 +313,8 @@ pub struct RenderAnimationOptions<'env> {
   pub font_families: Option<Vec<String>>,
   /// Default BCP-47 language applied to the root, inherited by nodes without their own lang.
   pub lang: Option<String>,
+  /// Opt-in future behavior flags.
+  pub future: Option<FutureFlags>,
 }
 
 /// Output format for animated images.

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -11,13 +11,14 @@ use takumi_core::{
 use crate::{
   JsBytes, map_error,
   renderer::{
-    ImageCacheMode, RendererState, SvgRenderOptions, collect_images, decode_images,
-    deserialize_keyframes, parse_lang,
+    ImageCacheMode, RendererState, SvgRenderOptions, class_name_utilities, collect_images,
+    decode_images, deserialize_keyframes, parse_lang,
   },
 };
 
 pub struct SvgRenderTask {
   pub(crate) node: Option<Node>,
+  pub(crate) class_name_utilities: bool,
   pub(crate) state: Arc<RendererState>,
   pub(crate) viewport: Viewport,
   pub(crate) time_ms: u64,
@@ -43,6 +44,7 @@ impl SvgRenderTask {
 
     Ok(SvgRenderTask {
       node: Some(node),
+      class_name_utilities: class_name_utilities(options.future),
       state,
       viewport: Viewport::new((options.width, options.height)),
       time_ms: options.time_ms.unwrap_or_default().max(0) as u64,
@@ -77,6 +79,7 @@ impl Task for SvgRenderTask {
         .fonts(&fonts)
         .font_families(take(&mut self.font_families))
         .lang(take(&mut self.lang))
+        .class_name_utilities(self.class_name_utilities)
         .build(),
     )
     .map_err(map_error)

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -34,6 +34,9 @@ pub struct RenderOptions<'g> {
   /// Whether to draw debug borders.
   #[builder(default = false)]
   pub(crate) draw_debug_border: bool,
+  /// Whether `class` names also parse as Tailwind utilities.
+  #[builder(default = false)]
+  pub(crate) class_name_utilities: bool,
   /// Pre-decoded images keyed by `src`, resolved when a node references that URL.
   #[builder(default)]
   pub(crate) images: HashMap<Arc<str>, ImageSource>,
@@ -152,6 +155,7 @@ pub fn measure<'g>(options: RenderOptions<'g>) -> Result<MeasuredNode> {
     fonts,
     node,
     draw_debug_border,
+    class_name_utilities,
     images,
     stylesheet,
     time_ms,
@@ -167,6 +171,7 @@ pub fn measure<'g>(options: RenderOptions<'g>) -> Result<MeasuredNode> {
     .stylesheet(stylesheet)
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
+    .class_name_utilities(class_name_utilities)
     .style(Box::new(ComputedStyle {
       lang,
       font_family: font_families.unwrap_or_default(),
@@ -388,6 +393,7 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
     fonts,
     node,
     draw_debug_border,
+    class_name_utilities,
     images,
     stylesheet,
     time_ms,
@@ -403,6 +409,7 @@ pub fn render<'g>(options: RenderOptions<'g>) -> Result<Bitmap> {
     .stylesheet(stylesheet)
     .time_ms(time_ms)
     .draw_debug_border(draw_debug_border)
+    .class_name_utilities(class_name_utilities)
     .style(Box::new(ComputedStyle {
       lang,
       font_family: font_families.unwrap_or_default(),
@@ -503,6 +510,7 @@ impl<'a, 'g> PreparedScene<'a, 'g> {
       .stylesheet(self.stylesheet.clone())
       .time_ms(time_ms)
       .draw_debug_border(options.draw_debug_border)
+      .class_name_utilities(options.class_name_utilities)
       .style(Box::new(ComputedStyle {
         lang: options.lang,
         font_family: options.font_families.clone().unwrap_or_default(),

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -57,6 +57,9 @@ pub struct SvgOptions<'g> {
   /// Global animation time in milliseconds.
   #[builder(default = 0)]
   pub(crate) time_ms: u64,
+  /// Whether `class` names also parse as Tailwind utilities.
+  #[builder(default = false)]
+  pub(crate) class_name_utilities: bool,
   /// Per-render font fallback chain (family names in order). `None` uses all
   /// registered families in registration order.
   #[builder(default)]
@@ -81,6 +84,7 @@ pub fn render(options: SvgOptions<'_>) -> Result<String> {
     .images(Rc::new(options.images))
     .stylesheet(options.stylesheet)
     .time_ms(options.time_ms)
+    .class_name_utilities(options.class_name_utilities)
     .style({
       Box::new(ComputedStyle {
         lang: options.lang,

--- a/takumi-wasm/src/dts-header.d.ts
+++ b/takumi-wasm/src/dts-header.d.ts
@@ -43,6 +43,12 @@ export type RendererOptions = {
   cacheMaxBytes?: number;
 };
 
+/** Opt-in flags for behavior that becomes the default in a future major. */
+export type FutureFlags = {
+  /** Parse `className` tokens as Tailwind utilities, the way `tw` does. */
+  classNameUtilities?: boolean;
+};
+
 export type RenderOptions = {
   /**
    * The width of the image. If not provided, the width will be automatically calculated based on the content.
@@ -110,6 +116,8 @@ export type RenderOptions = {
   fontFamilies?: string[];
   /** Default BCP-47 language applied to the root, inherited by nodes without their own lang. */
   lang?: string;
+  /** Opt-in future behavior flags. */
+  future?: FutureFlags;
 };
 
 /**
@@ -170,6 +178,8 @@ export type RenderAnimationOptions = {
   fontFamilies?: string[];
   /** Default BCP-47 language applied to the root, inherited by nodes without their own lang. */
   lang?: string;
+  /** Opt-in future behavior flags. */
+  future?: FutureFlags;
 };
 
 export type FontDetails = {

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -58,6 +58,22 @@ pub struct RendererOptions {
   pub cache_max_bytes: Option<u64>,
 }
 
+/// Opt-in flags for behavior that becomes the default in a future major.
+#[derive(Deserialize, Default, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct FutureFlags {
+  /// Parse `className` tokens as Tailwind utilities, the way `tw` does.
+  pub class_name_utilities: Option<bool>,
+}
+
+impl FutureFlags {
+  pub(crate) fn class_name_utilities(this: Option<Self>) -> bool {
+    this
+      .and_then(|flags| flags.class_name_utilities)
+      .unwrap_or_default()
+  }
+}
+
 /// Options for rendering an image.
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -92,6 +108,8 @@ pub struct RenderOptions {
   pub font_families: Option<Vec<String>>,
   /// Default BCP-47 language applied to the root, inherited by nodes without their own lang.
   pub lang: Option<String>,
+  /// Opt-in future behavior flags.
+  pub future: Option<FutureFlags>,
 }
 
 /// Options for rendering a node tree to an SVG document. SVG is a vector
@@ -120,6 +138,8 @@ pub struct SvgRenderOptions {
   pub font_families: Option<Vec<String>>,
   /// Default BCP-47 language applied to the root, inherited by nodes without their own lang.
   pub lang: Option<String>,
+  /// Opt-in future behavior flags.
+  pub future: Option<FutureFlags>,
 }
 
 /// Options for rendering an animated image.
@@ -153,6 +173,8 @@ pub struct RenderAnimationOptions {
   pub font_families: Option<Vec<String>>,
   /// Default BCP-47 language applied to the root, inherited by nodes without their own lang.
   pub lang: Option<String>,
+  /// Opt-in future behavior flags.
+  pub future: Option<FutureFlags>,
 }
 
 /// Details for loading a custom font.

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -96,6 +96,7 @@ fn raster_options<'fonts>(
         ),
       )
       .draw_debug_border(options.draw_debug_border.unwrap_or_default())
+      .class_name_utilities(FutureFlags::class_name_utilities(options.future))
       .images(images)
       .stylesheet(stylesheet)
       .time_ms(options.time_ms.unwrap_or_default().max(0) as u64)
@@ -254,6 +255,7 @@ impl Renderer {
         .fonts(&state)
         .font_families(options.font_families.map(FontFamily::from_names))
         .lang(lang)
+        .class_name_utilities(FutureFlags::class_name_utilities(options.future))
         .build(),
     )
     .map_err(map_error)?;
@@ -335,6 +337,7 @@ impl Renderer {
       fps,
       font_families,
       lang,
+      future,
     } = from_value(options.into()).map_err(map_error)?;
 
     let lang = parse_lang(lang)?;
@@ -352,6 +355,7 @@ impl Renderer {
     let viewport = Viewport::new((width, height))
       .with_device_pixel_ratio(device_pixel_ratio.unwrap_or(DEFAULT_DEVICE_PIXEL_RATIO));
     let draw_debug_border = draw_debug_border.unwrap_or_default();
+    let class_name_utilities = FutureFlags::class_name_utilities(future);
     let stylesheet = stylesheet(
       &self.resource_cache,
       stylesheets,
@@ -374,6 +378,7 @@ impl Renderer {
               .font_families(font_families.clone().map(FontFamily::from_names))
               .lang(lang)
               .draw_debug_border(draw_debug_border)
+              .class_name_utilities(class_name_utilities)
               .build(),
           )
           .build()


### PR DESCRIPTION
## Why
Tailwind users paste JSX that carries `className`, not `tw`, so the native parser never sees it and the pasted markup renders unstyled.

## What
A `future.classNameUtilities` render option feeds `className` tokens to the `tw` parser, applied at the same utility layer; `tw` wins ties on the same node. Off by default, planned as the next major's default, documented on a new future-flags docs page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `future.classNameUtilities` setting for raster, SVG, and animation rendering.
  * Class names can now be interpreted as Tailwind utilities when enabled.
  * Utility styles take precedence over stylesheet selectors when conflicts occur; non-utility class names continue to work normally.
  * The setting is disabled by default.

* **Documentation**
  * Added guidance for configuring future rendering options and class-name utility behavior.
  * Added the new future-options guide to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->