### PR TITLE
Core: take an inline-block baseline from the lines it laid out

### DIFF
--- a/.tegami/inline-block-baseline-width.md
+++ b/.tegami/inline-block-baseline-width.md
@@ -1,0 +1,10 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Take an inline-block's baseline from the lines it actually laid out
+
+An inline-block with horizontal padding re-wrapped its content against the
+border box to find its baseline, so text beside it aligned with the wrong line.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1957,7 +1957,15 @@ impl RenderNode {
     }
 
     let font_style = SizedFontStyle::from_style(&self.context.style, &self.context);
-    let max_width = size.width.max(0.0);
+    // `size` is the border box, but the content wrapped against the content box.
+    let (max_width, _) = create_inline_constraint(
+      &self.context,
+      available_space,
+      Size {
+        width: Some(size.width.max(0.0)),
+        height: None,
+      },
+    );
     let built = create_inline_layout(InlineLayoutRequest {
       items,
       available_space: Size {

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -417,6 +417,29 @@ fn test_measure_reports_runs_for_a_bare_text_node() {
   assert_close(bare_runs[0].height, wrapped_runs[0].height);
 }
 
+/// An inline-block sits on the baseline of its last line box. That baseline was
+/// replayed against the border-box width, so it landed on whichever line the
+/// content would have wrapped to had the padding not been there.
+#[test]
+fn test_measure_inline_block_baseline_follows_its_last_line() {
+  let out = measure(
+    Node::from_html(
+      r#"<div style="font-size:24px">x <span style="display:inline-block; width:160px; padding:0 60px">aaa bbb ccc ddd</span> y</div>"#,
+      FromHtmlOptions::default(),
+    )
+    .expect("parse"),
+    create_measure_viewport(),
+  );
+
+  let run = &measured_text_runs(&out)[0];
+  assert!(
+    run.y + run.height >= out.height - 2.0,
+    "adjacent text at {} should sit on the last line of a {} tall box",
+    run.y,
+    out.height
+  );
+}
+
 #[test]
 fn test_measure_skips_a_hidden_text_node() {
   let out = measure(


### PR DESCRIPTION
## Why

An inline-block sits on the baseline of its last line box. That baseline was found by re-wrapping the content against the border-box width, so a box with horizontal padding wrapped to a different number of lines than it actually laid out, and text beside it aligned with the wrong line.

## What

The replay wraps against the content box, through the same constraint the real measurement uses. In the added case the adjacent text moves from the second line of a four-line box to the fourth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed baseline alignment for inline-block content with horizontal padding.
  * Prevented adjacent text from aligning with an incorrect line when inline-block content wraps.
  * Improved measurement accuracy for wrapped inline-block elements.

* **Tests**
  * Added regression coverage for inline-block baseline alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->