### PR TITLE
Docs: stop the d key from flipping the theme

### DIFF
--- a/docs/press.config.tsx
+++ b/docs/press.config.tsx
@@ -11,6 +11,7 @@ import * as Twoslash from "fumadocs-twoslash/ui";
 import { defineConfig } from "fumapress";
 import { fumadocsMdx } from "fumapress/adapters/mdx";
 import { createDocsLayoutPage } from "fumapress/layouts/docs";
+import { createRootLayout } from "fumapress/layouts/root";
 import { oramaSearchPlugin } from "fumapress/plugins/orama-search";
 import { linkValidationPlugin } from "fumapress/plugins/link-validation";
 import { llmsPlugin } from "fumapress/plugins/llms.txt";
@@ -60,8 +61,15 @@ function tabIcon(icon: ReactNode, color: string) {
   );
 }
 
+const rootLayout = createRootLayout({
+  providerProps: {
+    theme: { hotKey: false },
+  },
+});
+
 export default defineConfig({
   mode: "static",
+  renderRoot: rootLayout,
   content: {
     docs: docs.toFumadocsSource({ baseDir: "docs" }),
   },


### PR DESCRIPTION
## Why

Pressing `d` outside an input flipped the docs site between light and dark. The shortcut comes from the `hotKey: "d"` default in fumadocs-ui `RootProvider`, not from anything the site asked for.

## What

Pass `theme.hotKey: false` through `renderRoot`, which drops the global keydown listener. The theme toggle in the navbar still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the documentation site’s root layout configuration.
  * Disabled the theme-switching keyboard shortcut for a more controlled presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->