### PR TITLE
WASM, PDF: serve a browser-only entry to client builds

### DIFF
--- a/.tegami/vite-client-noexternal.md
+++ b/.tegami/vite-client-noexternal.md
@@ -13,7 +13,7 @@ packages:
 ### Resolve a browser-only entry in client builds
 
 Bundlers that resolve the `browser` condition (Vite client, webpack web) now
-get `bundlers/browser.mjs`, which only fetches the `.wasm` asset. Client builds
+get `bundlers/browser.mjs`, which only fetches the `.wasm` asset by `import.meta.url`. Client builds
 with `noExternal` stop failing with `Cannot bundle Node.js built-in "node:fs/promises"`.
 The Vite server entry reads the asset through `process.getBuiltinModule`, so
 no bundler sees a Node import. These packages, plus `takumi-js` and `@takumi-rs/image-response` on top of them, now require Node 20.19 or newer.

--- a/.tegami/vite-client-noexternal.md
+++ b/.tegami/vite-client-noexternal.md
@@ -4,6 +4,10 @@ packages:
     type: patch
   "@takumi-rs/wasm":
     type: patch
+  "takumi-js":
+    type: patch
+  "@takumi-rs/image-response":
+    type: patch
 ---
 
 ### Resolve a browser-only entry in client builds
@@ -12,4 +16,4 @@ Bundlers that resolve the `browser` condition (Vite client, webpack web) now
 get `bundlers/browser.mjs`, which only fetches the `.wasm` asset. Client builds
 with `noExternal` stop failing with `Cannot bundle Node.js built-in "node:fs/promises"`.
 The Vite server entry reads the asset through `process.getBuiltinModule`, so
-no bundler sees a Node import. Both packages now require Node 20.19 or newer.
+no bundler sees a Node import. These packages, plus `takumi-js` and `@takumi-rs/image-response` on top of them, now require Node 20.19 or newer.

--- a/.tegami/vite-client-noexternal.md
+++ b/.tegami/vite-client-noexternal.md
@@ -11,5 +11,5 @@ packages:
 Bundlers that resolve the `browser` condition (Vite client, webpack web) now
 get `bundlers/browser.mjs`, which only fetches the `.wasm` asset. Client builds
 with `noExternal` stop failing with `Cannot bundle Node.js built-in "node:fs/promises"`.
-The Vite server entry also hides its `node:fs/promises` import from bundlers
-that skip the `browser` condition.
+The Vite server entry reads the asset through `process.getBuiltinModule`, so
+no bundler sees a Node import. Both packages now require Node 20.19 or newer.

--- a/.tegami/vite-client-noexternal.md
+++ b/.tegami/vite-client-noexternal.md
@@ -1,0 +1,13 @@
+---
+packages:
+  "takumi-pdf":
+    type: patch
+  "@takumi-rs/wasm":
+    type: patch
+---
+
+### Build client apps with `noExternal` on the Vite entry
+
+The Vite entry no longer imports `node:fs/promises` with a literal specifier,
+so client builds that bundle dependencies stop failing with
+`Cannot bundle Node.js built-in "node:fs/promises"`.

--- a/.tegami/vite-client-noexternal.md
+++ b/.tegami/vite-client-noexternal.md
@@ -6,8 +6,10 @@ packages:
     type: patch
 ---
 
-### Build client apps with `noExternal` on the Vite entry
+### Resolve a browser-only entry in client builds
 
-The Vite entry no longer imports `node:fs/promises` with a literal specifier,
-so client builds that bundle dependencies stop failing with
-`Cannot bundle Node.js built-in "node:fs/promises"`.
+Bundlers that resolve the `browser` condition (Vite client, webpack web) now
+get `bundlers/browser.mjs`, which only fetches the `.wasm` asset. Client builds
+with `noExternal` stop failing with `Cannot bundle Node.js built-in "node:fs/promises"`.
+The Vite server entry also hides its `node:fs/promises` import from bundlers
+that skip the `browser` condition.

--- a/takumi-image-response/package.json
+++ b/takumi-image-response/package.json
@@ -43,6 +43,6 @@
     "unrun": "catalog:"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   }
 }

--- a/takumi-js/package.json
+++ b/takumi-js/package.json
@@ -250,6 +250,6 @@
     "unrun": "catalog:"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   }
 }

--- a/takumi-pdf-js/bundlers/browser.mjs
+++ b/takumi-pdf-js/bundlers/browser.mjs
@@ -1,0 +1,7 @@
+import url from "../pkg/takumi_pdf_wasm_bg.wasm?url";
+import * as wasm from "../dist/export.mjs";
+
+wasm.initSync({ module: await fetch(url).then((response) => response.arrayBuffer()) });
+
+export * from "../dist/export.mjs";
+export default wasm.default;

--- a/takumi-pdf-js/bundlers/browser.mjs
+++ b/takumi-pdf-js/bundlers/browser.mjs
@@ -1,5 +1,5 @@
-import url from "../pkg/takumi_pdf_wasm_bg.wasm?url";
 import * as wasm from "../dist/export.mjs";
+import url from "./wasm-url.mjs";
 
 wasm.initSync({ module: await fetch(url).then((response) => response.arrayBuffer()) });
 

--- a/takumi-pdf-js/bundlers/vite.mjs
+++ b/takumi-pdf-js/bundlers/vite.mjs
@@ -5,7 +5,9 @@ import * as wasm from "../dist/export.mjs";
 // importing server chunk, so resolve relative to import.meta.url, not the framework output dir.
 async function resolveWasm() {
   if (typeof process !== "undefined" && process.versions?.node != null) {
-    const { readFile } = await import("node:fs/promises");
+    // Non-literal specifier keeps client builds with `noExternal` from trying to bundle the builtin.
+    const fsPromises = "node:fs/promises";
+    const { readFile } = await import(/* @vite-ignore */ fsPromises);
     const path = decodeURIComponent(url.replace(/[?#].*$/, ""));
 
     // Dev SSR serves an `/@fs/<abs-path>` URL.

--- a/takumi-pdf-js/bundlers/vite.mjs
+++ b/takumi-pdf-js/bundlers/vite.mjs
@@ -5,9 +5,7 @@ import * as wasm from "../dist/export.mjs";
 // importing server chunk, so resolve relative to import.meta.url, not the framework output dir.
 async function resolveWasm() {
   if (typeof process !== "undefined" && process.versions?.node != null) {
-    // Non-literal specifier keeps client builds with `noExternal` from trying to bundle the builtin.
-    const fsPromises = "node:fs/promises";
-    const { readFile } = await import(/* @vite-ignore */ fsPromises);
+    const { readFile } = process.getBuiltinModule("node:fs/promises");
     const path = decodeURIComponent(url.replace(/[?#].*$/, ""));
 
     // Dev SSR serves an `/@fs/<abs-path>` URL.

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -159,7 +159,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "readme": "README.md"
 }

--- a/takumi-pdf-js/package.json
+++ b/takumi-pdf-js/package.json
@@ -75,6 +75,10 @@
           "default": "./bundlers/vite.mjs"
         }
       },
+      "browser": {
+        "types": "./bundlers/node.d.ts",
+        "default": "./bundlers/browser.mjs"
+      },
       "module": {
         "types": "./bundlers/node.d.ts",
         "default": "./bundlers/vite.mjs"

--- a/takumi-wasm/bundlers/browser.mjs
+++ b/takumi-wasm/bundlers/browser.mjs
@@ -1,0 +1,3 @@
+import url from "../pkg/takumi_wasm_bg.wasm?url";
+
+export default fetch(url).then((response) => response.arrayBuffer());

--- a/takumi-wasm/bundlers/browser.mjs
+++ b/takumi-wasm/bundlers/browser.mjs
@@ -1,3 +1,3 @@
-import url from "../pkg/takumi_wasm_bg.wasm?url";
+import url from "./wasm-url.mjs";
 
 export default fetch(url).then((response) => response.arrayBuffer());

--- a/takumi-wasm/bundlers/vite.mjs
+++ b/takumi-wasm/bundlers/vite.mjs
@@ -4,7 +4,9 @@ import url from "../pkg/takumi_wasm_bg.wasm?url";
 // importing server chunk, so resolve relative to import.meta.url, not the framework output dir.
 async function processUrl() {
   if (typeof process !== "undefined" && process.versions?.node != null) {
-    const { readFile } = await import("node:fs/promises");
+    // Non-literal specifier keeps client builds with `noExternal` from trying to bundle the builtin.
+    const fsPromises = "node:fs/promises";
+    const { readFile } = await import(/* @vite-ignore */ fsPromises);
     const path = decodeURIComponent(url.replace(/[?#].*$/, ""));
 
     // Dev SSR serves an `/@fs/<abs-path>` URL.

--- a/takumi-wasm/bundlers/vite.mjs
+++ b/takumi-wasm/bundlers/vite.mjs
@@ -4,9 +4,7 @@ import url from "../pkg/takumi_wasm_bg.wasm?url";
 // importing server chunk, so resolve relative to import.meta.url, not the framework output dir.
 async function processUrl() {
   if (typeof process !== "undefined" && process.versions?.node != null) {
-    // Non-literal specifier keeps client builds with `noExternal` from trying to bundle the builtin.
-    const fsPromises = "node:fs/promises";
-    const { readFile } = await import(/* @vite-ignore */ fsPromises);
+    const { readFile } = process.getBuiltinModule("node:fs/promises");
     const path = decodeURIComponent(url.replace(/[?#].*$/, ""));
 
     // Dev SSR serves an `/@fs/<abs-path>` URL.

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -171,7 +171,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "readme": "README.md"
 }

--- a/takumi-wasm/package.json
+++ b/takumi-wasm/package.json
@@ -95,6 +95,10 @@
           "default": "./bundlers/vite.mjs"
         }
       },
+      "browser": {
+        "types": "./bundlers/vite.d.ts",
+        "default": "./bundlers/browser.mjs"
+      },
       "module": {
         "types": "./bundlers/vite.d.ts",
         "default": "./bundlers/vite.mjs"
@@ -133,8 +137,14 @@
       "default": "./bundlers/next.mjs"
     },
     "./vite": {
-      "types": "./bundlers/vite.d.ts",
-      "default": "./bundlers/vite.mjs"
+      "browser": {
+        "types": "./bundlers/vite.d.ts",
+        "default": "./bundlers/browser.mjs"
+      },
+      "default": {
+        "types": "./bundlers/vite.d.ts",
+        "default": "./bundlers/vite.mjs"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
## Why
Vite client builds with `noExternal` resolve `takumi-pdf` and `@takumi-rs/wasm/auto` to `bundlers/vite.mjs`, which imports `node:fs/promises` for SSR reads. Rollup resolves that literal specifier at build time and fails with `Cannot bundle Node.js built-in "node:fs/promises"`.

## What
Both packages gain a `browser` export condition pointing at `bundlers/browser.mjs`, which only fetches the `?url` asset, so client builds never see the SSR path. The Vite entry keeps its SSR lookup but reads the file through `process.getBuiltinModule`, so no bundler sees a Node import; that raises `engines.node` to `>=20.19` (Vite 7's floor) on the WASM packages and on `takumi-js` and `@takumi-rs/image-response` above them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved browser support for loading WebAssembly assets.
  * Browser and server environments now use optimized asset-loading paths.

* **Chores**
  * Updated package releases for the latest browser and server loading improvements.
  * Node.js 20.19 or newer is now required for the affected packages.
  * Added browser-specific package resolution for supported bundler configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->