### PR TITLE
Core: order important declarations by reversed layer order

### DIFF
--- a/.tegami/important-layer-order.md
+++ b/.tegami/important-layer-order.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+  "takumi-pdf":
+    type: patch
+---
+
+### Order important declarations by reversed layer order
+
+An important `tw` utility used to beat every important author rule. The cascade reverses layer order for important declarations, and `tw` is the last declared layer, so it now loses to them and still wins against their normal half. Inline important declarations stay on top.

--- a/.tegami/important-layer-order.md
+++ b/.tegami/important-layer-order.md
@@ -10,4 +10,4 @@ packages:
 
 ### Order important declarations by reversed layer order
 
-An important `tw` utility used to beat every important author rule. The cascade reverses layer order for important declarations, and `tw` is the last declared layer, so it now loses to them and still wins against their normal half. Inline important declarations stay on top.
+An important `tw` utility used to beat every important author rule. The cascade reverses layer order for important declarations, so it now loses to important rules in named `@layer`s while still beating unlayered ones. Inline important declarations stay on top.

--- a/.tegami/important-layer-order.md
+++ b/.tegami/important-layer-order.md
@@ -10,4 +10,4 @@ packages:
 
 ### Order important declarations by reversed layer order
 
-An important `tw` utility used to beat every important author rule. The cascade reverses layer order for important declarations, so it now loses to important rules in named `@layer`s while still beating unlayered ones. Inline important declarations stay on top.
+An important `tw` utility used to beat every important author rule. It now loses to important rules in named `@layer`s and still beats unlayered ones. Inline important declarations stay on top.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -3,7 +3,6 @@ use std::{
 };
 
 use parley::fontique::Attributes;
-use smallvec::SmallVec;
 use taffy::{
   BlockContext, Cache, CacheTree, Display as TaffyDisplay, Layout, LayoutBlockContainer,
   LayoutFlexboxContainer, LayoutGridContainer, LayoutInput, LayoutOutput, LayoutPartialTree,
@@ -223,6 +222,14 @@ fn resolve_normal_line_height(
     .unwrap_or(font_size)
 }
 
+/// The element's own important declarations, which straddle the stylesheet's
+/// important half: `tw` is the last declared layer so it goes under, while an
+/// inline declaration outranks every selector.
+struct ElementImportant {
+  tw: Option<StyleDeclarationBlock>,
+  inline: Option<StyleDeclarationBlock>,
+}
+
 /// The node's style, plus the important declarations that belong to the element
 /// rather than to a stylesheet, which the caller re-applies after sampling an
 /// animation.
@@ -231,7 +238,7 @@ fn build_style_layers(
   matched_declarations: &MatchedDeclarationsView<'_>,
   viewport: Viewport,
   stylesheet: &StyleSheet,
-) -> (NodeStyle, SmallVec<[StyleDeclarationBlock; 2]>) {
+) -> (NodeStyle, ElementImportant) {
   let mut style = NodeStyle::default();
 
   // `tw` is the last declared layer, below unlayered author rules, so its
@@ -283,22 +290,29 @@ fn build_style_layers(
     style.append_block(inline_normal);
   }
 
+  // Important declarations reverse layer order, and `tw` is the last declared
+  // layer, so its important half goes first.
+  if let Some(tw_important) = &tw_important {
+    style.append_block(tw_important.clone());
+  }
+
   for &declarations in matched_declarations.important() {
     for declaration in declarations.iter() {
       declaration.merge_into_ref(&mut style);
     }
   }
 
-  let element_important: SmallVec<[StyleDeclarationBlock; 2]> = [tw_important, inline_important]
-    .into_iter()
-    .flatten()
-    .collect();
-
-  for declarations in &element_important {
-    style.append_block(declarations.clone());
+  if let Some(inline_important) = &inline_important {
+    style.append_block(inline_important.clone());
   }
 
-  (style, element_important)
+  (
+    style,
+    ElementImportant {
+      tw: tw_important,
+      inline: inline_important,
+    },
+  )
 }
 
 fn registered_custom_property_parent_style<'a>(
@@ -1489,12 +1503,19 @@ impl RenderNode {
 
       // Important declarations outrank an animation, and `inherit` among them
       // needs the parent the first pass resolved against.
-      let important = matched
-        .important()
+      let important = element_important
+        .tw
         .iter()
         .map(|declarations| declarations.iter())
         .chain(
+          matched
+            .important()
+            .iter()
+            .map(|declarations| declarations.iter()),
+        )
+        .chain(
           element_important
+            .inline
             .iter()
             .map(|declarations| declarations.iter()),
         );

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -223,7 +223,7 @@ fn resolve_normal_line_height(
 }
 
 /// The element's own important declarations, which straddle the stylesheet's
-/// important half: `tw` is the last declared layer so it goes under, while an
+/// important half: `tw` sits between unlayered and named-layer rules, while an
 /// inline declaration outranks every selector.
 struct ElementImportant {
   tw: Option<StyleDeclarationBlock>,
@@ -290,13 +290,19 @@ fn build_style_layers(
     style.append_block(inline_normal);
   }
 
-  // Important declarations reverse layer order, and `tw` is the last declared
-  // layer, so its important half goes first.
+  // Important declarations reverse layer order, so `tw`, the last declared
+  // layer, sits above unlayered rules and below every named `@layer`.
+  for &declarations in matched_declarations.unlayered_important() {
+    for declaration in declarations.iter() {
+      declaration.merge_into_ref(&mut style);
+    }
+  }
+
   if let Some(tw_important) = &tw_important {
     style.append_block(tw_important.clone());
   }
 
-  for &declarations in matched_declarations.important() {
+  for &declarations in matched_declarations.layered_important() {
     for declaration in declarations.iter() {
       declaration.merge_into_ref(&mut style);
     }
@@ -1503,13 +1509,19 @@ impl RenderNode {
 
       // Important declarations outrank an animation, and `inherit` among them
       // needs the parent the first pass resolved against.
-      let important = element_important
-        .tw
+      let important = matched
+        .unlayered_important()
         .iter()
         .map(|declarations| declarations.iter())
         .chain(
+          element_important
+            .tw
+            .iter()
+            .map(|declarations| declarations.iter()),
+        )
+        .chain(
           matched
-            .important()
+            .layered_important()
             .iter()
             .map(|declarations| declarations.iter()),
         )

--- a/takumi-core/src/matching.rs
+++ b/takumi-core/src/matching.rs
@@ -364,6 +364,10 @@ pub(crate) struct MatchedDeclarationsView<'a> {
   /// Where unlayered blocks begin in `normal`. The `tw` layer slots in here:
   /// above every named `@layer`, below unlayered rules.
   unlayered_start: usize,
+  /// Where named-layer blocks begin in `important`, which reverses layer
+  /// order. The `tw` layer slots in here: above unlayered rules, below every
+  /// named `@layer`.
+  layered_important_start: usize,
 }
 
 impl<'a> MatchedDeclarationsView<'a> {
@@ -378,8 +382,19 @@ impl<'a> MatchedDeclarationsView<'a> {
   }
 
   /// Matched declaration blocks marked `!important`, in cascade order.
+  #[cfg(test)]
   pub(crate) fn important(&self) -> &[&'a StyleDeclarationBlock] {
     &self.important
+  }
+
+  /// Matched unlayered blocks marked `!important`, in cascade order.
+  pub(crate) fn unlayered_important(&self) -> &[&'a StyleDeclarationBlock] {
+    &self.important[..self.layered_important_start]
+  }
+
+  /// Matched blocks marked `!important` from named layers, in cascade order.
+  pub(crate) fn layered_important(&self) -> &[&'a StyleDeclarationBlock] {
+    &self.important[self.layered_important_start..]
   }
 }
 
@@ -745,6 +760,9 @@ fn finalize_bucket<'a>(
   });
   for rule in rules.drain(..) {
     if rule.important {
+      if rule.layer_order == 0 {
+        matched.layered_important_start += 1;
+      }
       matched.important.push(rule.declarations);
     } else {
       if rule.layer_order < layer_count {

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -79,10 +79,10 @@ fn tw_sits_below_author_rules() {
   assert_eq!(result.children[0].width, 100.0);
 }
 
-/// `tw` is the last declared layer, so its important half loses to every
-/// important author rule and still beats their normal ones.
+/// Unlayered important rules sort below every layer in the reversed important
+/// order, so `tw` beats them.
 #[test]
-fn important_tw_beats_normal_author_rules() {
+fn important_tw_beats_unlayered_author_rules() {
   let root = Node::container([
     tw_block("box", "block w-64!"),
     tw_block("shout", "block w-64!"),
@@ -96,7 +96,7 @@ fn important_tw_beats_normal_author_rules() {
   );
 
   assert_eq!(result.children[0].width, 256.0);
-  assert_eq!(result.children[1].width, 100.0);
+  assert_eq!(result.children[1].width, 256.0);
 }
 
 #[test]

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -79,8 +79,10 @@ fn tw_sits_below_author_rules() {
   assert_eq!(result.children[0].width, 100.0);
 }
 
+/// `tw` is the last declared layer, so its important half loses to every
+/// important author rule and still beats their normal ones.
 #[test]
-fn important_tw_beats_author_rules() {
+fn important_tw_beats_normal_author_rules() {
   let root = Node::container([
     tw_block("box", "block w-64!"),
     tw_block("shout", "block w-64!"),
@@ -94,7 +96,7 @@ fn important_tw_beats_author_rules() {
   );
 
   assert_eq!(result.children[0].width, 256.0);
-  assert_eq!(result.children[1].width, 256.0);
+  assert_eq!(result.children[1].width, 100.0);
 }
 
 #[test]
@@ -123,4 +125,15 @@ fn tw_beats_named_layer_rules() {
   );
 
   assert_eq!(result.children[0].width, 256.0);
+}
+
+/// A named layer's important half also outranks `tw`, which is declared last.
+#[test]
+fn important_layered_rules_beat_important_tw() {
+  let result = measure_with_css(
+    Node::container([tw_block("box", "block w-64!")]),
+    "@layer base { .box { width: 120px !important; } }",
+  );
+
+  assert_eq!(result.children[0].width, 120.0);
 }


### PR DESCRIPTION
## Why

An important `tw` utility beat every important author rule. Important declarations reverse layer order, so `tw`, the last declared layer, should lose to named `@layer` rules while still beating unlayered ones.

## What

Matched important declarations now split at the layered boundary, mirroring the normal-half split, and the element's `tw` half slots in between; inline important declarations stay on top. `important_layered_rules_beat_important_tw` pins the behavior change: `@layer base { width: 120px !important }` now beats `w-64!`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CSS cascade ordering for `!important` declarations.
  * Named-layer important rules now correctly take precedence over Tailwind utilities, while unlayered rules sort below layered rules.
  * Inline important declarations consistently override stylesheet declarations.
  * Improved rendering accuracy when animations and important styles interact.

* **Documentation**
  * Documented the reversed cascade ordering for important declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->