### PR TITLE
Core: stop a box narrower than its padding from panicking

### DIFF
--- a/.tegami/negative-inline-width.md
+++ b/.tegami/negative-inline-width.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Stop a box narrower than its padding from panicking
+
+A box whose horizontal padding exceeds its own width left the text a negative
+width to lay out in, which tripped an assertion inside the text layouter and
+crashed the render. The width the text lays out against now stops at zero.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -2932,7 +2932,12 @@ pub(crate) fn create_inline_constraint(
     AvailableSpace::MaxContent => None,
     AvailableSpace::Definite(width) => Some(width),
   };
-  let mut width_constraint = known_width.or(available_width).unwrap_or(f32::INFINITY);
+  // taffy subtracts the content-box inset without a floor, so a box narrower
+  // than its own padding arrives here negative. parley asserts on that.
+  let mut width_constraint = known_width
+    .or(available_width)
+    .unwrap_or(f32::INFINITY)
+    .max(0.0);
 
   if known_width.is_some()
     && context.style.box_sizing == BoxSizing::BorderBox

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -353,6 +353,20 @@ fn test_measure_text_fit_per_line_grow_scales_run_geometry() {
   assert!(fit.children[0].height > no_fit.children[0].height);
 }
 
+/// taffy subtracts the content-box inset without a floor, so the available
+/// width reaching the text can be negative. parley asserts on that.
+#[test]
+fn test_measure_padding_wider_than_the_box_does_not_panic() {
+  let node = Node::from_html(
+    r#"<div style="width:40px"><div style="padding:0 60px; font-size:24px">word up</div></div>"#,
+    FromHtmlOptions::default(),
+  )
+  .expect("parse");
+  let out = measure(node, create_measure_viewport());
+
+  assert_close(out.width, 40.0);
+}
+
 #[test]
 fn test_measure_text_fit_per_line_shrink_scales_run_geometry() {
   let base_style = Style::default()


### PR DESCRIPTION
## Why

A box whose horizontal padding exceeds its own width leaves the text a negative width to lay out in. That tripped an assertion inside parley and crashed the render, in release as well as debug.

## What

The width the text lays out against now stops at zero. `<div style="width:40px"><div style="padding:0 60px">word up</div></div>` measures instead of panicking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when horizontal padding exceeds a box’s width.
  * Text layout now safely handles constrained or zero-width content.
  * Preserved the container’s expected measured width in this scenario.

* **Tests**
  * Added regression coverage for oversized horizontal padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->