### PR TITLE
Core: accept CSS-wide keywords on shorthand properties

### DIFF
--- a/.tegami/shorthand-css-wide-keywords.md
+++ b/.tegami/shorthand-css-wide-keywords.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+  "takumi-pdf":
+    type: patch
+---
+
+### Accept CSS-wide keywords on shorthand properties
+
+`margin: inherit`, `padding: initial`, `border: unset` and every other shorthand paired with a CSS-wide keyword were rejected. Only longhands took them. A shorthand now expands the keyword across the longhands it targets.

--- a/.tegami/shorthand-css-wide-keywords.md
+++ b/.tegami/shorthand-css-wide-keywords.md
@@ -2,12 +2,8 @@
 packages:
   "@takumi-rs/core":
     type: patch
-  "@takumi-rs/wasm":
-    type: patch
-  "takumi-pdf":
-    type: patch
 ---
 
 ### Accept CSS-wide keywords on shorthand properties
 
-`margin: inherit`, `padding: initial`, `border: unset` and every other shorthand paired with a CSS-wide keyword were rejected. Only longhands took them. A shorthand now expands the keyword across the longhands it targets.
+`margin: inherit`, `padding: initial` and `border: unset` were rejected. Only longhands took CSS-wide keywords. A shorthand now expands the keyword across the longhands it targets.

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -456,7 +456,22 @@ macro_rules! define_style {
                 input.slice_from(start).trim().to_owned(),
               )])
             }
-            Self::Shorthand(property) => property.parse_declarations(input),
+            Self::Shorthand(property) => {
+              let state = input.state();
+
+              if let Ok(keyword) = input.try_parse(CssWideKeyword::from_css) {
+                return Ok(
+                  self
+                    .target_longhands()
+                    .iter()
+                    .map(|longhand| StyleDeclaration::CssWideKeyword(longhand, keyword))
+                    .collect(),
+                );
+              }
+
+              input.reset(&state);
+              property.parse_declarations(input)
+            }
             Self::Longhand(property) => property.parse_declarations(input),
           }
         }

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -1474,3 +1474,20 @@ fn preflight_resets_list_markers_to_none() {
     &[StyleDeclaration::list_style_type(ListStyleType::None)]
   );
 }
+
+#[test]
+fn shorthands_take_css_wide_keywords() {
+  let block = StyleDeclarationBlock::from_str("margin: inherit; overflow: initial").unwrap();
+
+  assert_eq!(
+    block.declarations.as_slice(),
+    &[
+      StyleDeclaration::CssWideKeyword(LonghandId::MarginTop, CssWideKeyword::Inherit),
+      StyleDeclaration::CssWideKeyword(LonghandId::MarginRight, CssWideKeyword::Inherit),
+      StyleDeclaration::CssWideKeyword(LonghandId::MarginBottom, CssWideKeyword::Inherit),
+      StyleDeclaration::CssWideKeyword(LonghandId::MarginLeft, CssWideKeyword::Inherit),
+      StyleDeclaration::CssWideKeyword(LonghandId::OverflowX, CssWideKeyword::Initial),
+      StyleDeclaration::CssWideKeyword(LonghandId::OverflowY, CssWideKeyword::Initial),
+    ]
+  );
+}


### PR DESCRIPTION
## Why

Only longhands accepted CSS-wide keywords, even though `margin: inherit`, `padding: initial`, and `border: unset` are valid CSS. The shorthand parser passed the value to the shorthand's own parser, which rejected the keyword; strict parsing failed the sheet, while lossy parsing dropped the rule without warning.

## What

`PropertyId::parse_declarations` now checks for a CSS-wide keyword before calling the shorthand parser. It expands the keyword across the shorthand's longhands, matching the longhand and JS-object paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSS-wide keywords such as `inherit`, `initial`, and `unset` now work correctly in shorthand CSS properties.
  * Shorthand values expand consistently across all applicable longhand properties.

* **Tests**
  * Added coverage for CSS-wide keywords in `margin` and `overflow` shorthands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->