### PR TITLE
JS: return css from fromJsx and fromHtml

### DIFF
--- a/.tegami/css-result-field.md
+++ b/.tegami/css-result-field.md
@@ -6,4 +6,4 @@ packages:
 
 ### Return `css` from `fromJsx` and `fromHtml`
 
-Both results now carry the extracted CSS in a `css` field, matching the render option's name. The old `stylesheets` field still works and is marked deprecated.
+Both results now carry the extracted CSS in a `css` field, matching the render option's name. Reading the old `stylesheets` field still returns the same array and warns once. It no longer shows up in `Object.keys` or a spread of the result.

--- a/.tegami/css-result-field.md
+++ b/.tegami/css-result-field.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: minor
+---
+
+### Return `css` from `fromJsx` and `fromHtml`
+
+Both results now carry the extracted CSS in a `css` field, matching the render option's name. The old `stylesheets` field still works and is marked deprecated.

--- a/.tegami/css-result-field.md
+++ b/.tegami/css-result-field.md
@@ -6,4 +6,4 @@ packages:
 
 ### Return `css` from `fromJsx` and `fromHtml`
 
-Both results now carry the extracted CSS in a `css` field, matching the render option's name. Reading the old `stylesheets` field still returns the same array and warns once. It no longer shows up in `Object.keys` or a spread of the result.
+Reading the old `stylesheets` field returns the same array and warns once. It no longer appears in `Object.keys` or a spread of the result.

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -176,9 +176,9 @@ async function renderOutput({
 async function renderRequest(renderer: Renderer, id: number, code: string) {
   const { default: component, options } = evaluateCodeExports(code, renderReact);
   const element = renderReact.createElement(component as JSXElementConstructor<unknown>);
-  const { node, stylesheets } = await fromJsx(element);
+  const { node, css: extractedCss } = await fromJsx(element);
   const optionCss = typeof options.css === "string" ? [options.css] : options.css;
-  const effectiveCss = optionCss ?? stylesheets;
+  const effectiveCss = optionCss ?? extractedCss;
   const geometry = outputGeometry(options);
 
   // A PDF renders pages, which a single HTML flow cannot stand in for, so the

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -41,10 +41,10 @@ Length and color shorthands return CSS strings. `vw`/`vh` are viewport width/hei
 
 ## Parsing templates
 
-| Helper                       | Import                   | Use                                                        |
-| :--------------------------- | :----------------------- | :--------------------------------------------------------- |
-| `fromJsx(element, options?)` | `takumi-js/helpers/jsx`  | Convert JSX or a React element to `{ node, stylesheets }`. |
-| `fromHtml(html)`             | `takumi-js/helpers/html` | Convert an HTML string to `{ node, stylesheets }`.         |
+| Helper                       | Import                   | Use                                                |
+| :--------------------------- | :----------------------- | :------------------------------------------------- |
+| `fromJsx(element, options?)` | `takumi-js/helpers/jsx`  | Convert JSX or a React element to `{ node, css }`. |
+| `fromHtml(html)`             | `takumi-js/helpers/html` | Convert an HTML string to `{ node, css }`.         |
 
 `fromJsx` resolves hooks and context itself: components using `useState`, `useContext`, or `use()` render with server semantics (initial state, no effects), without loading `react-dom`. Preact trees render too, as long as no component calls a Preact hook: those live on Preact's mangled internals, which no dispatcher can stand in for.
 

--- a/docs/content/docs/measure-api.mdx
+++ b/docs/content/docs/measure-api.mdx
@@ -11,10 +11,10 @@ import { Renderer } from "takumi-js/node";
 import { fromJsx } from "takumi-js/helpers/jsx";
 
 const renderer = new Renderer();
-const { node, stylesheets } = await fromJsx(<span tw="text-xl">I'm a text node</span>);
+const { node, css } = await fromJsx(<span tw="text-xl">I'm a text node</span>);
 
 // [!code ++]
-const { width, height } = await renderer.measure(node, { css: stylesheets }); // [!code highlight]
+const { width, height } = await renderer.measure(node, { css }); // [!code highlight]
 ```
 
 ```tsx twoslash tab="takumi-js/wasm"
@@ -22,10 +22,10 @@ import { Renderer } from "takumi-js/wasm";
 import { fromJsx } from "takumi-js/helpers/jsx";
 
 const renderer = new Renderer();
-const { node, stylesheets } = await fromJsx(<span tw="text-xl">I'm a text node</span>);
+const { node, css } = await fromJsx(<span tw="text-xl">I'm a text node</span>);
 
 // [!code ++]
-const { width, height } = await renderer.measure(node, { css: stylesheets }); // [!code highlight]
+const { width, height } = await renderer.measure(node, { css }); // [!code highlight]
 ```
 
 ## Returned fields

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -39,13 +39,13 @@ import { render } from "takumi-pdf";
 import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
 // [!code highlight]
-const { node, stylesheets } = fromHtml(html);
+const { node, css } = fromHtml(html);
 
 const pdf = await render(node, {
   size: "a4",
   margin: { top: 48, bottom: 64, left: 48, right: 48 },
   // [!code highlight]
-  css: stylesheets,
+  css,
   footer: (
     <div tw="flex w-full justify-center text-[10px]">
       Page <PageNumber /> of <TotalPages />
@@ -92,11 +92,11 @@ import { prepareImages } from "@takumi-rs/helpers";
 import { fromHtml } from "@takumi-rs/helpers/html";
 import { render } from "takumi-pdf";
 
-const { node, stylesheets } = fromHtml(html);
+const { node, css } = fromHtml(html);
 // [!code highlight]
 const images = await prepareImages({ node });
 
-const pdf = await render(node, { images, css: stylesheets }); // [!code highlight]
+const pdf = await render(node, { images, css }); // [!code highlight]
 ```
 
 `prepareImages` walks the tree, fetches every remote `<img>`, `background-image`, and `mask-image` URL, and returns the `images` entries. It takes a `fetchCache` to reuse bytes, an `allowUrl` predicate, and a `timeout`.

--- a/example/css-library-integration/README.md
+++ b/example/css-library-integration/README.md
@@ -1,6 +1,6 @@
 # CSS Library Integration Example
 
-This example compiles Tailwind CSS and UnoCSS in-process and passes the resulting CSS into Takumi's `stylesheets` render option.
+This example compiles Tailwind CSS and UnoCSS in-process and passes the resulting CSS into Takumi's `css` render option.
 
 ![Tailwind CSS output](./output/tailwind-stylesheets.png)
 ![UnoCSS output](./output/unocss-stylesheets.png)

--- a/example/twitter-images/components/google-fonts-video.tsx
+++ b/example/twitter-images/components/google-fonts-video.tsx
@@ -38,7 +38,7 @@ export const googleFonts: GoogleFontFamily[] = [
 
 export const images = [{ src: "takumi.svg", path: "takumi.svg" }];
 
-export const stylesheets = [
+export const css = [
   `@keyframes slide {
     0% { opacity: 0; transform: translateY(34px) scale(0.99); }
     24% { opacity: 1; transform: translateY(0) scale(1); }

--- a/example/twitter-images/components/home-filmstrip.tsx
+++ b/example/twitter-images/components/home-filmstrip.tsx
@@ -8,7 +8,7 @@ export const height = 480;
 // One frame per timestamp; the docs homepage lays them out as a film strip.
 export const timestamps = [0, 125, 250, 375, 500, 625, 750, 875];
 
-export const stylesheets = [
+export const css = [
   `@keyframes morph {
     from { border-radius: 12%; transform: rotate(0deg) scale(1); }
     50% { border-radius: 50%; transform: rotate(90deg) scale(0.72); }

--- a/example/twitter-images/index.tsx
+++ b/example/twitter-images/index.tsx
@@ -48,7 +48,7 @@ async function render(
   // default font stack.
   const renderer = new Renderer();
   const jsxPrepareStart = performance.now();
-  const { node, stylesheets } = await fromJsx(<module.default />);
+  const { node, css } = await fromJsx(<module.default />);
   const [fonts, images] = await Promise.all([loadFonts(module), loadImages(module)]);
   const renderStart = performance.now();
 
@@ -56,7 +56,7 @@ async function render(
     width: module.width * ratio,
     height: module.height * ratio,
     devicePixelRatio: ratio,
-    css: [...stylesheets, ...("stylesheets" in module ? module.stylesheets : [])],
+    css: [...css, ...("css" in module ? module.css : [])],
     drawDebugBorder: process.argv.includes("--debug"),
     images,
     fonts: fonts.length > 0 ? fonts : undefined,

--- a/example/twitter-images/video.tsx
+++ b/example/twitter-images/video.tsx
@@ -9,7 +9,7 @@ type VideoModule = AssetModule & {
   width: number;
   height: number;
   video: { durationMs: number; fps?: number; dpr?: number };
-  stylesheets?: string[];
+  css?: string[];
   frame?: (ms: number) => ReactNode;
   fontFamilies?: (ms: number) => string[];
   default: () => ReactNode;
@@ -79,14 +79,14 @@ for (let start = 0; start < frameCount; start += BATCH) {
   const buffers = await Promise.all(
     Array.from({ length: Math.min(BATCH, frameCount - start) }, async (_, offset) => {
       const ms = ((start + offset) * 1000) / fps;
-      const { node, stylesheets } = await fromJsx(frameAt(ms));
+      const { node, css } = await fromJsx(frameAt(ms));
 
       return renderer.render(node, {
         width: outWidth,
         height: outHeight,
         devicePixelRatio: dpr,
         format: "raw",
-        css: [...stylesheets, ...(module.stylesheets ?? [])],
+        css: [...css, ...(module.css ?? [])],
         images,
         fonts: fonts.length > 0 ? fonts : undefined,
         fontFamilies: module.fontFamilies?.(ms),

--- a/takumi-bindings-common/src/lib.rs
+++ b/takumi-bindings-common/src/lib.rs
@@ -113,11 +113,11 @@ fn css_variables_stylesheet(variables: HashMap<String, String>) -> Option<String
 /// the sheet list last, so an equally specific author `:root` loses to them.
 pub fn stylesheet(
   cache: &ResourceCache,
-  stylesheets: Option<Vec<String>>,
+  css: Option<Vec<String>>,
   keyframes: Vec<KeyframesRule>,
   css_variables: Option<HashMap<String, String>>,
 ) -> Arc<StyleSheet> {
-  let mut sheets = stylesheets.unwrap_or_default();
+  let mut sheets = css.unwrap_or_default();
 
   if let Some(sheet) = css_variables.and_then(css_variables_stylesheet) {
     sheets.push(sheet);

--- a/takumi-helpers/README.md
+++ b/takumi-helpers/README.md
@@ -16,12 +16,12 @@ npm install @takumi-rs/helpers
 
 ### JSX to Node Tree
 
-Convert React-like elements into a serializable node tree + stylesheets.
+Convert React-like elements into a serializable node tree + CSS.
 
 ```tsx
 import { fromJsx } from "@takumi-rs/helpers/jsx";
 
-const { node, stylesheets } = await fromJsx(<div style={{ display: "flex" }}>Hello</div>);
+const { node, css } = await fromJsx(<div style={{ display: "flex" }}>Hello</div>);
 ```
 
 ### HTML to Node Tree
@@ -31,7 +31,7 @@ Parse HTML strings into Takumi nodes.
 ```ts
 import { fromHtml } from "@takumi-rs/helpers/html";
 
-const { node, stylesheets } = await fromHtml("<div style='color: red'>Hello</div>");
+const { node, css } = await fromHtml("<div style='color: red'>Hello</div>");
 ```
 
 ### Emoji Processing

--- a/takumi-helpers/src/deprecation.ts
+++ b/takumi-helpers/src/deprecation.ts
@@ -1,0 +1,12 @@
+let warned = false;
+
+/** Hides the deprecated `stylesheets` alias from spreads, warning once when read. */
+export function hideStylesheetsAlias(result: object): void {
+  Object.defineProperty(result, "stylesheets", { enumerable: false });
+}
+
+export function warnStylesheetsDeprecated(): void {
+  if (warned) return;
+  warned = true;
+  console.warn("takumi: the `stylesheets` result field is deprecated, use `css` instead.");
+}

--- a/takumi-helpers/src/html/index.ts
+++ b/takumi-helpers/src/html/index.ts
@@ -1,3 +1,4 @@
+import { hideStylesheetsAlias, warnStylesheetsDeprecated } from "../deprecation";
 import { container, percentage } from "../helpers";
 import { fromStaticMarkup } from "./markup";
 import type { Node } from "../types";
@@ -38,5 +39,15 @@ export function fromHtml(html: string): FromHtmlResult {
     });
   }
 
-  return { node, css, stylesheets: css };
+  const aliased: FromHtmlResult = {
+    node,
+    css,
+    get stylesheets() {
+      warnStylesheetsDeprecated();
+      return css;
+    },
+  };
+
+  hideStylesheetsAlias(aliased);
+  return aliased;
 }

--- a/takumi-helpers/src/html/index.ts
+++ b/takumi-helpers/src/html/index.ts
@@ -2,11 +2,18 @@ import { container, percentage } from "../helpers";
 import { fromStaticMarkup } from "./markup";
 import type { Node } from "../types";
 
+export interface FromHtmlResult {
+  node: Node;
+  css: string[];
+  /** @deprecated Use `css` instead. */
+  stylesheets: string[];
+}
+
 const isWhitespaceOnlyText = (node: Node): boolean =>
   "text" in node && typeof node.text === "string" && node.text.trim() === "";
 
-export function fromHtml(html: string) {
-  const { nodes, stylesheets } = fromStaticMarkup(html);
+export function fromHtml(html: string): FromHtmlResult {
+  const { nodes, css } = fromStaticMarkup(html);
 
   while (nodes[0] && isWhitespaceOnlyText(nodes[0])) {
     nodes.shift();
@@ -15,29 +22,21 @@ export function fromHtml(html: string) {
     nodes.pop();
   }
 
+  let node: Node;
   if (nodes.length === 0) {
-    return {
-      node: container({}),
-      stylesheets,
-    };
-  }
-
-  if (nodes.length === 1 && nodes[0]) {
-    return {
-      node: nodes[0],
-      stylesheets,
-    };
-  }
-
-  return {
-    node: container({
+    node = container({});
+  } else if (nodes.length === 1 && nodes[0]) {
+    node = nodes[0];
+  } else {
+    node = container({
       style: {
         display: "block",
         width: percentage(100),
         height: percentage(100),
       },
       children: nodes,
-    }),
-    stylesheets,
-  };
+    });
+  }
+
+  return { node, css, stylesheets: css };
 }

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -17,7 +17,7 @@ export interface FromStaticMarkupOptions extends FromJsxOptions {}
 
 export interface FromStaticMarkupResult {
   nodes: Node[];
-  stylesheets: string[];
+  css: string[];
 }
 
 /**
@@ -35,12 +35,12 @@ export function fromStaticMarkup(
   options?: FromStaticMarkupOptions,
 ): FromStaticMarkupResult {
   const document = parse(markup) as UltraHtmlDocumentNode;
-  const result: FromStaticMarkupResult = { nodes: [], stylesheets: [] };
+  const result: FromStaticMarkupResult = { nodes: [], css: [] };
   const presets = getPresets(options?.defaultStyles);
   const tailwindClassesProperty = options?.tailwindClassesProperty ?? "tw";
 
   for (const child of document.children) {
-    buildStaticNodes(child, presets, tailwindClassesProperty, result.nodes, result.stylesheets);
+    buildStaticNodes(child, presets, tailwindClassesProperty, result.nodes, result.css);
   }
 
   return result;
@@ -51,7 +51,7 @@ function buildStaticNodes(
   presets: typeof defaultStylePresets | undefined,
   tailwindClassesProperty: string,
   nodes: Node[],
-  stylesheets: string[],
+  css: string[],
 ): void {
   if (node.type === COMMENT_NODE) {
     return;
@@ -72,7 +72,7 @@ function buildStaticNodes(
 
   if (node.type === DOCUMENT_NODE) {
     for (const child of node.children) {
-      buildStaticNodes(child, presets, tailwindClassesProperty, nodes, stylesheets);
+      buildStaticNodes(child, presets, tailwindClassesProperty, nodes, css);
     }
     return;
   }
@@ -92,7 +92,7 @@ function buildStaticNodes(
     }
 
     if (content) {
-      stylesheets.push(content);
+      css.push(content);
     }
     return;
   }
@@ -101,7 +101,7 @@ function buildStaticNodes(
     const discardedNodes: Node[] = [];
 
     for (const child of element.children) {
-      buildStaticNodes(child, presets, tailwindClassesProperty, discardedNodes, stylesheets);
+      buildStaticNodes(child, presets, tailwindClassesProperty, discardedNodes, css);
     }
     return;
   }
@@ -179,7 +179,7 @@ function buildStaticNodes(
 
   const childNodes: Node[] = [];
   for (const child of element.children) {
-    buildStaticNodes(child, presets, tailwindClassesProperty, childNodes, stylesheets);
+    buildStaticNodes(child, presets, tailwindClassesProperty, childNodes, css);
   }
 
   nodes.push(

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -68,16 +68,18 @@ interface ResolvedFromJsxOptions extends RenderEnv {
 
 export interface FromJsxResult {
   node: Node;
+  css: string[];
+  /** @deprecated Use `css` instead. */
   stylesheets: string[];
 }
 
 interface FromJsxTraversalResult {
   nodes: Node[];
-  stylesheets: string[];
+  css: string[];
 }
 
 function emptyTraversalResult(): FromJsxTraversalResult {
-  return { nodes: [], stylesheets: [] };
+  return { nodes: [], css: [] };
 }
 
 export async function fromJsx(
@@ -112,7 +114,8 @@ export async function fromJsx(
 
   return {
     node,
-    stylesheets: result.stylesheets,
+    css: result.css,
+    stylesheets: result.css,
   };
 }
 
@@ -143,7 +146,7 @@ async function fromJsxInternal(
         preset: options.presets?.span,
       }),
     ],
-    stylesheets: [],
+    css: [],
   };
 }
 
@@ -363,7 +366,7 @@ async function processReactElement(
     const css = collectStyleText(getElementChildren(element));
     return {
       nodes: [],
-      stylesheets: css && css.length > 0 ? [css] : [],
+      css: css && css.length > 0 ? [css] : [],
     };
   }
 
@@ -371,7 +374,7 @@ async function processReactElement(
     const children = await collectChildren(element, options);
     return {
       nodes: [],
-      stylesheets: children.stylesheets,
+      css: children.css,
     };
   }
 
@@ -390,21 +393,21 @@ async function processReactElement(
           ...metadata,
         }),
       ],
-      stylesheets: [],
+      css: [],
     };
   }
 
   if (isHtmlElement(element, "img")) {
     return {
       nodes: [createImageElement(element, options)],
-      stylesheets: [],
+      css: [],
     };
   }
 
   if (isHtmlElement(element, "svg")) {
     return {
       nodes: [createSvgElement(element, options)],
-      stylesheets: [],
+      css: [],
     };
   }
 
@@ -417,7 +420,7 @@ async function processReactElement(
           ...metadata,
         }),
       ],
-      stylesheets: [],
+      css: [],
     };
   }
 
@@ -430,7 +433,7 @@ async function processReactElement(
         ...metadata,
       }),
     ],
-    stylesheets: children.stylesheets,
+    css: children.css,
   };
 }
 
@@ -581,15 +584,15 @@ async function collectIterable(
   await Promise.all(inFlight);
 
   const flattenedNodes: Node[] = [];
-  const flattenedStylesheets: string[] = [];
+  const flattenedCss: string[] = [];
   for (const group of groupedResults) {
     if (!group) continue;
     flattenedNodes.push(...group.nodes);
-    flattenedStylesheets.push(...group.stylesheets);
+    flattenedCss.push(...group.css);
   }
 
   return {
     nodes: flattenedNodes,
-    stylesheets: flattenedStylesheets,
+    css: flattenedCss,
   };
 }

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -4,6 +4,7 @@ import type { Node, NodeMetadata, RgbaImage, ReactElementLike } from "../types";
 import { extractAttributes, getPresets, type HtmlProps } from "./metadata";
 export type { HtmlProps } from "./metadata";
 import { callWithDispatcher, getProperty, readContext, type RenderEnv } from "./dispatcher";
+import { hideStylesheetsAlias, warnStylesheetsDeprecated } from "../deprecation";
 import { defaultStylePresets } from "./style-presets";
 import { serializeSvg } from "./svg";
 import {
@@ -112,11 +113,18 @@ export async function fromJsx(
     });
   }
 
-  return {
+  const css = result.css;
+  const aliased: FromJsxResult = {
     node,
-    css: result.css,
-    stylesheets: result.css,
+    css,
+    get stylesheets() {
+      warnStylesheetsDeprecated();
+      return css;
+    },
   };
+
+  hideStylesheetsAlias(aliased);
+  return aliased;
 }
 
 async function fromJsxInternal(

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -8,13 +8,14 @@ const BODY = `<div class="box">x</div>`;
 
 describe("fromHtml", () => {
   test("collects <style> from a fragment", () => {
-    expect(fromHtml(`${STYLE}${BODY}`).stylesheets).toEqual([".box{background:#2c82c9}"]);
+    expect(fromHtml(`${STYLE}${BODY}`).css).toEqual([".box{background:#2c82c9}"]);
   });
 
   test("collects <style> from <head> in a full document", () => {
-    const { stylesheets } = fromHtml(`<html><head>${STYLE}</head><body>${BODY}</body></html>`);
+    const { css, stylesheets } = fromHtml(`<html><head>${STYLE}</head><body>${BODY}</body></html>`);
 
-    expect(stylesheets).toEqual([".box{background:#2c82c9}"]);
+    expect(css).toEqual([".box{background:#2c82c9}"]);
+    expect(stylesheets).toBe(css);
   });
 
   test("does not render <head> content as nodes", () => {
@@ -134,7 +135,7 @@ describe("fromHtml", () => {
 
 describe("fromJsx", () => {
   test("collects <style> from <head>", async () => {
-    const { stylesheets } = await fromJsx(
+    const { css, stylesheets } = await fromJsx(
       <html>
         <head>
           <style>{".box{background:#2c82c9}"}</style>
@@ -145,6 +146,7 @@ describe("fromJsx", () => {
       </html>,
     );
 
-    expect(stylesheets).toEqual([".box{background:#2c82c9}"]);
+    expect(css).toEqual([".box{background:#2c82c9}"]);
+    expect(stylesheets).toBe(css);
   });
 });

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -1,10 +1,28 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { fromHtml } from "../src/html";
 import { fromJsx } from "../src/jsx";
 import type { TextNode } from "../src/types";
 
 const STYLE = `<style>.box{background:#2c82c9}</style>`;
 const BODY = `<div class="box">x</div>`;
+
+// Runs first: the deprecation warning fires once per process, and every later
+// read of `stylesheets` trips it.
+test("stylesheets warns once and stays out of spreads", () => {
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  const result = fromHtml(`${STYLE}${BODY}`);
+
+  expect(Object.keys(result)).not.toContain("stylesheets");
+  expect({ ...result }).not.toHaveProperty("stylesheets");
+  expect(warn.mock.calls).toHaveLength(0);
+
+  expect(result.stylesheets).toBe(result.css);
+  expect(result.stylesheets).toBe(result.css);
+
+  expect(warn.mock.calls).toHaveLength(1);
+  expect(warn.mock.calls[0]?.[0]).toContain("`stylesheets` result field is deprecated");
+  warn.mockRestore();
+});
 
 describe("fromHtml", () => {
   test("collects <style> from a fragment", () => {

--- a/takumi-helpers/tests/jsx/jsx-processing.test.tsx
+++ b/takumi-helpers/tests/jsx/jsx-processing.test.tsx
@@ -856,15 +856,15 @@ describe("fromJsx", () => {
     } satisfies ContainerNode);
   });
 
-  test("extracts style tag contents into stylesheets", async () => {
-    const { node, stylesheets } = await fromJsx(
+  test("extracts style tag contents into css", async () => {
+    const { node, css } = await fromJsx(
       <div>
         <style>{".box { color: red; }"}</style>
         <span>Hello</span>
       </div>,
     );
 
-    expect(stylesheets).toEqual([".box { color: red; }"]);
+    expect(css).toEqual([".box { color: red; }"]);
     expect(node).toEqual({
       type: "container",
       tagName: "div",
@@ -880,10 +880,10 @@ describe("fromJsx", () => {
     } satisfies ContainerNode);
   });
 
-  test("extracts stylesheets from fragments and preserves order", async () => {
+  test("extracts css from fragments and preserves order", async () => {
     const Wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
 
-    const { node, stylesheets } = await fromJsx(
+    const { node, css } = await fromJsx(
       <div>
         <Wrapper>
           <style>{".a { color: red; }"}</style>
@@ -893,7 +893,7 @@ describe("fromJsx", () => {
       </div>,
     );
 
-    expect(stylesheets).toEqual([".a { color: red; }", ".b { color: blue; }"]);
+    expect(css).toEqual([".a { color: red; }", ".b { color: blue; }"]);
     expect(node).toEqual({
       type: "container",
       tagName: "div",
@@ -910,7 +910,7 @@ describe("fromJsx", () => {
   });
 
   test("ignores boolean children while extracting style text", async () => {
-    const { stylesheets } = await fromJsx(
+    const { css } = await fromJsx(
       <style>
         {"body{"}
         {true}
@@ -918,7 +918,7 @@ describe("fromJsx", () => {
       </style>,
     );
 
-    expect(stylesheets).toEqual(["body{color:red;}"]);
+    expect(css).toEqual(["body{color:red;}"]);
   });
 
   test("parses html dir field on text nodes", async () => {

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -127,7 +127,7 @@ async function transformElement(element: RenderInput, options?: PipelineOptions)
   if (isTakumiNode(element)) {
     return {
       node: element,
-      stylesheets: [],
+      css: [],
     };
   }
 
@@ -150,11 +150,11 @@ async function resolveRenderer(options?: PipelineOptions): Promise<Renderer> {
 
 /** Transforms an input into a node tree and extracts its emojis. */
 async function resolveContent(element: RenderInput, options?: PipelineOptions) {
-  const { node: originalNode, stylesheets } = await transformElement(element, options);
+  const { node: originalNode, css } = await transformElement(element, options);
   const emojiType = options?.emoji ?? "twemoji";
   const node = emojiType !== "from-font" ? extractEmojis(originalNode, emojiType) : originalNode;
 
-  return { node, stylesheets };
+  return { node, css };
 }
 
 /** Resolves the render's `images` option into concrete entries via {@link prepareImages}. */
@@ -237,7 +237,7 @@ export async function render(element: RenderInput, options?: RenderOptions) {
   options?.signal?.throwIfAborted();
 
   const renderer = await resolveRenderer(options);
-  const { node, stylesheets } = await resolveContent(element, options);
+  const { node, css: extractedCss } = await resolveContent(element, options);
   const images = await collectImages(node, options);
 
   // The WASM renderer is synchronous and ignores the signal argument, so honor an
@@ -249,7 +249,7 @@ export async function render(element: RenderInput, options?: RenderOptions) {
   return renderer.render(node, {
     ...forward,
     images,
-    css: mergeCss(options, stylesheets),
+    css: mergeCss(options, extractedCss),
   });
 }
 
@@ -277,7 +277,7 @@ export async function renderSvg(element: RenderInput, options?: RenderSvgOptions
   options?.signal?.throwIfAborted();
 
   const renderer = await resolveRenderer(options);
-  const { node, stylesheets } = await resolveContent(element, options);
+  const { node, css: extractedCss } = await resolveContent(element, options);
   const images = await collectImages(node, options);
 
   options?.signal?.throwIfAborted();
@@ -287,7 +287,7 @@ export async function renderSvg(element: RenderInput, options?: RenderSvgOptions
   return renderer.renderSvg(node, {
     ...forward,
     images,
-    css: mergeCss(options, stylesheets),
+    css: mergeCss(options, extractedCss),
   });
 }
 
@@ -323,8 +323,8 @@ export async function renderAnimation(options: RenderAnimationOptions) {
   const renderer = await resolveRenderer(options);
   const scenes = await Promise.all(
     options.scenes.map(async (scene) => {
-      const { node, stylesheets } = await resolveContent(scene.node, options);
-      return { node, durationMs: scene.durationMs, stylesheets };
+      const { node, css } = await resolveContent(scene.node, options);
+      return { node, durationMs: scene.durationMs, css };
     }),
   );
 
@@ -334,7 +334,7 @@ export async function renderAnimation(options: RenderAnimationOptions) {
   );
   const css = mergeCss(
     options,
-    scenes.flatMap((scene) => scene.stylesheets),
+    scenes.flatMap((scene) => scene.css),
   );
 
   options.signal?.throwIfAborted();

--- a/takumi-napi/tests/bench/index.tsx
+++ b/takumi-napi/tests/bench/index.tsx
@@ -78,54 +78,54 @@ bench("createNode", createNode);
 
 summary(() => {
   bench("createNode + render (raw)", async () => {
-    const { node, stylesheets } = await createNode();
+    const { node, css } = await createNode();
     return renderer.render(node, {
       width: 1200,
       height: 630,
       format: "raw",
-      css: stylesheets,
+      css,
     });
   });
 
   bench("createNode + render (png, fdeflate)", async () => {
-    const { node, stylesheets } = await createNode();
+    const { node, css } = await createNode();
     return renderer.render(node, {
       width: 1200,
       height: 630,
       quality: 75,
-      css: stylesheets,
+      css,
     });
   });
 
   bench("createNode + render (png, flate2)", async () => {
-    const { node, stylesheets } = await createNode();
+    const { node, css } = await createNode();
     return renderer.render(node, {
       width: 1200,
       height: 630,
       quality: 100,
-      css: stylesheets,
+      css,
     });
   });
 
   bench("createNode + render (webp 75%)", async () => {
-    const { node, stylesheets } = await createNode();
+    const { node, css } = await createNode();
     return renderer.render(node, {
       width: 1200,
       height: 630,
       format: "webp",
       quality: 75,
-      css: stylesheets,
+      css,
     });
   });
 
   bench("createNode + render (webp 100%)", async () => {
-    const { node, stylesheets } = await createNode();
+    const { node, css } = await createNode();
     return renderer.render(node, {
       width: 1200,
       height: 630,
       format: "webp",
       quality: 100,
-      css: stylesheets,
+      css,
     });
   });
 });
@@ -198,14 +198,14 @@ summary(() => {
   });
 });
 
-const { node, stylesheets } = await createNode();
+const { node, css } = await createNode();
 
 await writeFile(
   "tests/bench/bench.png",
   await renderer.render(node, {
     width: 1200,
     height: 630,
-    css: stylesheets,
+    css,
   }),
 );
 

--- a/takumi-napi/tests/render-svg.test.ts
+++ b/takumi-napi/tests/render-svg.test.ts
@@ -45,7 +45,7 @@ describe("renderSvg", () => {
   });
 
   test("interpolates a stylesheet animation at timeMs", async () => {
-    const stylesheets = [
+    const sheets = [
       `
         div {
           width: 100px;
@@ -67,7 +67,7 @@ describe("renderSvg", () => {
     const at = (timeMs: number) =>
       renderer.renderSvg(
         { type: "container", tagName: "div" },
-        { width: 220, height: 120, timeMs, css: stylesheets },
+        { width: 220, height: 120, timeMs, css: sheets },
       );
 
     const [start, mid, end] = await Promise.all([at(0), at(500), at(1000)]);

--- a/takumi-napi/tests/render.test.tsx
+++ b/takumi-napi/tests/render.test.tsx
@@ -201,7 +201,7 @@ describe("render", () => {
   });
 
   test("does not panic when inline text contains a nested flex span", async () => {
-    const { node, stylesheets } = await fromJsx(
+    const { node, css } = await fromJsx(
       <div
         style={{
           display: "flex",
@@ -238,7 +238,7 @@ describe("render", () => {
       width: 1200,
       height: 630,
       format: "png",
-      css: stylesheets,
+      css,
     });
 
     expect(result).toBeInstanceOf(Buffer);

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -85,7 +85,7 @@ export type PageMargin =
 /**
  * Paged output (the default): content flows across pages of `size`, like
  * Puppeteer's `page.pdf()`. The layout canvas has unbounded height, so
- * percentage heights do not resolve. CSS `@page` rules in `stylesheets` are
+ * percentage heights do not resolve. CSS `@page` rules in `css` are
  * not supported — page geometry comes from these options.
  */
 type PagedOptions = {
@@ -323,9 +323,9 @@ function ownCss(
   return stylesheets ?? [];
 }
 
-async function resolveNode(input: NodeInput): Promise<{ node: Node; stylesheets: string[] }> {
+async function resolveNode(input: NodeInput): Promise<{ node: Node; css: string[] }> {
   if (isNode(input)) {
-    return { node: input, stylesheets: [] };
+    return { node: input, css: [] };
   }
 
   if (typeof input === "string") {
@@ -369,9 +369,9 @@ export class PdfRenderer {
     );
     const sheets = [
       ...ownCss(css, stylesheets),
-      ...main.stylesheets,
-      ...(headerResult?.stylesheets ?? []),
-      ...(footerResult?.stylesheets ?? []),
+      ...main.css,
+      ...(headerResult?.css ?? []),
+      ...(footerResult?.css ?? []),
     ];
 
     return this.inner.render(main.node, {
@@ -408,7 +408,7 @@ export class PdfRenderer {
       images,
       fontFamilies,
     );
-    const sheets = [...ownCss(css, stylesheets), ...main.stylesheets];
+    const sheets = [...ownCss(css, stylesheets), ...main.css];
 
     return this.inner.measure(main.node, {
       ...rest,

--- a/takumi-wasm/tests/render-svg.test.ts
+++ b/takumi-wasm/tests/render-svg.test.ts
@@ -45,7 +45,7 @@ describe("renderSvg", () => {
   });
 
   test("interpolates a stylesheet animation at timeMs", async () => {
-    const stylesheets = [
+    const sheets = [
       `
         div {
           width: 100px;
@@ -67,7 +67,7 @@ describe("renderSvg", () => {
     const at = (timeMs: number) =>
       renderer.renderSvg(
         { type: "container", tagName: "div" },
-        { width: 220, height: 120, timeMs, css: stylesheets },
+        { width: 220, height: 120, timeMs, css: sheets },
       );
 
     const [start, mid, end] = await Promise.all([at(0), at(500), at(1000)]);


### PR DESCRIPTION
## Why
`fromJsx` and `fromHtml` still return the extracted CSS as `stylesheets`, so callers destructure that name only to feed it into the render option now called `css`.

## What
Both results carry a `css` field, with `stylesheets` kept as a deprecated alias to the same array. Internal plumbing, tests, docs and examples read `css`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSS extracted from JSX and HTML is now available through the `css` field.
  * Rendering, measurement, animation, and PDF workflows now use the standardized `css` option.
  * The deprecated `stylesheets` field remains available for compatibility, returns the same CSS, warns once when accessed, and is excluded from enumeration and object spreads.

* **Documentation**
  * Updated guides, examples, playground content, and migration examples to use `css`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->