### PR TITLE
Core: pick breakpoint overrides by cascade layer

### DIFF
--- a/.tegami/breakpoint-layer-cascade.md
+++ b/.tegami/breakpoint-layer-cascade.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+  "takumi-pdf":
+    type: patch
+---
+
+### Resolve `--breakpoint-*` overrides by cascade layer
+
+A `--breakpoint-*` declaration inside `@layer` used to beat an unlayered one that came before it. Overrides now follow the cascade: unlayered wins over any layer, and a later layer wins over an earlier one.

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1473,11 +1473,16 @@ impl StyleSheet {
 /// parse time, so only statically-known declarations can re-size them.
 fn collect_breakpoints(rules: &[CssRule]) -> BreakpointOverrides {
   let mut breakpoints = BreakpointOverrides::default();
+  let mut winners = HashMap::<String, usize>::new();
 
   for rule in rules {
     if !rule.media_queries.is_empty() || selector_list_text(&rule.selectors) != ":root" {
       continue;
     }
+
+    // Unlayered declarations outrank every layer, so they sort above the
+    // highest ordinal rather than below the lowest.
+    let precedence = rule.layer_order.unwrap_or(usize::MAX);
 
     for declaration in rule.normal_declarations.declarations.iter() {
       if let StyleDeclaration::CustomProperty(name, value) = declaration
@@ -1486,7 +1491,9 @@ fn collect_breakpoints(rules: &[CssRule]) -> BreakpointOverrides {
         // Only units `Breakpoint::matches` resolves; anything else would
         // shadow the built-in width with a dead one.
         && matches!(width, Length::Rem(_) | Length::Px(_) | Length::Vw(_))
+        && winners.get(token).is_none_or(|winner| precedence >= *winner)
       {
+        winners.insert(token.to_owned(), precedence);
         breakpoints.insert(token.to_owned(), width);
       }
     }
@@ -2582,6 +2589,21 @@ mod tests {
     assert_eq!(sheet.breakpoints.get("md"), Some(&Length::Rem(30.0)));
     assert_eq!(sheet.breakpoints.get("lg"), None);
     assert_eq!(sheet.breakpoints.get("xl"), None);
+  }
+
+  #[test]
+  fn test_breakpoint_takes_the_winning_cascade_layer() {
+    let sheet = parse_stylesheet(
+      r#"
+        @layer base, theme;
+        :root { --breakpoint-md: 30rem; }
+        @layer theme { :root { --breakpoint-md: 50rem; --breakpoint-lg: 70rem; } }
+        @layer base { :root { --breakpoint-lg: 60rem; } }
+      "#,
+    );
+
+    assert_eq!(sheet.breakpoints.get("md"), Some(&Length::Rem(30.0)));
+    assert_eq!(sheet.breakpoints.get("lg"), Some(&Length::Rem(70.0)));
   }
 
   /// A width `Breakpoint::matches` cannot resolve stays out of the overrides,


### PR DESCRIPTION
## Why

`collect_breakpoints` walked the `:root` rules in source order and let the last `--breakpoint-*` declaration win, ignoring the `layer_order` it already had on hand. A `@layer` block could therefore override an unlayered declaration that came before it, which is the opposite of what the cascade says.

## What

Each token now keeps the declaration with the highest layer precedence, with unlayered sorting above every ordinal and later layers above earlier ones. Ties still fall back to source order.

Only normal declarations are collected, same as before. `--breakpoint-*` marked `!important` stays out of the overrides entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breakpoint overrides now follow CSS cascade-layer precedence.
  * Unlayered declarations take priority over layered declarations, while later layers override earlier ones.
  * Duplicate root breakpoint declarations now consistently select the correct value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->