### PR TITLE
Separate the parse_loosy binding from its return

### DIFF
--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -1485,6 +1485,7 @@ impl StyleSheet {
     let Ok(stylesheet) = Self::parse_with_mode(css, true) else {
       return Self::default();
     };
+
     stylesheet
   }
 


### PR DESCRIPTION
Whitespace only. The `let ... else` binding sat against the `stylesheet` expression that follows it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting for better readability.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->