### PR TITLE
Core: serialize and strip through cssparser instead of hand-rolled scanners

### DIFF
--- a/.tegami/css-string-escaping.md
+++ b/.tegami/css-string-escaping.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Escape control characters in serialized CSS strings
+
+A quoted string containing a newline left it unescaped. This produced invalid CSS. CSS strings now use cssparser's escaping.

--- a/takumi-core/src/style/properties/animation.rs
+++ b/takumi-core/src/style/properties/animation.rs
@@ -1,12 +1,11 @@
 use std::{borrow::Cow, fmt, vec::Vec};
 
-use cssparser::{BasicParseErrorKind, Parser, Token, match_ignore_ascii_case};
+use cssparser::{BasicParseErrorKind, Parser, Token, match_ignore_ascii_case, serialize_string};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
-  ToCss, declare_enum_from_css_impl, next_is_comma, properties::write_css_string,
-  tw::TailwindPropertyParser, unexpected_token,
+  ToCss, declare_enum_from_css_impl, next_is_comma, tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Implements `FromCss` for a `Box<[T]>` animation list type as a comma-separated list of `$elem`.
@@ -703,7 +702,7 @@ impl ToCss for Animation {
         .chars()
         .any(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-'));
       if needs_quoting {
-        write_css_string(dest, name)?;
+        serialize_string(name, dest)?;
       } else {
         dest.write_str(name)?;
       }

--- a/takumi-core/src/style/properties/background_image.rs
+++ b/takumi-core/src/style/properties/background_image.rs
@@ -1,11 +1,11 @@
 use std::{fmt, sync::Arc};
 
-use cssparser::{Parser, Token, match_ignore_ascii_case};
+use cssparser::{Parser, Token, match_ignore_ascii_case, serialize_string};
 
 use crate::style::{
   Animatable, ConicGradient, CssDescriptorKind, CssToken, FromCss, LinearGradient,
   ListInterpolationStrategy, MakeComputed, ParseResult, RadialGradient, SizingContext, ToCss,
-  properties::write_css_string, tw::TailwindPropertyParser, unexpected_token,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Background image variants supported by Takumi.
@@ -130,7 +130,7 @@ impl ToCss for BackgroundImage {
       Self::Conic(conic) => conic.to_css(dest),
       Self::Url(url) => {
         dest.write_str("url(")?;
-        write_css_string(dest, url)?;
+        serialize_string(url, dest)?;
         dest.write_char(')')
       }
     }

--- a/takumi-core/src/style/properties/clip_path.rs
+++ b/takumi-core/src/style/properties/clip_path.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
-use cssparser::{Parser, Token, match_ignore_ascii_case};
+use cssparser::{Parser, Token, match_ignore_ascii_case, serialize_string};
 
 use crate::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult, Sides,
-  SizingContext, SpacePair, ToCss, properties::write_css_string, unexpected_token,
+  SizingContext, SpacePair, ToCss, unexpected_token,
 };
 
 /// Represents the fill rule used for determining the interior of shapes.
@@ -373,7 +373,7 @@ impl ToCss for BasicShape {
           rule.to_css(dest)?;
           dest.write_str(", ")?;
         }
-        write_css_string(dest, &shape.path)?;
+        serialize_string(&shape.path, dest)?;
         dest.write_char(')')
       }
     }

--- a/takumi-core/src/style/properties/content.rs
+++ b/takumi-core/src/style/properties/content.rs
@@ -1,10 +1,10 @@
 use std::{fmt, sync::Arc};
 
-use cssparser::{Parser, Token, match_ignore_ascii_case};
+use cssparser::{Parser, Token, match_ignore_ascii_case, serialize_string};
 
 use crate::style::{
   Animatable, BackgroundImage, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
-  properties::write_css_string, tw::TailwindPropertyParser, unexpected_token,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// CSS `content` property value for `::before` / `::after` pseudo-elements.
@@ -166,7 +166,7 @@ impl ToCss for ContentValue {
 impl ToCss for ContentItem {
   fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
     match self {
-      ContentItem::Text(value) => write_css_string(dest, value),
+      ContentItem::Text(value) => serialize_string(value, dest),
       ContentItem::Image(image) => image.to_css(dest),
       ContentItem::Attr(attr) => attr.to_css(dest),
     }
@@ -179,7 +179,7 @@ impl ToCss for AttrRef {
     dest.write_str(&self.name)?;
     if !self.fallback.is_empty() {
       dest.write_str(", ")?;
-      write_css_string(dest, &self.fallback)?;
+      serialize_string(&self.fallback, dest)?;
     }
     dest.write_char(')')
   }
@@ -210,6 +210,13 @@ mod tests {
     };
     assert_eq!(items.len(), 1);
     assert_eq!(items[0], ContentItem::Text("hello".into()));
+  }
+
+  #[test]
+  fn round_trips_control_characters() {
+    let parsed = parse("\"a\\a b\"");
+
+    assert_eq!(parse(&parsed.to_css_string()), parsed);
   }
 
   #[test]

--- a/takumi-core/src/style/properties/font_family.rs
+++ b/takumi-core/src/style/properties/font_family.rs
@@ -1,12 +1,11 @@
 use std::{fmt, string::ToString, sync::Arc};
 
-use cssparser::{Parser, match_ignore_ascii_case};
+use cssparser::{Parser, match_ignore_ascii_case, serialize_string};
 use parley::{FontFamilyName, GenericFamily};
 
 use crate::style::tw::Namespace;
 use crate::style::{
-  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
-  tw::TailwindPropertyParser,
+  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, tw::TailwindPropertyParser,
 };
 
 /// Represents a font family for text rendering.
@@ -116,7 +115,7 @@ impl ToCss for FontFamilyToken {
           || name.contains('\\')
           || name.chars().next().is_some_and(|c| c.is_ascii_digit());
         if needs_quoting {
-          write_css_string(dest, name)
+          serialize_string(name, dest)
         } else {
           dest.write_str(name)
         }

--- a/takumi-core/src/style/properties/line_clamp.rs
+++ b/takumi-core/src/style/properties/line_clamp.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 
-use cssparser::Parser;
+use cssparser::{Parser, serialize_string};
 
 use crate::style::{
   Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
-  declare_enum_from_css_impl, properties::write_css_string, tw::TailwindPropertyParser,
+  declare_enum_from_css_impl, tw::TailwindPropertyParser,
 };
 
 /// `block-ellipsis`: `none | auto | <string>`. Inherited.
@@ -46,7 +46,7 @@ impl ToCss for BlockEllipsis {
     match self {
       Self::None => dest.write_str("none"),
       Self::Auto => dest.write_str("auto"),
-      Self::String(value) => write_css_string(dest, value),
+      Self::String(value) => serialize_string(value, dest),
     }
   }
 }

--- a/takumi-core/src/style/properties/list_style.rs
+++ b/takumi-core/src/style/properties/list_style.rs
@@ -1,10 +1,10 @@
 use std::{fmt, sync::Arc};
 
-use cssparser::{Parser, Token, match_ignore_ascii_case};
+use cssparser::{Parser, Token, match_ignore_ascii_case, serialize_string};
 
 use crate::style::{
   Animatable, BackgroundImage, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
-  declare_enum_from_css_impl, properties::write_css_string, unexpected_token,
+  declare_enum_from_css_impl, unexpected_token,
 };
 
 /// The counter style a list item's marker is generated from.
@@ -266,7 +266,7 @@ impl ToCss for ListStyleType {
       ListStyleType::UpperAlpha => dest.write_str("upper-alpha"),
       ListStyleType::LowerRoman => dest.write_str("lower-roman"),
       ListStyleType::UpperRoman => dest.write_str("upper-roman"),
-      ListStyleType::String(value) => write_css_string(dest, value),
+      ListStyleType::String(value) => serialize_string(value, dest),
     }
   }
 }

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -261,19 +261,6 @@ pub(crate) fn merge_enum_values(values: &[CssToken]) -> String {
   }
 }
 
-/// Write a CSS quoted string, escaping backslashes and double quotes.
-pub(crate) fn write_css_string<W: fmt::Write>(dest: &mut W, s: &str) -> fmt::Result {
-  dest.write_char('"')?;
-  for ch in s.chars() {
-    match ch {
-      '\\' => dest.write_str("\\\\")?,
-      '"' => dest.write_str("\\\"")?,
-      c => dest.write_char(c)?,
-    }
-  }
-  dest.write_char('"')
-}
-
 /// Defines how an image should be resized to fit its container.
 ///
 /// Similar to CSS object-fit property.
@@ -643,7 +630,7 @@ impl<'i> FromCss<'i> for BorderSpacing {
 }
 
 impl ToCss for BorderSpacing {
-  fn to_css<W: std::fmt::Write>(&self, dest: &mut W) -> std::fmt::Result {
+  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
     self.0.to_css(dest)
   }
 }

--- a/takumi-core/src/style/properties/text_overflow.rs
+++ b/takumi-core/src/style/properties/text_overflow.rs
@@ -1,10 +1,8 @@
 use std::fmt;
 
-use cssparser::{Parser, match_ignore_ascii_case};
+use cssparser::{Parser, match_ignore_ascii_case, serialize_string};
 
-use crate::style::{
-  CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, properties::write_css_string,
-};
+use crate::style::{CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss};
 
 /// Defines how text should be overflowed.
 ///
@@ -46,7 +44,7 @@ impl ToCss for TextOverflow {
     match self {
       Self::Clip => dest.write_str("clip"),
       Self::Ellipsis => dest.write_str("ellipsis"),
-      Self::Custom(s) => write_css_string(dest, s),
+      Self::Custom(s) => serialize_string(s, dest),
     }
   }
 }

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -912,9 +912,23 @@ fn parse_at_rule_prelude<'i, 't>(
   }
 
   if name.eq_ignore_ascii_case("apply") {
-    let start = input.position();
-    while input.next_including_whitespace_and_comments().is_ok() {}
-    let block = expand_apply(input.slice_from(start))
+    let mut source = String::new();
+    let mut start = input.position();
+    loop {
+      let before = input.position();
+      match input.next_including_whitespace_and_comments() {
+        Ok(Token::Comment(_)) => {
+          source.push_str(input.slice(start..before));
+          source.push(' ');
+          start = input.position();
+        }
+        Ok(_) => {}
+        Err(_) => break,
+      }
+    }
+    source.push_str(input.slice_from(start));
+
+    let block = expand_apply(&source)
       .ok_or_else(|| input.new_custom_error(StyleSheetParseError::invalid_apply_utility()))?;
 
     return Ok(AtRulePrelude::Apply(Box::new(block)));

--- a/takumi-core/src/style/tw/mod.rs
+++ b/takumi-core/src/style/tw/mod.rs
@@ -81,60 +81,11 @@ fn blur_css(blur: &TwBlur) -> String {
   }
 }
 
-/// Blanks `/* … */` runs so comments separate utilities the way whitespace
-/// does. Quoted spans, as arbitrary values carry, pass through untouched.
-fn strip_css_comments(source: &str) -> Cow<'_, str> {
-  if !source.contains("/*") {
-    return Cow::Borrowed(source);
-  }
-
-  let bytes = source.as_bytes();
-  let mut out = String::with_capacity(source.len());
-  let mut segment_start = 0;
-  let mut quote: Option<u8> = None;
-  let mut index = 0;
-
-  while index < bytes.len() {
-    match quote {
-      Some(closing) => {
-        if bytes[index] == b'\\' {
-          index += 2;
-          continue;
-        }
-        if bytes[index] == closing {
-          quote = None;
-        }
-      }
-      None => match bytes[index] {
-        opening @ (b'\'' | b'"') => quote = Some(opening),
-        b'/' if bytes.get(index + 1) == Some(&b'*') => {
-          out.push_str(&source[segment_start..index]);
-          out.push(' ');
-          index += 2;
-          while index < bytes.len()
-            && !(bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/'))
-          {
-            index += 1;
-          }
-          index += 2;
-          segment_start = index.min(bytes.len());
-          continue;
-        }
-        _ => {}
-      },
-    }
-    index += 1;
-  }
-
-  out.push_str(&source[segment_start..]);
-  Cow::Owned(out)
-}
-
 /// Expands an `@apply` utility list into the declarations it stands for.
+/// The list must arrive comment-free; the stylesheet tokenizer drops them.
 /// `None` when a token is unknown or carries a variant, which `@apply` rejects.
 pub(crate) fn expand_apply(source: &str) -> Option<StyleDeclarationBlock> {
   let mut builder = TailwindDeclarationBuilder::default();
-  let source = strip_css_comments(source);
 
   for token in source.split_whitespace() {
     let value = TailwindValue::parse(token)?;


### PR DESCRIPTION
## Why
The `@apply` prelude walked every token with cssparser, then re-sliced the raw source, so a hand-written scanner stripped comments again downstream. `write_css_string` re-implemented cssparser's `serialize_string` and skipped the control-character escapes the spec requires.

## What
The `@apply` branch now collects non-comment spans during its existing token walk, and `strip_css_comments` is gone. CSS strings serialize through `serialize_string`, so a string containing a newline now round-trips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for legacy WebKit flex display values and corresponding flex alignment options.
* **Bug Fixes**
  * Improved CSS serialization for quoted values containing control characters, including newlines, preventing invalid CSS output.
  * Preserved control characters when reading and re-serializing content values.
  * Improved `@apply` handling when utility declarations include CSS comments.
* **Documentation**
  * Added release documentation for the CSS serialization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->