### PR TITLE
Docs: resolve waku to a single copy so the docs router mounts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,7 @@
     "rolldown-plugin-dts": "0.27.6",
     "takumi-js": "workspace:*",
     "vite": "8.2.1",
+    "waku": "1.0.0-rc.0",
   },
   "catalog": {
     "@types/bun": "^1.4.0",
@@ -2760,8 +2761,6 @@
     "fumadocs-ui/cnfast": ["cnfast@0.1.0", "", { "bin": { "cnfast": "bin/cli.js" } }, "sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ=="],
 
     "fumapress/cnfast": ["cnfast@0.1.0", "", { "bin": { "cnfast": "bin/cli.js" } }, "sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ=="],
-
-    "fumapress/waku": ["waku@1.0.0-beta.9", "", { "dependencies": { "@hono/node-server": "^2.0.11", "@vitejs/plugin-react": "^6.0.1", "@vitejs/plugin-rsc": "^0.5.33", "dotenv": "^17.4.2", "hono": "^4.12.14", "magic-string": "^1.0.0", "picocolors": "^1.1.1", "rsc-html-stream": "^0.0.7", "vite": "^8.0.0" }, "peerDependencies": { "react": "~19.2.4", "react-dom": "~19.2.4", "react-server-dom-webpack": "~19.2.4" }, "bin": { "waku": "./cli.js" } }, "sha512-XSFP07L2u5XoZf2Qt3k6AGv9q4Iogzdt9be6imJjpld/VUVZhTA5KzL3aBEdjuplYJNlNZLMZPdM9j1Kw62ZUA=="],
 
     "h3-v2/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@takumi-rs/image-response": "workspace:*",
     "rolldown-plugin-dts": "0.27.6",
     "takumi-js": "workspace:*",
-    "vite": "8.2.1"
+    "vite": "8.2.1",
+    "waku": "1.0.0-rc.0"
   },
   "catalog": {
     "@types/bun": "^1.4.0",


### PR DESCRIPTION
## Why

fumapress pins waku `1.0.0-beta.9` while docs is on `1.0.0-rc.0`, so the install kept two copies. The layout's client components read a `RouterContext` from the beta copy that the app never fills, and every docs page dies with `Uncaught Error: Missing Router`.

## What

A root `overrides` entry pins waku to `1.0.0-rc.0`, so fumapress and docs share one copy. The same install now also collapses the two `fumadocs-core` copies, which the Vite `dedupe` list was papering over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s dependency configuration to use a specific Waku release for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->