### PR TITLE
Showcase: Add Enka Embed entry to showcase

### DIFF
--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -109,6 +109,13 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
+    image: "https://card.astrxl.dev/banner.webp",
+    url: "https://git.astrxl.dev/astral/api",
+    title: "Enka Embed",
+    width: 1359,
+    height: 604,
+  },
+  {
     url: "https://who-to-bother-at.com",
     image: "https://who-to-bother-at.com/og/vercel",
     width: 1200,

--- a/docs/app/data/showcase.ts
+++ b/docs/app/data/showcase.ts
@@ -109,7 +109,7 @@ export const showcaseProjects: Project[] = [
     height: 630,
   },
   {
-    image: "https://card.astrxl.dev/banner.webp",
+    image: "https://cdn.astrxl.dev/takumi-enka-embed-example.webp",
     url: "https://git.astrxl.dev/astral/api",
     title: "Enka Embed",
     width: 1359,


### PR DESCRIPTION
Hi, I've been using Takumi to generate image cards for showing ingame characters, weapons, artifacts stats for a game Genshin Impact, utilizing Enka.Network API as the data source. It's been great and stable for few months now so I want to put it on showcase as well :>(also ngl Takumi handles complex flex layout super well for this job, sometimes even better than traditional renderer that utilizes puppeteer, somehow)

Here's uh... free samples (might not load due to github's image loading timeout):
![Profile Card](https://api.astrxl.dev/v1/card/genshin/775956514?error=card)
![Character Card](https://api.astrxl.dev/v1/card/genshin/775956514/ororon?error=card)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Enka Embed to the project showcase, including a preview image and repository link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->