### PR TITLE
Docs: restructure the styling page around user paths

### DIFF
--- a/docs/content/docs/future.mdx
+++ b/docs/content/docs/future.mdx
@@ -16,7 +16,7 @@ const image = await render(node, {
 
 ## classNameUtilities
 
-`className` tokens use the same parser as [the `tw` prop](/docs/styling#native-parser). JSX pasted from your app renders without a build step.
+`className` tokens use the same parser as [the `tw` prop](/docs/styling#tailwind-without-a-build-step). JSX pasted from your app renders without a build step.
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -29,7 +29,7 @@ const image = await render(<div className="flex p-4 bg-brand-500">Hello</div>, {
 ```
 
 - A token that is not a utility still matches stylesheet selectors.
-- A stylesheet rule and a utility for the same token both apply. [The cascade resolves conflicts as it does for `tw`](/docs/styling#native-parser).
+- A stylesheet rule and a utility for the same token both apply. [The cascade resolves conflicts as it does for `tw`](/docs/styling#tailwind-without-a-build-step).
 - `tw` wins a tie against a `className` utility on the same node.
 
 The flag is off by default because a class name can match utility syntax by accident. A plain `hidden` class with no matching rule would hide the node.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -4,12 +4,25 @@ description: How CSS reaches a node, what the stylesheet engine supports, and th
 icon: Palette
 ---
 
-Four ways to put CSS on a node:
+Pick a path by what you already have:
 
-- `style` prop: inline `CSSProperties` on one node. Overrides the tag default.
-- `tw` prop: Tailwind classes on one node.
-- `<style>` tags: CSS that travels inside the JSX.
-- `stylesheets` option: full stylesheets matched against `className` and `id`.
+| You have                                   | Use                                                  |
+| ------------------------------------------ | ---------------------------------------------------- |
+| Tailwind classes, compiled by your bundler | [`stylesheets`](#stylesheets) with the generated CSS |
+| Tailwind classes, no build step            | [the `tw` prop](#tailwind-without-a-build-step)      |
+| Plain CSS                                  | [`stylesheets`](#stylesheets) or a `<style>` tag     |
+| Design tokens to theme with                | [`cssVariables` or a `:root` rule](#design-tokens)   |
+| One-off styles on one node                 | [the `style` prop](#inline-styles)                   |
+
+The paths combine. Each section spells out who wins when they collide.
+
+## Inline styles
+
+The `style` prop puts `CSSProperties` on one node. It overrides the tag default and every matching stylesheet rule at the same importance.
+
+```tsx
+<div style={{ display: "flex", padding: 48, background: "#0f172a" }}>Hello</div>
+```
 
 ## Stylesheets
 
@@ -27,9 +40,9 @@ const image = await render(<div className="card">Hello</div>, {
 
 The engine handles:
 
-| Selectors             | At-rules                            | Properties                                                                                                                      |
-| --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| class, id, descendant | `@keyframes`, `@media`, `@supports` | custom properties with `var()`, shorthands, gradients, `box-shadow`, `filter`, `backdrop-filter`, `mix-blend-mode`, `transform` |
+| Selectors             | At-rules                                      | Properties                                                                                                                      |
+| --------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| class, id, descendant | `@keyframes`, `@media`, `@supports`, `@layer` | custom properties with `var()`, shorthands, gradients, `box-shadow`, `filter`, `backdrop-filter`, `mix-blend-mode`, `transform` |
 
 <Callout type="info">
   A render is one static frame, so interactive pseudo-classes like `:hover` and `:focus` parse but
@@ -45,46 +58,9 @@ A `<style>` tag feeds the same engine and gets extracted from the JSX automatica
 </div>
 ```
 
-### CSS variables
+## Tailwind with your bundler
 
-The `cssVariables` option declares CSS custom properties without writing CSS. Each entry becomes one `:root` declaration. The leading `--` is optional.
-
-```tsx twoslash
-import { render } from "takumi-js";
-
-const image = await render(<div className="card">Hello</div>, {
-  width: 1200,
-  height: 630,
-  stylesheets: [`.card { color: var(--brand) }`],
-  cssVariables: { "--brand": "#5b21b6" },
-});
-```
-
-**Every `var()` reads them**, in stylesheets, in `<style>` tags, and in `tw`.
-
-| Competing declaration                | Result                   |
-| ------------------------------------ | ------------------------ |
-| Equally specific `:root` rule in CSS | `cssVariables` wins      |
-| Declaration on the element           | Element declaration wins |
-
-The generated rule comes after every stylesheet, so a media query at equal specificity still loses. Override an entry with a more specific selector, such as `:root:root`.
-
-**Values containing `;`, `{`, `}`, `/*` or `!important` are dropped.** They could escape the generated rule.
-
-A nested palette flattens with the `cssVariables` helper. Keys join with `-` into one variable name.
-
-```tsx twoslash
-import { cssVariables } from "takumi-js/helpers";
-
-const flat = cssVariables({ color: { brand: { 500: "#5b21b6" } } });
-// { "--color-brand-500": "#5b21b6" }
-```
-
-## Tailwind
-
-### Bring your stylesheet
-
-Compile Tailwind with your bundler. Pass the generated CSS through `stylesheets`. With Vite, import it using `?inline`.
+Compile Tailwind with your bundler and pass the generated CSS through `stylesheets`. This path covers every Tailwind feature, because Tailwind itself does the compiling. With Vite, import the stylesheet using `?inline`.
 
 ```tsx title="og.tsx"
 import { ImageResponse } from "takumi-js/response";
@@ -116,49 +92,9 @@ export default defineConfig({
 });
 ```
 
-### Native parser
+## Tailwind without a build step
 
-The `tw` prop runs a built-in parser with no build step. It won't cover every Tailwind feature.
-
-- Arbitrary values work.
-- See the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-core/src/style/tw/map.rs) for every supported class.
-
-<Callout type="warn">
-  `tw` has no Tailwind Preflight by default, so elements keep their UA margins. A `<h1>` gets a
-  `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`.
-</Callout>
-
-The [`classNameUtilities` future flag](/docs/future#classnameutilities) feeds `className` tokens to this parser too.
-
-### Tailwind at-rules
-
-The engine parses Tailwind source stylesheets as-is. It reads these directives:
-
-| At-rule                 | Reads as                                                                                               | Rejected                |
-| ----------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------- |
-| `@theme`                | its `:root` rule. Nested `@keyframes` register. Modifiers like `reference` and `inline` change nothing | `prefix()`              |
-| `@import "tailwindcss"` | Preflight: drops the UA margins, list markers and heading font tweaks                                  | any other import target |
-| `@apply`                | the utilities' declarations, expanded in place, `!` suffix included                                    | variants like `md:`     |
-
-Other Tailwind directives (`@utility`, `@custom-variant`, `@source`, `@plugin`, `@config`) do not parse. Compile those with Tailwind, then [bring the stylesheet](#bring-your-stylesheet).
-
-The import line goes through `stylesheets`:
-
-```tsx
-const image = await render(node, {
-  stylesheets: [`@import "tailwindcss";`],
-});
-```
-
-`@apply` expands inside stylesheet rules:
-
-```css
-.card {
-  @apply mt-4 bg-brand-500;
-}
-```
-
-**Unlayered stylesheet rules override `tw` utilities**, and rules in a named `@layer` lose to them. That is Tailwind's own order: utilities are the last declared layer. Prefix a utility with `!` to override an unlayered rule.
+The `tw` prop runs a built-in parser. Arbitrary values work. It won't cover every Tailwind feature; the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-core/src/style/tw/map.rs) lists every supported class.
 
 ```tsx
 <div tw="bg-blue-500 p-4 rounded-lg">
@@ -166,11 +102,69 @@ const image = await render(node, {
 </div>
 ```
 
-### Utilities read CSS variables
+`tw` is a plain prop, so build it dynamically:
 
-A utility reads a CSS custom property, the way Tailwind compiles it. `bg-red-500` resolves `var(--color-red-500)`, `p-4` resolves `calc(var(--spacing) * 4)`. The built-in scale sits behind them as the fallback.
+```tsx
+import clsx from "clsx";
 
-Declare tokens in a `:root` rule, in a [Tailwind `@theme` block](#tailwind-at-rules) pasted as-is, or pass them as [the `cssVariables` option](#css-variables).
+const isError = true;
+
+<div tw={clsx("p-4 rounded", isError ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700")}>
+  {isError ? "Something went wrong" : "Success!"}
+</div>;
+```
+
+The [`classNameUtilities` future flag](/docs/future#classnameutilities) feeds `className` tokens to the same parser, so JSX pasted from an app renders without renaming props.
+
+### Preflight
+
+`tw` applies no Tailwind Preflight by default, so elements keep their UA margins: a `<h1>` gets a `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`. The same import line a Tailwind stylesheet starts with turns Preflight on. It drops the UA margins, list markers and heading font tweaks.
+
+```tsx
+const image = await render(node, {
+  stylesheets: [`@import "tailwindcss";`],
+});
+```
+
+### Utilities in the cascade
+
+Utilities sit in the last declared layer, Tailwind's own order:
+
+| Against a `tw` utility       | Winner           |
+| ---------------------------- | ---------------- |
+| An unlayered stylesheet rule | the rule         |
+| A rule in a named `@layer`   | the utility      |
+| The `style` prop             | the `style` prop |
+
+Prefix a utility with `!` to beat an unlayered rule.
+
+### At-rules
+
+A Tailwind source stylesheet parses as-is. The engine reads these directives:
+
+| At-rule                 | Reads as                                                                                               | Rejected                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `@theme`                | its `:root` rule. Nested `@keyframes` register. Modifiers like `reference` and `inline` change nothing | `prefix()`              |
+| `@import "tailwindcss"` | Preflight: drops the UA margins, list markers and heading font tweaks                                  | any other import target |
+| `@apply`                | the utilities' declarations, expanded in place, `!` suffix included                                    | variants like `md:`     |
+
+```css
+.card {
+  @apply mt-4 bg-brand-500;
+}
+```
+
+Other Tailwind directives (`@utility`, `@custom-variant`, `@source`, `@plugin`, `@config`) do not parse. Compile those with Tailwind and use [the bundler path](#tailwind-with-your-bundler).
+
+## Design tokens
+
+A utility reads a CSS custom property, the way Tailwind compiles it: `bg-red-500` resolves `var(--color-red-500)`, `p-4` resolves `calc(var(--spacing) * 4)`. The built-in scale sits behind them as the fallback, so tokens are optional until you want your own palette.
+
+### Declaring tokens
+
+Three equivalent places. All of them feed every `var()`, in stylesheets, in `<style>` tags, and in `tw`.
+
+A `:root` rule, or a [Tailwind `@theme` block](#at-rules) pasted as-is:
 
 ```css
 :root {
@@ -179,19 +173,30 @@ Declare tokens in a `:root` rule, in a [Tailwind `@theme` block](#tailwind-at-ru
 }
 ```
 
-```tsx
-<div tw="bg-brand-500 p-gutter" />
+Or the `cssVariables` option, which becomes one `:root` declaration per entry. The leading `--` is optional.
+
+```tsx twoslash
+import { render } from "takumi-js";
+
+const image = await render(<div tw="bg-brand-500 p-gutter">Hello</div>, {
+  width: 1200,
+  height: 630,
+  cssVariables: { "--color-brand-500": "#5b21b6", "--spacing-gutter": "2.5rem" },
+});
 ```
 
-Tokens declared in a stylesheet follow the CSS cascade. A media query or a selector can override them. Tokens passed as `cssVariables` sit after every stylesheet, so overriding one takes a more specific selector.
+**`cssVariables` values containing `;`, `{`, `}`, `/*` or `!important` are dropped.** They could escape the generated rule.
 
-```css
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-brand-500: #a78bfa;
-  }
-}
+A nested palette flattens with the `cssVariables` helper. Keys join with `-` into one variable name.
+
+```tsx twoslash
+import { cssVariables } from "takumi-js/helpers";
+
+const flat = cssVariables({ color: { brand: { 500: "#5b21b6" } } });
+// { "--color-brand-500": "#5b21b6" }
 ```
+
+### Which utilities read a token
 
 The namespace picks which utilities a token reaches:
 
@@ -213,7 +218,27 @@ The namespace picks which utilities a token reaches:
 | `--animate-*`                                       | `animate-*`. An unknown token like `animate-wiggle` reads `var(--animate-wiggle)`; pair it with its `@keyframes`                               |
 | `--breakpoint-*`                                    | the `sm:`–`2xl:` variants, and new ones like `3xl:`. Variants gate before the cascade, so only an unconditional `:root` declaration moves them |
 
-Some things behave differently from Tailwind here:
+### Overriding tokens
+
+Tokens declared in a stylesheet follow the CSS cascade. A media query or a selector can override them:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-brand-500: #a78bfa;
+  }
+}
+```
+
+Tokens passed as `cssVariables` sit in a rule after every stylesheet:
+
+| Competing declaration                  | Result                   |
+| -------------------------------------- | ------------------------ |
+| Equally specific `:root` rule in CSS   | `cssVariables` wins      |
+| A more specific selector, `:root:root` | the selector wins        |
+| Declaration on the element             | Element declaration wins |
+
+## Where this differs from Tailwind
 
 - Colours reach gradients and shadows: `from-brand-500` and `shadow-brand-500` read `--color-brand-500` like `bg-brand-500` does.
 - A gradient needs `bg-linear-*`, `bg-radial` or `bg-conic`. Stops alone paint nothing, as in Tailwind.
@@ -221,15 +246,3 @@ Some things behave differently from Tailwind here:
 - A bare `rounded` keeps its built-in value; `rounded-sm` and the rest read the variable.
 - `--spacing` needs a unit. A bare number makes `p-4` compute pixels here, where a browser rejects the declaration.
 - An aliased token stays live. `--color-brand: var(--background)` follows a subtree `--background` override. In a browser, `@theme inline` exists to arrange that.
-
-`tw` is a plain prop, so build it dynamically:
-
-```tsx
-import clsx from "clsx";
-
-const isError = true;
-
-<div tw={clsx("p-4 rounded", isError ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700")}>
-  {isError ? "Something went wrong" : "Success!"}
-</div>;
-```

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -6,13 +6,13 @@ icon: Palette
 
 Pick a path by what you already have:
 
-| You have                                   | Use                                                  |
-| ------------------------------------------ | ---------------------------------------------------- |
-| Tailwind classes, compiled by your bundler | [`stylesheets`](#stylesheets) with the generated CSS |
-| Tailwind classes, no build step            | [the `tw` prop](#tailwind-without-a-build-step)      |
-| Plain CSS                                  | [`stylesheets`](#stylesheets) or a `<style>` tag     |
-| Design tokens to theme with                | [`cssVariables` or a `:root` rule](#design-tokens)   |
-| One-off styles on one node                 | [the `style` prop](#inline-styles)                   |
+| You have                                   | Use                                                           |
+| ------------------------------------------ | ------------------------------------------------------------- |
+| Tailwind classes, compiled by your bundler | [`stylesheets`](#stylesheets) with the generated CSS          |
+| Tailwind classes, no build step            | [`className` + a future flag](#tailwind-without-a-build-step) |
+| Plain CSS                                  | [`stylesheets`](#stylesheets) or a `<style>` tag              |
+| Design tokens to theme with                | [`cssVariables` or a `:root` rule](#design-tokens)            |
+| One-off styles on one node                 | [the `style` prop](#inline-styles)                            |
 
 The paths combine. Each section spells out who wins when they collide.
 
@@ -94,31 +94,51 @@ export default defineConfig({
 
 ## Tailwind without a build step
 
-The `tw` prop runs a built-in parser. Arbitrary values work. It won't cover every Tailwind feature; the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-core/src/style/tw/map.rs) lists every supported class.
+Turn on [the `classNameUtilities` future flag](/docs/future#classnameutilities) and `className` tokens run through a built-in parser. JSX pasted from an app renders without renaming a prop.
 
-```tsx
-<div tw="bg-blue-500 p-4 rounded-lg">
-  <h1 tw="text-white text-2xl font-bold">Hello Tailwind!</h1>
-</div>
+```tsx twoslash
+import { render } from "takumi-js";
+
+const image = await render(
+  <div className="bg-blue-500 p-4 rounded-lg">
+    <h1 className="text-white text-2xl font-bold">Hello Tailwind!</h1>
+  </div>,
+  {
+    width: 1200,
+    height: 630,
+    future: { classNameUtilities: true },
+  },
+);
 ```
 
-`tw` is a plain prop, so build it dynamically:
+Arbitrary values work. The parser won't cover every Tailwind feature; the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-core/src/style/tw/map.rs) lists every supported class.
+
+`className` is a plain prop, so build it dynamically:
 
 ```tsx
 import clsx from "clsx";
 
 const isError = true;
 
-<div tw={clsx("p-4 rounded", isError ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700")}>
+<div
+  className={clsx(
+    "p-4 rounded",
+    isError ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700",
+  )}
+>
   {isError ? "Something went wrong" : "Success!"}
 </div>;
 ```
 
-The [`classNameUtilities` future flag](/docs/future#classnameutilities) feeds `className` tokens to the same parser, so JSX pasted from an app renders without renaming props.
+The `tw` prop feeds the same parser without any flag. It exists for satori compatibility, and it wins a tie against a `className` utility on the same node.
+
+```tsx
+<div tw="bg-blue-500 p-4 rounded-lg">Hello</div>
+```
 
 ### Preflight
 
-`tw` applies no Tailwind Preflight by default, so elements keep their UA margins: a `<h1>` gets a `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`. The same import line a Tailwind stylesheet starts with turns Preflight on. It drops the UA margins, list markers and heading font tweaks.
+The native parser applies no Tailwind Preflight by default, so elements keep their UA margins: a `<h1>` gets a `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`. The same import line a Tailwind stylesheet starts with turns Preflight on. It drops the UA margins, list markers and heading font tweaks.
 
 ```tsx
 const image = await render(node, {
@@ -130,7 +150,7 @@ const image = await render(node, {
 
 Utilities sit in the last declared layer, Tailwind's own order:
 
-| Against a `tw` utility       | Winner           |
+| Against a utility            | Winner           |
 | ---------------------------- | ---------------- |
 | An unlayered stylesheet rule | the rule         |
 | A rule in a named `@layer`   | the utility      |
@@ -162,7 +182,7 @@ A utility reads a CSS custom property, the way Tailwind compiles it: `bg-red-500
 
 ### Declaring tokens
 
-Three equivalent places. All of them feed every `var()`, in stylesheets, in `<style>` tags, and in `tw`.
+Three equivalent places. All of them feed every `var()`, in stylesheets, in `<style>` tags, and in utilities.
 
 A `:root` rule, or a [Tailwind `@theme` block](#at-rules) pasted as-is:
 
@@ -178,10 +198,11 @@ Or the `cssVariables` option, which becomes one `:root` declaration per entry. T
 ```tsx twoslash
 import { render } from "takumi-js";
 
-const image = await render(<div tw="bg-brand-500 p-gutter">Hello</div>, {
+const image = await render(<div className="bg-brand-500 p-gutter">Hello</div>, {
   width: 1200,
   height: 630,
   cssVariables: { "--color-brand-500": "#5b21b6", "--spacing-gutter": "2.5rem" },
+  future: { classNameUtilities: true },
 });
 ```
 

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -60,7 +60,7 @@ A `<style>` tag feeds the same engine and gets extracted from the JSX automatica
 
 ## Tailwind with your bundler
 
-Compile Tailwind with your bundler and pass the generated CSS through `stylesheets`. This path covers every Tailwind feature, because Tailwind itself does the compiling. With Vite, import the stylesheet using `?inline`.
+Compile Tailwind with your bundler and pass the generated CSS through `stylesheets`. Tailwind itself does the compiling, so every directive and class name works; [the engine's CSS support](#stylesheets) still bounds what renders. With Vite, import the stylesheet using `?inline`.
 
 ```tsx title="og.tsx"
 import { ImageResponse } from "takumi-js/response";
@@ -130,7 +130,7 @@ const isError = true;
 </div>;
 ```
 
-The `tw` prop feeds the same parser without any flag. It exists for satori compatibility, and it wins a tie against a `className` utility on the same node.
+The `tw` prop feeds the same parser without any flag. It is a plain prop too, takes the same dynamic expressions, exists for satori compatibility, and wins a tie against a `className` utility on the same node.
 
 ```tsx
 <div tw="bg-blue-500 p-4 rounded-lg">Hello</div>
@@ -156,16 +156,16 @@ Utilities sit in the last declared layer, Tailwind's own order:
 | A rule in a named `@layer`   | the utility      |
 | The `style` prop             | the `style` prop |
 
-Prefix a utility with `!` to beat an unlayered rule.
+Prefix a utility with `!` to flip the result: important declarations reverse the layer order, so a `!` utility beats an unlayered rule and a normal `style` declaration.
 
-### At-rules
+### Tailwind at-rules
 
-A Tailwind source stylesheet parses as-is. The engine reads these directives:
+A Tailwind source stylesheet drops into `stylesheets` unchanged. The engine reads these directives and skips the rest:
 
 | At-rule                 | Reads as                                                                                               | Rejected                |
 | ----------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------- |
 | `@theme`                | its `:root` rule. Nested `@keyframes` register. Modifiers like `reference` and `inline` change nothing | `prefix()`              |
-| `@import "tailwindcss"` | Preflight: drops the UA margins, list markers and heading font tweaks                                  | any other import target |
+| `@import "tailwindcss"` | [Preflight](#preflight), at the top level only                                                         | any other import target |
 | `@apply`                | the utilities' declarations, expanded in place, `!` suffix included                                    | variants like `md:`     |
 
 ```css
@@ -184,7 +184,7 @@ A utility reads a CSS custom property, the way Tailwind compiles it: `bg-red-500
 
 Three equivalent places. All of them feed every `var()`, in stylesheets, in `<style>` tags, and in utilities.
 
-A `:root` rule, or a [Tailwind `@theme` block](#at-rules) pasted as-is:
+A `:root` rule, or a [Tailwind `@theme` block](#tailwind-at-rules) pasted as-is:
 
 ```css
 :root {
@@ -193,7 +193,7 @@ A `:root` rule, or a [Tailwind `@theme` block](#at-rules) pasted as-is:
 }
 ```
 
-Or the `cssVariables` option, which becomes one `:root` declaration per entry. The leading `--` is optional.
+Or the `cssVariables` option, which compiles into a `:root` rule. The leading `--` is optional.
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -206,7 +206,7 @@ const image = await render(<div className="bg-brand-500 p-gutter">Hello</div>, {
 });
 ```
 
-**`cssVariables` values containing `;`, `{`, `}`, `/*` or `!important` are dropped.** They could escape the generated rule.
+**`cssVariables` entries whose value contains `;`, `{`, `}`, `/*` or `!important`, or whose name contains `:`, `;`, `{` or `}`, are dropped.** They could escape the generated rule.
 
 A nested palette flattens with the `cssVariables` helper. Keys join with `-` into one variable name.
 
@@ -262,7 +262,7 @@ Tokens passed as `cssVariables` sit in a rule after every stylesheet:
 ## Where this differs from Tailwind
 
 - Colours reach gradients and shadows: `from-brand-500` and `shadow-brand-500` read `--color-brand-500` like `bg-brand-500` does.
-- A gradient needs `bg-linear-*`, `bg-radial` or `bg-conic`. Stops alone paint nothing, as in Tailwind.
+- Same as Tailwind, but easy to miss: a gradient needs `bg-linear-*`, `bg-radial` or `bg-conic`. Stops alone paint nothing.
 - `--color-red-500: initial` falls back to the built-in red instead of removing `bg-red-500`.
 - A bare `rounded` keeps its built-in value; `rounded-sm` and the rest read the variable.
 - `--spacing` needs a unit. A bare number makes `p-4` compute pixels here, where a browser rejects the declaration.

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -14,7 +14,7 @@ Pick a path by what you already have:
 | Design tokens to theme with                | [`cssVariables` or a `:root` rule](#design-tokens)            |
 | One-off styles on one node                 | [the `style` prop](#inline-styles)                            |
 
-The paths combine. Each section spells out who wins when they collide.
+The paths combine. Each section says who wins when they collide.
 
 ## Inline styles
 
@@ -26,7 +26,7 @@ The `style` prop puts `CSSProperties` on one node. It overrides the tag default 
 
 ## Stylesheets
 
-Pass real CSS through `stylesheets` and match it by `className` or `id`.
+Pass real CSS through `stylesheets`. The engine matches it by `className` or `id`.
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -49,7 +49,7 @@ The engine handles:
   never match.
 </Callout>
 
-A `<style>` tag feeds the same engine and gets extracted from the JSX automatically.
+A `<style>` tag feeds the same engine. Takumi extracts it from the JSX for you.
 
 ```tsx
 <div className="card">
@@ -60,7 +60,7 @@ A `<style>` tag feeds the same engine and gets extracted from the JSX automatica
 
 ## Tailwind with your bundler
 
-Compile Tailwind with your bundler and pass the generated CSS through `stylesheets`. Tailwind itself does the compiling, so every directive and class name works; [the engine's CSS support](#stylesheets) still bounds what renders. With Vite, import the stylesheet using `?inline`.
+Compile Tailwind with your bundler, then pass the generated CSS through `stylesheets`. Tailwind does the compiling, so every directive and class name works. What renders is still bounded by [the engine's CSS support](#stylesheets). With Vite, import the stylesheet using `?inline`.
 
 ```tsx title="og.tsx"
 import { ImageResponse } from "takumi-js/response";
@@ -94,7 +94,7 @@ export default defineConfig({
 
 ## Tailwind without a build step
 
-Turn on [the `classNameUtilities` future flag](/docs/future#classnameutilities) and `className` tokens run through a built-in parser. JSX pasted from an app renders without renaming a prop.
+Turn on [the `classNameUtilities` future flag](/docs/future#classnameutilities). `className` tokens then run through a built-in parser. JSX pasted from an app renders without renaming a prop.
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -111,7 +111,7 @@ const image = await render(
 );
 ```
 
-Arbitrary values work. The parser won't cover every Tailwind feature; the [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-core/src/style/tw/map.rs) lists every supported class.
+Arbitrary values work. The parser does not cover every Tailwind feature. The [parser mapping](https://github.com/kane50613/takumi/blob/master/takumi-core/src/style/tw/map.rs) lists every supported class.
 
 `className` is a plain prop, so build it dynamically:
 
@@ -130,7 +130,7 @@ const isError = true;
 </div>;
 ```
 
-The `tw` prop feeds the same parser without any flag. It is a plain prop too, takes the same dynamic expressions, exists for satori compatibility, and wins a tie against a `className` utility on the same node.
+The `tw` prop feeds the same parser without any flag. It exists for satori compatibility. It takes the same dynamic expressions, and it wins a tie against a `className` utility on the same node.
 
 ```tsx
 <div tw="bg-blue-500 p-4 rounded-lg">Hello</div>
@@ -138,7 +138,9 @@ The `tw` prop feeds the same parser without any flag. It is a plain prop too, ta
 
 ### Preflight
 
-The native parser applies no Tailwind Preflight by default, so elements keep their UA margins: a `<h1>` gets a `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`. The same import line a Tailwind stylesheet starts with turns Preflight on. It drops the UA margins, list markers and heading font tweaks.
+The native parser applies no Tailwind Preflight by default, so elements keep their UA margins. A `<h1>` gets a `0.67em` top margin until you add `mt-0`. `box-sizing` still defaults to `border-box`.
+
+The same import line a Tailwind stylesheet starts with turns Preflight on. It drops the UA margins, list markers and heading font tweaks.
 
 ```tsx
 const image = await render(node, {
@@ -156,7 +158,7 @@ Utilities sit in the last declared layer, Tailwind's own order:
 | A rule in a named `@layer`   | the utility      |
 | The `style` prop             | the `style` prop |
 
-Prefix a utility with `!` to flip the result: important declarations reverse the layer order, so a `!` utility beats an unlayered rule and a normal `style` declaration.
+Prefix a utility with `!` to flip the result. Important declarations reverse the layer order, so a `!` utility beats an unlayered rule and a normal `style` declaration.
 
 ### Tailwind at-rules
 
@@ -174,11 +176,11 @@ A Tailwind source stylesheet drops into `stylesheets` unchanged. The engine read
 }
 ```
 
-Other Tailwind directives (`@utility`, `@custom-variant`, `@source`, `@plugin`, `@config`) do not parse. Compile those with Tailwind and use [the bundler path](#tailwind-with-your-bundler).
+Other Tailwind directives do not parse: `@utility`, `@custom-variant`, `@source`, `@plugin` and `@config`. Compile those with Tailwind and use [the bundler path](#tailwind-with-your-bundler).
 
 ## Design tokens
 
-A utility reads a CSS custom property, the way Tailwind compiles it: `bg-red-500` resolves `var(--color-red-500)`, `p-4` resolves `calc(var(--spacing) * 4)`. The built-in scale sits behind them as the fallback, so tokens are optional until you want your own palette.
+A utility reads a CSS custom property, the way Tailwind compiles it. `bg-red-500` resolves `var(--color-red-500)`, and `p-4` resolves `calc(var(--spacing) * 4)`. The built-in scale sits behind them as the fallback, so tokens stay optional until you want your own palette.
 
 ### Declaring tokens
 
@@ -206,7 +208,7 @@ const image = await render(<div className="bg-brand-500 p-gutter">Hello</div>, {
 });
 ```
 
-**`cssVariables` entries whose value contains `;`, `{`, `}`, `/*` or `!important`, or whose name contains `:`, `;`, `{` or `}`, are dropped.** They could escape the generated rule.
+**Takumi drops an entry whose value contains `;`, `{`, `}`, `/*` or `!important`. It also drops an entry whose name contains `:`, `;`, `{` or `}`.** Those entries could escape the generated rule.
 
 A nested palette flattens with the `cssVariables` helper. Keys join with `-` into one variable name.
 
@@ -236,7 +238,7 @@ The namespace picks which utilities a token reaches:
 | `--blur-*`                                          | `blur-*` and `backdrop-blur-*` presets                                                                                                         |
 | `--drop-shadow-*`                                   | `drop-shadow-*` presets                                                                                                                        |
 | `--shadow-*`, `--inset-shadow-*`, `--text-shadow-*` | shadow preset shapes. A custom shape carries its own colours, so shadow colour utilities only reach the built-in fallback                      |
-| `--animate-*`                                       | `animate-*`. An unknown token like `animate-wiggle` reads `var(--animate-wiggle)`; pair it with its `@keyframes`                               |
+| `--animate-*`                                       | `animate-*`. An unknown token like `animate-wiggle` reads `var(--animate-wiggle)`. Pair it with its `@keyframes`                               |
 | `--breakpoint-*`                                    | the `sm:`–`2xl:` variants, and new ones like `3xl:`. Variants gate before the cascade, so only an unconditional `:root` declaration moves them |
 
 ### Overriding tokens
@@ -261,9 +263,9 @@ Tokens passed as `cssVariables` sit in a rule after every stylesheet:
 
 ## Where this differs from Tailwind
 
-- Colours reach gradients and shadows: `from-brand-500` and `shadow-brand-500` read `--color-brand-500` like `bg-brand-500` does.
+- Colours reach gradients and shadows. `from-brand-500` and `shadow-brand-500` read `--color-brand-500` like `bg-brand-500` does.
 - Same as Tailwind, but easy to miss: a gradient needs `bg-linear-*`, `bg-radial` or `bg-conic`. Stops alone paint nothing.
 - `--color-red-500: initial` falls back to the built-in red instead of removing `bg-red-500`.
-- A bare `rounded` keeps its built-in value; `rounded-sm` and the rest read the variable.
+- A bare `rounded` keeps its built-in value. `rounded-sm` and the rest read the variable.
 - `--spacing` needs a unit. A bare number makes `p-4` compute pixels here, where a browser rejects the declaration.
 - An aliased token stays live. `--color-brand: var(--background)` follows a subtree `--background` override. In a browser, `@theme inline` exists to arrange that.


### PR DESCRIPTION
## Why
The styling page grew by accretion through the Tailwind stack and reads as a pile of loosely ordered sections; readers cannot tell which path applies to them.

## What
The page now opens with a pick-your-path table and groups everything under five sections (inline styles, stylesheets, Tailwind with a bundler, Tailwind without a build step, design tokens), with cascade collisions and cssVariables overrides expressed as tables. Content is reorganized, not changed; the only additions are an inline-style example and `@layer` in the engine support table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized and expanded the styling guide to clarify CSS input options, inline styles, stylesheets, Tailwind integration, cascading behavior, at-rules, Preflight, token namespaces, and overrides.
  - Added guidance for stylesheet `@layer` support and CSS variable filtering.
  - Clarified the differences between native class utilities and the compatible `tw` path.
  - Updated documentation links for the no-build Tailwind parser workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->