### PR TITLE
Core: keep clippy clean when optional features are off

### DIFF
--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "svg")]
 use std::borrow::Cow;
+#[cfg(feature = "svg")]
 use std::str::{FromStr, from_utf8};
 use std::sync::{Arc, OnceLock, Weak};
 
@@ -50,8 +51,10 @@ use crate::{
   style::{Color, ImageScalingAlgorithm, IntrinsicSizing, SizingContext, StyleSheet},
 };
 
+#[cfg(feature = "svg")]
 const MAX_RASTER_PIXELS: u64 = 16 << 20;
 
+#[cfg(feature = "svg")]
 fn within_raster_pixel_budget(width: u32, height: u32) -> bool {
   u64::from(width) * u64::from(height) <= MAX_RASTER_PIXELS
 }
@@ -770,7 +773,7 @@ impl ImageSource {
     height: u32,
     image_rendering: ImageScalingAlgorithm,
     time_ms: u64,
-    current_color: Color,
+    #[cfg_attr(not(feature = "svg"), allow(unused_variables))] current_color: Color,
   ) -> Result<RenderedImage, ImageError> {
     match self {
       ImageSource::Bitmap(bitmap) => Ok(RenderedImage::Sampled {

--- a/takumi-core/src/resources/image_decoder.rs
+++ b/takumi-core/src/resources/image_decoder.rs
@@ -123,6 +123,7 @@ const MAX_ANIMATION_TOTAL_PIXELS: u64 = 4 * MAX_IMAGE_PIXELS;
 pub(crate) const MAX_ANIMATION_FRAMES: usize = 1024;
 
 /// Rejects decoded images whose pixel count exceeds [`MAX_IMAGE_PIXELS`].
+#[cfg(feature = "webp")]
 fn check_pixel_budget(width: u32, height: u32) -> ImageResult<()> {
   if width as u64 * height as u64 > MAX_IMAGE_PIXELS {
     return Err(pixel_budget_error(width, height));
@@ -131,11 +132,6 @@ fn check_pixel_budget(width: u32, height: u32) -> ImageResult<()> {
   Ok(())
 }
 
-#[cfg(any(
-  feature = "gif",
-  feature = "webp",
-  not(all(feature = "jpeg", feature = "webp"))
-))]
 fn pixel_budget_error(width: u32, height: u32) -> ImageError {
   ImageError::Decoding(DecodingError::new(
     ImageFormatHint::Unknown,


### PR DESCRIPTION
cargo clippy -p takumi-raster --all-targets --all-features fails on master with:

```
error: function `check_pixel_budget` is never used
```

takumi-raster pulls takumi-core with default-features = false, so webp is off in that graph. Every caller of check_pixel_budget sits behind the webp feature, but the function itself was ungated. The svg-only helpers in image.rs had the same problem under --no-default-features.

This gates each item behind the feature its callers already use, and drops the cfg on pixel_budget_error. That cfg could never evaluate to false.

Lint-only change, no behavior difference in any shipped feature set. No changeset for that reason.

Verified clippy clean on: no-default-features alone and with each of svg / webp / gif / jpeg, default, all-features, and the wasm32 CI invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when optional SVG and WebP image features are disabled.
  * Reduced build warnings and ensured image decoding components compile correctly across feature configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->