### PR TITLE
Reject trailing content in style values

### DIFF
--- a/.tegami/strict-inline-values.md
+++ b/.tegami/strict-inline-values.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+---
+
+### Reject trailing content in `style` values
+
+A `style` object accepted `width: "55px zzz"`, applied `55px`, and ignored the rest. It now rejects the whole value, the way a stylesheet already drops such a declaration. A substituted `var()` value follows the same rule.

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -529,11 +529,13 @@ macro_rules! define_style {
             let mut parser_input = ParserInput::new(&source);
             let mut parser = Parser::new(&mut parser_input);
 
-            match self {
-              Self::Shorthand(property) => property.parse_declarations(&mut parser),
-              Self::Longhand(property) => property.parse_declarations(&mut parser),
+            // `parse_entirely`, because a declaration list drops a value with
+            // anything left over and a lone value has no `;` to stop at.
+            parser.parse_entirely(|parser| match self {
+              Self::Shorthand(property) => property.parse_declarations(parser),
+              Self::Longhand(property) => property.parse_declarations(parser),
               Self::Ignored | Self::Custom => unreachable!(),
-            }
+            })
           }
           .map_err(|error| {
             (

--- a/takumi-core/src/style/stylesheets_tests.rs
+++ b/takumi-core/src/style/stylesheets_tests.rs
@@ -111,6 +111,15 @@ fn importance_split(value: serde_json::Value) -> Result<(usize, usize), serde_js
   Ok((normal.declarations.len(), important.declarations.len()))
 }
 
+/// A `style` object is hand-written, so a value the parser cannot read to its
+/// end is an error rather than a truncated declaration.
+#[test]
+fn an_inline_value_parses_entirely() {
+  assert!(from_value::<Style>(json!({ "width": "55px" })).is_ok());
+  assert!(from_value::<Style>(json!({ "width": "55px zzz" })).is_err());
+  assert!(from_value::<Style>(json!({ "width": "55px 99px" })).is_err());
+}
+
 #[test]
 fn inline_important_marks_the_declaration() -> Result<(), serde_json::Error> {
   assert_eq!(importance_split(json!({ "width": "55px" }))?, (1, 0));
@@ -148,7 +157,7 @@ fn inline_important_reads_as_a_token() -> Result<(), serde_json::Error> {
     importance_split(json!({ "content": "\"a\" !important" }))?,
     (0, 1)
   );
-  assert_eq!(importance_split(json!({ "width": "55px !nope" }))?, (1, 0));
+  assert!(from_value::<Style>(json!({ "width": "55px !nope" })).is_err());
   Ok(())
 }
 
@@ -1335,14 +1344,18 @@ fn test_var_rejects_non_custom_property_name() {
   assert_eq!(style.width, Length::default());
 }
 
+/// A substituted value is syntax-checked as a whole, so `24px 10px` is invalid
+/// at computed-value time rather than a `24px` the trailing tokens follow.
+///
+/// Ref: https://drafts.csswg.org/css-variables-1/#invalid-variables
 #[test]
-fn test_var_allows_trailing_tokens_when_property_parser_is_loose() {
+fn test_var_rejects_trailing_tokens_after_substitution() {
   let style = inherited_style_from_pairs(
     [("--size", "24px"), ("width", "var(--size) 10px")],
     &ComputedStyle::default(),
   );
 
-  assert_eq!(style.width, Length::Px(24.0));
+  assert_eq!(style.width, Length::default());
 }
 
 #[test]


### PR DESCRIPTION
## Why

A `style` object accepted `width: "55px zzz"`, applied `55px`, and dropped the rest. The same string in a stylesheet drops the whole declaration, so one value had two meanings depending on which door it entered. The lax half is the error-first surface, which makes it the wrong half.

## What

`parse_css_input_declarations` now parses the value entirely, so anything left over is an error. Substituted `var()` values take the same path, so `width: var(--size) 10px` with `--size: 24px` is invalid at computed-value time instead of a `24px` with trailing tokens ignored, matching [css-variables-1](https://drafts.csswg.org/css-variables-1/#invalid-variables).

One existing test changed sides: `test_var_allows_trailing_tokens_when_property_parser_is_loose` asserted the old truncation. Its name conceded the point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inline style values are now rejected when they contain trailing or invalid content, instead of being partially applied.
  * Invalid `!important` markers now correctly cause style parsing to fail.
  * Substituted `var()` values follow the same strict validation rules as regular style values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->