### PR TITLE
Docs: add a charts guide

### DIFF
--- a/docs/content/docs/charts.mdx
+++ b/docs/content/docs/charts.mdx
@@ -1,0 +1,91 @@
+---
+title: Charts
+description: Render charts from any library that outputs SVG
+icon: ChartColumn
+---
+
+Takumi renders SVG natively: any chart library that outputs an SVG string works, with no browser, DOM, or canvas. The same chart renders to a PNG for an OG image or stays vector in a PDF.
+
+## ECharts
+
+[Apache ECharts](https://echarts.apache.org) has zero-dependency server-side rendering: pass `null` as the container and read the SVG back as a string.
+
+```tsx
+import * as echarts from "echarts";
+
+const chart = echarts.init(null, null, {
+  renderer: "svg",
+  ssr: true,
+  width: 560,
+  height: 360,
+});
+
+chart.setOption({
+  animation: false,
+  xAxis: { type: "category", data: ["Q1", "Q2", "Q3", "Q4"] },
+  yAxis: { type: "value" },
+  series: [{ type: "bar", data: [320, 730, 550, 910] }],
+});
+
+const svg = chart.renderToSVGString();
+chart.dispose();
+```
+
+Set `animation: false`. An animated chart's SVG carries its first keyframe, which renders as an empty or partly drawn chart.
+
+Embed the string straight into the markup:
+
+```tsx
+import { render } from "takumi-pdf";
+
+const pdf = await render(`<div style="display:flex">${svg}</div>`, {
+  page: "a4",
+});
+```
+
+Or pass the SVG bytes through `images` and reference the key in an `<img>`:
+
+```tsx
+const pdf = await render('<img src="revenue-chart" alt="Quarterly revenue" />', {
+  page: "a4",
+  images: { "revenue-chart": new TextEncoder().encode(svg) },
+});
+```
+
+Both embedding forms also work with the raster renderers in `@takumi-rs/core` and `takumi-js`.
+
+## PDF output stays vector
+
+The chart is drawn as PDF paths, not a rasterized picture. Gradients become PDF shadings and dashed lines keep their dash pattern. A page with two full charts is around 20 KB.
+
+Text inside the chart is drawn as outlines. It is visible but not selectable or extractable. In tagged output, give the `<img>` an `alt` so the chart becomes a `Figure` with a description.
+
+## Fonts for chart labels
+
+SVG text renders through the same font registry as everything else. Missing glyphs render as tofu, so CJK labels need a registered CJK font.
+
+One catch with [`googleFonts`](/docs/typography-and-fonts): the renderer subsets fonts against the text in your element tree, and it cannot see text inside an SVG string. Filter the subsets against the label text yourself, then clear `ranges` so the renderer keeps the result:
+
+```tsx
+import { googleFonts, subsetFonts } from "@takumi-rs/helpers";
+
+const labels = ["一月", "二月", "三月", "四月"];
+const all = await googleFonts(["Noto Sans TC"]);
+const fonts = subsetFonts({ fonts: all, source: labels.join("") }).map((font) => ({
+  ...font,
+  ranges: [],
+}));
+```
+
+## Picking a library
+
+Choose a library that produces SVG without a DOM:
+
+| Library            | Server-side SVG                                                |
+| ------------------ | -------------------------------------------------------------- |
+| ECharts            | `ssr: true` + `renderToSVGString()`                            |
+| Vega / Vega-Lite   | `new View(parse(spec), { renderer: "none" })` + `view.toSVG()` |
+| d3-shape, d3-scale | Pure math; build the `<svg>` in JSX from the path strings      |
+| visx               | React SVG primitives through `renderToStaticMarkup`            |
+
+Observable Plot and Recharts need a DOM implementation on the server. Chart.js, uPlot, and lightweight-charts render to canvas only. Prefer a library from the table above.

--- a/docs/content/docs/charts.mdx
+++ b/docs/content/docs/charts.mdx
@@ -33,26 +33,20 @@ chart.dispose();
 
 Set `animation: false`. An animated chart's SVG carries its first keyframe, which renders as an empty or partly drawn chart.
 
-Embed the string straight into the markup:
+An `<img>` takes the SVG string directly as its `src`. A chart is one-off content, so nothing needs registering under `images`:
 
 ```tsx
 import { render } from "takumi-js";
 
-const png = await render(`<div style="display:flex">${svg}</div>`, {
-  width: 1200,
-  height: 630,
-});
+const png = await render(
+  <div style={{ display: "flex" }}>
+    <img src={svg} alt="Quarterly revenue" style={{ width: 560, height: 360 }} />
+  </div>,
+  { width: 1200, height: 630 },
+);
 ```
 
-Or pass the SVG bytes through `images` and reference the source in an `<img>`:
-
-```tsx
-const png = await render('<img src="revenue-chart" alt="Quarterly revenue" />', {
-  width: 1200,
-  height: 630,
-  images: [{ src: "revenue-chart", data: new TextEncoder().encode(svg) }],
-});
-```
+An HTML string works too, with the SVG inlined into the markup: ``render(`<div style="display:flex">${svg}</div>`, …)``.
 
 The same SVG stays vector in a PDF. See [Charts in PDF](/docs/pdf/charts).
 

--- a/docs/content/docs/charts.mdx
+++ b/docs/content/docs/charts.mdx
@@ -36,29 +36,25 @@ Set `animation: false`. An animated chart's SVG carries its first keyframe, whic
 Embed the string straight into the markup:
 
 ```tsx
-import { render } from "takumi-pdf";
+import { render } from "takumi-js";
 
-const pdf = await render(`<div style="display:flex">${svg}</div>`, {
-  page: "a4",
+const png = await render(`<div style="display:flex">${svg}</div>`, {
+  width: 1200,
+  height: 630,
 });
 ```
 
-Or pass the SVG bytes through `images` and reference the key in an `<img>`:
+Or pass the SVG bytes through `images` and reference the source in an `<img>`:
 
 ```tsx
-const pdf = await render('<img src="revenue-chart" alt="Quarterly revenue" />', {
-  page: "a4",
-  images: { "revenue-chart": new TextEncoder().encode(svg) },
+const png = await render('<img src="revenue-chart" alt="Quarterly revenue" />', {
+  width: 1200,
+  height: 630,
+  images: [{ src: "revenue-chart", data: new TextEncoder().encode(svg) }],
 });
 ```
 
-Both embedding forms also work with the raster renderers in `@takumi-rs/core` and `takumi-js`.
-
-## PDF output stays vector
-
-The chart is drawn as PDF paths, not a rasterized picture. Gradients become PDF shadings and dashed lines keep their dash pattern. A page with two full charts is around 20 KB.
-
-Text inside the chart is drawn as outlines. It is visible but not selectable or extractable. In tagged output, give the `<img>` an `alt` so the chart becomes a `Figure` with a description.
+The same SVG stays vector in a PDF. See [Charts in PDF](/docs/pdf/charts).
 
 ## Fonts for chart labels
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -9,6 +9,7 @@
     "--- Guides ---",
     "styling",
     "tables",
+    "charts",
     "typography-and-fonts",
     "load-images",
     "output-formats",

--- a/docs/content/docs/pdf/charts.mdx
+++ b/docs/content/docs/pdf/charts.mdx
@@ -1,0 +1,32 @@
+---
+title: Charts
+description: Vector charts from SVG-producing libraries
+icon: ChartColumn
+---
+
+A chart embedded as SVG stays vector in the PDF. It is drawn as paths, gradients become PDF shadings, and dashed lines keep their dash pattern. A page with two full charts is around 20 KB.
+
+Generate the SVG with any library that renders without a DOM, like [ECharts in SSR mode](/docs/charts):
+
+```tsx
+import { render } from "takumi-pdf";
+
+const pdf = await render(`<div style="display:flex">${svg}</div>`, {
+  page: "a4",
+});
+```
+
+Or pass the SVG bytes through `images` and reference the key in an `<img>`:
+
+```tsx
+const pdf = await render('<img src="revenue-chart" alt="Quarterly revenue" />', {
+  page: "a4",
+  images: { "revenue-chart": new TextEncoder().encode(svg) },
+});
+```
+
+## Text inside the chart
+
+Axis labels and values are drawn as outlines. They are visible but not selectable or extractable. In tagged output, give the `<img>` an `alt` so the chart becomes a `Figure` with a description.
+
+Labels need a registered font that covers them. See [fonts for chart labels](/docs/charts#fonts-for-chart-labels) for the CJK subsetting catch.

--- a/docs/content/docs/pdf/charts.mdx
+++ b/docs/content/docs/pdf/charts.mdx
@@ -6,23 +6,17 @@ icon: ChartColumn
 
 A chart embedded as SVG stays vector in the PDF. It is drawn as paths, gradients become PDF shadings, and dashed lines keep their dash pattern. A page with two full charts is around 20 KB.
 
-Generate the SVG with any library that renders without a DOM, like [ECharts in SSR mode](/docs/charts):
+Generate the SVG with any library that renders without a DOM, like [ECharts in SSR mode](/docs/charts), and hand the string to an `<img>` as its `src`:
 
 ```tsx
 import { render } from "takumi-pdf";
 
-const pdf = await render(`<div style="display:flex">${svg}</div>`, {
-  page: "a4",
-});
-```
-
-Or pass the SVG bytes through `images` and reference the key in an `<img>`:
-
-```tsx
-const pdf = await render('<img src="revenue-chart" alt="Quarterly revenue" />', {
-  page: "a4",
-  images: { "revenue-chart": new TextEncoder().encode(svg) },
-});
+const pdf = await render(
+  <div style={{ display: "flex" }}>
+    <img src={svg} alt="Quarterly revenue" style={{ width: 560, height: 360 }} />
+  </div>,
+  { page: "a4" },
+);
 ```
 
 ## Text inside the chart

--- a/docs/content/docs/pdf/meta.json
+++ b/docs/content/docs/pdf/meta.json
@@ -16,6 +16,7 @@
     "--- Use cases ---",
     "invoices",
     "reports",
+    "charts",
     "tickets",
     "--- Migration ---",
     "from-puppeteer",


### PR DESCRIPTION
## Why
Chart rendering already works through the SVG pipeline, but nothing documents it, and the font-subsetting interaction with SVG text is a silent tofu trap.

## What
A Guides page showing the ECharts SSR recipe, the three embedding forms, the vector PDF behavior, and the label-font workaround. Every claim on the page was verified by rendering through the published packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Charts guide covering server-side SVG rendering with supported chart libraries.
  * Documented embedding charts in web content and PDFs, including vector output and accessibility considerations.
  * Added guidance on PNG rendering, font handling, and CJK label support.
  * Added Charts pages to the main and PDF documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->