### PR TITLE
Playground: refresh the templates around one idea each

### DIFF
--- a/docs/app/playground/preview-css.test.ts
+++ b/docs/app/playground/preview-css.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "bun:test";
+import { cssEntryToText } from "./preview-css";
+
+describe("preview css", () => {
+  it("rewrites a @theme block to :root", () => {
+    expect(cssEntryToText("@theme inline { --color-brand: #f00; }")).toBe(
+      ":root { --color-brand: #f00; }",
+    );
+  });
+});

--- a/docs/app/playground/preview-css.ts
+++ b/docs/app/playground/preview-css.ts
@@ -22,7 +22,8 @@ function groupToCss(rules: CssEntry[] | undefined): string {
  * browser preview pane only understands text.
  */
 export function cssEntryToText(entry: CssEntry): string {
-  if (typeof entry === "string") return entry;
+  // The engine reads `@theme` as a `:root` rule; a browser drops the block whole.
+  if (typeof entry === "string") return entry.replace(/@theme[^{]*\{/g, ":root {");
 
   if ("keyframes" in entry) {
     const body = entry.steps

--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -1,10 +1,12 @@
 import animatedShowcase from "./templates/animated-showcase?raw";
+import accessible from "./templates/accessible?raw";
 import articleCover from "./templates/article-cover?raw";
 import gradientPoster from "./templates/gradient-poster?raw";
 import invoice from "./templates/invoice?raw";
 import multilingual from "./templates/multilingual?raw";
 import receipt from "./templates/receipt?raw";
 import report from "./templates/report?raw";
+import svgText from "./templates/svg-text?raw";
 import themeTokens from "./templates/theme-tokens?raw";
 import twitterProfileCard from "./templates/twitter-profile-card?raw";
 import watermark from "./templates/watermark?raw";
@@ -63,9 +65,16 @@ export const templates: Template[] = [
     code: gradientPoster,
   },
   {
+    id: "svg-text",
+    name: "SVG text",
+    description: "An SVG source whose <text> and textPath draw from the registered fonts",
+    kind: "image",
+    code: svgText,
+  },
+  {
     id: "keyframe-animation",
     name: "Keyframe loop",
-    description: "Staggered Japanese text sampled into an animated WebP",
+    description: "Staggered keyframes sampled into an animated WebP",
     kind: "animation",
     code: animatedShowcase,
   },
@@ -85,10 +94,17 @@ export const templates: Template[] = [
   },
   {
     id: "report",
-    name: "Report",
-    description: "Four scripts across pages, with a counted footer and bookmarks",
+    name: "Paged table",
+    description: "A long table whose header repeats on every page",
     kind: "pdf",
     code: report,
+  },
+  {
+    id: "accessible",
+    name: "Tagged pages",
+    description: "PDF/A-4 with PDF/UA-2 tagging, bookmarks from the headings",
+    kind: "pdf",
+    code: accessible,
   },
   {
     id: "receipt",

--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -5,6 +5,7 @@ import invoice from "./templates/invoice?raw";
 import multilingual from "./templates/multilingual?raw";
 import receipt from "./templates/receipt?raw";
 import report from "./templates/report?raw";
+import themeTokens from "./templates/theme-tokens?raw";
 import twitterProfileCard from "./templates/twitter-profile-card?raw";
 import watermark from "./templates/watermark?raw";
 import welcome from "./templates/welcome?raw";
@@ -22,7 +23,7 @@ export const templates: Template[] = [
   {
     id: "welcome",
     name: "Welcome",
-    description: "Edit the code, press Run. The palette lives in a :root rule in options.css",
+    description: "Edit the code, press Run",
     kind: "image",
     code: welcome,
   },
@@ -46,6 +47,13 @@ export const templates: Template[] = [
     description: "Blog header with a gradient background, themed by a brand scale",
     kind: "image",
     code: articleCover,
+  },
+  {
+    id: "theme-tokens",
+    name: "Theme tokens",
+    description: "A Tailwind @theme block drives the colours, spacing, radius and display size",
+    kind: "image",
+    code: themeTokens,
   },
   {
     id: "gradient-poster",

--- a/docs/app/playground/templates/accessible.tsx
+++ b/docs/app/playground/templates/accessible.tsx
@@ -1,0 +1,45 @@
+const sections = [
+  {
+    title: "Summary",
+    body: "Every heading below becomes a bookmark and a tagged structure element, so a screen reader walks the document in reading order.",
+  },
+  {
+    title: "Method",
+    body: "Each run renders the same four-page document ten times on a warm renderer, and the middle eight runs are kept.",
+  },
+  {
+    title: "Results",
+    body: "Median render time fell from 41 ms to 28 ms. Per-document font subsetting took a four-page invoice from 78 KB to 62 KB.",
+  },
+  {
+    title: "Next steps",
+    body: "Cold starts still dominate the first request, so a shared renderer is worth keeping alive between jobs.",
+  },
+];
+
+export default function Accessible() {
+  return (
+    <div tw="flex w-full flex-col text-[#1f2430]">
+      <h1 tw="m-0 text-3xl font-semibold">Quarterly notes</h1>
+
+      {sections.map((section) => (
+        <div key={section.title} tw="mt-8 flex flex-col">
+          <h2 tw="m-0 border-l-4 border-[#4338ca] pl-3 text-lg font-semibold">{section.title}</h2>
+          <p tw="mt-2 mb-0 text-sm leading-6 text-[#374151]">{section.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const options: PlaygroundOptions = {
+  pdf: {
+    size: "a4",
+    margin: 56,
+    pdfa: "4",
+    tagged: "ua2",
+    outline: true,
+    lang: "en",
+    metadata: { title: "Quarterly notes", creationDate: "2026-04-02" },
+  },
+};

--- a/docs/app/playground/templates/animated-showcase.tsx
+++ b/docs/app/playground/templates/animated-showcase.tsx
@@ -1,10 +1,9 @@
 const DURATION_MS = 3000;
 
 const words = [
-  { text: "動", delay: 0 },
-  { text: "く", delay: 200 },
-  { text: "文", delay: 400 },
-  { text: "字", delay: 600 },
+  { text: "Type", delay: 0 },
+  { text: "that", delay: 200 },
+  { text: "moves", delay: 400 },
 ];
 
 export default function AnimatedShowcase() {
@@ -16,7 +15,6 @@ export default function AnimatedShowcase() {
       {words.map((word) => (
         <span
           key={word.text}
-          lang="ja"
           tw="mx-2 text-7xl font-bold text-orange-950"
           style={{
             animationName: "bob",

--- a/docs/app/playground/templates/invoice.tsx
+++ b/docs/app/playground/templates/invoice.tsx
@@ -1,7 +1,7 @@
 const items = [
-  { name: "設計月費 · Design retainer", qty: 1, price: 3200 },
-  { name: "元件庫檢查 · Component audit", qty: 12, price: 140 },
-  { name: "動效原型 · Motion prototype", qty: 6, price: 180 },
+  { name: "Design retainer", qty: 1, price: 3200 },
+  { name: "Component audit", qty: 12, price: 140 },
+  { name: "Motion prototype", qty: 6, price: 180 },
 ];
 
 const TAX_RATE = 0.05;
@@ -12,35 +12,35 @@ const money = (value: number) => `$${value.toLocaleString("en-US")}`;
 
 export default function Invoice() {
   return (
-    <div lang="zh-Hant" tw="flex w-full flex-col text-[#30313d]">
+    <div tw="flex w-full flex-col text-[#30313d]">
       <div tw="flex items-start justify-between">
         <div tw="flex flex-col">
-          <h1 tw="m-0 text-2xl font-semibold">發票 INV-2043</h1>
-          <p tw="mt-2 mb-0 text-xs text-[#687385]">開立 2026-03-01 · 到期 2026-03-31</p>
+          <h1 tw="m-0 text-2xl font-semibold">Invoice INV-2043</h1>
+          <p tw="mt-2 mb-0 text-xs text-[#687385]">Issued 2026-03-01 · Due 2026-03-31</p>
         </div>
         <span tw="rounded-full bg-[#eef2ff] px-3 py-1 text-xs font-semibold text-[#4338ca]">
-          未付款
+          Unpaid
         </span>
       </div>
 
       <div tw="mt-8 flex text-xs">
         <div tw="flex w-[240px] flex-col">
-          <span tw="mb-1 font-semibold text-[#687385]">賣方</span>
-          <span>匠 Werkstatt · 台北市窯街 12 號</span>
-          <span tw="text-[#687385]">統一編號 88012345</span>
+          <span tw="mb-1 font-semibold text-[#687385]">From</span>
+          <span>Kiln Werkstatt · 12 Kiln Street, Taipei</span>
+          <span tw="text-[#687385]">Tax ID 88012345</span>
         </div>
         <div tw="flex w-[240px] flex-col">
-          <span tw="mb-1 font-semibold text-[#687385]">買方</span>
+          <span tw="mb-1 font-semibold text-[#687385]">To</span>
           <span>Northwind Studio · Vancouver</span>
           <span tw="text-[#687385]">VAT CA-77400221</span>
         </div>
       </div>
 
       <div tw="mt-8 flex border-b border-[#ebeef1] pb-2 text-[11px] font-semibold text-[#687385]">
-        <span tw="flex-1">品項</span>
-        <span tw="w-[60px] text-right">數量</span>
-        <span tw="w-[100px] text-right">單價</span>
-        <span tw="w-[100px] text-right">金額</span>
+        <span tw="flex-1">Item</span>
+        <span tw="w-[60px] text-right">Qty</span>
+        <span tw="w-[100px] text-right">Unit</span>
+        <span tw="w-[100px] text-right">Amount</span>
       </div>
       {items.map((item) => (
         <div key={item.name} tw="flex break-inside-avoid pt-3 text-xs">
@@ -54,22 +54,23 @@ export default function Invoice() {
       <div tw="mt-8 flex break-inside-avoid justify-end">
         <div tw="flex w-[260px] flex-col text-xs">
           <div tw="flex justify-between">
-            <span tw="text-[#687385]">未稅金額</span>
+            <span tw="text-[#687385]">Subtotal</span>
             <span>{money(net)}</span>
           </div>
           <div tw="mt-2 flex justify-between">
-            <span tw="text-[#687385]">營業稅 {TAX_RATE * 100}%</span>
+            <span tw="text-[#687385]">Tax {TAX_RATE * 100}%</span>
             <span>{money(tax)}</span>
           </div>
           <div tw="mt-3 flex justify-between border-t border-[#ebeef1] pt-3 text-sm font-semibold">
-            <span>應付總額</span>
+            <span>Total due</span>
             <span>{money(net + tax)}</span>
           </div>
         </div>
       </div>
 
       <p tw="mt-10 mb-0 text-[11px] text-[#687385]">
-        文件與附件都通過 PDF/A-3b 驗證。中文字是真的文字,可以選取,不是圖片。
+        The document and its attachment both validate as PDF/A-3b. The text is selectable, not an
+        image.
       </p>
     </div>
   );
@@ -98,10 +99,10 @@ export const options: PlaygroundOptions = {
       },
     ],
     metadata: {
-      title: "發票 INV-2043",
-      authors: ["匠 Werkstatt"],
+      title: "Invoice INV-2043",
+      authors: ["Kiln Werkstatt"],
       creationDate: "2026-03-01",
     },
-    lang: "zh-Hant",
+    lang: "en",
   },
 };

--- a/docs/app/playground/templates/receipt.tsx
+++ b/docs/app/playground/templates/receipt.tsx
@@ -1,35 +1,35 @@
 const items = [
-  { name: "衣索比亞 古吉 · 250g", price: 560 },
-  { name: "冷萃咖啡", price: 200 },
-  { name: "杏仁可頌", price: 130 },
+  { name: "Guji washed · 250g", price: 18 },
+  { name: "Cold brew", price: 6 },
+  { name: "Almond croissant", price: 4 },
 ];
 
 const total = items.reduce((sum, item) => sum + item.price, 0);
 
 export default function Receipt() {
   return (
-    <div lang="zh-Hant" tw="flex w-full flex-col bg-white px-5 py-6 text-[11px] text-black">
-      <span tw="text-center text-sm font-bold tracking-[6px]">窯 咖 啡</span>
-      <span tw="mt-1 text-center text-[10px]">台北市窯街 12 號 · 02-2345-6789</span>
+    <div tw="flex w-full flex-col bg-white px-5 py-6 text-[11px] text-black">
+      <span tw="text-center text-sm font-bold tracking-[6px]">KILN COFFEE</span>
+      <span tw="mt-1 text-center text-[10px]">12 Kiln Street · 555-2345</span>
 
-      <span tw="mt-4 border-t border-black/20 pt-3">訂單 A-1182</span>
+      <span tw="mt-4 border-t border-black/20 pt-3">Order A-1182</span>
       <span>2026-03-01 09:14</span>
 
       <div tw="mt-3 flex flex-col border-t border-black/20 pt-3">
         {items.map((item) => (
           <div key={item.name} tw="flex justify-between">
             <span>{item.name}</span>
-            <span>NT${item.price}</span>
+            <span>${item.price}</span>
           </div>
         ))}
       </div>
 
       <div tw="mt-3 flex justify-between border-t border-black/20 pt-3 text-xs font-bold">
-        <span>合計</span>
-        <span>NT${total}</span>
+        <span>Total</span>
+        <span>${total}</span>
       </div>
 
-      <span tw="mt-6 text-center text-[10px]">謝謝光臨,下次見 ☕</span>
+      <span tw="mt-6 text-center text-[10px]">Thanks, see you soon ☕</span>
     </div>
   );
 }
@@ -37,7 +37,6 @@ export default function Receipt() {
 export const options: PlaygroundOptions = {
   pdf: {
     viewport: { width: 320 },
-    metadata: { title: "窯咖啡 · 訂單 A-1182", creationDate: "2026-03-01" },
-    lang: "zh-Hant",
+    metadata: { title: "Kiln Coffee · Order A-1182", creationDate: "2026-03-01" },
   },
 };

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -1,30 +1,6 @@
 import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
-const sections = [
-  {
-    title: "Summary",
-    lang: "en",
-    body: "Render throughput held steady through the quarter while the output size dropped by a fifth. The gains came from the layout cache and a tighter content stream, not from lowering quality.",
-  },
-  {
-    title: "本季重點",
-    lang: "zh-Hant",
-    body: "中位數渲染時間從 41 毫秒降到 28 毫秒。冷啟動仍然主導第一個請求,所以共用的 renderer 值得留著不要關掉。字型子集化改成逐份文件丟掉沒用到的字符,四頁的發票從 78 KB 降到 62 KB。",
-  },
-  {
-    title: "この四半期の成果",
-    lang: "ja",
-    body: "レイアウトキャッシュにより、同じ文書を二度組む必要がなくなりました。日本語の本文も欧文と同じ経路で組版され、行分割は言語ごとの規則に従います。",
-  },
-  {
-    title: "ملخص",
-    lang: "ar",
-    rtl: true,
-    body: "يجري النص العربي من اليمين إلى اليسار، ويحتفظ الجدول أدناه باتجاهه الأصلي.",
-  },
-];
-
-const days = Array.from({ length: 90 }, (_, index) => ({
+const days = Array.from({ length: 72 }, (_, index) => ({
   day: new Date(2026, 0, index + 1).toLocaleDateString("en-US", {
     month: "short",
     day: "2-digit",
@@ -38,27 +14,9 @@ export default function Report() {
   return (
     <div tw="flex w-full flex-col text-ink">
       <h1 tw="m-0 text-3xl font-semibold">Rendering report</h1>
-      <p tw="mt-2 mb-0 text-xs text-faint">
-        Q1 2026 · <span tw="text-brand">匠 Werkstatt</span>
-      </p>
+      <p tw="mt-2 mb-6 text-xs text-faint">Median render time and output size, day by day</p>
 
-      {sections.map((section) => (
-        <div key={section.title} tw="mt-8 flex flex-col">
-          <h2 lang={section.lang} tw="m-0 border-l-4 border-brand pl-3 text-lg font-semibold">
-            {section.title}
-          </h2>
-          <p
-            lang={section.lang}
-            dir={section.rtl ? "rtl" : undefined}
-            tw="mt-2 mb-0 text-sm leading-6 text-body"
-          >
-            {section.body}
-          </p>
-        </div>
-      ))}
-
-      <h2 tw="mt-8 mb-0 border-l-4 border-brand pl-3 text-lg font-semibold">Daily measurements</h2>
-      <table tw="mt-3 w-full text-xs">
+      <table tw="w-full text-xs">
         <thead>
           <tr tw="text-[11px] font-semibold text-faint">
             <th tw="border-b-2 border-brand/40 pb-2 text-left">Day</th>
@@ -90,33 +48,18 @@ export const options: PlaygroundOptions = {
       "--color-ink": "#1f2430",
       "--color-body": "#374151",
       "--color-faint": "#6b7280",
-      "--color-hairline": "#e5e7eb",
     },
   },
   pdf: {
     size: "a4",
     margin: { right: 56, left: 56 },
-    header: (
-      <div tw="flex w-full flex-col px-14 py-6">
-        <div tw="flex w-full items-end justify-between">
-          <span tw="text-lg font-semibold text-ink">匠 Werkstatt</span>
-          <span tw="text-[10px] text-faint">Rendering report · Q1 2026</span>
-        </div>
-        <div tw="mt-3 flex h-[3px] w-full bg-brand" />
-        <span tw="mt-2 text-[10px] text-faint">Prepared for the platform team</span>
-      </div>
-    ),
     footer: (
-      <div tw="flex w-full flex-col items-center pb-6">
-        <div tw="mb-2 flex h-[1px] w-[420px] bg-hairline" />
-        <span tw="text-[10px] text-faint">匠 Werkstatt · Kawagoe, Saitama · werkstatt.example</span>
-        <span tw="mt-1 text-[10px] text-faint">
-          第 <PageNumber format="trad-chinese-informal" /> 頁,共{" "}
-          <TotalPages format="trad-chinese-informal" /> 頁
+      <div tw="flex w-full justify-center pb-6 text-[10px] text-faint">
+        <span>
+          <PageNumber /> / <TotalPages />
         </span>
       </div>
     ),
-    outline: true,
     metadata: { title: "Rendering report — Q1 2026", creationDate: "2026-04-02" },
   },
 };

--- a/docs/app/playground/templates/svg-text.tsx
+++ b/docs/app/playground/templates/svg-text.tsx
@@ -1,0 +1,27 @@
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="760" height="420" viewBox="0 0 760 420">
+  <defs>
+    <path id="arc" d="M 90 380 A 290 290 0 0 1 670 380" fill="none" />
+  </defs>
+  <circle cx="380" cy="300" r="200" fill="none" stroke="#1d4ed8" stroke-width="2" />
+  <text font-family="Noto Sans" font-size="46" font-weight="700" fill="#1d4ed8">
+    <textPath href="#arc" startOffset="50%" text-anchor="middle">Text on a path</textPath>
+  </text>
+  <text x="380" y="290" font-family="Noto Sans" font-size="120" font-weight="800" fill="#0f172a" text-anchor="middle">SVG</text>
+  <text x="380" y="340" font-family="Noto Sans" font-size="28" fill="#475569" text-anchor="middle">
+    <tspan>drawn from</tspan><tspan dx="8" fill="#1d4ed8">registered fonts</tspan>
+  </text>
+</svg>`;
+
+export default function SvgText() {
+  return (
+    <div tw="flex h-full w-full items-center justify-center bg-white">
+      <img src={`data:image/svg+xml;utf8,${encodeURIComponent(svg)}`} width={760} height={420} />
+    </div>
+  );
+}
+
+export const options: PlaygroundOptions = {
+  width: 1200,
+  height: 630,
+  format: "png",
+};

--- a/docs/app/playground/templates/theme-tokens.tsx
+++ b/docs/app/playground/templates/theme-tokens.tsx
@@ -1,0 +1,42 @@
+const tiers = [
+  { name: "Base", price: "$0", tw: "bg-surface text-ink" },
+  { name: "Pro", price: "$29", tw: "bg-brand text-paper" },
+  { name: "Team", price: "$99", tw: "bg-accent text-ink" },
+];
+
+export default function Pricing() {
+  return (
+    <div tw="flex h-full w-full flex-col justify-center bg-paper p-gutter">
+      <h1 tw="m-0 text-display font-bold tracking-tight text-ink">Pricing</h1>
+      <div tw="mt-8 flex">
+        {tiers.map((tier, index) => (
+          <div
+            key={tier.name}
+            tw={`flex flex-1 flex-col rounded-card p-8 ${tier.tw} ${index ? "ml-6" : ""}`}
+          >
+            <span tw="text-3xl opacity-80">{tier.name}</span>
+            <span tw="mt-3 text-6xl font-black">{tier.price}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const options: PlaygroundOptions = {
+  width: 1200,
+  height: 630,
+  format: "png",
+  css: `
+    @theme {
+      --color-paper: #f6f5f2;
+      --color-surface: #e6e3dc;
+      --color-ink: #1c1a17;
+      --color-brand: #6d28d9;
+      --color-accent: #fcd34d;
+      --spacing-gutter: 4rem;
+      --radius-card: 1.5rem;
+      --text-display: 5rem;
+    }
+  `,
+};

--- a/docs/app/playground/templates/watermark.tsx
+++ b/docs/app/playground/templates/watermark.tsx
@@ -10,44 +10,12 @@ const clauses = [
     body: "The receiving party uses the material only to evaluate the transaction described in Schedule A. Any other use, including training a model or benchmarking against a competing product, needs written permission.",
   },
   {
-    title: "3. Named recipients",
-    body: "Disclosure inside the receiving party is limited to employees and advisers who need the material for the permitted use and who are bound by obligations at least as strict as these.",
-  },
-  {
-    title: "4. Return and destruction",
+    title: "3. Return and destruction",
     body: "On written request the receiving party returns or destroys the material within thirty days, and confirms in writing that it did. Backups made in the ordinary course may be kept until they expire.",
   },
   {
-    title: "5. Term",
+    title: "4. Term",
     body: "These obligations run for three years from the last disclosure. Material that qualifies as a trade secret stays protected for as long as it qualifies.",
-  },
-  {
-    title: "6. No licence",
-    body: "Nothing here transfers ownership or grants a licence under any patent, copyright, or trademark. The material is provided as is, with no warranty of accuracy or completeness.",
-  },
-  {
-    title: "7. Governing law",
-    body: "This agreement is governed by the laws of Taiwan. The parties submit to the exclusive jurisdiction of the Taipei District Court.",
-  },
-  {
-    title: "8. Residual knowledge",
-    body: "Nothing prevents a person from using general knowledge, skills, and experience retained in unaided memory. This clause does not license the deliberate memorisation of the material.",
-  },
-  {
-    title: "9. Notices",
-    body: "Notices are given in writing to the addresses in Schedule A, by hand, by courier, or by email with confirmed receipt. A notice takes effect when it arrives.",
-  },
-  {
-    title: "10. Assignment",
-    body: "Neither party assigns this agreement without the other's written consent, except to a successor of substantially the whole of its business, who is bound by the same obligations.",
-  },
-  {
-    title: "11. Remedies",
-    body: "The parties agree that damages alone may not remedy a breach, and that the disclosing party may seek injunctive relief without posting a bond.",
-  },
-  {
-    title: "12. Entire agreement",
-    body: "This document, with Schedule A, is the whole agreement about its subject. It replaces earlier drafts, and it changes only in writing signed by both parties.",
   },
 ];
 
@@ -75,22 +43,6 @@ function TiledWatermark({ label }: { label: string }) {
           ))}
         </div>
       ))}
-    </div>
-  );
-}
-
-function Watermark({ label }: { label: string }) {
-  return (
-    <div
-      tw="fixed inset-0 flex items-center justify-center"
-      style={{ zIndex: -1, transform: "rotate(-30deg)" }}
-    >
-      <span
-        tw="w-full text-center text-[7vw] font-bold tracking-[0.14em]"
-        style={{ color: "rgba(17,24,39,0.1)" }}
-      >
-        {label}
-      </span>
     </div>
   );
 }
@@ -139,7 +91,6 @@ export default function Agreement() {
   return (
     <div tw="flex w-full flex-col text-[#111827]">
       <TiledWatermark label="CONFIDENTIAL" />
-      <Watermark label="CONFIDENTIAL" />
       <Heading />
       {clauses.map((clause) => (
         <Clause key={clause.title} title={clause.title} body={clause.body} />

--- a/docs/app/playground/templates/welcome.tsx
+++ b/docs/app/playground/templates/welcome.tsx
@@ -16,9 +16,7 @@ export default function Welcome() {
       </h1>
       <h1 tw="m-0 mt-2 text-8xl font-bold leading-none tracking-tighter text-coral">Press Run.</h1>
       <p tw="mt-10 mb-0 text-3xl leading-snug text-faded">
-        The exported options decide what comes out: an image, an animation, or a PDF. The colours
-        come from <span tw="text-honey">the css option</span>. Rename a token and every class
-        reading it follows.
+        The <span tw="text-honey">options</span> pick the output: image, animation or PDF.
       </p>
     </div>
   );

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -180,12 +180,8 @@ async function renderRequest(renderer: Renderer, id: number, code: string) {
   // The pane compiles utilities itself, so it needs the theme as declarations
   // rather than as the `:root` rule the renderer reads.
   const theme = effectiveCss
-    .flatMap((entry) =>
-      typeof entry === "object" && "selector" in entry && entry.selector === ":root"
-        ? Object.entries(entry.style ?? {})
-        : [],
-    )
-    .map(([name, value]) => `${name}:${value};`)
+    .map(cssEntryToText)
+    .flatMap((text) => [...text.matchAll(/:root\s*\{([^{}]*)\}/g)].map(([, body]) => body))
     .join("");
   const geometry = outputGeometry(options);
 


### PR DESCRIPTION
## Why

The playground templates had drifted: the report crammed four scripts, a 90-row table, bookmarks and a counted footer into one file, and most templates were written in Chinese even when the point had nothing to do with script coverage. Nothing showed the newer `@theme`, SVG `<text>` or PDF/UA-2 support.

## What

Each template now demonstrates one thing, in English unless multilingual text is the point, and three new ones cover a Tailwind `@theme` block, SVG `<text>`/`textPath`, and PDF/A-4 with UA-2 tagging. The browser preview pane reads its theme declarations from the CSS text now, so a raw `@theme` block skins the pane the same way it skins the render.

Local renders lose CJK because the worker cannot reach Google Fonts from this machine, so the multilingual template was checked in Latin fallback only.

![Theme tokens template](https://github.com/user-attachments/assets/04cb541e-362c-462e-bd52-f3bb381982ca)

![SVG text template](https://github.com/user-attachments/assets/c5c27995-504a-4eb2-880a-2d274994f8c0)

![Tagged pages template](https://github.com/user-attachments/assets/5bf72ce6-8b0a-40c3-9987-f298f438853d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playground templates for accessible tagged PDFs, SVG text rendering, and theme-token pricing cards.
  * Added support for converting inline theme styles into usable document color variables.
* **Improvements**
  * Updated invoice and receipt templates with English content and metadata.
  * Refreshed the report template with a repeating-header table layout.
  * Updated the animation, welcome, and watermark examples for clearer demonstrations.
* **Bug Fixes**
  * Improved theme styling support in playground previews and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->