### PR TITLE
CI: restore the Linux napi cross builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
           # instead of aborting the host process.
           CARGO_PROFILE_RELEASE_PANIC: unwind
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Zunstable-options
-        run: ${{ matrix.settings.build }} && bun build:js
+        run: ${{ matrix.settings.build }} -- --locked && bun build:js
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/takumi-napi/package.json
+++ b/takumi-napi/package.json
@@ -61,7 +61,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "napi build --release --no-const-enum --platform --esm --strip -- --locked",
+    "build": "napi build --release --no-const-enum --platform --esm --strip",
     "build:js": "tsdown",
     "prepublishOnly": "bun artifacts && napi prepublish -t npm --no-gh-release",
     "artifacts": "napi create-npm-dirs && napi artifacts && napi version",


### PR DESCRIPTION
## Why

`takumi-napi`'s build script ended in `-- --locked`, and the workflow appends the per-target flags after it, so `--use-napi-cross` and `-x` reached `cargo build` instead of the napi CLI. All four Linux targets failed with `error: unexpected argument '--use-napi-cross' found`.

## What

The script stops at the napi flags and the workflow step adds `-- --locked` after whatever the matrix passes, which keeps the cargo passthrough last.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build consistency by enforcing locked dependency resolution during CI builds.
  * Updated the project’s build command so dependency-locking behavior is handled consistently by the CI environment.
  * These changes help ensure builds use the expected dependency versions and reduce inconsistencies between local and automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->