### PR TITLE
CI: stop duplicate runs on branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
`on: push` had no branch filter. Pushing a feature branch started a push run next to the pull request run for the same commit.

The push run took the master half of the napi matrix and built all eight targets. Pull requests deliberately skip those seven.

Both runs landed in the same concurrency group and cancelled each other. `Pass Test` uses `if: always()`, so a cancelled upstream job showed up as a red required check on a pull request that was otherwise fine.

Push now triggers only on master. Pull request runs are unchanged, and the master pipeline still builds every target after a merge.
