### PR TITLE
Bindings: warn when a render takes the deprecated stylesheets option

### DIFF
--- a/.tegami/bindings-stylesheets-warning.md
+++ b/.tegami/bindings-stylesheets-warning.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+  "takumi-pdf":
+    type: patch
+---
+
+### Warn when the bindings take the deprecated `stylesheets` option
+
+`@takumi-rs/core` and `@takumi-rs/wasm` accept `stylesheets` as an alias for `css` but said nothing about it. The first render that passes the old name now writes one `console.warn`.

--- a/.tegami/bindings-stylesheets-warning.md
+++ b/.tegami/bindings-stylesheets-warning.md
@@ -10,4 +10,4 @@ packages:
 
 ### Warn when the bindings take the deprecated `stylesheets` option
 
-`@takumi-rs/core` and `@takumi-rs/wasm` accept `stylesheets` as an alias for `css` but said nothing about it. The first render that passes the old name now writes one `console.warn`.
+`@takumi-rs/core` and `@takumi-rs/wasm` accept `stylesheets` as an alias for `css` but said nothing about it. The first call that passes the old name now writes one `console.warn`, whether it renders or measures.

--- a/takumi-bindings-common/src/lib.rs
+++ b/takumi-bindings-common/src/lib.rs
@@ -8,7 +8,10 @@
 
 use std::{
   collections::{BTreeMap, HashMap},
-  sync::Arc,
+  sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+  },
 };
 
 use takumi_core::{
@@ -132,6 +135,23 @@ pub fn stylesheet(
   let mut extended = (*sheet).clone();
   extended.extend_keyframes(keyframes);
   Arc::new(extended)
+}
+
+static STYLESHEETS_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// The CSS for a render, taking the deprecated `stylesheets` alias when `css`
+/// is absent. `warn` reaches the host's console the first time the alias is
+/// used, so a binding caller learns to migrate before the alias is removed.
+pub fn resolve_css(
+  css: Option<Vec<String>>,
+  stylesheets: Option<Vec<String>>,
+  warn: impl FnOnce(&str),
+) -> Option<Vec<String>> {
+  if stylesheets.is_some() && !STYLESHEETS_WARNED.swap(true, Ordering::Relaxed) {
+    warn("takumi: the `stylesheets` option is deprecated, use `css` instead.");
+  }
+
+  css.or(stylesheets)
 }
 
 #[cfg(test)]

--- a/takumi-napi/src/lib.rs
+++ b/takumi-napi/src/lib.rs
@@ -192,3 +192,18 @@ pub(crate) fn deserialize_with_tracing<T: DeserializeOwned>(value: Object) -> Re
 pub(crate) fn map_error<E: Display>(err: E) -> napi::Error {
   napi::Error::from_reason(err.to_string())
 }
+
+/// Writes to the host's `console.warn`, staying silent if the call fails.
+pub(crate) fn console_warn(env: Env, message: &str) {
+  let Ok(global) = env.get_global() else {
+    return;
+  };
+  let Ok(console) = global.get_named_property::<Object>("console") else {
+    return;
+  };
+  let Ok(warn) = console.get_named_property::<Function<String, Unknown>>("warn") else {
+    return;
+  };
+
+  let _ = warn.call(message.to_owned());
+}

--- a/takumi-napi/src/measure_task.rs
+++ b/takumi-napi/src/measure_task.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
-use takumi_bindings_common::stylesheet;
+use takumi_bindings_common::{resolve_css, stylesheet};
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
@@ -37,7 +37,9 @@ impl MeasureTask {
   ) -> Result<Self> {
     let stylesheet = stylesheet(
       &state.resource_cache,
-      options.css.or(options.stylesheets),
+      resolve_css(options.css, options.stylesheets, |m| {
+        crate::console_warn(env, m)
+      }),
       deserialize_keyframes(options.keyframes)?,
       options.css_variables,
     );

--- a/takumi-napi/src/render_animation_task.rs
+++ b/takumi-napi/src/render_animation_task.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
-use takumi_bindings_common::stylesheet;
+use takumi_bindings_common::{resolve_css, stylesheet};
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, KeyframesRule, Lang},
@@ -88,7 +88,7 @@ impl RenderAnimationTask {
       quality,
       lossless,
       draw_debug_border: draw_debug_border.unwrap_or_default(),
-      css: css.or(stylesheets),
+      css: resolve_css(css, stylesheets, |m| crate::console_warn(env, m)),
       keyframes: deserialize_keyframes(keyframes)?,
       css_variables,
       images: collect_images(env, images)?,

--- a/takumi-napi/src/render_task.rs
+++ b/takumi-napi/src/render_task.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
-use takumi_bindings_common::stylesheet;
+use takumi_bindings_common::{resolve_css, stylesheet};
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
@@ -42,7 +42,9 @@ impl RenderTask {
   ) -> Result<Self> {
     let stylesheet = stylesheet(
       &state.resource_cache,
-      options.css.or(options.stylesheets),
+      resolve_css(options.css, options.stylesheets, |m| {
+        crate::console_warn(env, m)
+      }),
       deserialize_keyframes(options.keyframes)?,
       options.css_variables,
     );

--- a/takumi-napi/src/svg_render_task.rs
+++ b/takumi-napi/src/svg_render_task.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, mem::take, sync::Arc};
 
 use napi::bindgen_prelude::*;
-use takumi_bindings_common::stylesheet;
+use takumi_bindings_common::{resolve_css, stylesheet};
 use takumi_core::{
   layout::node::Node,
   style::{FontFamily, Lang, StyleSheet},
@@ -36,7 +36,9 @@ impl SvgRenderTask {
   ) -> Result<Self> {
     let stylesheet = stylesheet(
       &state.resource_cache,
-      options.css.or(options.stylesheets),
+      resolve_css(options.css, options.stylesheets, |m| {
+        crate::console_warn(env, m)
+      }),
       deserialize_keyframes(options.keyframes)?,
       options.css_variables,
     );

--- a/takumi-napi/tests/render.test.tsx
+++ b/takumi-napi/tests/render.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { container, image, text } from "@takumi-rs/helpers";
 import { fromJsx } from "@takumi-rs/helpers/jsx";
@@ -276,17 +276,28 @@ describe("render", () => {
     expect(animated.width).toBe(150);
   });
 
-  test("measures through the deprecated stylesheets alias", async () => {
+  // The deprecation warning fires once per process, so this has to be the
+  // first test that passes `stylesheets`.
+  test("measures through the deprecated stylesheets alias, warning once", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
     const node = { type: "container", tagName: "div" } as const;
     const sheet = "div { width: 120px; height: 40px; }";
 
-    const [viaCss, viaAlias] = await Promise.all([
-      renderer.measure(node, { width: 200, height: 100, css: [sheet] }),
-      renderer.measure(node, { width: 200, height: 100, stylesheets: [sheet] }),
-    ]);
+    const viaCss = await renderer.measure(node, { width: 200, height: 100, css: [sheet] });
+    expect(warn.mock.calls).toHaveLength(0);
+
+    const viaAlias = await renderer.measure(node, {
+      width: 200,
+      height: 100,
+      stylesheets: [sheet],
+    });
+    await renderer.measure(node, { width: 200, height: 100, stylesheets: [sheet] });
 
     expect(viaAlias).toEqual(viaCss);
     expect(viaAlias.width).toBe(120);
+    expect(warn.mock.calls).toHaveLength(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("`stylesheets` option is deprecated");
+    warn.mockRestore();
   });
 
   test("with structured keyframes in render options", async () => {

--- a/takumi-napi/tests/render.test.tsx
+++ b/takumi-napi/tests/render.test.tsx
@@ -292,6 +292,8 @@ describe("render", () => {
         height: 100,
         stylesheets: [sheet],
       });
+      expect(warn.mock.calls).toHaveLength(1);
+
       await renderer.measure(node, { width: 200, height: 100, stylesheets: [sheet] });
 
       expect(viaAlias).toEqual(viaCss);

--- a/takumi-napi/tests/render.test.tsx
+++ b/takumi-napi/tests/render.test.tsx
@@ -283,21 +283,24 @@ describe("render", () => {
     const node = { type: "container", tagName: "div" } as const;
     const sheet = "div { width: 120px; height: 40px; }";
 
-    const viaCss = await renderer.measure(node, { width: 200, height: 100, css: [sheet] });
-    expect(warn.mock.calls).toHaveLength(0);
+    try {
+      const viaCss = await renderer.measure(node, { width: 200, height: 100, css: [sheet] });
+      expect(warn.mock.calls).toHaveLength(0);
 
-    const viaAlias = await renderer.measure(node, {
-      width: 200,
-      height: 100,
-      stylesheets: [sheet],
-    });
-    await renderer.measure(node, { width: 200, height: 100, stylesheets: [sheet] });
+      const viaAlias = await renderer.measure(node, {
+        width: 200,
+        height: 100,
+        stylesheets: [sheet],
+      });
+      await renderer.measure(node, { width: 200, height: 100, stylesheets: [sheet] });
 
-    expect(viaAlias).toEqual(viaCss);
-    expect(viaAlias.width).toBe(120);
-    expect(warn.mock.calls).toHaveLength(1);
-    expect(warn.mock.calls[0]?.[0]).toContain("`stylesheets` option is deprecated");
-    warn.mockRestore();
+      expect(viaAlias).toEqual(viaCss);
+      expect(viaAlias.width).toBe(120);
+      expect(warn.mock.calls).toHaveLength(1);
+      expect(warn.mock.calls[0]?.[0]).toContain("`stylesheets` option is deprecated");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test("with structured keyframes in render options", async () => {

--- a/takumi-wasm/src/helper.rs
+++ b/takumi-wasm/src/helper.rs
@@ -24,3 +24,13 @@ pub fn map_error<E: Display>(err: E) -> js_sys::Error {
 pub fn set_glyph_cache_max_bytes(bytes: f64) {
   glyph_cache::set_glyph_cache_max_bytes(bytes.max(0.0) as usize);
 }
+
+#[wasm_bindgen]
+extern "C" {
+  #[wasm_bindgen(js_namespace = console, js_name = warn)]
+  fn console_warn_raw(message: &str);
+}
+
+pub(crate) fn console_warn(message: &str) {
+  console_warn_raw(message);
+}

--- a/takumi-wasm/src/renderer.rs
+++ b/takumi-wasm/src/renderer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use serde_wasm_bindgen::{from_value, to_value};
-use takumi_bindings_common::{build_font_resource, default_fonts, stylesheet};
+use takumi_bindings_common::{build_font_resource, default_fonts, resolve_css, stylesheet};
 use takumi_core::{
   Fonts,
   layout::node::Node,
@@ -24,7 +24,10 @@ use takumi_raster::{
 };
 use wasm_bindgen::prelude::*;
 
-use crate::{helper::map_error, model::*};
+use crate::{
+  helper::{console_warn, map_error},
+  model::*,
+};
 
 /// The main renderer for Takumi image rendering engine.
 ///
@@ -80,7 +83,7 @@ fn raster_options<'fonts>(
 ) -> Result<takumi_raster::RenderOptions<'fonts>, js_sys::Error> {
   let stylesheet = stylesheet(
     resource_cache,
-    options.css.or(options.stylesheets),
+    resolve_css(options.css, options.stylesheets, console_warn),
     options.keyframes.unwrap_or_default(),
     options.css_variables,
   );
@@ -236,7 +239,7 @@ impl Renderer {
     let images = self.images_map(options.images.as_deref())?;
     let stylesheet = stylesheet(
       &self.resource_cache,
-      options.css.or(options.stylesheets),
+      resolve_css(options.css, options.stylesheets, console_warn),
       options.keyframes.unwrap_or_default(),
       options.css_variables,
     );
@@ -355,7 +358,7 @@ impl Renderer {
     let draw_debug_border = draw_debug_border.unwrap_or_default();
     let stylesheet = stylesheet(
       &self.resource_cache,
-      css.or(stylesheets),
+      resolve_css(css, stylesheets, console_warn),
       keyframes.unwrap_or_default(),
       css_variables,
     );


### PR DESCRIPTION
## Why
`takumi-js` and `takumi-pdf` warn once when a caller passes `stylesheets`, but `@takumi-rs/core` and `@takumi-rs/wasm` took the alias in silence. Anyone calling the bindings directly gets no signal before the alias is removed.

## What
`resolve_css` in `takumi-bindings-common` picks `css` over the alias and hands the deprecation message to a warn callback the first time the alias appears. napi reaches `console.warn` through the `Env` its task constructors already receive, and wasm through a `wasm-bindgen` extern, so neither binding gains a dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS configuration handling across rendering, animation, SVG, and measurement.
  * The deprecated `stylesheets` option remains supported as an alias for `css`.
  * A deprecation warning now appears in the console only once, when the alias is first used.
  * When both options are provided, the standard `css` option is used consistently.
* **Documentation**
  * Added release notes for the updated bindings and PDF package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->