### PR TITLE
Docs: trim the Tailwind changesets to what a reader needs

### DIFF
--- a/.tegami/css-variables-helper.md
+++ b/.tegami/css-variables-helper.md
@@ -6,4 +6,4 @@ packages:
 
 ### Add the `cssVariables` helper
 
-Flattens a nested tree into the flat map the `cssVariables` option takes: `{ color: { brand: { 500: "#5b21b6" } } }` becomes `{ "--color-brand-500": "#5b21b6" }`.
+Flattens a nested tree into the flat map the `cssVariables` option takes. `{ color: { brand: { 500: "#5b21b6" } } }` becomes `{ "--color-brand-500": "#5b21b6" }`.

--- a/.tegami/tailwind-import-preflight.md
+++ b/.tegami/tailwind-import-preflight.md
@@ -10,4 +10,4 @@ packages:
 
 ### Turn on Preflight through `@import "tailwindcss"`
 
-The import line at the top of a Tailwind v4 stylesheet now works: it drops the UA preset cosmetics (element margins, list markers, heading font tweaks), the part of Preflight the renderer itself supplies. The theme defaults already back every utility, so nothing else needs importing. Other `@import` targets stay unsupported.
+The import line at the top of a Tailwind v4 stylesheet now works. It drops the UA preset cosmetics that Preflight replaces: element margins, list markers and heading font tweaks. The theme defaults already back every utility, so nothing else needs importing. Other `@import` targets stay unsupported.

--- a/.tegami/tw-apply-at-rule.md
+++ b/.tegami/tw-apply-at-rule.md
@@ -10,4 +10,4 @@ packages:
 
 ### Expand `@apply` inside stylesheet rules
 
-`.card { @apply mt-4 bg-brand-500; }` now expands through the `tw` parser at the spot it is written, `!` suffix included. Variants like `md:` are rejected; a static render has nothing for them to gate on.
+`.card { @apply mt-4 bg-brand-500; }` now expands through the `tw` parser where it is written, `!` suffix included. Variants like `md:` are rejected. A static render has nothing for them to gate on.

--- a/.tegami/tw-css-variables.md
+++ b/.tegami/tw-css-variables.md
@@ -10,17 +10,10 @@ packages:
 
 ### Resolve `tw` utilities through CSS variables
 
-Utilities now read the CSS variables Tailwind compiles them to, with the built-in value as the fallback. Define tokens in `:root` or the `cssVariables` option; `--color-brand-500` makes `bg-brand-500` work.
+Utilities now read the CSS variables Tailwind compiles them to, falling back to the built-in value. Define tokens in `:root` or through the `cssVariables` option. `--color-brand-500` makes `bg-brand-500` work, and spacing, fonts, shadows, animations and breakpoints follow the same rule.
 
-- Colours: `bg-*`, `text-*`, `border-*`, gradient stops (`from-brand-500`), and shadow colours (`shadow-brand-500` through `--tw-shadow-color`).
-- Lengths: `p-4` reads `calc(var(--spacing) * 4)`, `p-gutter` reads `--spacing-gutter`; same for `max-w-*`, `rounded-*`, `tracking-*`, `leading-*`, `aspect-*`. Text sizes read `--text-*`: `text-xl` reads `--text-xl`, while `text-red-500` is a colour under `--color-*`.
-- Fonts: `font-sans` reads `--font-sans`, `font-bold` reads `--font-weight-bold`.
-- Shapes: `blur-md`, `drop-shadow-md`, `shadow-md`, `inset-shadow-sm` and `text-shadow-sm` read their `--blur-*` / `--drop-shadow-*` / `--shadow-*` / `--inset-shadow-*` / `--text-shadow-*` tokens. A custom shadow shape carries its own colours, so shadow colour utilities only reach the built-in fallback.
-- Animations: `animate-spin` reads `var(--animate-spin)`, and an unknown token like `animate-wiggle` reads `var(--animate-wiggle)` alone; pair it with its `@keyframes`.
-- Breakpoints: an unconditional `:root` `--breakpoint-*` declaration re-sizes the `sm:`–`2xl:` variants and defines new ones like `3xl:`. Variants gate before the cascade, so a media query cannot move them.
-
-Two gradient behaviours move to match Tailwind: stops alone no longer paint without `bg-linear-*`, `bg-radial` or `bg-conic`, and a missing `to` stop fades to `transparent`.
+Gradients now match Tailwind on two counts. Stops alone no longer paint without `bg-linear-*`, `bg-radial` or `bg-conic`, and a missing `to` stop fades to `transparent`.
 
 ### Let stylesheet rules win over `tw` utilities
 
-Utilities now sit in the last cascade layer: below unlayered CSS, above rules in a named `@layer`. Templates that relied on `tw` beating a matching rule need the rule moved into a layer, or the utility marked `!`.
+Utilities now sit in the last cascade layer, below unlayered CSS and above rules in a named `@layer`. A template that relied on `tw` beating a matching rule needs a fix. Move that rule into a layer, or mark the utility `!`.


### PR DESCRIPTION
## Why
`tw-css-variables` carried a six-bullet reference table of which utility reads which token, which the "Which utilities read a token" section of `styling.mdx` already documents. Three other entries ran a single sentence past thirty words or joined two thoughts with a semicolon.

## What
The bullet list is gone and the surviving entries read as short sentences. `classname-utilities` is untouched because #1431 deletes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CSS variable resolution across colors, spacing, fonts, shadows, animations, and breakpoints.
  * Updated guidance for Tailwind Preflight support and CSS utility cascade behavior.
  * Improved wording and readability for `@apply` usage and CSS variable helper examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->