### PR TITLE
Write a group of css entries as an object

### DIFF
--- a/.tegami/structured-at-rules.md
+++ b/.tegami/structured-at-rules.md
@@ -1,5 +1,7 @@
 ---
 packages:
+  "@takumi-rs/helpers":
+    type: minor
   "@takumi-rs/core":
     type: minor
   "@takumi-rs/wasm":

--- a/.tegami/structured-at-rules.md
+++ b/.tegami/structured-at-rules.md
@@ -1,0 +1,15 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: minor
+  "@takumi-rs/wasm":
+    type: minor
+  "takumi-js":
+    type: minor
+  "takumi-pdf":
+    type: minor
+---
+
+### Write a group of `css` entries as an object
+
+A `css` entry can be `{ media, rules }`, `{ supports, rules }`, or `{ layer, rules }`. A layer without `rules` declares its order alone. Takumi reads each prelude with the grammar its rule takes, so it cannot close the rule and open another.

--- a/docs/app/playground/options.ts
+++ b/docs/app/playground/options.ts
@@ -42,7 +42,7 @@ declare global {
      */
     css?: CssEntry | CssEntry[];
     /**
-     * @deprecated use a `{ keyframes, steps }` entry in `css`. Removed in v3.
+     * @deprecated use a `{ keyframes, steps }` entry in `css`. Will be removed in v3.
      * @description structured keyframes registered alongside the CSS.
      */
     keyframes?: Keyframes;

--- a/docs/app/playground/options.ts
+++ b/docs/app/playground/options.ts
@@ -1,4 +1,3 @@
-import type { Keyframes } from "takumi-js";
 import type { CssEntry } from "./schema";
 import type { RenderOptions } from "takumi-pdf";
 
@@ -41,11 +40,6 @@ declare global {
      * @description CSS applied before rendering: stylesheet text, or a rule written as an object. A `{ selector: ":root", style: { "--color-brand": "#7c3aed" } }` entry makes `bg-brand` resolve.
      */
     css?: CssEntry | CssEntry[];
-    /**
-     * @deprecated use a `{ keyframes, steps }` entry in `css`. Will be removed in v3.
-     * @description structured keyframes registered alongside the CSS.
-     */
-    keyframes?: Keyframes;
     /**
      * @description timeline animation output. When present, the playground renders an animated image instead of a single frame.
      */

--- a/docs/app/playground/options.ts
+++ b/docs/app/playground/options.ts
@@ -1,4 +1,5 @@
-import type { CssInput, Keyframes } from "takumi-js";
+import type { Keyframes } from "takumi-js";
+import type { CssEntry } from "./schema";
 import type { RenderOptions } from "takumi-pdf";
 
 // `Omit` collapses a union, which would lose the paged/viewport split that makes
@@ -39,7 +40,7 @@ declare global {
     /**
      * @description CSS applied before rendering: stylesheet text, or a rule written as an object. A `{ selector: ":root", style: { "--color-brand": "#7c3aed" } }` entry makes `bg-brand` resolve.
      */
-    css?: CssInput | CssInput[];
+    css?: CssEntry | CssEntry[];
     /**
      * @deprecated use a `{ keyframes, steps }` entry in `css`. Removed in v3.
      * @description structured keyframes registered alongside the CSS.

--- a/docs/app/playground/preview-css.ts
+++ b/docs/app/playground/preview-css.ts
@@ -43,29 +43,3 @@ export function cssEntryToText(entry: CssEntry): string {
 
   return styleRuleToCss(entry);
 }
-
-/**
- * Serializes the animations the deprecated `keyframes` option carries.
- *
- * @deprecated Will be removed in v3, with the option itself.
- */
-export function keyframesToCss(keyframes: NonNullable<PlaygroundOptions["keyframes"]>): string {
-  const rules = Array.isArray(keyframes)
-    ? keyframes.map((rule) => {
-        const body = rule.keyframes
-          .map(
-            (frame) =>
-              `${frame.offsets.map((offset) => `${offset * 100}%`).join(", ")} { ${declarationsToCss(frame.declarations)} }`,
-          )
-          .join(" ");
-        return `@keyframes ${rule.name} { ${body} }`;
-      })
-    : Object.entries(keyframes).map(([name, offsets]) => {
-        const body = Object.entries(offsets)
-          .map(([offset, declarations]) => `${offset} { ${declarationsToCss(declarations)} }`)
-          .join(" ");
-        return `@keyframes ${name} { ${body} }`;
-      });
-
-  return rules.join("\n");
-}

--- a/docs/app/playground/preview-css.ts
+++ b/docs/app/playground/preview-css.ts
@@ -47,7 +47,7 @@ export function cssEntryToText(entry: CssEntry): string {
 /**
  * Serializes the animations the deprecated `keyframes` option carries.
  *
- * @deprecated Removed in v3, with the option itself.
+ * @deprecated Will be removed in v3, with the option itself.
  */
 export function keyframesToCss(keyframes: NonNullable<PlaygroundOptions["keyframes"]>): string {
   const rules = Array.isArray(keyframes)

--- a/docs/app/playground/preview-css.ts
+++ b/docs/app/playground/preview-css.ts
@@ -1,4 +1,4 @@
-import type { AnimationRule, CssInput, StyleRule } from "takumi-js";
+import type { CssEntry } from "./schema";
 
 function declarationsToCss(declarations: object): string {
   return Object.entries(declarations)
@@ -9,35 +9,39 @@ function declarationsToCss(declarations: object): string {
     .join(" ");
 }
 
-function isAnimationRule(entry: CssInput): entry is AnimationRule {
-  return typeof entry === "object" && "keyframes" in entry;
+function styleRuleToCss(rule: Extract<CssEntry, { selector: string }>): string {
+  return `${rule.selector} { ${declarationsToCss(rule.style ?? {})} ${groupToCss(rule.rules)} }`;
 }
 
-function styleRuleToCss(rule: StyleRule): string {
-  const nested = (rule.rules ?? []).map((child: StyleRule) => styleRuleToCss(child)).join(" ");
-
-  return `${rule.selector} { ${declarationsToCss(rule.style ?? {})} ${nested} }`;
-}
-
-function animationRuleToCss(rule: AnimationRule): string {
-  const body = rule.steps
-    .map(
-      (step: AnimationRule["steps"][number]) =>
-        `${step.offset} { ${declarationsToCss(step.style ?? {})} }`,
-    )
-    .join(" ");
-
-  return `@keyframes ${rule.keyframes} { ${body} }`;
+function groupToCss(rules: CssEntry[] | undefined): string {
+  return (rules ?? []).map(cssEntryToText).join(" ");
 }
 
 /**
  * The CSS a `css` entry stands for. The engine reads a rule as an object; the
  * browser preview pane only understands text.
  */
-export function cssEntryToText(entry: CssInput): string {
+export function cssEntryToText(entry: CssEntry): string {
   if (typeof entry === "string") return entry;
 
-  return isAnimationRule(entry) ? animationRuleToCss(entry) : styleRuleToCss(entry);
+  if ("keyframes" in entry) {
+    const body = entry.steps
+      .map((step) => `${step.offset} { ${declarationsToCss(step.style ?? {})} }`)
+      .join(" ");
+
+    return `@keyframes ${entry.keyframes} { ${body} }`;
+  }
+
+  if ("media" in entry) return `@media ${entry.media} { ${groupToCss(entry.rules)} }`;
+  if ("supports" in entry) return `@supports ${entry.supports} { ${groupToCss(entry.rules)} }`;
+
+  if ("layer" in entry) {
+    return entry.rules
+      ? `@layer ${entry.layer} { ${groupToCss(entry.rules)} }`
+      : `@layer ${entry.layer};`;
+  }
+
+  return styleRuleToCss(entry);
 }
 
 /**

--- a/docs/app/playground/schema.test.ts
+++ b/docs/app/playground/schema.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { optionsSchema } from "./schema";
+
+function accepts(css: unknown): boolean {
+  return optionsSchema.safeParse({ width: 1, height: 1, css }).success;
+}
+
+test("takes one entry or a list of them", () => {
+  expect(accepts(undefined)).toBe(true);
+  expect(accepts("div{color:red}")).toBe(true);
+  expect(accepts(["a{}", { selector: ".b" }])).toBe(true);
+});
+
+test("takes every rule shape, nested", () => {
+  expect(accepts({ selector: ":root", style: { "--a": "1px", "--b": 2 } })).toBe(true);
+  expect(accepts({ selector: ".a", rules: [{ selector: "&:hover" }] })).toBe(true);
+  expect(accepts({ keyframes: "spin", steps: [{ offset: "from", style: { opacity: "0" } }] })).toBe(
+    true,
+  );
+  expect(accepts({ media: "(min-width: 800px)", rules: [{ selector: ".a" }] })).toBe(true);
+  expect(accepts({ supports: "(display: grid)", rules: ["a{}"] })).toBe(true);
+  expect(accepts({ layer: "base" })).toBe(true);
+});
+
+test("rejects a value that is not an entry", () => {
+  expect(accepts(null)).toBe(false);
+  expect(accepts(42)).toBe(false);
+  expect(accepts(["a{}", null])).toBe(false);
+  expect(accepts({ style: { color: "red" } })).toBe(false);
+});
+
+/// A stripped key would leave a rule the renderer never sees, so a typo has to
+/// fail here rather than render as an empty rule.
+test("rejects an unknown key", () => {
+  expect(accepts({ selector: ".a", declarations: { color: "red" } })).toBe(false);
+  expect(accepts({ selector: ".a", rules: [{ selector: ".b", declarations: {} }] })).toBe(false);
+  expect(accepts({ keyframes: "spin", steps: [{ offset: "from", declarations: {} }] })).toBe(false);
+  expect(accepts({ media: "print", entries: [] })).toBe(false);
+});

--- a/docs/app/playground/schema.test.ts
+++ b/docs/app/playground/schema.test.ts
@@ -29,6 +29,18 @@ test("rejects a value that is not an entry", () => {
   expect(accepts({ style: { color: "red" } })).toBe(false);
 });
 
+/// Only a layer has a statement form; a media or support group without its
+/// entries is a typo, not an empty block.
+/// A style rule nests style rules alone; text belongs in a group or at the top.
+test("rejects text nested in a style rule", () => {
+  expect(accepts({ selector: ".a", rules: ["b{}"] })).toBe(false);
+});
+
+test("rejects a media or supports group without rules", () => {
+  expect(accepts({ media: "print" })).toBe(false);
+  expect(accepts({ supports: "(display: grid)" })).toBe(false);
+});
+
 /// A stripped key would leave a rule the renderer never sees, so a typo has to
 /// fail here rather than render as an empty rule.
 test("rejects an unknown key", () => {

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -1,4 +1,3 @@
-import type { Keyframes } from "takumi-js";
 import * as z from "zod/mini";
 import type { PdfInspection } from "./inspect-pdf";
 import type { PlaygroundPdfOptions } from "./options";
@@ -53,8 +52,6 @@ export const optionsSchema = z.object({
   format: z.optional(z.enum(["png", "jpeg", "webp"])),
   devicePixelRatio: z.optional(z.number().check(z.positive(), z.minimum(0.1), z.maximum(10.0))),
   css: z.optional(z.union([cssInputSchema, z.array(cssInputSchema)])),
-  /** @deprecated use a `{ keyframes, steps }` entry in `css`. Will be removed in v3. */
-  keyframes: z.optional(z.custom<Keyframes>()),
   animation: z.optional(
     z.object({
       durationMs: z.int().check(z.positive(), z.minimum(1)),

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -5,27 +5,39 @@ import type { PlaygroundPdfOptions } from "./options";
 
 const declarationsSchema = z.record(z.string(), z.union([z.string(), z.number()]));
 
-/** A rule's own nesting, which the renderer reads as CSS nesting. */
-type StyleRuleShape = {
-  selector: string;
-  style?: Record<string, string | number>;
-  rules?: StyleRuleShape[];
-};
+/**
+ * A `css` entry. Declared here rather than taken from `takumi-js`, whose type
+ * reaches this app through a re-export that resolves to `any`.
+ */
+export type CssEntry =
+  | string
+  | { selector: string; style?: Declarations; rules?: CssEntry[] }
+  | { keyframes: string; steps: { offset: string; style?: Declarations }[] }
+  | { media: string; rules?: CssEntry[] }
+  | { supports: string; rules?: CssEntry[] }
+  | { layer: string; rules?: CssEntry[] };
 
-const styleRuleSchema: z.ZodMiniType<StyleRuleShape> = z.lazy(() =>
-  z.object({
-    selector: z.string(),
-    style: z.optional(declarationsSchema),
-    rules: z.optional(z.array(styleRuleSchema)),
-  }),
+type Declarations = Record<string, string | number>;
+
+// `strictObject`, so a typo like `declarations` is an error rather than a rule
+// the renderer never sees.
+const cssInputSchema: z.ZodMiniType<CssEntry> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.strictObject({
+      keyframes: z.string(),
+      steps: z.array(z.strictObject({ offset: z.string(), style: z.optional(declarationsSchema) })),
+    }),
+    z.strictObject({ media: z.string(), rules: z.optional(z.array(cssInputSchema)) }),
+    z.strictObject({ supports: z.string(), rules: z.optional(z.array(cssInputSchema)) }),
+    z.strictObject({ layer: z.string(), rules: z.optional(z.array(cssInputSchema)) }),
+    z.strictObject({
+      selector: z.string(),
+      style: z.optional(declarationsSchema),
+      rules: z.optional(z.array(cssInputSchema)),
+    }),
+  ]),
 );
-
-const animationRuleSchema = z.object({
-  keyframes: z.string(),
-  steps: z.array(z.object({ offset: z.string(), style: z.optional(declarationsSchema) })),
-});
-
-const cssInputSchema = z.union([z.string(), animationRuleSchema, styleRuleSchema]);
 
 export const optionsSchema = z.object({
   width: z.optional(z.int().check(z.positive(), z.minimum(1))),

--- a/docs/app/playground/schema.ts
+++ b/docs/app/playground/schema.ts
@@ -1,4 +1,4 @@
-import type { CssInput, Keyframes } from "takumi-js";
+import type { Keyframes } from "takumi-js";
 import * as z from "zod/mini";
 import type { PdfInspection } from "./inspect-pdf";
 import type { PlaygroundPdfOptions } from "./options";
@@ -11,16 +11,27 @@ const declarationsSchema = z.record(z.string(), z.union([z.string(), z.number()]
  */
 export type CssEntry =
   | string
-  | { selector: string; style?: Declarations; rules?: CssEntry[] }
+  | StyleRuleEntry
   | { keyframes: string; steps: { offset: string; style?: Declarations }[] }
-  | { media: string; rules?: CssEntry[] }
-  | { supports: string; rules?: CssEntry[] }
+  | { media: string; rules: CssEntry[] }
+  | { supports: string; rules: CssEntry[] }
   | { layer: string; rules?: CssEntry[] };
+
+/** A style rule nests style rules alone, as CSS nesting. */
+type StyleRuleEntry = { selector: string; style?: Declarations; rules?: StyleRuleEntry[] };
 
 type Declarations = Record<string, string | number>;
 
 // `strictObject`, so a typo like `declarations` is an error rather than a rule
 // the renderer never sees.
+const styleRuleSchema: z.ZodMiniType<StyleRuleEntry> = z.lazy(() =>
+  z.strictObject({
+    selector: z.string(),
+    style: z.optional(declarationsSchema),
+    rules: z.optional(z.array(styleRuleSchema)),
+  }),
+);
+
 const cssInputSchema: z.ZodMiniType<CssEntry> = z.lazy(() =>
   z.union([
     z.string(),
@@ -28,14 +39,10 @@ const cssInputSchema: z.ZodMiniType<CssEntry> = z.lazy(() =>
       keyframes: z.string(),
       steps: z.array(z.strictObject({ offset: z.string(), style: z.optional(declarationsSchema) })),
     }),
-    z.strictObject({ media: z.string(), rules: z.optional(z.array(cssInputSchema)) }),
-    z.strictObject({ supports: z.string(), rules: z.optional(z.array(cssInputSchema)) }),
+    z.strictObject({ media: z.string(), rules: z.array(cssInputSchema) }),
+    z.strictObject({ supports: z.string(), rules: z.array(cssInputSchema) }),
     z.strictObject({ layer: z.string(), rules: z.optional(z.array(cssInputSchema)) }),
-    z.strictObject({
-      selector: z.string(),
-      style: z.optional(declarationsSchema),
-      rules: z.optional(z.array(cssInputSchema)),
-    }),
+    styleRuleSchema,
   ]),
 );
 
@@ -46,7 +53,7 @@ export const optionsSchema = z.object({
   format: z.optional(z.enum(["png", "jpeg", "webp"])),
   devicePixelRatio: z.optional(z.number().check(z.positive(), z.minimum(0.1), z.maximum(10.0))),
   css: z.optional(z.union([cssInputSchema, z.array(cssInputSchema)])),
-  /** @deprecated use a `{ keyframes, steps }` entry in `css`. Removed in v3. */
+  /** @deprecated use a `{ keyframes, steps }` entry in `css`. Will be removed in v3. */
   keyframes: z.optional(z.custom<Keyframes>()),
   animation: z.optional(
     z.object({

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -14,7 +14,7 @@ import { evaluateCodeExports } from "./evaluate";
 import { renderReact } from "./render-react";
 import { FALLBACK_FONT_URL, FONT_FAMILIES } from "./fonts";
 import { inspectPdf } from "./inspect-pdf";
-import { cssEntryToText, keyframesToCss } from "./preview-css";
+import { cssEntryToText } from "./preview-css";
 import { messageSchema, type CssEntry, type OutputKind, type RenderMessageInput } from "./schema";
 
 const DEFAULT_IMAGE_SIZE = { width: 1200, height: 630 };
@@ -154,7 +154,6 @@ async function renderOutput({
         fps,
         quality: options.quality,
         devicePixelRatio: options.devicePixelRatio,
-        keyframes: options.keyframes,
         images,
         fonts,
         css,
@@ -200,10 +199,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
       width: geometry.width,
       height: geometry.height,
       padding: geometry.padding,
-      cssContents: [
-        ...effectiveCss.map(cssEntryToText),
-        ...(options.keyframes ? [keyframesToCss(options.keyframes)] : []),
-      ],
+      cssContents: effectiveCss.map(cssEntryToText),
       theme,
     });
   }

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -1,7 +1,6 @@
 import { googleFonts, prepareImages } from "takumi-js/helpers";
 import { extractEmojis } from "takumi-js/helpers/emoji";
 import { fromJsx } from "takumi-js/helpers/jsx";
-import type { CssInput } from "takumi-js";
 import type { FetchedImage, Node } from "takumi-js/helpers";
 import wasm, { init, Renderer } from "takumi-js/wasm";
 import pdfWasm from "takumi-pdf/wasm-url";
@@ -16,7 +15,7 @@ import { renderReact } from "./render-react";
 import { FALLBACK_FONT_URL, FONT_FAMILIES } from "./fonts";
 import { inspectPdf } from "./inspect-pdf";
 import { cssEntryToText, keyframesToCss } from "./preview-css";
-import { messageSchema, type OutputKind, type RenderMessageInput } from "./schema";
+import { messageSchema, type CssEntry, type OutputKind, type RenderMessageInput } from "./schema";
 
 const DEFAULT_IMAGE_SIZE = { width: 1200, height: 630 };
 
@@ -89,7 +88,7 @@ function loadPdfRenderer() {
 }
 
 /** Everything a render needs beyond the tree itself, fetched once per request. */
-async function loadResources(node: Node, css: CssInput[]) {
+async function loadResources(node: Node, css: CssEntry[]) {
   const [images, fonts] = await Promise.all([
     prepareImages<FetchedImage>({ node, fetchCache }),
     googleFonts(GOOGLE_FONTS).catch(() => undefined),
@@ -178,7 +177,7 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
   const { node, css: extractedCss } = await fromJsx(element);
   const optionCss =
     options.css === undefined || Array.isArray(options.css) ? options.css : [options.css];
-  const effectiveCss: CssInput[] = optionCss ?? extractedCss;
+  const effectiveCss: CssEntry[] = optionCss ?? extractedCss;
   // The pane compiles utilities itself, so it needs the theme as declarations
   // rather than as the `:root` rule the renderer reads.
   const theme = effectiveCss

--- a/docs/content/docs/styling.mdx
+++ b/docs/content/docs/styling.mdx
@@ -60,6 +60,33 @@ A `<style>` tag feeds the same engine. Takumi extracts it from the JSX for you.
 </div>
 ```
 
+### Rule objects
+
+A `css` entry can be an object. Object entries keep application data out of
+CSS strings.
+
+| Entry                        | Writes                                                    |
+| ---------------------------- | --------------------------------------------------------- |
+| `{ selector, style, rules }` | a style rule; `rules` nests child rules                   |
+| `{ keyframes, steps }`       | a [`@keyframes` rule](/docs/keyframe-animation)           |
+| `{ media, rules }`           | a `@media` group holding entries of its own               |
+| `{ supports, rules }`        | a `@supports` group                                       |
+| `{ layer, rules }`           | a `@layer` block; without `rules` it declares order alone |
+
+```tsx
+css: [
+  { layer: "theme" },
+  {
+    media: "(prefers-color-scheme: dark)",
+    rules: [{ selector: ".card", style: { background: "#0f172a" } }],
+  },
+];
+```
+
+Takumi parses each prelude with the grammar its rule takes. A prelude that
+does not parse entirely is an error, so it cannot close the rule and open
+another.
+
 ## Tailwind with your bundler
 
 Compile Tailwind with your bundler, then pass the generated CSS through `css`. Tailwind does the compiling, so every directive and class name works. What renders is still bounded by [the engine's CSS support](#css). With Vite, import the stylesheet using `?inline`.

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "build": "waku build",
     "dev": "portless run --name takumi waku dev",
     "start": "waku start",
+    "test": "bun test app/playground",
     "typecheck": "fumadocs-mdx && tsc --noEmit"
   },
   "dependencies": {

--- a/takumi-core/src/style/css_source.rs
+++ b/takumi-core/src/style/css_source.rs
@@ -10,9 +10,12 @@ use serde::{
   de::{MapAccess, Visitor},
 };
 
+use crate::error::StyleSheetParseError;
 use crate::style::{
   CssInput, CssUnexpected, CssValueSeed, PropertyId,
-  selector::{SelectorImpl, TakumiSelectorParser},
+  media_query::MediaQueryList,
+  selector::{SelectorImpl, TakumiSelectorParser, parse_layer_name},
+  supports::parse_supports_condition,
 };
 
 /// A declaration as written. Kept in source order, because a shorthand and the
@@ -104,6 +107,38 @@ pub struct AnimationRule {
   steps: Vec<AnimationStep>,
 }
 
+/// A group of entries gated by a media query.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MediaRule {
+  /// The query the group is gated by.
+  pub media: String,
+  /// The entries inside the group.
+  #[serde(default)]
+  rules: Vec<CssSource>,
+}
+
+/// A group of entries gated by a support condition.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SupportsRule {
+  /// The condition the group is gated by.
+  pub supports: String,
+  /// The entries inside the group.
+  #[serde(default)]
+  rules: Vec<CssSource>,
+}
+
+/// A cascade layer, either declaring the layer or filling it.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LayerRule {
+  /// The layer's name.
+  pub layer: String,
+  /// The entries inside the layer. Absent declares the layer's order alone.
+  rules: Option<Vec<CssSource>>,
+}
+
 /// One entry of the `css` render option.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(untagged)]
@@ -114,17 +149,24 @@ pub enum CssSource {
   Rule(StyleRule),
   /// An animation object, validated before it reaches the parser.
   Keyframes(AnimationRule),
+  /// A media group, validated before it reaches the parser.
+  Media(MediaRule),
+  /// A support group, validated before it reaches the parser.
+  Supports(SupportsRule),
+  /// A cascade layer, validated before it reaches the parser.
+  Layer(LayerRule),
 }
 
 /// Why a rule object could not become CSS.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CssSourceError {
-  /// The selector is not a selector list.
-  Selector(String),
-  /// The animation name is not an identifier.
-  KeyframesName(String),
-  /// The step is not `from`, `to`, or a percentage.
-  KeyframeOffset(String),
+  /// A rule's prelude is not what that rule takes.
+  Prelude {
+    /// What the prelude was read as, e.g. `selector` or `@media`.
+    rule: &'static str,
+    /// The prelude as written.
+    value: String,
+  },
   /// A declaration value is not a value for its property.
   Declaration {
     /// The property the value was written for.
@@ -137,9 +179,7 @@ pub enum CssSourceError {
 impl std::fmt::Display for CssSourceError {
   fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
-      Self::Selector(selector) => write!(formatter, "invalid selector {selector:?}"),
-      Self::KeyframesName(name) => write!(formatter, "invalid keyframes name {name:?}"),
-      Self::KeyframeOffset(offset) => write!(formatter, "invalid keyframe offset {offset:?}"),
+      Self::Prelude { rule, value } => write!(formatter, "invalid {rule} {value:?}"),
       Self::Declaration { name, value } => {
         write!(formatter, "invalid value for {name}: {value:?}")
       }
@@ -152,26 +192,101 @@ impl std::error::Error for CssSourceError {}
 impl CssSource {
   /// The CSS this source stands for, with a rule object validated on the way.
   pub fn into_css(self) -> Result<String, CssSourceError> {
+    let mut css = String::new();
+    self.write_css(&mut css)?;
+    Ok(css)
+  }
+
+  fn write_css(&self, css: &mut String) -> Result<(), CssSourceError> {
     match self {
-      Self::Text(text) => Ok(text),
-      Self::Rule(rule) => {
-        let mut css = String::new();
-        rule.write_css(&mut css)?;
-        Ok(css)
+      Self::Text(text) => {
+        css.push_str(text);
+        Ok(())
       }
-      Self::Keyframes(rule) => {
-        let mut css = String::new();
-        rule.write_css(&mut css)?;
-        Ok(css)
-      }
+      Self::Rule(rule) => rule.write_css(css),
+      Self::Keyframes(rule) => rule.write_css(css),
+      Self::Media(rule) => rule.write_css(css),
+      Self::Supports(rule) => rule.write_css(css),
+      Self::Layer(rule) => rule.write_css(css),
     }
+  }
+}
+
+impl MediaRule {
+  fn write_css(&self, css: &mut String) -> Result<(), CssSourceError> {
+    validate_prelude("@media", &self.media, |parser| {
+      MediaQueryList::parse(parser).map(|_| ())
+    })?;
+    write_group(css, "@media ", &self.media, &self.rules)
+  }
+}
+
+impl SupportsRule {
+  fn write_css(&self, css: &mut String) -> Result<(), CssSourceError> {
+    validate_prelude("@supports", &self.supports, |parser| {
+      parse_supports_condition(parser).map(|_| ())
+    })?;
+    write_group(css, "@supports ", &self.supports, &self.rules)
+  }
+}
+
+impl LayerRule {
+  fn write_css(&self, css: &mut String) -> Result<(), CssSourceError> {
+    validate_prelude("@layer", &self.layer, |parser| {
+      parse_layer_name(parser).map(|_| ())
+    })?;
+
+    let Some(rules) = &self.rules else {
+      let _ = write!(css, "@layer {};", self.layer);
+      return Ok(());
+    };
+
+    write_group(css, "@layer ", &self.layer, rules)
+  }
+}
+
+fn write_group(
+  css: &mut String,
+  at_rule: &str,
+  prelude: &str,
+  rules: &[CssSource],
+) -> Result<(), CssSourceError> {
+  let _ = write!(css, "{at_rule}{prelude}{{");
+
+  for entry in rules {
+    entry.write_css(css)?;
+  }
+
+  css.push('}');
+  Ok(())
+}
+
+/// Reads a prelude with the grammar its rule takes, leaving nothing over, so it
+/// cannot close the rule and open another.
+fn validate_prelude(
+  rule: &'static str,
+  prelude: &str,
+  parse: impl for<'i, 't> FnOnce(
+    &mut Parser<'i, 't>,
+  ) -> Result<(), ParseError<'i, StyleSheetParseError>>,
+) -> Result<(), CssSourceError> {
+  let mut parser_input = ParserInput::new(prelude);
+  let mut parser = Parser::new(&mut parser_input);
+
+  match parser.parse_entirely(parse) {
+    Ok(()) => Ok(()),
+    Err(_) => Err(CssSourceError::Prelude {
+      rule,
+      value: prelude.to_owned(),
+    }),
   }
 }
 
 impl AnimationRule {
   fn write_css(&self, css: &mut String) -> Result<(), CssSourceError> {
-    validate_ident(&self.keyframes)
-      .map_err(|_| CssSourceError::KeyframesName(self.keyframes.clone()))?;
+    validate_prelude("@keyframes name", &self.keyframes, |parser| {
+      parser.expect_ident().map(|_| ()).map_err(Into::into)
+    })?;
 
     let _ = write!(css, "@keyframes {}{{", self.keyframes);
 
@@ -219,16 +334,6 @@ fn write_declarations(declarations: &Declarations, css: &mut String) -> Result<(
   Ok(())
 }
 
-fn validate_ident(ident: &str) -> Result<(), ()> {
-  let mut parser_input = ParserInput::new(ident);
-  let mut parser = Parser::new(&mut parser_input);
-
-  parser
-    .parse_entirely(|parser| parser.expect_ident().cloned().map_err(Into::into))
-    .map(|_| ())
-    .map_err(|_: ParseError<'_, ()>| ())
-}
-
 /// A step selector is a comma list of `from`, `to`, or a percentage.
 fn validate_keyframe_offset(offset: &str) -> Result<(), CssSourceError> {
   let mut parser_input = ParserInput::new(offset);
@@ -252,7 +357,10 @@ fn validate_keyframe_offset(offset: &str) -> Result<(), CssSourceError> {
       })
     })
     .map(|_| ())
-    .map_err(|_: ParseError<'_, ()>| CssSourceError::KeyframeOffset(offset.to_owned()))
+    .map_err(|_: ParseError<'_, ()>| CssSourceError::Prelude {
+      rule: "keyframe offset",
+      value: offset.to_owned(),
+    })
 }
 
 /// The CSS spelling of a property name written in camelCase.
@@ -284,7 +392,10 @@ fn validate_selector(selector: &str) -> Result<(), CssSourceError> {
 
   match parsed {
     Ok(_) => Ok(()),
-    Err(_) => Err(CssSourceError::Selector(selector.to_owned())),
+    Err(_) => Err(CssSourceError::Prelude {
+      rule: "selector",
+      value: selector.to_owned(),
+    }),
   }
 }
 
@@ -365,15 +476,24 @@ mod tests {
   fn a_selector_cannot_carry_a_second_rule() {
     assert!(matches!(
       css(json!({ "selector": ".a{color:red}.b" })),
-      Err(CssSourceError::Selector(_))
+      Err(CssSourceError::Prelude {
+        rule: "selector",
+        ..
+      })
     ));
     assert!(matches!(
       css(json!({ "selector": "}" })),
-      Err(CssSourceError::Selector(_))
+      Err(CssSourceError::Prelude {
+        rule: "selector",
+        ..
+      })
     ));
     assert!(matches!(
       css(json!({ "selector": "@media print" })),
-      Err(CssSourceError::Selector(_))
+      Err(CssSourceError::Prelude {
+        rule: "selector",
+        ..
+      })
     ));
   }
 
@@ -399,11 +519,64 @@ mod tests {
   fn a_keyframes_name_and_offset_cannot_carry_a_second_rule() {
     assert!(matches!(
       css(json!({ "keyframes": "a{}.b", "steps": [] })),
-      Err(CssSourceError::KeyframesName(_))
+      Err(CssSourceError::Prelude {
+        rule: "@keyframes name",
+        ..
+      })
     ));
     assert!(matches!(
       css(json!({ "keyframes": "spin", "steps": [{ "offset": "from{}.b" }] })),
-      Err(CssSourceError::KeyframeOffset(_))
+      Err(CssSourceError::Prelude {
+        rule: "keyframe offset",
+        ..
+      })
+    ));
+  }
+
+  #[test]
+  fn a_group_wraps_the_entries_it_holds() {
+    assert_eq!(
+      css(json!({
+        "media": "(min-width: 800px)",
+        "rules": [
+          ".a{color:red}",
+          { "selector": ".b", "style": { "width": "1px" } },
+        ],
+      })),
+      Ok("@media (min-width: 800px){.a{color:red}.b{width:1px;}}".into())
+    );
+    assert_eq!(
+      css(json!({ "supports": "(display: grid)", "rules": [{ "selector": ".a" }] })),
+      Ok("@supports (display: grid){.a{}}".into())
+    );
+  }
+
+  /// A layer with no entries declares its order alone.
+  #[test]
+  fn a_layer_writes_a_statement_without_entries() {
+    assert_eq!(css(json!({ "layer": "base" })), Ok("@layer base;".into()));
+    assert_eq!(
+      css(json!({ "layer": "base.reset", "rules": [{ "selector": ".a" }] })),
+      Ok("@layer base.reset{.a{}}".into())
+    );
+  }
+
+  #[test]
+  fn a_group_prelude_cannot_carry_a_second_rule() {
+    assert!(matches!(
+      css(json!({ "media": "print){} .b{color:red}(", "rules": [] })),
+      Err(CssSourceError::Prelude { rule: "@media", .. })
+    ));
+    assert!(matches!(
+      css(json!({ "supports": "(display:grid){} .b", "rules": [] })),
+      Err(CssSourceError::Prelude {
+        rule: "@supports",
+        ..
+      })
+    ));
+    assert!(matches!(
+      css(json!({ "layer": "a{}.b" })),
+      Err(CssSourceError::Prelude { rule: "@layer", .. })
     ));
   }
 

--- a/takumi-core/src/style/css_source.rs
+++ b/takumi-core/src/style/css_source.rs
@@ -114,7 +114,6 @@ pub struct MediaRule {
   /// The query the group is gated by.
   pub media: String,
   /// The entries inside the group.
-  #[serde(default)]
   rules: Vec<CssSource>,
 }
 
@@ -125,7 +124,6 @@ pub struct SupportsRule {
   /// The condition the group is gated by.
   pub supports: String,
   /// The entries inside the group.
-  #[serde(default)]
   rules: Vec<CssSource>,
 }
 
@@ -578,6 +576,32 @@ mod tests {
       css(json!({ "layer": "a{}.b" })),
       Err(CssSourceError::Prelude { rule: "@layer", .. })
     ));
+  }
+
+  /// A layer name is dot-separated identifiers alone: no quoted strings, and no
+  /// reserved keywords, which would write CSS that means something else.
+  #[test]
+  fn a_layer_name_takes_identifiers_alone() {
+    assert!(matches!(
+      css(json!({ "layer": "\"base\"" })),
+      Err(CssSourceError::Prelude { rule: "@layer", .. })
+    ));
+    assert!(matches!(
+      css(json!({ "layer": "revert-layer" })),
+      Err(CssSourceError::Prelude { rule: "@layer", .. })
+    ));
+    assert!(matches!(
+      css(json!({ "layer": "base.default" })),
+      Err(CssSourceError::Prelude { rule: "@layer", .. })
+    ));
+  }
+
+  /// Only a layer has a statement form; a media or support group without its
+  /// entries is a typo, not an empty block.
+  #[test]
+  fn a_media_or_supports_group_needs_its_rules() {
+    assert!(from_value::<CssSource>(json!({ "media": "print" })).is_err());
+    assert!(from_value::<CssSource>(json!({ "supports": "(display: grid)" })).is_err());
   }
 
   #[test]

--- a/takumi-core/src/style/mod.rs
+++ b/takumi-core/src/style/mod.rs
@@ -15,10 +15,7 @@ pub(crate) use animation::apply_stylesheet_animations;
 pub use animation::{KeyframeRule, KeyframesRule};
 pub(crate) use calc::{CalcArena, parse_calc_number_expression};
 pub(crate) use css_input::{CssInput, CssNumber, CssUnexpected, CssValueSeed};
-pub use css_source::{
-  AnimationRule, AnimationStep, CssSource, CssSourceError, LayerRule, MediaRule, StyleRule,
-  SupportsRule,
-};
+pub use css_source::{AnimationRule, AnimationStep, CssSource, CssSourceError, StyleRule};
 pub(crate) use math::lerp;
 pub(crate) use properties::unexpected_token;
 pub use properties::*;

--- a/takumi-core/src/style/mod.rs
+++ b/takumi-core/src/style/mod.rs
@@ -15,7 +15,10 @@ pub(crate) use animation::apply_stylesheet_animations;
 pub use animation::{KeyframeRule, KeyframesRule};
 pub(crate) use calc::{CalcArena, parse_calc_number_expression};
 pub(crate) use css_input::{CssInput, CssNumber, CssUnexpected, CssValueSeed};
-pub use css_source::{AnimationRule, AnimationStep, CssSource, CssSourceError, StyleRule};
+pub use css_source::{
+  AnimationRule, AnimationStep, CssSource, CssSourceError, LayerRule, MediaRule, StyleRule,
+  SupportsRule,
+};
 pub(crate) use math::lerp;
 pub(crate) use properties::unexpected_token;
 pub use properties::*;

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -872,13 +872,12 @@ fn parse_at_rule_prelude<'i, 't>(
   input: &mut Parser<'i, 't>,
 ) -> Result<AtRulePrelude, ParseError<'i, StyleSheetParseError>> {
   if name.eq_ignore_ascii_case("layer") {
-    let mut layer_names = input
-      .try_parse(|input| input.parse_comma_separated(parse_layer_name))
-      .unwrap_or_default();
-    if layer_names.is_empty() {
-      layer_names.push(vec![LayerName::Anonymous]);
+    if input.is_exhausted() {
+      return Ok(AtRulePrelude::Layer(vec![vec![LayerName::Anonymous]]));
     }
-    return Ok(AtRulePrelude::Layer(layer_names));
+    return Ok(AtRulePrelude::Layer(
+      input.parse_comma_separated(parse_layer_name)?,
+    ));
   }
 
   if name.eq_ignore_ascii_case("keyframes") {
@@ -2478,6 +2477,23 @@ mod tests {
       ])
     );
     assert_ne!(sheet.rules[0].layer_order, sheet.rules[1].layer_order);
+  }
+
+  /// An invalid layer name drops its block; it does not fall back to an
+  /// anonymous layer.
+  #[test]
+  fn test_parse_invalid_layer_name_drops_the_block() {
+    for prelude in ["inherit", "\"quoted\"", "base.default"] {
+      let sheet = parse_stylesheet_loosy(&format!(
+        r#"
+          @layer {prelude} {{ .card {{ width: 50px; }} }}
+          .card {{ width: 100px; }}
+        "#
+      ));
+
+      assert_eq!(sheet.rules.len(), 1);
+      assert_eq!(sheet.rules[0].layer, None);
+    }
   }
 
   #[test]

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -957,7 +957,7 @@ fn parse_at_rule_prelude<'i, 't>(
   Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name)))
 }
 
-fn parse_layer_name<'i, 't>(
+pub(crate) fn parse_layer_name<'i, 't>(
   input: &mut Parser<'i, 't>,
 ) -> Result<LayerPath, ParseError<'i, StyleSheetParseError>> {
   let mut segments = Vec::new();

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -965,7 +965,7 @@ pub(crate) fn parse_layer_name<'i, 't>(
   loop {
     let location = input.current_source_location();
     let segment = match input.next()? {
-      Token::Ident(value) | Token::QuotedString(value) => value.to_string(),
+      Token::Ident(value) if !is_reserved_layer_name(value) => value.to_string(),
       token => return Err(location.new_unexpected_token_error(token.clone())),
     };
     segments.push(LayerName::Named(segment));
@@ -976,6 +976,21 @@ pub(crate) fn parse_layer_name<'i, 't>(
   }
 
   Ok(segments)
+}
+
+/// CSS-wide keywords and `default` are reserved, per
+/// <https://drafts.csswg.org/css-cascade-5/#layer-names>.
+fn is_reserved_layer_name(ident: &str) -> bool {
+  [
+    "initial",
+    "inherit",
+    "unset",
+    "revert",
+    "revert-layer",
+    "default",
+  ]
+  .iter()
+  .any(|keyword| ident.eq_ignore_ascii_case(keyword))
 }
 
 fn extend_layer_name(current_layer: Option<&LayerPath>, layer_name: &[LayerName]) -> LayerPath {

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -41,8 +41,26 @@ export type AnimationRule = {
   steps: { offset: string; style?: Declarations }[];
 };
 
+/** A group of entries gated by a media query. */
+export type MediaRule = {
+  media: string;
+  rules?: CssInput[];
+};
+
+/** A group of entries gated by a support condition. */
+export type SupportsRule = {
+  supports: string;
+  rules?: CssInput[];
+};
+
+/** A cascade layer. Without `rules` it declares the layer's order alone. */
+export type LayerRule = {
+  layer: string;
+  rules?: CssInput[];
+};
+
 /** One entry of the `css` render option: stylesheet text, or a rule object. */
-export type CssInput = string | StyleRule | AnimationRule;
+export type CssInput = string | StyleRule | AnimationRule | MediaRule | SupportsRule | LayerRule;
 
 /**
  * A JSX element from any React-shaped runtime; Preact vnodes fit too, so

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -44,13 +44,13 @@ export type AnimationRule = {
 /** A group of entries gated by a media query. */
 export type MediaRule = {
   media: string;
-  rules?: CssInput[];
+  rules: CssInput[];
 };
 
 /** A group of entries gated by a support condition. */
 export type SupportsRule = {
   supports: string;
-  rules?: CssInput[];
+  rules: CssInput[];
 };
 
 /** A cascade layer. Without `rules` it declares the layer's order alone. */

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -42,19 +42,19 @@ export type AnimationRule = {
 };
 
 /** A group of entries gated by a media query. */
-type MediaRule = {
+export type MediaRule = {
   media: string;
   rules: CssInput[];
 };
 
 /** A group of entries gated by a support condition. */
-type SupportsRule = {
+export type SupportsRule = {
   supports: string;
   rules: CssInput[];
 };
 
 /** A cascade layer. Without `rules` it declares the layer's order alone. */
-type LayerRule = {
+export type LayerRule = {
   layer: string;
   rules?: CssInput[];
 };

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -42,19 +42,19 @@ export type AnimationRule = {
 };
 
 /** A group of entries gated by a media query. */
-export type MediaRule = {
+type MediaRule = {
   media: string;
   rules: CssInput[];
 };
 
 /** A group of entries gated by a support condition. */
-export type SupportsRule = {
+type SupportsRule = {
   supports: string;
   rules: CssInput[];
 };
 
 /** A cascade layer. Without `rules` it declares the layer's order alone. */
-export type LayerRule = {
+type LayerRule = {
   layer: string;
   rules?: CssInput[];
 };

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -34,7 +34,15 @@ export type {
   RenderOptions,
   RenderSvgOptions,
 } from "./render";
-export type { AnimationRule, CssInput, Declarations, StyleRule } from "@takumi-rs/helpers";
+export type {
+  AnimationRule,
+  CssInput,
+  Declarations,
+  LayerRule,
+  MediaRule,
+  StyleRule,
+  SupportsRule,
+} from "@takumi-rs/helpers";
 
 declare module "react" {
   interface DOMAttributes<T> {

--- a/takumi-js/src/index.ts
+++ b/takumi-js/src/index.ts
@@ -34,15 +34,7 @@ export type {
   RenderOptions,
   RenderSvgOptions,
 } from "./render";
-export type {
-  AnimationRule,
-  CssInput,
-  Declarations,
-  LayerRule,
-  MediaRule,
-  StyleRule,
-  SupportsRule,
-} from "@takumi-rs/helpers";
+export type { AnimationRule, CssInput, Declarations, StyleRule } from "@takumi-rs/helpers";
 
 declare module "react" {
   interface DOMAttributes<T> {

--- a/takumi-js/src/render.ts
+++ b/takumi-js/src/render.ts
@@ -72,7 +72,7 @@ type CssOptions = {
   css?: CssInput | readonly CssInput[];
   /**
    * CSS stylesheets to apply before rendering.
-   * @deprecated Use `css` instead. Removed in v3.
+   * @deprecated Use `css` instead. Will be removed in v3.
    */
   stylesheets?: string[];
 };

--- a/takumi-napi/src/dts-header.d.ts
+++ b/takumi-napi/src/dts-header.d.ts
@@ -64,7 +64,9 @@ export interface FontDetails {
 
 export type Font = FontDetails | ByteBuf;
 
+/** @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3. */
 export type KeyframesMap = Record<string, Record<string, Properties>>;
+/** @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3. */
 export type KeyframesRuleList = {
   name: string;
   keyframes: {
@@ -72,4 +74,5 @@ export type KeyframesRuleList = {
     declarations: Record<string, Properties>;
   }[];
 }[];
+/** @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3. */
 export type Keyframes = KeyframesMap | KeyframesRuleList;

--- a/takumi-napi/src/renderer.rs
+++ b/takumi-napi/src/renderer.rs
@@ -199,9 +199,9 @@ pub struct RenderOptions<'env> {
   /// object.
   #[napi(ts_type = "CssInput[]")]
   pub css: Option<Object<'env>>,
-  /// @deprecated Use `css` instead. Removed in v3.
+  /// @deprecated Use `css` instead. Will be removed in v3.
   pub stylesheets: Option<Vec<String>>,
-  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
   #[napi(ts_type = "Keyframes")]
   pub keyframes: Option<Object<'env>>,
   /// The device pixel ratio.
@@ -234,9 +234,9 @@ pub struct SvgRenderOptions<'env> {
   /// object.
   #[napi(ts_type = "CssInput[]")]
   pub css: Option<Object<'env>>,
-  /// @deprecated Use `css` instead. Removed in v3.
+  /// @deprecated Use `css` instead. Will be removed in v3.
   pub stylesheets: Option<Vec<String>>,
-  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
   #[napi(ts_type = "Keyframes")]
   pub keyframes: Option<Object<'env>>,
   /// The animation timeline time in milliseconds.
@@ -306,9 +306,9 @@ pub struct RenderAnimationOptions<'env> {
   /// object.
   #[napi(ts_type = "CssInput[]")]
   pub css: Option<Object<'env>>,
-  /// @deprecated Use `css` instead. Removed in v3.
+  /// @deprecated Use `css` instead. Will be removed in v3.
   pub stylesheets: Option<Vec<String>>,
-  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
   #[napi(ts_type = "Keyframes")]
   pub keyframes: Option<Object<'env>>,
   /// The device pixel ratio.

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -139,7 +139,7 @@ export type MeasureOptions = (
   css?: CssInput | readonly CssInput[];
   /**
    * CSS stylesheets to apply before layout.
-   * @deprecated Use `css` instead. Removed in v3.
+   * @deprecated Use `css` instead. Will be removed in v3.
    */
   stylesheets?: string[];
   /** Per-render font stack: ordered family names used as the fallback chain. */
@@ -271,7 +271,7 @@ export type RenderOptions = (PagedOptions | ViewportOptions) &
     css?: CssInput | readonly CssInput[];
     /**
      * CSS stylesheets to apply before layout.
-     * @deprecated Use `css` instead. Removed in v3.
+     * @deprecated Use `css` instead. Will be removed in v3.
      */
     stylesheets?: string[];
     /** CSS custom properties for `:root`; the `--` prefix is optional. */

--- a/takumi-wasm/src/dts-header.d.ts
+++ b/takumi-wasm/src/dts-header.d.ts
@@ -12,7 +12,9 @@ export {
 
 export type ByteBuf = Uint8Array | ArrayBuffer | Buffer;
 
+/** @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3. */
 export type KeyframesMap = Record<string, Record<string, Properties>>;
+/** @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3. */
 export type KeyframesRuleList = {
   name: string;
   keyframes: {
@@ -20,6 +22,7 @@ export type KeyframesRuleList = {
     declarations: Record<string, Properties>;
   }[];
 }[];
+/** @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3. */
 export type Keyframes = KeyframesMap | KeyframesRuleList;
 export type { CssInput };
 
@@ -79,11 +82,11 @@ export type RenderOptions = {
    */
   css?: CssInput[];
   /**
-   * @deprecated Use `css` instead. Removed in v3.
+   * @deprecated Use `css` instead. Will be removed in v3.
    */
   stylesheets?: string[];
   /**
-   * @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+   * @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
    */
   keyframes?: Keyframes;
   /**
@@ -148,11 +151,11 @@ export type RenderAnimationOptions = {
    */
   css?: CssInput[];
   /**
-   * @deprecated Use `css` instead. Removed in v3.
+   * @deprecated Use `css` instead. Will be removed in v3.
    */
   stylesheets?: string[];
   /**
-   * @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+   * @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
    */
   keyframes?: Keyframes;
   /**

--- a/takumi-wasm/src/model.rs
+++ b/takumi-wasm/src/model.rs
@@ -75,9 +75,9 @@ pub struct RenderOptions {
   /// CSS to apply before rendering: stylesheet text, or a rule written as an
   /// object.
   pub css: Option<Vec<CssSource>>,
-  /// @deprecated Use `css` instead. Removed in v3.
+  /// @deprecated Use `css` instead. Will be removed in v3.
   pub stylesheets: Option<Vec<String>>,
-  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
   #[serde(default, deserialize_with = "deserialize_optional_keyframes")]
   pub(crate) keyframes: Option<Vec<KeyframesRule>>,
   /// Whether to draw debug borders around layout elements.
@@ -110,9 +110,9 @@ pub struct SvgRenderOptions {
   /// CSS to apply before rendering: stylesheet text, or a rule written as an
   /// object.
   pub css: Option<Vec<CssSource>>,
-  /// @deprecated Use `css` instead. Removed in v3.
+  /// @deprecated Use `css` instead. Will be removed in v3.
   pub stylesheets: Option<Vec<String>>,
-  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
   #[serde(default, deserialize_with = "deserialize_optional_keyframes")]
   pub(crate) keyframes: Option<Vec<KeyframesRule>>,
   /// The animation timeline time in milliseconds.
@@ -143,9 +143,9 @@ pub struct RenderAnimationOptions {
   /// CSS to apply before rendering: stylesheet text, or a rule written as an
   /// object.
   pub css: Option<Vec<CssSource>>,
-  /// @deprecated Use `css` instead. Removed in v3.
+  /// @deprecated Use `css` instead. Will be removed in v3.
   pub stylesheets: Option<Vec<String>>,
-  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Removed in v3.
+  /// @deprecated Use a `{ keyframes, steps }` entry in `css` instead. Will be removed in v3.
   #[serde(default, deserialize_with = "deserialize_optional_keyframes")]
   pub(crate) keyframes: Option<Vec<KeyframesRule>>,
   /// The device pixel ratio for scaling.


### PR DESCRIPTION
## Why

The structured `css` option covered a rule and an animation but not the at-rules that hold them, so anything gated by a media query, a support condition, or a cascade layer still had to be concatenated into a string. That is the half of a stylesheet most likely to carry a value from application data.

## What

A `css` entry can now be `{ media, rules }`, `{ supports, rules }`, or `{ layer, rules }`, each holding entries of its own. A layer without `rules` writes `@layer name;`, which declares the order alone. Every prelude is read with the grammar its rule takes and has to consume the whole string, so `{ media: "print){} .b{color:red}(" }` is an error rather than two rules.

The error type collapsed to one `Prelude { rule, value }` variant rather than growing a variant per at-rule. It shipped in #1456 and has not been released, so nothing depends on the old shape.

The playground now declares its own `CssEntry` type instead of importing `CssInput`: that import resolved to `any` in the docs app, so the shape it was meant to check went unchecked. Its schema uses `strictObject`, so a typo like `declarations` fails instead of being stripped into a rule the renderer never sees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CSS `@media`, `@supports`, and `@layer` rules, including layer-order declarations.
  * Extended public CSS types and rendering support across previews, PDFs, images, and animations.
  * Added strict validation to reject malformed CSS entries and unknown properties.

* **Documentation**
  * Documented supported structured CSS at-rules and their syntax.
  * Clarified the timeline for removing deprecated styling and keyframe options.

* **Tests**
  * Added coverage for supported CSS rule types, nesting, validation, and layer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->