### PR TITLE
Docs: drop the For LLMs menu from the nav

### DIFF
--- a/docs/app/layout-config.tsx
+++ b/docs/app/layout-config.tsx
@@ -26,23 +26,5 @@ export const baseOptions: BaseLayoutProps = {
       text: "Showcase",
       url: "/showcase",
     },
-    {
-      text: "For LLMs",
-      type: "menu",
-      items: [
-        {
-          text: "llms.txt",
-          url: "/llms.txt",
-          description: "Outline of the documentation",
-          external: true,
-        },
-        {
-          text: "llms-full.txt",
-          url: "/llms-full.txt",
-          description: "Full text of the documentation",
-          external: true,
-        },
-      ],
-    },
   ],
 };

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -2,9 +2,6 @@
   "title": "Documentation for Takumi",
   "root": true,
   "pages": [
-    "--- For LLMs ---",
-    "[Leaf][llms.txt](https://takumi.kane.tw/llms.txt)",
-    "[Brain][llms-full.txt](https://takumi.kane.tw/llms-full.txt)",
     "--- Get started ---",
     "index",
     "integration",


### PR DESCRIPTION
## Why
The nav bar spent a whole dropdown on two text files most readers never open, and the docs sidebar repeated them in its own group.

## What
The "For LLMs" menu is gone from the header, the mobile sidebar, and the docs sidebar group in `content/docs/meta.json`. `/llms.txt` and `/llms-full.txt` are still generated and still served.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the “For LLMs” navigation menu and its links from the application navigation and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->