### PR TITLE
Core: wrap content-box text inside its padding

### DIFF
--- a/.tegami/content-box-wrap-width.md
+++ b/.tegami/content-box-wrap-width.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Wrap `box-sizing: content-box` text inside its padding
+
+A box with `box-sizing: content-box` and horizontal padding wrapped its text
+against the border box, so the text took fewer lines than it needed and
+overflowed the bottom of the box.

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -17,7 +17,7 @@ use crate::{
     glyph::{ResolvedColorLayer, ResolvedGlyph, ResolvedOutlineGlyph},
   },
   style::{
-    Affine, BoxSizing, Color, Direction, Float, FontSynthesis, Lang, Length, ResolvedVerticalAlign,
+    Affine, Color, Direction, Float, FontSynthesis, Lang, Length, ResolvedVerticalAlign,
     SizedTextDecorationThickness, TextDecorationLines, TextDecorationSkipInk, TextFitMode,
     TextFitTarget, TextOverflow, TextUnderlinePosition, TextWrapMode, TextWrapStyle, VerticalAlign,
     VerticalAlignKeyword, WhiteSpaceCollapse,
@@ -2939,10 +2939,9 @@ pub(crate) fn create_inline_constraint(
     .unwrap_or(f32::INFINITY)
     .max(0.0);
 
-  if known_width.is_some()
-    && context.style.box_sizing == BoxSizing::BorderBox
-    && width_constraint.is_finite()
-  {
+  // taffy hands the measure function a border-box width whatever `box-sizing`
+  // says, so the insets always come off.
+  if known_width.is_some() && width_constraint.is_finite() {
     let sizing = &context.sizing;
     let horizontal_insets = context.style.padding_left.to_px(sizing, 0.0)
       + context.style.padding_right.to_px(sizing, 0.0)

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -367,6 +367,35 @@ fn test_measure_padding_wider_than_the_box_does_not_panic() {
   assert_close(out.width, 40.0);
 }
 
+/// taffy hands the measure function a border-box width whatever `box-sizing`
+/// says, so a content-box box used to wrap against its border-box width.
+#[test]
+fn test_measure_content_box_wraps_inside_its_padding() {
+  let text = "aa bb cc dd ee ff gg hh";
+  let content_box = measure(
+    Node::from_html(
+      &format!(
+        r#"<div style="display:flex"><div style="box-sizing:content-box; width:100px; padding:0 40px; font-size:24px">{text}</div></div>"#
+      ),
+      FromHtmlOptions::default(),
+    )
+    .expect("parse"),
+    create_measure_viewport(),
+  );
+  let border_box = measure(
+    Node::from_html(
+      &format!(
+        r#"<div style="display:flex"><div style="box-sizing:border-box; width:180px; padding:0 40px; font-size:24px">{text}</div></div>"#
+      ),
+      FromHtmlOptions::default(),
+    )
+    .expect("parse"),
+    create_measure_viewport(),
+  );
+
+  assert_close(content_box.height, border_box.height);
+}
+
 #[test]
 fn test_measure_text_fit_per_line_shrink_scales_run_geometry() {
   let base_style = Style::default()


### PR DESCRIPTION
## Why

taffy hands the measure function a border-box width whatever `box-sizing` says, but the inline constraint only subtracted the padding and border when the box was already `border-box`. A `content-box` box wrapped its text against the wider box.

## What

A known width always has its insets removed before the text wraps against it. The same geometry written either way now measures the same height, where `content-box` previously came out a line short and overflowed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected text wrapping for `content-box` elements with horizontal padding.
  * Prevented text from wrapping too late and overflowing at the bottom.
  * Ensured content width is measured consistently across box-sizing modes.

* **Tests**
  * Added coverage verifying equivalent wrapping behavior for content-box and border-box layouts.

* **Documentation**
  * Added a changelog entry for the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->