### PR TITLE
Core: support the disclosure counter styles

### DIFF
--- a/.tegami/disclosure-counter-styles.md
+++ b/.tegami/disclosure-counter-styles.md
@@ -8,4 +8,4 @@ packages:
 
 ### Support the `disclosure-open` and `disclosure-closed` counter styles
 
-`list-style-type` takes both names and draws the triangles CSS Counter Styles names for them. `disclosure-closed` points the way the text runs, so it flips under `direction: rtl`. Font subsetting covers the three characters.
+`list-style-type` now accepts `disclosure-open` and `disclosure-closed`, drawing the triangles CSS Counter Styles defines. `disclosure-closed` points the way the text runs, so it flips under `direction: rtl`. Font subsetting covers all three characters.

--- a/.tegami/disclosure-counter-styles.md
+++ b/.tegami/disclosure-counter-styles.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/helpers":
+    type: minor
+---
+
+### Support the `disclosure-open` and `disclosure-closed` counter styles
+
+`list-style-type` takes both names and draws the triangles CSS Counter Styles names for them. `disclosure-closed` points the way the text runs, so it flips under `direction: rtl`. Font subsetting covers the three characters.

--- a/takumi-core/src/layout/list_marker.rs
+++ b/takumi-core/src/layout/list_marker.rs
@@ -45,7 +45,7 @@ pub(super) fn list_marker(item_context: &RenderContext, ordinal: i32) -> Option<
     Some(image) => marker_image(&context, image, is_rtl),
     None => {
       let style_type = &item_context.style.list_style_type;
-      let text = style_type.marker_text(ordinal)?;
+      let text = style_type.marker_text(ordinal, is_rtl)?;
 
       // Blink spaces a symbol marker with margins, not its suffix
       // (`InlineMarginsForInside`/`Outside`).

--- a/takumi-core/src/style/properties/list_style.rs
+++ b/takumi-core/src/style/properties/list_style.rs
@@ -34,6 +34,10 @@ pub enum ListStyleType {
   LowerRoman,
   /// Uppercase roman numerals.
   UpperRoman,
+  /// A triangle pointing at the closed disclosure widget's content.
+  DisclosureClosed,
+  /// A triangle pointing down at the open disclosure widget's content.
+  DisclosureOpen,
   /// A literal string used for every item.
   String(Arc<str>),
 }
@@ -174,12 +178,18 @@ impl ListStyleType {
   pub(crate) fn is_symbolic(&self) -> bool {
     matches!(
       self,
-      ListStyleType::Disc | ListStyleType::Circle | ListStyleType::Square
+      ListStyleType::Disc
+        | ListStyleType::Circle
+        | ListStyleType::Square
+        | ListStyleType::DisclosureClosed
+        | ListStyleType::DisclosureOpen
     )
   }
 
-  /// The marker string for an item at `ordinal`, including the counter style's suffix.
-  pub(crate) fn marker_text(&self, ordinal: i32) -> Option<String> {
+  /// The marker string for an item at `ordinal`, including the counter style's
+  /// suffix. `is_rtl` only reaches `disclosure-closed`, whose triangle points
+  /// the way the text runs.
+  pub(crate) fn marker_text(&self, ordinal: i32, is_rtl: bool) -> Option<String> {
     let (representation, suffix) = match self {
       ListStyleType::None => return None,
       ListStyleType::String(value) => return Some(value.as_ref().to_owned()),
@@ -188,6 +198,10 @@ impl ListStyleType {
       // Blink paints `square` at `(ascent*2/3 + 1)/2` px
       // (`RelativeSymbolMarkerRect`); `▪` tracks that size, `■` does not.
       ListStyleType::Square => ("\u{25aa}".to_owned(), " "),
+      // Ref: https://drafts.csswg.org/css-counter-styles-3/#simple-symbolic
+      ListStyleType::DisclosureClosed if is_rtl => ("\u{25c2}".to_owned(), " "),
+      ListStyleType::DisclosureClosed => ("\u{25b8}".to_owned(), " "),
+      ListStyleType::DisclosureOpen => ("\u{25be}".to_owned(), " "),
       ListStyleType::Decimal => (ordinal.to_string(), ". "),
       ListStyleType::DecimalLeadingZero => (decimal_leading_zero(ordinal), ". "),
       ListStyleType::LowerAlpha => (alphabetic(ordinal, 'a'), ". "),
@@ -211,6 +225,8 @@ impl ListStyleType {
       "upper-alpha" | "upper-latin" => Some(ListStyleType::UpperAlpha),
       "lower-roman" => Some(ListStyleType::LowerRoman),
       "upper-roman" => Some(ListStyleType::UpperRoman),
+      "disclosure-closed" => Some(ListStyleType::DisclosureClosed),
+      "disclosure-open" => Some(ListStyleType::DisclosureOpen),
       _ => None,
     }
   }
@@ -266,6 +282,8 @@ impl ToCss for ListStyleType {
       ListStyleType::UpperAlpha => dest.write_str("upper-alpha"),
       ListStyleType::LowerRoman => dest.write_str("lower-roman"),
       ListStyleType::UpperRoman => dest.write_str("upper-roman"),
+      ListStyleType::DisclosureClosed => dest.write_str("disclosure-closed"),
+      ListStyleType::DisclosureOpen => dest.write_str("disclosure-open"),
       ListStyleType::String(value) => serialize_string(value, dest),
     }
   }
@@ -333,7 +351,7 @@ mod tests {
   /// Every character `marker_text` can generate across the predefined counter
   /// styles. Mirrored by `LIST_MARKER_CHARACTERS` in
   /// `takumi-helpers/src/fonts.ts`, which font subsetting feeds to callers.
-  const MARKER_CHARACTERS: &str = "\u{2022}\u{25e6}\u{25a0}\u{25aa} 0123456789.-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const MARKER_CHARACTERS: &str = "\u{2022}\u{25e6}\u{25a0}\u{25aa}\u{25b8}\u{25c2}\u{25be} 0123456789.-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   #[test]
   fn parses_keywords_and_strings() {
@@ -348,6 +366,14 @@ mod tests {
     assert_eq!(
       ListStyleType::from_css_str("\"-\""),
       Ok(ListStyleType::String("-".into()))
+    );
+    assert_eq!(
+      ListStyleType::from_css_str("disclosure-closed"),
+      Ok(ListStyleType::DisclosureClosed)
+    );
+    assert_eq!(
+      ListStyleType::from_css_str("disclosure-open"),
+      Ok(ListStyleType::DisclosureOpen)
     );
     assert!(ListStyleType::from_css_str("bogus").is_err());
   }
@@ -383,32 +409,62 @@ mod tests {
   #[test]
   fn numbers_the_marker_per_counter_style() {
     assert_eq!(
-      ListStyleType::Decimal.marker_text(3).as_deref(),
+      ListStyleType::Decimal.marker_text(3, false).as_deref(),
       Some("3. ")
     );
     assert_eq!(
-      ListStyleType::DecimalLeadingZero.marker_text(7).as_deref(),
+      ListStyleType::DecimalLeadingZero
+        .marker_text(7, false)
+        .as_deref(),
       Some("07. ")
     );
     assert_eq!(
-      ListStyleType::LowerAlpha.marker_text(28).as_deref(),
+      ListStyleType::LowerAlpha.marker_text(28, false).as_deref(),
       Some("ab. ")
     );
     assert_eq!(
-      ListStyleType::UpperRoman.marker_text(1994).as_deref(),
+      ListStyleType::UpperRoman
+        .marker_text(1994, false)
+        .as_deref(),
       Some("MCMXCIV. ")
     );
     assert_eq!(
-      ListStyleType::Disc.marker_text(1).as_deref(),
+      ListStyleType::DisclosureClosed
+        .marker_text(1, false)
+        .as_deref(),
+      Some("\u{25b8} ")
+    );
+    assert_eq!(
+      ListStyleType::DisclosureClosed
+        .marker_text(1, true)
+        .as_deref(),
+      Some("\u{25c2} ")
+    );
+    assert_eq!(
+      ListStyleType::DisclosureOpen
+        .marker_text(1, false)
+        .as_deref(),
+      Some("\u{25be} ")
+    );
+    assert_eq!(
+      ListStyleType::DisclosureOpen
+        .marker_text(9, true)
+        .as_deref(),
+      Some("\u{25be} ")
+    );
+    assert_eq!(
+      ListStyleType::Disc.marker_text(1, false).as_deref(),
       Some("\u{2022} ")
     );
-    assert_eq!(ListStyleType::None.marker_text(1), None);
+    assert_eq!(ListStyleType::None.marker_text(1, false), None);
   }
 
   #[test]
   fn a_negative_value_spends_its_padding_on_the_sign() {
     assert_eq!(
-      ListStyleType::DecimalLeadingZero.marker_text(-7).as_deref(),
+      ListStyleType::DecimalLeadingZero
+        .marker_text(-7, false)
+        .as_deref(),
       Some("-7. ")
     );
   }
@@ -430,6 +486,8 @@ mod tests {
       ListStyleType::UpperAlpha,
       ListStyleType::LowerRoman,
       ListStyleType::UpperRoman,
+      ListStyleType::DisclosureClosed,
+      ListStyleType::DisclosureOpen,
       ListStyleType::String("marker".into()),
     ];
 
@@ -438,7 +496,11 @@ mod tests {
       // the shared character set.
       let covered: &[i32] = match style {
         ListStyleType::None | ListStyleType::String(_) => &[],
-        ListStyleType::Disc | ListStyleType::Circle | ListStyleType::Square => &[1, 100],
+        ListStyleType::Disc
+        | ListStyleType::Circle
+        | ListStyleType::Square
+        | ListStyleType::DisclosureClosed
+        | ListStyleType::DisclosureOpen => &[1, 100],
         ListStyleType::Decimal
         | ListStyleType::DecimalLeadingZero
         | ListStyleType::LowerAlpha
@@ -448,13 +510,15 @@ mod tests {
       };
 
       for ordinal in covered {
-        let marker = style.marker_text(*ordinal).expect("marker text");
+        for is_rtl in [false, true] {
+          let marker = style.marker_text(*ordinal, is_rtl).expect("marker text");
 
-        for character in marker.chars() {
-          assert!(
-            MARKER_CHARACTERS.contains(character),
-            "{style:?} at {ordinal} generates {character:?} outside MARKER_CHARACTERS"
-          );
+          for character in marker.chars() {
+            assert!(
+              MARKER_CHARACTERS.contains(character),
+              "{style:?} at {ordinal} generates {character:?} outside MARKER_CHARACTERS"
+            );
+          }
         }
       }
     }
@@ -463,11 +527,11 @@ mod tests {
   #[test]
   fn falls_back_to_decimal_outside_the_counter_range() {
     assert_eq!(
-      ListStyleType::LowerAlpha.marker_text(0).as_deref(),
+      ListStyleType::LowerAlpha.marker_text(0, false).as_deref(),
       Some("0. ")
     );
     assert_eq!(
-      ListStyleType::LowerRoman.marker_text(-2).as_deref(),
+      ListStyleType::LowerRoman.marker_text(-2, false).as_deref(),
       Some("-2. ")
     );
   }

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1326,8 +1326,8 @@ impl From<Vec<PropertyRule>> for StyleSheet {
 
 /// Tailwind's Preflight, minus rules takumi cannot honor: form controls,
 /// `::placeholder`, vendor pseudo-elements, elements that never become a node,
-/// `abbr[title]` (needs an unparsed `text-decoration` style) and `summary`
-/// (`display: list-item` would paint a disc for the disclosure marker).
+/// `abbr[title]` (needs `text-decoration-style: dotted`, which is unparsed) and
+/// `summary` (`display: list-item` would draw a marker no bundled font covers).
 /// `:root` stands in for upstream's `html, :host`.
 /// https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/preflight.css
 const PREFLIGHT_CSS: &str = r"
@@ -1398,6 +1398,7 @@ const PREFLIGHT_CSS: &str = r"
   ol, ul, menu {
     list-style: none;
   }
+
 
   img, svg {
     display: block;

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1399,7 +1399,6 @@ const PREFLIGHT_CSS: &str = r"
     list-style: none;
   }
 
-
   img, svg {
     display: block;
     vertical-align: middle;

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -353,7 +353,7 @@ export type CodepointSource = string | Node | (string | Node)[];
  * source of truth. `list-style-type: "…"` strings are not covered.
  */
 export const LIST_MARKER_CHARACTERS =
-  "•◦■▪ 0123456789.-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  "•◦■▪▸◂▾ 0123456789.-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 /** Collect every codepoint the content will render. */
 export function collectCodepoints(source: CodepointSource): Set<number> {


### PR DESCRIPTION
## Why
`list-style-type: disclosure-open` and `disclosure-closed` were rejected, so a stylesheet naming either lost the whole declaration. They are two of the six counter styles CSS marks non-overridable.

## What
Both parse, serialize and draw the triangles the spec names, and `disclosure-closed` flips to U+25C2 under `direction: rtl`. `marker_text` takes the direction for that. Font subsetting carries the three characters, and the exhaustive coverage test now runs each style in both directions.

Preflight still leaves `summary` alone. Wiring it up needs two things this does not do: no bundled font covers the triangles, and the `summary` preset never reaches a node in the HTML path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `disclosure-open` and `disclosure-closed` list marker styles.
  * Disclosure markers now display correctly in both left-to-right and right-to-left layouts.
  * Added font support for the new disclosure marker characters, including proper subsetting coverage.
  * Ensured disclosure markers render consistently across supported list configurations.

* **Documentation**
  * Updated release documentation for the new list marker styles, including RTL behavior and font support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->