### PR TITLE
Core: keep parsing a stylesheet past an unknown media query

### DIFF
--- a/.tegami/media-query-not-all.md
+++ b/.tegami/media-query-not-all.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "takumi-core":
+    type: patch
+---
+
+### Keep parsing a stylesheet past an unknown media query
+
+An unknown media feature such as `(prefers-color-scheme: dark)` used to fail
+the whole stylesheet. The query now matches nothing and the rest of the sheet
+still applies, as the spec requires.

--- a/takumi-core/src/style/media_query.rs
+++ b/takumi-core/src/style/media_query.rs
@@ -170,7 +170,7 @@ impl MediaQueryList {
           .filter(|_| input.is_exhausted())
           .unwrap_or_else(MediaQuery::not_all);
 
-        while input.next().is_ok() {}
+        skip_malformed_query(input)?;
 
         Ok(query)
       })?,
@@ -198,6 +198,32 @@ impl MediaQueryList {
       .queries
       .iter()
       .any(|query| query.matches(viewport, &sizing))
+  }
+}
+
+/// Consumes what is left of a query that parsed as `not all`. A block or a
+/// stray closing delimiter means the text was never a prelude, which is how a
+/// caller assembling CSS from strings catches a rule smuggled into one.
+fn skip_malformed_query<'i>(
+  input: &mut Parser<'i, '_>,
+) -> Result<(), ParseError<'i, StyleSheetParseError>> {
+  loop {
+    let location = input.current_source_location();
+    let Ok(token) = input.next() else {
+      return Ok(());
+    };
+
+    if matches!(
+      token,
+      Token::CurlyBracketBlock
+        | Token::CloseCurlyBracket
+        | Token::CloseParenthesis
+        | Token::CloseSquareBracket
+    ) {
+      let token = token.clone();
+
+      return Err(location.new_unexpected_token_error(token));
+    }
   }
 }
 

--- a/takumi-core/src/style/media_query.rs
+++ b/takumi-core/src/style/media_query.rs
@@ -128,6 +128,16 @@ impl MediaFeature {
 }
 
 impl MediaQuery {
+  /// The `not all` an unknown or malformed query is replaced by.
+  /// <https://drafts.csswg.org/mediaqueries-4/#error-handling>
+  fn not_all() -> Self {
+    Self {
+      media_type: MediaType::All,
+      features: Vec::new(),
+      negated: true,
+    }
+  }
+
   fn matches(&self, viewport: Viewport, sizing: &SizingContext) -> bool {
     let media_type_matches = match &self.media_type {
       MediaType::All | MediaType::Screen => true,
@@ -153,7 +163,17 @@ impl MediaQueryList {
     input: &mut Parser<'i, 't>,
   ) -> Result<Self, ParseError<'i, StyleSheetParseError>> {
     Ok(Self {
-      queries: input.parse_comma_separated(parse_media_query)?,
+      queries: input.parse_comma_separated(|input| {
+        let query = input
+          .try_parse(parse_media_query)
+          .ok()
+          .filter(|_| input.is_exhausted())
+          .unwrap_or_else(MediaQuery::not_all);
+
+        while input.next().is_ok() {}
+
+        Ok(query)
+      })?,
     })
   }
 

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -2018,8 +2018,38 @@ mod tests {
   }
 
   #[test]
-  fn test_parse_media_rule_rejects_opposing_range_comparisons() {
-    assert!(StyleSheet::parse("@media (400px < width > 700px) { .card { width: 1px; } }").is_err());
+  fn test_parse_media_rule_replaces_malformed_queries_with_not_all() {
+    for prelude in [
+      "(400px < width > 700px)",
+      "(unsupported-feature: 10px)",
+      "not (unsupported-feature: 10px)",
+      "(min-width: 600px) trailing-junk",
+      "braille",
+    ] {
+      let sheet = parse_stylesheet(&format!("@media {prelude} {{ .card {{ width: 100px; }} }}"));
+      let Some(media) = sheet.rules[0].media_queries.first() else {
+        unreachable!("expected media queries on parsed rule: {prelude}");
+      };
+
+      assert!(!media.matches(Viewport::new((800, 600))), "{prelude}");
+    }
+  }
+
+  #[test]
+  fn test_parse_media_rule_keeps_valid_queries_beside_malformed_ones() {
+    let sheet = parse_stylesheet(
+      r#"
+        @media (unsupported-feature: 10px), (min-width: 600px) {
+          .card { width: 100px; }
+        }
+      "#,
+    );
+
+    let Some(media) = sheet.rules[0].media_queries.first() else {
+      unreachable!("expected media queries on parsed rule");
+    };
+    assert!(media.matches(Viewport::new((800, 600))));
+    assert!(!media.matches(Viewport::new((400, 600))));
   }
 
   #[test]

--- a/takumi-core/src/style/selector.rs
+++ b/takumi-core/src/style/selector.rs
@@ -2701,14 +2701,7 @@ mod tests {
 
   #[test]
   fn test_lossy_parse_rejects_unknown_rules_and_keeps_valid_siblings() {
-    for css in [
-      r#"
-        @media (resolution: 2dppx) {
-          .card { width: 10px; }
-        }
-
-        .card { width: 100px; }
-      "#,
+    assert_lossy_parse_keeps_single_valid_rule(
       r#"
         @unknown something {
           .card { width: 10px; }
@@ -2716,9 +2709,7 @@ mod tests {
 
         .card { width: 100px; }
       "#,
-    ] {
-      assert_lossy_parse_keeps_single_valid_rule(css);
-    }
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Why

An unknown media feature made `StyleSheet::parse` fail, so one `@media (prefers-color-scheme: dark)` block took every other rule in the sheet down with it. Media Queries Level 4 asks for the query to become `not all` instead.

## What

A query that does not parse now matches nothing and the rest of the sheet still applies. A prelude carrying a block or a stray closing delimiter is still an error, which is what stops a rule smuggled into the `media` string of a `css` entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stylesheets now continue parsing when they contain unsupported or malformed media queries.
  * Invalid media queries are treated as non-matching, while valid queries in the same list continue to work.
  * Unsupported features, such as `prefers-color-scheme`, no longer prevent the rest of a stylesheet from applying.
  * Media feature names using `min-` and `max-` prefixes are now matched case-insensitively.

* **Documentation**
  * Added a changelog entry describing the improved media-query handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->