### PR TITLE
Playground: let templates import echarts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "beautiful-mermaid": "^1.1.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "echarts": "^6.1.0",
         "fumadocs-core": "^16.14.5",
         "fumadocs-mdx": "^15.3.0",
         "fumadocs-twoslash": "^3.3.0",
@@ -1747,6 +1748,8 @@
 
     "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
 
+    "echarts": ["echarts@6.1.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.1.0" } }, "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.412", "", {}, "sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA=="],
 
     "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
@@ -2507,7 +2510,7 @@
 
     "tsdown": ["tsdown@0.22.14", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.4", "picomatch": "^4.0.5", "rolldown": "~1.2.0", "rolldown-plugin-dts": "^0.27.13", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "verkit": "^0.3.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.14", "@tsdown/exe": "0.22.14", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ=="],
 
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+    "tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
     "turbo-stream": ["turbo-stream@3.2.1", "", {}, "sha512-BaX0eWz3IrypOVDFqPv3VGD6uZZW8y3oFAOJqZQ+oopmOyQ8/xNm7IMwAJFvxax2DBa8zSk+/AeqA6D6b1PXGg=="],
 
@@ -2667,6 +2670,8 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "zrender": ["zrender@6.1.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
@@ -2686,6 +2691,12 @@
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
@@ -2713,6 +2724,8 @@
 
     "@sveltejs/kit/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "@tailwindcss/node/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -2733,6 +2746,8 @@
 
     "@tanstack/start-plugin-core/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
 
+    "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@unocss/transformer-attributify-jsx/oxc-parser": ["oxc-parser@0.131.0", "", { "dependencies": { "@oxc-project/types": "^0.131.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.131.0", "@oxc-parser/binding-android-arm64": "0.131.0", "@oxc-parser/binding-darwin-arm64": "0.131.0", "@oxc-parser/binding-darwin-x64": "0.131.0", "@oxc-parser/binding-freebsd-x64": "0.131.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.131.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.131.0", "@oxc-parser/binding-linux-arm64-gnu": "0.131.0", "@oxc-parser/binding-linux-arm64-musl": "0.131.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.131.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.131.0", "@oxc-parser/binding-linux-riscv64-musl": "0.131.0", "@oxc-parser/binding-linux-s390x-gnu": "0.131.0", "@oxc-parser/binding-linux-x64-gnu": "0.131.0", "@oxc-parser/binding-linux-x64-musl": "0.131.0", "@oxc-parser/binding-openharmony-arm64": "0.131.0", "@oxc-parser/binding-wasm32-wasi": "0.131.0", "@oxc-parser/binding-win32-arm64-msvc": "0.131.0", "@oxc-parser/binding-win32-ia32-msvc": "0.131.0", "@oxc-parser/binding-win32-x64-msvc": "0.131.0" } }, "sha512-SJ3/7ZPbgie8dr5Z9BI/M51zZbpXba+hRSG0MDzVwMW5CRQg2fjYE0jHGlLX4eeiibGgC/mzoDFKSDHwVZEHRQ=="],
 
     "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -2742,6 +2757,8 @@
     "@vitest/mocker/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@vitest/snapshot/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "brotli/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -2758,6 +2775,8 @@
     "docs/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "framer-motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "fumadocs-ui/cnfast": ["cnfast@0.1.0", "", { "bin": { "cnfast": "bin/cli.js" } }, "sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ=="],
 
@@ -2781,6 +2800,8 @@
 
     "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 
+    "motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -2788,6 +2809,12 @@
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "puppeteer-core/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "react-remove-scroll/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "react-remove-scroll-bar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "react-style-singleton/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
 
@@ -2808,6 +2835,10 @@
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "unicode-properties/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "use-callback-ref/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "use-sidecar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -2837,13 +2868,23 @@
 
     "@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "@img/sharp-wasm32/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@napi-rs/wasm-tools-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@napi-rs/wasm-tools-wasm32-wasi/@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@napi-rs/wasm-tools-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@oxc-parser/binding-wasm32-wasi/@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
@@ -3034,5 +3075,9 @@
     "miniflare/sharp/@img/sharp-freebsd-wasm32/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "miniflare/sharp/@img/sharp-webcontainers-wasm32/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "miniflare/sharp/@img/sharp-freebsd-wasm32/@img/sharp-wasm32/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "miniflare/sharp/@img/sharp-webcontainers-wasm32/@img/sharp-wasm32/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
   }
 }

--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -82,11 +82,11 @@ const announce = () => {
     sheet.textContent = paint.data.css;
     mount.style.cssText = paint.data.mountStyle;
     mount.innerHTML = paint.data.html;
-    // Takumi accepts inline SVG markup as an image source; a browser needs it
-    // wrapped in a data URI.
+    // Takumi treats any source containing "<svg" as inline SVG markup; a
+    // browser needs it wrapped in a data URI.
     for (const img of mount.querySelectorAll("img")) {
       const src = img.getAttribute("src") ?? "";
-      if (src.trimStart().startsWith("<svg"))
+      if (src.includes("<svg"))
         img.src = "data:image/svg+xml;utf8," + encodeURIComponent(src);
     }
     observer.observe(mount);

--- a/docs/app/components/playground/browser-preview.tsx
+++ b/docs/app/components/playground/browser-preview.tsx
@@ -82,6 +82,13 @@ const announce = () => {
     sheet.textContent = paint.data.css;
     mount.style.cssText = paint.data.mountStyle;
     mount.innerHTML = paint.data.html;
+    // Takumi accepts inline SVG markup as an image source; a browser needs it
+    // wrapped in a data URI.
+    for (const img of mount.querySelectorAll("img")) {
+      const src = img.getAttribute("src") ?? "";
+      if (src.trimStart().startsWith("<svg"))
+        img.src = "data:image/svg+xml;utf8," + encodeURIComponent(src);
+    }
     observer.observe(mount);
   };
   parent.postMessage({ type: "ready" }, "*", [channel.port2]);

--- a/docs/app/components/playground/component-editor.tsx
+++ b/docs/app/components/playground/component-editor.tsx
@@ -7,12 +7,47 @@ import { useEffect, useRef, useState } from "react";
 import type { ComponentProps } from "react";
 import { createHighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine-oniguruma.mjs";
-import pdfPrimitivesTypings from "../../../node_modules/takumi-pdf/dist/primitives.d.mts?raw";
-import takumiTypings from "../../../node_modules/@takumi-rs/wasm/pkg/takumi_wasm_bg.wasm.d.ts?raw";
-import reactTypings from "../../../node_modules/@types/react/index.d.ts?raw";
-import reactJsxRuntimeTypings from "../../../node_modules/@types/react/jsx-runtime.d.ts?raw";
-import cssTypings from "../../../node_modules/csstype/index.d.ts?raw";
-import playgroundOptionsTypings from "../../playground/options.ts?raw";
+// Dynamic imports keep the typings out of the playground chunk; they load as
+// their own chunks alongside the editor.
+const [
+  reactTypings,
+  reactJsxRuntimeTypings,
+  cssTypings,
+  takumiTypings,
+  pdfPrimitivesTypings,
+  playgroundOptionsTypings,
+  echartsCoreTypings,
+  echartsChartsTypings,
+  echartsComponentsTypings,
+  echartsRenderersTypings,
+  echartsSharedTypings,
+] = await Promise.all([
+  import("../../../node_modules/@types/react/index.d.ts?raw").then((module) => module.default),
+  import("../../../node_modules/@types/react/jsx-runtime.d.ts?raw").then(
+    (module) => module.default,
+  ),
+  import("../../../node_modules/csstype/index.d.ts?raw").then((module) => module.default),
+  import("../../../node_modules/@takumi-rs/wasm/pkg/takumi_wasm_bg.wasm.d.ts?raw").then(
+    (module) => module.default,
+  ),
+  import("../../../node_modules/takumi-pdf/dist/primitives.d.mts?raw").then(
+    (module) => module.default,
+  ),
+  import("../../playground/options.ts?raw").then((module) => module.default),
+  import("../../../node_modules/echarts/types/dist/core.d.ts?raw").then((module) => module.default),
+  import("../../../node_modules/echarts/types/dist/charts.d.ts?raw").then(
+    (module) => module.default,
+  ),
+  import("../../../node_modules/echarts/types/dist/components.d.ts?raw").then(
+    (module) => module.default,
+  ),
+  import("../../../node_modules/echarts/types/dist/renderers.d.ts?raw").then(
+    (module) => module.default,
+  ),
+  import("../../../node_modules/echarts/types/dist/shared.d.ts?raw").then(
+    (module) => module.default,
+  ),
+]);
 
 function createHighlighter() {
   return createHighlighterCore({
@@ -121,6 +156,10 @@ export function ComponentEditor({
           esModuleInterop: true,
           jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
           typeRoots: ["node_modules/@types"],
+          baseUrl: "file:///",
+          paths: {
+            "echarts/*": ["node_modules/echarts/types/dist/*"],
+          },
         });
 
         monaco.languages.typescript.typescriptDefaults.setExtraLibs([
@@ -147,6 +186,26 @@ export function ComponentEditor({
           {
             content: playgroundOptionsTypings,
             filePath: "file:///options.d.ts",
+          },
+          {
+            content: echartsCoreTypings,
+            filePath: "file:///node_modules/echarts/types/dist/core.d.ts",
+          },
+          {
+            content: echartsChartsTypings,
+            filePath: "file:///node_modules/echarts/types/dist/charts.d.ts",
+          },
+          {
+            content: echartsComponentsTypings,
+            filePath: "file:///node_modules/echarts/types/dist/components.d.ts",
+          },
+          {
+            content: echartsRenderersTypings,
+            filePath: "file:///node_modules/echarts/types/dist/renderers.d.ts",
+          },
+          {
+            content: echartsSharedTypings,
+            filePath: "file:///node_modules/echarts/types/dist/shared.d.ts",
           },
           {
             content: tailwindTypings,

--- a/docs/app/components/playground/output-panel.tsx
+++ b/docs/app/components/playground/output-panel.tsx
@@ -218,6 +218,26 @@ function PdfPreview({ url, dimmed }: { url: string | undefined; dimmed: boolean 
   );
 }
 
+/** The pane before any output exists: a review prompt for shared code, a progress line otherwise. */
+function IdlePane({ isReady, waitingForRun }: { isReady: boolean; waitingForRun?: boolean }) {
+  if (waitingForRun) {
+    return (
+      <div className="flex h-full items-center justify-center bg-muted/20 font-mono text-xs text-muted-foreground">
+        Read the code, then press Run.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center gap-2 bg-muted/20 font-mono text-xs text-muted-foreground">
+      <Loader2Icon className="size-3.5 animate-spin" />
+      <span className={isReady ? undefined : "playground-breathe"}>
+        {isReady ? "rendering…" : "loading wasm…"}
+      </span>
+    </div>
+  );
+}
+
 export function OutputPanel({
   lastSuccess,
   error,
@@ -235,22 +255,7 @@ export function OutputPanel({
   waitingForRun?: boolean;
 }) {
   if (!lastSuccess && !error) {
-    if (waitingForRun) {
-      return (
-        <div className="flex h-full items-center justify-center bg-muted/20 font-mono text-xs text-muted-foreground">
-          Read the code, then press Run.
-        </div>
-      );
-    }
-
-    return (
-      <div className="flex h-full items-center justify-center gap-2 bg-muted/20 font-mono text-xs text-muted-foreground">
-        <Loader2Icon className="size-3.5 animate-spin" />
-        <span className={isReady ? undefined : "playground-breathe"}>
-          {isReady ? "rendering…" : "loading wasm…"}
-        </span>
-      </div>
-    );
+    return <IdlePane isReady={isReady} waitingForRun={waitingForRun} />;
   }
 
   // The browser's own PDF viewer brings paging, zoom and text selection, which

--- a/docs/app/components/playground/output-panel.tsx
+++ b/docs/app/components/playground/output-panel.tsx
@@ -224,14 +224,25 @@ export function OutputPanel({
   zoom,
   isReady,
   pdfView,
+  waitingForRun,
 }: {
   lastSuccess: RenderSuccess | undefined;
   error: RenderError | undefined;
   zoom: Zoom;
   isReady: boolean;
   pdfView: PdfView;
+  /** Shared code renders nothing until the reader has pressed Run themselves. */
+  waitingForRun?: boolean;
 }) {
   if (!lastSuccess && !error) {
+    if (waitingForRun) {
+      return (
+        <div className="flex h-full items-center justify-center bg-muted/20 font-mono text-xs text-muted-foreground">
+          Read the code, then press Run.
+        </div>
+      );
+    }
+
     return (
       <div className="flex h-full items-center justify-center gap-2 bg-muted/20 font-mono text-xs text-muted-foreground">
         <Loader2Icon className="size-3.5 animate-spin" />

--- a/docs/app/components/playground/playground.tsx
+++ b/docs/app/components/playground/playground.tsx
@@ -67,6 +67,12 @@ export default function Playground() {
     if (ranCode === undefined && code !== undefined && !isShared) setRanCode(code);
   }, [code, ranCode, isShared]);
 
+  // A hash change clears the code while the next link decompresses; clearing
+  // what ran with it puts a newly opened share back behind Run.
+  useEffect(() => {
+    if (code === undefined) setRanCode(undefined);
+  }, [code]);
+
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {

--- a/docs/app/components/playground/playground.tsx
+++ b/docs/app/components/playground/playground.tsx
@@ -154,6 +154,7 @@ export default function Playground() {
       zoom={zoom}
       isReady={isReady}
       pdfView={pdfView}
+      waitingForRun={isUnrunShare}
     />
   );
   const browserPane = (

--- a/docs/app/components/playground/use-render-worker.ts
+++ b/docs/app/components/playground/use-render-worker.ts
@@ -149,7 +149,16 @@ export function useRenderWorker(ranCode: string | undefined) {
   }, [generation]);
 
   useEffect(() => {
-    if (!isReady || ranCode === undefined) return;
+    // A cleared editor (a new share decompressing) drops the previous run, so
+    // the pane returns to its idle prompt instead of stale output.
+    if (ranCode === undefined) {
+      setLastSuccess(undefined);
+      setRenderError(undefined);
+      setBrowserPreview(undefined);
+      return;
+    }
+
+    if (!isReady) return;
 
     const requestId = currentRequestIdRef.current + 1;
     currentRequestIdRef.current = requestId;

--- a/docs/app/components/playground/use-render-worker.ts
+++ b/docs/app/components/playground/use-render-worker.ts
@@ -150,8 +150,10 @@ export function useRenderWorker(ranCode: string | undefined) {
 
   useEffect(() => {
     // A cleared editor (a new share decompressing) drops the previous run, so
-    // the pane returns to its idle prompt instead of stale output.
+    // the pane returns to its idle prompt instead of stale output. Bumping the
+    // request id orphans an in-flight result that would paint over it.
     if (ranCode === undefined) {
+      currentRequestIdRef.current += 1;
       setLastSuccess(undefined);
       setRenderError(undefined);
       setBrowserPreview(undefined);

--- a/docs/app/playground/evaluate.ts
+++ b/docs/app/playground/evaluate.ts
@@ -10,6 +10,36 @@ const MODULES: Record<string, unknown> = {
   "takumi-pdf/primitives": primitives,
 };
 
+// zrender reads the Node `global`, which a worker does not define.
+function shimGlobal() {
+  if (!("global" in globalThis)) Reflect.set(globalThis, "global", globalThis);
+}
+
+/// Heavy modules fetched as their own chunk the first time a template imports them.
+const LAZY_MODULES: Record<string, () => Promise<unknown>> = {
+  "echarts/core": () => import("echarts/core"),
+  "echarts/charts": () => import("echarts/charts"),
+  "echarts/components": () => import("echarts/components"),
+  "echarts/renderers": () => import("echarts/renderers"),
+};
+
+async function loadLazyModules(transformed: string) {
+  const ids = new Set(
+    [...transformed.matchAll(/\brequire\((['"])([^'"]+)\1\)/g)].map((match) => match[2]),
+  );
+
+  const pending = Object.entries(LAZY_MODULES).filter(([id]) => ids.has(id) && !(id in MODULES));
+
+  // Every lazy module is echarts today.
+  if (pending.length > 0) shimGlobal();
+
+  await Promise.all(
+    pending.map(async ([id, load]) => {
+      MODULES[id] = await load();
+    }),
+  );
+}
+
 function requireModule(id: string): unknown {
   const module = MODULES[id];
 
@@ -31,10 +61,14 @@ function transformCode(code: string) {
   }).code;
 }
 
-export function evaluateCodeExports(code: string, react: typeof React) {
+export async function evaluateCodeExports(code: string, react: typeof React) {
+  const transformed = transformCode(code);
+
+  await loadLazyModules(transformed);
+
   const exports = {};
 
-  new Function("exports", "require", "React", transformCode(code))(exports, requireModule, react);
+  new Function("exports", "require", "React", transformed)(exports, requireModule, react);
 
   return exportsSchema.parse(exports);
 }

--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -103,7 +103,7 @@ export const templates: Template[] = [
   {
     id: "report",
     name: "Paged table",
-    description: "A long table whose header repeats on every page",
+    description: "An ECharts line chart above a long table whose header repeats on every page",
     kind: "pdf",
     code: report,
   },

--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -1,5 +1,6 @@
 import animatedShowcase from "./templates/animated-showcase?raw";
 import accessible from "./templates/accessible?raw";
+import analyticsChart from "./templates/analytics-chart?raw";
 import articleCover from "./templates/article-cover?raw";
 import gradientPoster from "./templates/gradient-poster?raw";
 import invoice from "./templates/invoice?raw";
@@ -70,6 +71,13 @@ export const templates: Template[] = [
     description: "An SVG source whose <text> and textPath draw from the registered fonts",
     kind: "image",
     code: svgText,
+  },
+  {
+    id: "analytics-chart",
+    name: "Analytics chart",
+    description: "An ECharts SVG rendered off-DOM, passed straight to an img src",
+    kind: "image",
+    code: analyticsChart,
   },
   {
     id: "keyframe-animation",

--- a/docs/app/playground/templates/analytics-chart.tsx
+++ b/docs/app/playground/templates/analytics-chart.tsx
@@ -1,0 +1,52 @@
+import { init, use } from "echarts/core";
+import { BarChart } from "echarts/charts";
+import { GridComponent } from "echarts/components";
+import { SVGRenderer } from "echarts/renderers";
+
+use([BarChart, GridComponent, SVGRenderer]);
+
+const chart = init(null, null, { renderer: "svg", ssr: true, width: 1072, height: 320 });
+
+chart.setOption({
+  animation: false,
+  grid: { left: 0, right: 0, top: 10, bottom: 0, containLabel: true },
+  xAxis: {
+    type: "category",
+    data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    axisLine: { show: false },
+    axisTick: { show: false },
+    axisLabel: { color: "#666666", fontSize: 13, margin: 14 },
+  },
+  yAxis: {
+    type: "value",
+    splitLine: { lineStyle: { color: "#1f1f1f" } },
+    axisLabel: { color: "#666666", fontSize: 13 },
+  },
+  series: [
+    {
+      type: "bar",
+      data: [420, 561, 483, 610, 745, 380, 290],
+      itemStyle: { color: "#0070f3", borderRadius: [4, 4, 0, 0] },
+      barWidth: 28,
+    },
+  ],
+});
+
+const svg = chart.renderToSVGString();
+
+export default function AnalyticsChart() {
+  return (
+    <div tw="flex h-full w-full bg-black p-10 text-white">
+      <div tw="flex h-full w-full flex-col rounded-xl border border-[#1f1f1f] bg-[#0a0a0a] p-10">
+        <span tw="text-sm font-medium tracking-widest text-[#888888] uppercase">Renders</span>
+        <div tw="mt-2 flex items-baseline">
+          <span tw="text-5xl font-semibold tracking-tight">3,489</span>
+          <span tw="ml-4 text-lg text-[#666666]">past 7 days</span>
+        </div>
+        <img src={svg} width={1072} height={320} tw="mt-8" />
+      </div>
+    </div>
+  );
+}
+
+export const options: PlaygroundOptions = { width: 1200, height: 630, format: "png" };

--- a/docs/app/playground/templates/analytics-chart.tsx
+++ b/docs/app/playground/templates/analytics-chart.tsx
@@ -1,21 +1,42 @@
 import { init, use } from "echarts/core";
-import { BarChart } from "echarts/charts";
+import { BarChart, LineChart } from "echarts/charts";
 import { GridComponent } from "echarts/components";
 import { SVGRenderer } from "echarts/renderers";
 
-use([BarChart, GridComponent, SVGRenderer]);
+use([BarChart, LineChart, GridComponent, SVGRenderer]);
 
-const chart = init(null, null, { renderer: "svg", ssr: true, width: 1072, height: 320 });
+const start = new Date(2026, 7, 3);
+const renders = Array.from({ length: 28 }, (_, index) => {
+  const weekend = index % 7 >= 5;
+  const base = (2400 + index * 65) * (weekend ? 0.55 : 1);
+
+  return Math.round(base + Math.sin(index * 1.3) * 140);
+});
+const average = renders.map((_, index) => {
+  const window = renders.slice(Math.max(0, index - 6), index + 1);
+
+  return Math.round(window.reduce((sum, value) => sum + value, 0) / window.length);
+});
+const labels = renders.map((_, index) => {
+  const date = new Date(start);
+
+  date.setDate(start.getDate() + index);
+
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+});
+const total = renders.reduce((sum, value) => sum + value, 0);
+
+const chart = init(null, null, { renderer: "svg", ssr: true, width: 1072, height: 300 });
 
 chart.setOption({
   animation: false,
-  grid: { left: 0, right: 0, top: 10, bottom: 0, containLabel: true },
+  grid: { left: 0, right: 0, top: 10, bottom: 0 },
   xAxis: {
     type: "category",
-    data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+    data: labels,
     axisLine: { show: false },
     axisTick: { show: false },
-    axisLabel: { color: "#666666", fontSize: 13, margin: 14 },
+    axisLabel: { color: "#666666", fontSize: 13, margin: 14, interval: 6 },
   },
   yAxis: {
     type: "value",
@@ -25,25 +46,41 @@ chart.setOption({
   series: [
     {
       type: "bar",
-      data: [420, 561, 483, 610, 745, 380, 290],
-      itemStyle: { color: "#0070f3", borderRadius: [4, 4, 0, 0] },
-      barWidth: 28,
+      data: renders,
+      itemStyle: { color: "#0070f3", borderRadius: [3, 3, 0, 0] },
+      barWidth: 16,
+    },
+    {
+      type: "line",
+      data: average,
+      symbol: "none",
+      lineStyle: { color: "#ededed", width: 2 },
     },
   ],
 });
 
 const svg = chart.renderToSVGString();
 
+chart.dispose();
+
 export default function AnalyticsChart() {
   return (
     <div tw="flex h-full w-full bg-black p-10 text-white">
       <div tw="flex h-full w-full flex-col rounded-xl border border-[#1f1f1f] bg-[#0a0a0a] p-10">
-        <span tw="text-sm font-medium tracking-widest text-[#888888] uppercase">Renders</span>
-        <div tw="mt-2 flex items-baseline">
-          <span tw="text-5xl font-semibold tracking-tight">3,489</span>
-          <span tw="ml-4 text-lg text-[#666666]">past 7 days</span>
+        <div tw="flex items-center justify-between">
+          <span tw="text-sm font-medium tracking-widest text-[#888888] uppercase">Renders</span>
+          <div tw="flex items-center text-sm text-[#888888]">
+            <span tw="h-2.5 w-2.5 rounded-sm bg-[#0070f3]" />
+            <span tw="ml-2">daily</span>
+            <span tw="ml-5 h-0.5 w-4 bg-[#ededed]" />
+            <span tw="ml-2">7-day average</span>
+          </div>
         </div>
-        <img src={svg} width={1072} height={320} tw="mt-8" />
+        <div tw="mt-2 flex items-baseline">
+          <span tw="text-5xl font-semibold tracking-tight">{total.toLocaleString("en-US")}</span>
+          <span tw="ml-4 text-lg text-[#666666]">past 4 weeks · weekends dip, trend climbs</span>
+        </div>
+        <img src={svg} width={1072} height={300} tw="mt-8" />
       </div>
     </div>
   );

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -1,20 +1,154 @@
+import { init, use } from "echarts/core";
+import { BarChart, LineChart } from "echarts/charts";
+import { GridComponent } from "echarts/components";
+import { SVGRenderer } from "echarts/renderers";
 import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
-const days = Array.from({ length: 72 }, (_, index) => ({
-  day: new Date(2026, 0, index + 1).toLocaleDateString("en-US", {
-    month: "short",
-    day: "2-digit",
-  }),
-  median: 41 - (index % 13),
-  p95: 96 - (index % 13) * 2,
-  size: 78 - (index % 13) * 1.2,
-}));
+use([BarChart, LineChart, GridComponent, SVGRenderer]);
+
+const days = Array.from({ length: 72 }, (_, index) => {
+  const released = index >= 30;
+  const median = Math.round((44 + Math.sin(index * 0.9) * 3) * (released ? 0.72 : 1));
+  const incident = index === 12 || index === 47 ? 55 : 0;
+  const weekend = index % 7 >= 5 ? 0.6 : 1;
+  const png = Math.round((1850 + index * 6 + Math.sin(index * 1.3) * 120) * weekend);
+  const webp = Math.round((640 + index * 5) * weekend);
+  const pdf = Math.round((released ? 180 + (index - 30) * 14 : 0) * weekend);
+
+  return {
+    day: new Date(2026, 0, index + 1).toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+    }),
+    median,
+    p95: Math.round(median * 2.1 + Math.sin(index * 1.7) * 6 + incident),
+    png,
+    webp,
+    pdf,
+  };
+});
+
+const weeks = Array.from({ length: Math.floor(days.length / 7) }, (_, index) => {
+  const chunk = days.slice(index * 7, index * 7 + 7);
+  const sum = (key: "png" | "webp" | "pdf") => chunk.reduce((total, row) => total + row[key], 0);
+
+  return { label: chunk[0].day, png: sum("png"), webp: sum("webp"), pdf: sum("pdf") };
+});
+
+const axis = {
+  axisLine: { show: false },
+  axisTick: { show: false },
+  axisLabel: { color: "#6b7280", fontSize: 9 },
+};
+
+function chartSvg(height: number, option: object) {
+  const chart = init(null, null, { renderer: "svg", ssr: true, width: 483, height });
+
+  chart.setOption({
+    animation: false,
+    textStyle: { fontFamily: "Noto Sans, Geist" },
+    grid: { left: 0, right: 0, top: 8, bottom: 0 },
+    yAxis: {
+      type: "value",
+      splitLine: { lineStyle: { color: "#e5e7eb" } },
+      axisLabel: axis.axisLabel,
+    },
+    ...option,
+  });
+
+  const svg = chart.renderToSVGString();
+
+  chart.dispose();
+
+  return svg;
+}
+
+const latencySvg = chartSvg(160, {
+  xAxis: {
+    type: "category",
+    data: days.map((row) => row.day),
+    ...axis,
+    axisLabel: { ...axis.axisLabel, interval: 12 },
+  },
+  series: [
+    {
+      type: "line",
+      data: days.map((row) => row.median),
+      symbol: "none",
+      lineStyle: { color: "#0d9488", width: 1.5 },
+    },
+    {
+      type: "line",
+      data: days.map((row) => row.p95),
+      symbol: "none",
+      lineStyle: { color: "#6b7280", width: 1, type: "dashed" },
+    },
+  ],
+});
+
+const volumeSvg = chartSvg(150, {
+  xAxis: { type: "category", data: weeks.map((week) => week.label), ...axis },
+  series: [
+    {
+      type: "bar",
+      stack: "renders",
+      data: weeks.map((week) => week.png),
+      itemStyle: { color: "#0d9488" },
+      barWidth: 22,
+    },
+    {
+      type: "bar",
+      stack: "renders",
+      data: weeks.map((week) => week.webp),
+      itemStyle: { color: "#5eead4" },
+    },
+    {
+      type: "bar",
+      stack: "renders",
+      data: weeks.map((week) => week.pdf),
+      itemStyle: { color: "#9ca3af" },
+      barWidth: 22,
+    },
+  ],
+});
+
+function Legend({ entries }: { entries: [string, string][] }) {
+  return (
+    <div tw="mt-5 flex items-center text-[10px] text-faint">
+      {entries.map(([color, label]) => (
+        <div key={label} tw="mr-4 flex items-center">
+          <span tw="h-2 w-2 rounded-sm" style={{ backgroundColor: color }} />
+          <span tw="ml-1.5">{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function Report() {
   return (
     <div tw="flex w-full flex-col text-ink">
       <h1 tw="m-0 text-3xl font-semibold">Rendering report</h1>
-      <p tw="mt-2 mb-6 text-xs text-faint">Median render time and output size, day by day</p>
+      <p tw="mt-2 mb-0 text-xs text-faint">
+        Q1 2026 · v1.4 shipped Jan 31: layout got 28% cheaper and PDF output went live
+      </p>
+
+      <Legend
+        entries={[
+          ["#0d9488", "median (ms)"],
+          ["#6b7280", "p95 (ms)"],
+        ]}
+      />
+      <img src={latencySvg} width={483} height={160} tw="mt-2" />
+
+      <Legend
+        entries={[
+          ["#0d9488", "PNG"],
+          ["#5eead4", "WebP"],
+          ["#9ca3af", "PDF"],
+        ]}
+      />
+      <img src={volumeSvg} width={483} height={150} tw="mt-2 mb-6" />
 
       <table tw="w-full text-xs">
         <thead>
@@ -22,7 +156,7 @@ export default function Report() {
             <th tw="border-b-2 border-brand/40 pb-2 text-left">Day</th>
             <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">Median (ms)</th>
             <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">p95 (ms)</th>
-            <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">Size (KB)</th>
+            <th tw="w-[110px] border-b-2 border-brand/40 pb-2 text-right">Renders</th>
           </tr>
         </thead>
         <tbody>
@@ -31,7 +165,9 @@ export default function Report() {
               <td tw="pt-2">{row.day}</td>
               <td tw="pt-2 text-right text-body">{row.median}</td>
               <td tw="pt-2 text-right text-body">{row.p95}</td>
-              <td tw="pt-2 text-right text-body">{row.size.toFixed(1)}</td>
+              <td tw="pt-2 text-right text-body">
+                {(row.png + row.webp + row.pdf).toLocaleString("en-US")}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/docs/app/playground/templates/report.tsx
+++ b/docs/app/playground/templates/report.tsx
@@ -46,7 +46,6 @@ function chartSvg(height: number, option: object) {
 
   chart.setOption({
     animation: false,
-    textStyle: { fontFamily: "Noto Sans, Geist" },
     grid: { left: 0, right: 0, top: 8, bottom: 0 },
     yAxis: {
       type: "value",

--- a/docs/app/playground/worker.ts
+++ b/docs/app/playground/worker.ts
@@ -5,8 +5,7 @@ import type { FetchedImage, Node } from "takumi-js/helpers";
 import wasm, { init, Renderer } from "takumi-js/wasm";
 import pdfWasm from "takumi-pdf/wasm-url";
 // `no-init` over the entry that instantiates the module: the worker has the
-// asset URL already, and that entry needs top-level await, which an iife worker
-// bundle cannot have.
+// asset URL already, and instantiating up front would defeat the lazy fetch.
 import initPdf, { PdfRenderer } from "takumi-pdf/no-init";
 import type { JSXElementConstructor } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -171,7 +170,7 @@ async function renderOutput({
 }
 
 async function renderRequest(renderer: Renderer, id: number, code: string) {
-  const { default: component, options } = evaluateCodeExports(code, renderReact);
+  const { default: component, options } = await evaluateCodeExports(code, renderReact);
   const element = renderReact.createElement(component as JSXElementConstructor<unknown>);
   const { node, css: extractedCss } = await fromJsx(element);
   const optionCss =

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "beautiful-mermaid": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "echarts": "^6.1.0",
     "fumadocs-core": "^16.14.5",
     "fumadocs-mdx": "^15.3.0",
     "fumadocs-twoslash": "^3.3.0",

--- a/docs/waku.config.ts
+++ b/docs/waku.config.ts
@@ -5,6 +5,11 @@ import { defineConfig } from "waku/config";
 
 export default defineConfig({
   vite: {
+    // The render worker splits lazily-imported template modules (echarts) into
+    // their own chunks, which an iife worker bundle would inline instead.
+    worker: {
+      format: "es",
+    },
     ssr: {
       external: ["typescript", "twoslash", "shiki", "@takumi-rs/core"],
     },


### PR DESCRIPTION
## Why
Templates can only import `takumi-pdf/primitives`, so one that wants a chart has nowhere to get it.

## What
Templates can now import the `echarts/core` entry points, fetched lazily as their own chunks so the worker bundle stays the same size, with typings wired into the editor and an Analytics chart template that passes the SVG straight to an `img` src. The editor typings also moved to lazy chunks, which shrinks the playground chunk from 1.8 MB to 265 kB, and a shared link's output pane now asks the reader to review the code instead of showing a spinner.

![Analytics chart template rendered in the playground](https://github.com/user-attachments/assets/cdc9a5c3-a745-4e53-b541-c8b47cd03af2)

![Shared link output pane prompting to read the code before Run](https://github.com/user-attachments/assets/2158a7cb-2427-4059-a724-ebe2cb069cb6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an analytics chart template for PNG dashboard visuals.
  * Added ECharts support for chart-based playground templates, including analytics and rendering reports.
  * Reports now include latency, render-volume charts, totals, and visualization legends.
  * Added clearer guidance when shared playground code has not yet been run.

* **Bug Fixes**
  * Improved inline SVG rendering, chart code completion, and module loading.
  * Fixed stale playground output when opening shared links or clearing code.
  * Enhanced compatibility when rendering chart-based templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->