### PR TITLE
Core: keep font styles outside headings under Preflight

### DIFF
--- a/.tegami/preflight-heading-font-only.md
+++ b/.tegami/preflight-heading-font-only.md
@@ -10,4 +10,4 @@ packages:
 
 ### Keep font styles outside headings under Preflight
 
-Preflight used to strip declarations off the UA preset, which cost `<b>`, `<strong>`, `<small>`, `<sub>`, `<sup>` and `<th>` their font sizing and weight. It is now a real stylesheet in its own layer, so only `h1` through `h6` give those up and every author rule still outranks it.
+Preflight used to strip declarations off the UA preset. That cost `<b>`, `<strong>`, `<small>`, `<sub>`, `<sup>` and `<th>` their font sizing and weight. Only `h1` through `h6` give those up now, and every author rule outranks Preflight.

--- a/.tegami/preflight-heading-font-only.md
+++ b/.tegami/preflight-heading-font-only.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+  "takumi-pdf":
+    type: patch
+---
+
+### Keep font styles outside headings under Preflight
+
+Preflight used to strip declarations off the UA preset, which cost `<b>`, `<strong>`, `<small>`, `<sub>`, `<sup>` and `<th>` their font sizing and weight. It is now a real stylesheet in its own layer, so only `h1` through `h6` give those up and every author rule still outranks it.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -254,7 +254,7 @@ fn build_style_layers(
     .unzip();
 
   if let Some(preset) = node_layers.preset {
-    style.merge_preset(preset, stylesheet.preflight);
+    style.merge_from(preset);
   }
 
   if let Some(dir) = node_layers.dir {

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -3,6 +3,7 @@ use std::{
   fmt::{self, Write},
   mem::take,
   ops::Deref,
+  sync::LazyLock,
 };
 
 use cssparser::*;
@@ -1453,16 +1454,16 @@ impl StyleSheet {
     }
 
     if preflight {
-      let mut preflight_sheet = Self::parse_loosy(PREFLIGHT_CSS);
+      static PREFLIGHT_RULES: LazyLock<Vec<CssRule>> =
+        LazyLock::new(|| StyleSheet::parse_loosy(PREFLIGHT_CSS).rules);
+
+      let mut preflight_rules = PREFLIGHT_RULES.clone();
       declared_layers.splice(
         0..0,
-        preflight_sheet
-          .rules
-          .iter()
-          .filter_map(|rule| rule.layer.clone()),
+        preflight_rules.iter().filter_map(|rule| rule.layer.clone()),
       );
-      preflight_sheet.rules.append(&mut rules);
-      rules = preflight_sheet.rules;
+      preflight_rules.append(&mut rules);
+      rules = preflight_rules;
     }
 
     let mut layer_order = HashMap::<LayerPath, usize>::new();

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1302,9 +1302,6 @@ pub struct StyleSheet {
   /// Widths from unconditional `:root` `--breakpoint-*` declarations, which
   /// gate `tw` variants before the cascade runs and so resolve at parse time.
   pub(crate) breakpoints: BreakpointOverrides,
-  /// Whether `@import "tailwindcss"` turned Preflight on, dropping the UA
-  /// preset cosmetics.
-  pub(crate) preflight: bool,
 }
 
 impl From<Vec<KeyframesRule>> for StyleSheet {
@@ -1325,6 +1322,29 @@ impl From<Vec<PropertyRule>> for StyleSheet {
     }
   }
 }
+
+/// The subset of Tailwind's Preflight takumi applies, in Tailwind's `base`
+/// layer so every author rule outranks it.
+/// https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/preflight.css
+const PREFLIGHT_CSS: &str = r"
+@layer base {
+  *,
+  ::before,
+  ::after {
+    margin: 0;
+    padding: 0;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  ol, ul, menu {
+    list-style: none;
+  }
+}
+";
 
 impl StyleSheet {
   /// The `@property` registrations declared by this stylesheet.
@@ -1432,6 +1452,19 @@ impl StyleSheet {
       }
     }
 
+    if preflight {
+      let mut preflight_sheet = Self::parse_loosy(PREFLIGHT_CSS);
+      declared_layers.splice(
+        0..0,
+        preflight_sheet
+          .rules
+          .iter()
+          .filter_map(|rule| rule.layer.clone()),
+      );
+      preflight_sheet.rules.append(&mut rules);
+      rules = preflight_sheet.rules;
+    }
+
     let mut layer_order = HashMap::<LayerPath, usize>::new();
 
     for layer_name in declared_layers {
@@ -1464,7 +1497,6 @@ impl StyleSheet {
       keyframes,
       property_rules,
       layer_count: layer_order.len(),
-      preflight,
     })
   }
 }
@@ -2663,11 +2695,25 @@ mod tests {
     }
   }
 
+  fn preflight_rule_count(sheet: &StyleSheet) -> usize {
+    sheet
+      .rules
+      .iter()
+      .filter(|rule| {
+        rule.layer.as_ref().is_some_and(|layer| {
+          layer
+            .first()
+            .is_some_and(|name| matches!(name, LayerName::Named(named) if named == "base"))
+        })
+      })
+      .count()
+  }
+
   #[test]
   fn test_tailwind_import_turns_preflight_on() {
     let sheet = parse_stylesheet(r#"@import "tailwindcss"; .card { width: 100px; }"#);
-    assert!(sheet.preflight);
-    assert_eq!(sheet.rules.len(), 1);
+    assert!(preflight_rule_count(&sheet) > 0);
+    assert_eq!(sheet.rules.last().map(selector_text), Some(".card".into()));
   }
 
   /// `@import` is only valid at the top of a stylesheet; a nested one must
@@ -2684,7 +2730,7 @@ mod tests {
       assert!(StyleSheet::parse(css).is_err(), "{css}");
 
       let sheet = parse_stylesheet_loosy(css);
-      assert!(!sheet.preflight, "{css}");
+      assert_eq!(preflight_rule_count(&sheet), 0, "{css}");
     }
   }
 
@@ -2692,7 +2738,7 @@ mod tests {
   fn test_other_imports_are_dropped() {
     for import in [r#"@import "./app.css";"#, r#"@import "TAILWINDCSS";"#] {
       let sheet = parse_stylesheet_loosy(&format!("{import} .card {{ width: 100px; }}"));
-      assert!(!sheet.preflight, "{import}");
+      assert_eq!(preflight_rule_count(&sheet), 0, "{import}");
       assert_eq!(sheet.rules.len(), 1, "{import}");
     }
   }

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -1914,64 +1914,6 @@ impl FromStr for Style {
   }
 }
 
-/// The UA cosmetics Preflight clears: margins, paddings, list markers, and
-/// heading font tweaks. Structural declarations like `display` stay, matching
-/// what Tailwind's Preflight leaves to the UA.
-const PREFLIGHT_RESET: &[LonghandId] = &[
-  LonghandId::MarginTop,
-  LonghandId::MarginRight,
-  LonghandId::MarginBottom,
-  LonghandId::MarginLeft,
-  LonghandId::MarginInlineStart,
-  LonghandId::MarginInlineEnd,
-  LonghandId::PaddingTop,
-  LonghandId::PaddingRight,
-  LonghandId::PaddingBottom,
-  LonghandId::PaddingLeft,
-  LonghandId::PaddingInlineStart,
-  LonghandId::PaddingInlineEnd,
-  LonghandId::ListStyleType,
-  LonghandId::ListStylePosition,
-  LonghandId::ListStyleImage,
-  LonghandId::FontSize,
-  LonghandId::FontWeight,
-];
-
-impl Style {
-  /// Merges a UA preset; with Preflight on, its cosmetic declarations drop.
-  /// A dropped `list-style-type` becomes `none` rather than the initial
-  /// `disc`, matching Preflight's `ol, ul, menu { list-style: none }`.
-  pub(crate) fn merge_preset(&mut self, preset: Style, preflight: bool) {
-    if !preflight {
-      return self.merge_from(preset);
-    }
-
-    let block = preset.declarations;
-    let mut reset_list_marker = false;
-
-    for (declaration, important) in block.declarations.into_iter().zip(block.important) {
-      let affected = declaration.affected_longhands();
-
-      if affected
-        .iter()
-        .any(|longhand| PREFLIGHT_RESET.contains(&longhand))
-      {
-        reset_list_marker |= affected.contains(&LonghandId::ListStyleType);
-        continue;
-      }
-
-      self.declarations.push(declaration, important);
-    }
-
-    if reset_list_marker {
-      self.declarations.push(
-        StyleDeclaration::list_style_type(ListStyleType::None),
-        false,
-      );
-    }
-  }
-}
-
 #[cfg(test)]
 #[path = "stylesheets_tests.rs"]
 mod tests;

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1443,39 +1443,6 @@ fn overflow_visible_paired_with_clip_stays_mixed() {
 }
 
 #[test]
-fn preflight_drops_preset_cosmetics() {
-  let preset = Style::default()
-    .with(StyleDeclaration::margin_top(Length::Em(0.67)))
-    .with(StyleDeclaration::display(Display::Block));
-
-  let mut with_preflight = Style::default();
-  with_preflight.merge_preset(preset.clone(), true);
-  assert_eq!(
-    with_preflight.declarations.declarations.as_slice(),
-    &[StyleDeclaration::display(Display::Block)]
-  );
-
-  let mut without_preflight = Style::default();
-  without_preflight.merge_preset(preset, false);
-  assert_eq!(without_preflight.declarations.declarations.len(), 2);
-}
-
-/// Dropping `ol`'s `decimal` alone would fall back to the initial `disc`;
-/// Preflight removes markers, so the preset entry becomes `none`.
-#[test]
-fn preflight_resets_list_markers_to_none() {
-  let preset = Style::default().with(StyleDeclaration::list_style_type(ListStyleType::Decimal));
-
-  let mut style = Style::default();
-  style.merge_preset(preset, true);
-
-  assert_eq!(
-    style.declarations.declarations.as_slice(),
-    &[StyleDeclaration::list_style_type(ListStyleType::None)]
-  );
-}
-
-#[test]
 fn shorthands_take_css_wide_keywords() {
   let block = StyleDeclarationBlock::from_str("margin: inherit; overflow: initial").unwrap();
 

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -137,3 +137,53 @@ fn important_layered_rules_beat_important_tw() {
 
   assert_eq!(result.children[0].width, 120.0);
 }
+
+fn tagged(tag: &str, preset: Style) -> Node {
+  Node::container([block("probe")])
+    .with_tag_name(tag)
+    .with_preset(preset.with(StyleDeclaration::display(Display::Block)))
+}
+
+#[test]
+fn preflight_clears_preset_padding() {
+  let preset = Style::default().with(StyleDeclaration::padding_top(Length::Px(30.0)));
+
+  let without = measure_with_css(Node::container([tagged("h1", preset.clone())]), "");
+  assert_eq!(without.children[0].height, 30.0);
+
+  let with_preflight = measure_with_css(
+    Node::container([tagged("h1", preset)]),
+    r#"@import "tailwindcss";"#,
+  );
+  assert_eq!(with_preflight.children[0].height, 0.0);
+}
+
+/// Preflight resets `font-size` on headings only, so a preset that sizes any
+/// other element still reaches the cascade.
+#[test]
+fn preflight_keeps_preset_font_size_outside_headings() {
+  let preset = Style::default().with(StyleDeclaration::font_size(FontSize::Length(Length::Px(
+    8.0,
+  ))));
+  let css = r#"@import "tailwindcss"; .probe { width: 2em; }"#;
+
+  let paragraph = measure_with_css(Node::container([tagged("p", preset.clone())]), css);
+  assert_eq!(paragraph.children[0].children[0].width, 16.0);
+
+  let heading = measure_with_css(Node::container([tagged("h1", preset)]), css);
+  assert_eq!(heading.children[0].children[0].width, 32.0);
+}
+
+/// Preflight resets heading fonts to `inherit`, not to the initial size.
+#[test]
+fn preflight_inherits_the_parent_font_size_on_headings() {
+  let preset = Style::default().with(StyleDeclaration::font_size(FontSize::Length(Length::Px(
+    8.0,
+  ))));
+  let heading = measure_with_css(
+    Node::container([tagged("h1", preset)]),
+    r#"@import "tailwindcss"; :root { font-size: 20px; } .probe { width: 2em; }"#,
+  );
+
+  assert_eq!(heading.children[0].children[0].width, 40.0);
+}


### PR DESCRIPTION
## Why

`merge_preset` treated Preflight as a list of longhands and removed them from every UA preset. The list included `font-size` and `font-weight`, although Preflight resets them only on `h1` through `h6`. As a result, `<b>`, `<strong>`, `<small>`, `<sub>`, `<sup>`, and `<th>` also lost their font styles.

## What

Preflight is now parsed as CSS into Tailwind's `base` layer and prepended to the sheet when `@import "tailwindcss"` is present. `merge_preset` and the longhand list are gone. The preset merges unconditionally, so every author rule outranks Preflight and heading fonts resolve to `inherit` instead of the initial size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tailwind Preflight now applies as a layered stylesheet, improving compatibility with author styles and important utilities.
  - CSS-wide keywords such as `inherit` and `initial` now work correctly in shorthand properties.
- **Bug Fixes**
  - Heading styles now inherit font sizing appropriately while preserving expected sizing for inline elements and table headers.
  - Preflight correctly resets heading padding without unexpectedly removing other preset styles.
  - Important Tailwind utilities now take precedence over unlayered author rules as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->