### PR TITLE
Core: hide elements carrying the hidden attribute

### DIFF
--- a/.tegami/preflight-hidden-attribute.md
+++ b/.tegami/preflight-hidden-attribute.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+  "takumi-pdf":
+    type: patch
+---
+
+### Hide elements carrying the `hidden` attribute
+
+With Tailwind imported, `hidden` now hides an element the way Preflight does, including against an important utility.

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1408,6 +1408,10 @@ const PREFLIGHT_CSS: &str = r"
     max-width: 100%;
     height: auto;
   }
+
+  [hidden]:where(:not([hidden='until-found'])) {
+    display: none !important;
+  }
 }
 ";
 
@@ -2782,11 +2786,13 @@ mod tests {
     let declarations: usize = sheet
       .rules
       .iter()
-      .map(|rule| rule.normal_declarations.declarations.len())
+      .map(|rule| {
+        rule.normal_declarations.declarations.len() + rule.important_declarations.declarations.len()
+      })
       .sum();
 
-    assert_eq!(sheet.rules.len(), 15);
-    assert_eq!(declarations, 55);
+    assert_eq!(sheet.rules.len(), 16);
+    assert_eq!(declarations, 56);
   }
 
   #[test]

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -187,3 +187,17 @@ fn preflight_inherits_the_parent_font_size_on_headings() {
 
   assert_eq!(heading.children[0].children[0].width, 40.0);
 }
+
+/// Preflight's `[hidden]` rule is important, so it survives a `tw` utility
+/// that is important too.
+#[test]
+fn preflight_hides_the_hidden_attribute() {
+  use std::str::FromStr;
+
+  let hidden = Node::container([])
+    .with_attributes([("hidden".into(), "".into())].into_iter().collect())
+    .with_tw(TailwindValues::from_str("block w-64!").expect("tailwind values should parse"));
+  let result = measure_with_css(Node::container([hidden]), r#"@import "tailwindcss";"#);
+
+  assert_eq!(result.children[0].width, 0.0);
+}

--- a/takumi/tests/cascade_tests.rs
+++ b/takumi/tests/cascade_tests.rs
@@ -201,3 +201,20 @@ fn preflight_hides_the_hidden_attribute() {
 
   assert_eq!(result.children[0].width, 0.0);
 }
+
+/// `until-found` is the one `hidden` value Preflight leaves visible.
+#[test]
+fn preflight_keeps_hidden_until_found_visible() {
+  use std::str::FromStr;
+
+  let node = Node::container([])
+    .with_attributes(
+      [("hidden".into(), "until-found".into())]
+        .into_iter()
+        .collect(),
+    )
+    .with_tw(TailwindValues::from_str("block w-64!").expect("tailwind values should parse"));
+  let result = measure_with_css(Node::container([node]), r#"@import "tailwindcss";"#);
+
+  assert_eq!(result.children[0].width, 256.0);
+}


### PR DESCRIPTION
## Why

Preflight hides elements with the `hidden` attribute using an important declaration. The rule was omitted because the previous cascade let important `tw` utilities, including `hidden!`-style classes, override it.

## What

The Preflight block now includes `[hidden]:where(:not([hidden='until-found'])) { display: none !important }`, following the reversed layer order for important declarations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tailwind Preflight is now automatically applied when importing Tailwind CSS.
  * Elements with the `hidden` attribute remain hidden, even when conflicting important display utilities are used.
  * `[hidden="until-found"]` elements remain visible as intended.
  * Improved cascade handling for responsive breakpoints and important utilities.
  * Corrected heading styles, including padding resets and font-size inheritance.

* **Documentation**
  * Documented the updated Preflight behavior across supported packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->