### PR TITLE
Core: report text runs for a node that holds text directly

### DIFF
--- a/.tegami/measure-text-leaf-runs.md
+++ b/.tegami/measure-text-leaf-runs.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Report text runs for a node that holds text directly
+
+`measure` returned no text runs for `<div>word</div>`, the shape an HTML parse
+produces most often, while `<div><span>word</span></div>` reported them. The
+render was correct either way; only the measurement was missing its geometry.

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, rc::Rc, sync::Arc};
 use serde::Serialize;
 use takumi_core::{
   geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Size},
+  layout::node::NodeKind,
   scene::build_stacking_contexts,
   style::{ComputedStyle, Lang},
 };
@@ -241,7 +242,15 @@ fn collect_measure_result(
         let mut children = Vec::new();
         let mut runs = Vec::new();
 
-        if current.should_create_inline_layout() {
+        // A text node carries its own inline content but has no children, so
+        // `should_create_inline_layout` says no while it still produces runs.
+        let is_text_leaf = current.children.is_none()
+          && current
+            .node
+            .as_ref()
+            .is_some_and(|node| matches!(node.kind, NodeKind::Text(_)));
+
+        if current.should_create_inline_layout() || is_text_leaf {
           let font_style = SizedFontStyle::from_style(&current.context.style, &current.context);
           let built = create_inline_layout(InlineLayoutRequest::in_available_space(
             collect_inline_items(current),

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -5,7 +5,7 @@ use takumi_core::{
   geometry::{AvailableSpace, ComputedLayout as Layout, NodeId, Size},
   layout::node::NodeKind,
   scene::build_stacking_contexts,
-  style::{ComputedStyle, Lang},
+  style::{ComputedStyle, Display, Lang},
 };
 use typed_builder::TypedBuilder;
 
@@ -245,6 +245,7 @@ fn collect_measure_result(
         // A text node carries its own inline content but has no children, so
         // `should_create_inline_layout` says no while it still produces runs.
         let is_text_leaf = current.children.is_none()
+          && current.context.style.display != Display::None
           && current
             .node
             .as_ref()

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -13,7 +13,9 @@ use crate::{
   AnimationFrame, Bitmap, Canvas, DitheringAlgorithm, Error, Fonts, RenderContext, Result,
   SizedFontStyle, apply_dithering,
   layout::{
-    inline::{InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout},
+    inline::{
+      InlineItem, InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,
+    },
     node::Node,
     tree::{LayoutResults, LayoutTree, RenderNode},
   },
@@ -242,16 +244,7 @@ fn collect_measure_result(
         let mut children = Vec::new();
         let mut runs = Vec::new();
 
-        // A text node carries its own inline content but has no children, so
-        // `should_create_inline_layout` says no while it still produces runs.
-        let is_text_leaf = current.children.is_none()
-          && current.context.style.display != Display::None
-          && current
-            .node
-            .as_ref()
-            .is_some_and(|node| matches!(node.kind, NodeKind::Text(_)));
-
-        if current.should_create_inline_layout() || is_text_leaf {
+        if current.should_create_inline_layout() {
           let font_style = SizedFontStyle::from_style(&current.context.style, &current.context);
           let built = create_inline_layout(InlineLayoutRequest::in_available_space(
             collect_inline_items(current),
@@ -289,6 +282,41 @@ fn collect_measure_result(
             create_measured_node(layout, local_transform, children, runs),
           );
           continue;
+        }
+
+        // Paint always draws a text node's own text, even when generated
+        // content gave it box children; its runs sit beside those children.
+        if current.context.style.display != Display::None
+          && !current.has_anonymous_text_item_child()
+          && let Some(text) = current.node.as_ref().and_then(|node| match &node.kind {
+            NodeKind::Text(data) => Some(data.text.as_str()),
+            _ => None,
+          })
+        {
+          let font_style = SizedFontStyle::from_style(&current.context.style, &current.context);
+          let built = create_inline_layout(InlineLayoutRequest::in_available_space(
+            vec![InlineItem::Text {
+              text: text.into(),
+              context: &current.context,
+              link: None,
+            }],
+            Size {
+              width: AvailableSpace::Definite(layout.content_box_width()),
+              height: AvailableSpace::Definite(layout.content_box_height()),
+            },
+            Size::NONE,
+            &font_style,
+            &current.context,
+            InlineLayoutMode::Measure,
+          ));
+          let (measured_runs, _) = built.measure_runs(layout);
+          runs.extend(measured_runs.into_iter().map(|run| MeasuredTextRun {
+            text: run.text.to_string(),
+            x: run.x,
+            y: run.y,
+            width: run.width,
+            height: run.height,
+          }));
         }
 
         if current.children.is_none() {

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -418,6 +418,29 @@ fn test_measure_reports_runs_for_a_bare_text_node() {
 }
 
 #[test]
+fn test_measure_skips_a_hidden_text_node() {
+  let out = measure(
+    Node::from_html(
+      r#"<div><div style="display:none">hidden</div><div>shown</div></div>"#,
+      FromHtmlOptions::default(),
+    )
+    .expect("parse"),
+    create_measure_viewport(),
+  );
+
+  fn runs(node: &MeasuredNode) -> Vec<&str> {
+    node
+      .runs
+      .iter()
+      .map(|run| run.text.as_str())
+      .chain(node.children.iter().flat_map(runs))
+      .collect()
+  }
+
+  assert_eq!(runs(&out), ["shown"]);
+}
+
+#[test]
 fn test_measure_text_fit_per_line_shrink_scales_run_geometry() {
   let base_style = Style::default()
     .with(StyleDeclaration::display(Display::Flex))

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -440,6 +440,37 @@ fn test_measure_skips_a_hidden_text_node() {
   assert_eq!(runs(&out), ["shown"]);
 }
 
+/// Generated block content turns a text node into a box container, but paint
+/// still draws the authored text, so measure has to report it too.
+#[test]
+fn test_measure_keeps_authored_text_beside_generated_block_content() {
+  let out = takumi::measure(
+    RenderOptions::builder()
+      .viewport(create_measure_viewport())
+      .node(
+        Node::from_html(r#"<div><p>word</p></div>"#, FromHtmlOptions::default()).expect("parse"),
+      )
+      .fonts(&CONTEXT)
+      .images(TEST_IMAGES.clone())
+      .stylesheet(std::sync::Arc::new(
+        StyleSheet::parse_list([r#"p::after { content: "!"; display: block }"#]).expect("css"),
+      ))
+      .build(),
+  )
+  .unwrap();
+
+  fn runs(node: &MeasuredNode) -> Vec<&str> {
+    node
+      .runs
+      .iter()
+      .map(|run| run.text.as_str())
+      .chain(node.children.iter().flat_map(runs))
+      .collect()
+  }
+
+  assert_eq!(runs(&out), ["word", "!"]);
+}
+
 #[test]
 fn test_measure_text_fit_per_line_shrink_scales_run_geometry() {
   let base_style = Style::default()

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -396,6 +396,27 @@ fn test_measure_content_box_wraps_inside_its_padding() {
   assert_close(content_box.height, border_box.height);
 }
 
+/// A text node carries its own inline content but has no children, so the
+/// measure traversal used to walk past it without emitting a run.
+#[test]
+fn test_measure_reports_runs_for_a_bare_text_node() {
+  let html = |body: &str| {
+    Node::from_html(
+      &format!(r#"<div style="width:320px; font-size:32px;">{body}</div>"#),
+      FromHtmlOptions::default(),
+    )
+    .expect("parse")
+  };
+  let bare = measure(html("word"), create_measure_viewport());
+  let wrapped = measure(html("<span>word</span>"), create_measure_viewport());
+
+  let bare_runs = measured_text_runs(&bare);
+  let wrapped_runs = measured_text_runs(&wrapped);
+  assert_eq!(bare_runs.len(), wrapped_runs.len());
+  assert_close(bare_runs[0].width, wrapped_runs[0].width);
+  assert_close(bare_runs[0].height, wrapped_runs[0].height);
+}
+
 #[test]
 fn test_measure_text_fit_per_line_shrink_scales_run_geometry() {
   let base_style = Style::default()


### PR DESCRIPTION
## Why

`measure` walked past a node that holds text directly, so `<div>word</div>` reported no text runs while `<div><span>word</span></div>` reported them. An HTML parse produces the first shape most of the time.

## What

The measure traversal now treats a childless text node as its own inline content. Rendering was already correct; only the reported geometry was missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text measurement for text placed directly inside an element.
  * Direct text now reports runs consistently with nested text, including accurate dimensions.
  * Hidden text (`display: none`) is excluded from measurement results.
  * Preserved authored text alongside generated block content.

* **Tests**
  * Added coverage for direct, nested, hidden, and generated text measurement.

* **Documentation**
  * Documented the patch release and corrected measurement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->