### PR TITLE
Core: cut allocations in style property parsing

### DIFF
--- a/.tegami/style-parse-allocations.md
+++ b/.tegami/style-parse-allocations.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Cut allocations in style property parsing
+
+Parsing a string-valued property copied the value before handing it to cssparser. Normalizing a kebab-case or camelCase property name allocated a second string just to trim leading underscores. String values now parse in place, and names normalize in one allocation.

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -504,17 +504,35 @@ macro_rules! define_style {
             });
           }
 
-          let source = css_input.to_string();
-          let mut parser_input = ParserInput::new(&source);
-          let mut parser = Parser::new(&mut parser_input);
-          let result = match self {
-            Self::Shorthand(property) => property.parse_declarations(&mut parser),
-            Self::Longhand(property) => property.parse_declarations(&mut parser),
-            Self::Ignored | Self::Custom => unreachable!(),
+          let source: Cow<'_, str> = match &css_input {
+            CssInput::Str(value) => Cow::Borrowed(value.as_ref()),
+            CssInput::Number(number) => Cow::Owned(number.to_string()),
+            CssInput::Unexpected(_) => unreachable!(),
           };
 
-          result
-            .map_err(|error| css_input_parse_error(css_input, &source, self.expected_message(&source), error))
+          let result = {
+            let mut parser_input = ParserInput::new(&source);
+            let mut parser = Parser::new(&mut parser_input);
+
+            match self {
+              Self::Shorthand(property) => property.parse_declarations(&mut parser),
+              Self::Longhand(property) => property.parse_declarations(&mut parser),
+              Self::Ignored | Self::Custom => unreachable!(),
+            }
+          }
+          .map_err(|error| {
+            (
+              self.expected_message(&source),
+              css_input_parse_failure(&source, error),
+            )
+          });
+
+          drop(source);
+
+          match result {
+            Ok(declarations) => Ok(declarations),
+            Err((expected, failure)) => Err(css_input_parse_error(css_input, expected, failure)),
+          }
         }
 
         /// Parse-error "expected ..." text for this property's value type.

--- a/takumi-core/src/style/stylesheets_helpers.rs
+++ b/takumi-core/src/style/stylesheets_helpers.rs
@@ -104,15 +104,14 @@ pub(crate) fn parse_css_wide_keyword(css_input: &CssInput<'_>) -> Option<CssWide
 
 pub(crate) fn css_input_parse_error<'de>(
   css_input: CssInput<'de>,
-  source: &str,
   expected: String,
-  error: ParseError<'_, Cow<'_, str>>,
+  failure: CssInputParseFailure,
 ) -> CssInputParseError<'de> {
   match css_input {
     CssInput::Str(value) => CssInputParseError::Value {
       value,
       expected: expected.into(),
-      failure: Some(css_input_parse_failure(source, error)),
+      failure: Some(failure),
     },
     CssInput::Number(number) => CssInputParseError::NumberType {
       number,
@@ -125,7 +124,7 @@ pub(crate) fn css_input_parse_error<'de>(
   }
 }
 
-fn css_input_parse_failure(
+pub(crate) fn css_input_parse_failure(
   source: &str,
   error: ParseError<'_, Cow<'_, str>>,
 ) -> CssInputParseFailure {
@@ -227,7 +226,7 @@ pub(crate) fn normalize_kebab_property_name(name: &str) -> Cow<'_, str> {
     return Cow::Borrowed(name);
   }
 
-  let normalized: String = name
+  let mut normalized: String = name
     .chars()
     .map(|ch| match ch {
       '-' => '_',
@@ -235,7 +234,13 @@ pub(crate) fn normalize_kebab_property_name(name: &str) -> Cow<'_, str> {
     })
     .collect();
 
-  Cow::Owned(normalized.trim_start_matches('_').to_owned())
+  let leading = normalized.len() - normalized.trim_start_matches('_').len();
+
+  if leading > 0 {
+    normalized.drain(..leading);
+  }
+
+  Cow::Owned(normalized)
 }
 
 pub(crate) fn normalize_camel_property_name(name: &str) -> Cow<'_, str> {
@@ -253,7 +258,13 @@ pub(crate) fn normalize_camel_property_name(name: &str) -> Cow<'_, str> {
     }
   }
 
-  Cow::Owned(normalized.trim_start_matches('_').to_owned())
+  let leading = normalized.len() - normalized.trim_start_matches('_').len();
+
+  if leading > 0 {
+    normalized.drain(..leading);
+  }
+
+  Cow::Owned(normalized)
 }
 
 pub(crate) fn contains_var_function(specified_value: &str) -> bool {


### PR DESCRIPTION
## Why
`parse_css_input_declarations` copied every string value into a fresh `String` before handing it to cssparser. `normalize_kebab_property_name` and `normalize_camel_property_name` built the normalized name, then allocated it again through `trim_start_matches('_').to_owned()`. Every property in a JS style object paid the first copy. Every multi-word name paid the second.

## What
String values parse straight from the borrowed input. Only numbers format into a temporary. The error path builds `(expected, failure)` before the input moves, so `css_input_parse_error` now takes the precomputed failure. Name normalization drains leading underscores in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Reduced memory allocations when parsing string-based style properties.
  - Improved efficiency when normalizing property names, including names with leading underscores.
  - Streamlined handling of numeric style values and parsing failures.

- **Compatibility**
  - Preserved existing style parsing and property-normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->