### PR TITLE
CI: resolve dependencies from the committed lockfile only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          binstall: cargo-audit,cargo-llvm-cov,cargo-rdme@1.5.1,cargo-machete
+          binstall: cargo-audit,cargo-deny,cargo-llvm-cov,cargo-rdme@1.5.1,cargo-machete
           components: rustfmt,clippy
           targets: wasm32-unknown-unknown
           stage: test
@@ -66,38 +66,28 @@ jobs:
       - name: Check unused dependencies
         run: cargo machete
 
-      # syn 2 and 3 both live in the proc-macro graph and never reach a
-      # binary. Every other duplicate is ours to fix, usually by holding our
-      # requirement at the major an upstream crate already resolves to.
-      - name: Check for duplicate dependency versions
-        run: |
-          tree=$(cargo tree -d --workspace --all-features -e normal --depth 0)
-          dupes=$(printf '%s\n' "$tree" | grep -vE '^(syn v|$)' || true)
-          if [ -n "$dupes" ]; then
-            echo "Duplicate versions in the dependency tree:"
-            echo "$dupes"
-            exit 1
-          fi
+      - name: Check dependency sources and duplicates
+        run: cargo deny --locked check bans sources
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       # The host pass never sees the `target_arch = "wasm32"` half of the
       # decoders, so it is blind to whatever the published wasm compiles.
       - name: Run Clippy for wasm
-        run: cargo clippy --target wasm32-unknown-unknown -p takumi-wasm -p takumi-pdf-wasm -- -D warnings
+        run: cargo clippy --locked --target wasm32-unknown-unknown -p takumi-wasm -p takumi-pdf-wasm -- -D warnings
 
       - name: Test README.md is up to date
         run: |
           fail=0
           while read -r dir; do
             (cd "$dir" && cargo rdme --check) || fail=1
-          done < <(cargo metadata --format-version 1 --no-deps \
+          done < <(cargo metadata --locked --format-version 1 --no-deps \
             | jq -r '.packages[] | select(.publish != []) | select(any(.targets[]; .kind | index("lib"))) | .manifest_path | rtrimstr("/Cargo.toml")')
           exit $fail
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --locked
 
       # The fixtures claim PDF/A and PDF/UA conformance in their metadata. Only
       # the reference validator can tell whether the claim holds.
@@ -193,12 +183,11 @@ jobs:
           exit 1
 
       - name: Run security audit
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: cargo audit
 
       - name: Test Publish (--dry-run)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: cargo publish --dry-run --workspace
+        run: cargo publish --locked --dry-run --workspace
 
   build-helpers:
     name: Build @takumi-rs/helpers

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,14 @@
+[graph]
+all-features = true
+
+[bans]
+multiple-versions = "deny"
+# syn 1 and 2 both live in the proc-macro graph and never reach a binary.
+skip = [{ crate = "syn" }]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# The hinting-gate fork the font stack is pinned to, by rev.
+allow-git = ["https://github.com/kane50613/fontations"]

--- a/takumi-napi/package.json
+++ b/takumi-napi/package.json
@@ -61,7 +61,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "napi build --release --no-const-enum --platform --esm --strip",
+    "build": "napi build --release --no-const-enum --platform --esm --strip -- --locked",
     "build:js": "tsdown",
     "prepublishOnly": "bun artifacts && napi prepublish -t npm --no-gh-release",
     "artifacts": "napi create-npm-dirs && napi artifacts && napi version",

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -134,7 +134,7 @@
     }
   },
   "scripts": {
-    "build": "wasm-pack build ../takumi-pdf-wasm --no-pack --release --out-dir ../takumi-pdf-js/pkg --target web && bun build:js",
+    "build": "wasm-pack build ../takumi-pdf-wasm --no-pack --release --out-dir ../takumi-pdf-js/pkg --target web -- --locked && bun build:js",
     "build:js": "tsdown",
     "publish-lint": "attw --pack . && publint --strict ."
   },

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -138,9 +138,9 @@
     }
   },
   "scripts": {
-    "build": "wasm-pack build --no-pack --release --out-dir pkg --target web && bun build:js",
+    "build": "wasm-pack build --no-pack --release --out-dir pkg --target web -- --locked && bun build:js",
     "build:js": "tsdown",
-    "build:debug": "wasm-pack build --no-pack --dev --out-dir pkg --target web && bun build:js",
+    "build:debug": "wasm-pack build --no-pack --dev --out-dir pkg --target web -- --locked && bun build:js",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "dependencies": {


### PR DESCRIPTION
## Why

Build scripts run arbitrary code, and CI resolved dependencies fresh on every run instead of building what `Cargo.lock` pins. The arrayref compromise on 2026-08-20 hid its payload in a build script and yanked the older releases so resolution would land on it.

## What

Every cargo invocation passes `--locked`, including the napi and wasm-pack builds, which forward it through `--`. `cargo deny check bans sources` replaces the shell duplicate-version check and rejects any dependency outside crates.io and the pinned fontations fork. `cargo audit` runs on pull requests instead of only on pushes to master.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Reliability**
  * Builds and tests now consistently use locked dependency versions for reproducible results.
  * Added dependency checks to detect duplicate packages and unapproved dependency sources.
  * Dependency security auditing now runs more consistently across CI workflows.
  * Publishing dry runs also validate against the locked dependency set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->