### PR TITLE
Core: compare layout values against one epsilon

### DIFF
--- a/.tegami/layout-unit-epsilon.md
+++ b/.tegami/layout-unit-epsilon.md
@@ -1,0 +1,11 @@
+---
+packages:
+  "takumi-core":
+    type: patch
+---
+
+### Treat layout values a browser reads as equal as equal
+
+Text outline fragments, uniform border widths, and the ellipsis overflow check
+all compare against 1/64px now, the step Blink stores layout on. Each used to
+carry its own tolerance, so the same difference counted three ways.

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -4,6 +4,12 @@ use std::ops::{Add, Sub};
 
 use crate::style::Affine;
 
+/// The smallest difference between two layout values a browser can tell apart:
+/// Blink stores layout in 1/64px fixed point, so anything closer is one value
+/// there.
+/// <https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/geometry/layout_unit.h>
+pub(crate) const LAYOUT_UNIT_EPSILON: f32 = 1.0 / 64.0;
+
 /// A 2D point.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Point<T> {

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 use crate::{
   context::RenderContext,
-  geometry::{PathBuilder, PathCommand as Command, Point, Rect, Size},
+  geometry::{LAYOUT_UNIT_EPSILON, PathBuilder, PathCommand as Command, Point, Rect, Size},
   layout::corner_shape::{CornerContour, contour_arc_length, corner_contour},
   style::{BorderStyle, Color, ImageScalingAlgorithm, Sides, SpacePair, Superellipse},
 };
@@ -283,9 +283,9 @@ impl BorderProperties {
   /// True if every side has equal nonzero width and the given style.
   pub fn is_uniform_all_sides_style(&self, style: BorderStyle) -> bool {
     let has_uniform_width = self.width.top > 0.0
-      && (self.width.top - self.width.right).abs() <= f32::EPSILON
-      && (self.width.top - self.width.bottom).abs() <= f32::EPSILON
-      && (self.width.top - self.width.left).abs() <= f32::EPSILON;
+      && (self.width.top - self.width.right).abs() <= LAYOUT_UNIT_EPSILON
+      && (self.width.top - self.width.bottom).abs() <= LAYOUT_UNIT_EPSILON
+      && (self.width.top - self.width.left).abs() <= LAYOUT_UNIT_EPSILON;
 
     has_uniform_width
       && self.style.top == style

--- a/takumi-core/src/layout/inline.rs
+++ b/takumi-core/src/layout/inline.rs
@@ -10,7 +10,10 @@ use xxhash_rust::xxh3::Xxh3;
 use crate::{
   context::RenderContext,
   font_style::{SizedFontStyle, contains_variation_selector, presentation_segments},
-  geometry::{AvailableSpace, ComputedLayout, PathBuilder, PathCommand, Point, Rect, Size},
+  geometry::{
+    AvailableSpace, ComputedLayout, LAYOUT_UNIT_EPSILON, PathBuilder, PathCommand, Point, Rect,
+    Size,
+  },
   layout::{intercept::skip_ink_spans, node::Node, tree::RenderNode},
   resources::{
     font::{FontClasses, FontError, run_synthesis, run_variations},
@@ -2154,12 +2157,7 @@ pub fn create_inline_layout<'c>(request: InlineLayoutRequest<'c>) -> BuiltInline
 
     if style.parent.text_overflow == TextOverflow::Ellipsis {
       // A line's advance is an f32 sum over glyphs, so an exactly-fitting line
-      // can land a hair past max_width and must not sprout an ellipsis. A
-      // quarter pixel sits above that drift and below visible overflow. Blink
-      // avoids the problem class entirely by comparing in 1/64px fixed-point
-      // LayoutUnit.
-      const INLINE_OVERFLOW_TOLERANCE: f32 = 0.25;
-
+      // can land a hair past max_width and must not sprout an ellipsis.
       // Overflow shows up two ways: text truncated past the last committed
       // line, or a line wider than the box because nothing in it could break.
       // Browsers ellipsize the second case too: Blink runs
@@ -2173,7 +2171,7 @@ pub fn create_inline_layout<'c>(request: InlineLayoutRequest<'c>) -> BuiltInline
         let metrics = last_line.metrics();
         last_line.text_range().end < text.len()
           || metrics.inline_min_coord + metrics.advance - metrics.trailing_whitespace
-            > max_width + INLINE_OVERFLOW_TOLERANCE
+            > max_width + LAYOUT_UNIT_EPSILON
       });
 
       if is_overflowing {
@@ -2371,11 +2369,9 @@ fn scale_outline_rect(
   }
 }
 
-const OUTLINE_COORD_TOLERANCE: f32 = 1e-3;
-
 fn x_ranges_touch(left: InlineOutlineRect, right: InlineOutlineRect) -> bool {
-  left.x <= right.x + right.width + OUTLINE_COORD_TOLERANCE
-    && right.x <= left.x + left.width + OUTLINE_COORD_TOLERANCE
+  left.x <= right.x + right.width + LAYOUT_UNIT_EPSILON
+    && right.x <= left.x + left.width + LAYOUT_UNIT_EPSILON
 }
 
 fn expand_outline_rect(rect: InlineOutlineRect, amount: f32) -> Option<InlineOutlineRect> {
@@ -2413,9 +2409,9 @@ fn merge_inline_rects(mut rects: Vec<InlineOutlineRect>) -> Vec<InlineOutlineRec
 
     let same_group =
       previous_rect.span_id == rect.span_id && previous_rect.line_index == rect.line_index;
-    let touching = rect.x <= previous_rect.x + previous_rect.width + OUTLINE_COORD_TOLERANCE;
-    let same_band = (rect.y - previous_rect.y).abs() <= OUTLINE_COORD_TOLERANCE
-      && (rect.height - previous_rect.height).abs() <= OUTLINE_COORD_TOLERANCE;
+    let touching = rect.x <= previous_rect.x + previous_rect.width + LAYOUT_UNIT_EPSILON;
+    let same_band = (rect.y - previous_rect.y).abs() <= LAYOUT_UNIT_EPSILON
+      && (rect.height - previous_rect.height).abs() <= LAYOUT_UNIT_EPSILON;
 
     if same_group && same_band && touching {
       let right_edge = (previous_rect.x + previous_rect.width).max(rect.x + rect.width);
@@ -4307,5 +4303,20 @@ mod tests {
       segments.iter().any(|(_, text, _)| text.contains("before")),
       "{segments:#?}"
     );
+  }
+
+  #[test]
+  fn outline_rects_a_layout_unit_apart_touch() {
+    let rect = |x: f32, width: f32| InlineOutlineRect {
+      span_id: 0,
+      line_index: 0,
+      x,
+      y: 0.0,
+      width,
+      height: 10.0,
+    };
+
+    assert!(x_ranges_touch(rect(0.0, 10.0), rect(10.01, 10.0)));
+    assert!(!x_ranges_touch(rect(0.0, 10.0), rect(10.1, 10.0)));
   }
 }

--- a/takumi-core/src/style/media_query.rs
+++ b/takumi-core/src/style/media_query.rs
@@ -4,7 +4,7 @@ use cssparser::*;
 
 use crate::{
   error::StyleSheetParseError,
-  geometry::Size,
+  geometry::{LAYOUT_UNIT_EPSILON, Size},
   style::{CalcArena, FromCss, Length, SizingContext},
   viewport::{MediaTarget, Viewport},
 };
@@ -640,8 +640,3 @@ impl MediaQueryList {
       .any(|query| query.matches(viewport, &sizing))
   }
 }
-
-/// Blink compares lengths against `LayoutUnit::Epsilon()`, the step of the grid
-/// it rounds layout onto.
-/// <https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/media_query_evaluator.cc>
-const LAYOUT_UNIT_EPSILON: f32 = 1.0 / 64.0;


### PR DESCRIPTION
## Why

Three places compared layout geometry, each with a tolerance picked on its own: a quarter pixel for the ellipsis overflow check, `1e-3` for merging text outline fragments, and `f32::EPSILON` for uniform border widths. The same difference counted as equal in one and not in another.

## What

All three read `LAYOUT_UNIT_EPSILON` in `geometry.rs`, 1/64px, the step Blink stores layout on. No golden moved: every fixture sits outside the band these tolerances disagree about, so the outline merge carries a unit test at the boundary instead.