### PR TITLE
PDF: simplify the page pipeline's types

### DIFF
--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -1,6 +1,8 @@
 //! Unsplittable vertical extents and paragraphs collected from the laid-out
 //! scene, which pagination cuts around.
 
+use std::ops::Range;
+
 use takumi_core::{
   font_style::SizedFontStyle,
   geometry::{ComputedLayout as Layout, NodeId},
@@ -18,6 +20,39 @@ use crate::{
   pagination::{Atom, Paragraph},
 };
 
+/// What the cut search works around, in content coordinates.
+#[derive(Default)]
+pub(crate) struct Atoms {
+  /// Unsplittable extents: text lines, images, `break-inside: avoid` boxes and
+  /// transformed subtrees.
+  pub(crate) extents: Vec<Atom>,
+  /// Where `break-before` / `break-after: page` force a cut.
+  pub(crate) forced: Vec<f32>,
+  /// Text boxes with their `widows` / `orphans` minimums.
+  pub(crate) paragraphs: Vec<Paragraph>,
+}
+
+impl Atoms {
+  /// Records the box's lines as a [`Paragraph`] for the widow/orphan solver.
+  fn push_paragraph(&mut self, node: &RenderNode, lines: Range<usize>) {
+    let style = &node.context.style;
+    let before = style.orphans.get();
+    let after = style.widows.get();
+
+    if lines.len() < 2 || (before <= 1 && after <= 1) {
+      return;
+    }
+    let mut lines = self.extents[lines].to_vec();
+
+    lines.sort_by(|a, b| a.0.total_cmp(&b.0));
+    self.paragraphs.push(Paragraph {
+      lines,
+      before,
+      after,
+    });
+  }
+}
+
 /// Walks the scene like the emitter, recording unsplittable vertical extents
 /// instead of painting.
 pub(crate) struct AtomCollector<'a> {
@@ -28,50 +63,20 @@ pub(crate) struct AtomCollector<'a> {
 }
 
 impl AtomCollector<'_> {
-  pub(crate) fn collect(
-    &self,
-    atoms: &mut Vec<Atom>,
-    forced: &mut Vec<f32>,
-    paragraphs: &mut Vec<Paragraph>,
-  ) -> Result<(), PdfError> {
-    self.context_atoms(0, Affine::IDENTITY, atoms, forced, paragraphs)
+  pub(crate) fn collect(&self) -> Result<Atoms, PdfError> {
+    let mut atoms = Atoms::default();
+
+    self.context_atoms(0, Affine::IDENTITY, &mut atoms)?;
+    Ok(atoms)
   }
-}
 
-/// Records the box's lines as a [`Paragraph`] for the widow/orphan solver.
-fn push_paragraph(node: &RenderNode, lines: &[Atom], paragraphs: &mut Vec<Paragraph>) {
-  let style = &node.context.style;
-  let before = style.orphans.get();
-  let after = style.widows.get();
-
-  if lines.len() < 2 || (before <= 1 && after <= 1) {
-    return;
-  }
-  let mut lines = lines.to_vec();
-
-  lines.sort_by(|a, b| a.0.total_cmp(&b.0));
-  paragraphs.push(Paragraph {
-    lines,
-    before,
-    after,
-  });
-}
-
-impl AtomCollector<'_> {
-  fn context_atoms(
-    &self,
-    id: usize,
-    parent: Affine,
-    atoms: &mut Vec<Atom>,
-    forced: &mut Vec<f32>,
-    paragraphs: &mut Vec<Paragraph>,
-  ) -> Result<(), PdfError> {
+  fn context_atoms(&self, id: usize, parent: Affine, atoms: &mut Atoms) -> Result<(), PdfError> {
     let Some(context) = self.contexts.get(id) else {
       return Ok(());
     };
 
     let child_frame = match context.root() {
-      Some(paint) => self.box_atoms(paint, parent, atoms, forced, paragraphs)?,
+      Some(paint) => self.box_atoms(paint, parent, atoms)?,
       None => parent,
     };
 
@@ -79,10 +84,10 @@ impl AtomCollector<'_> {
       for item in bucket {
         match &item.kind {
           PaintItemKind::Node(paint) => {
-            self.box_atoms(paint, child_frame, atoms, forced, paragraphs)?;
+            self.box_atoms(paint, child_frame, atoms)?;
           }
           PaintItemKind::Context(child) => {
-            self.context_atoms(*child, child_frame, atoms, forced, paragraphs)?;
+            self.context_atoms(*child, child_frame, atoms)?;
           }
         }
       }
@@ -97,9 +102,7 @@ impl AtomCollector<'_> {
     &self,
     paint: &NodePaint,
     parent: Affine,
-    atoms: &mut Vec<Atom>,
-    forced: &mut Vec<f32>,
-    paragraphs: &mut Vec<Paragraph>,
+    atoms: &mut Atoms,
   ) -> Result<Affine, PdfError> {
     let Some(node) = self.root.node_at_path(&paint.path) else {
       return Ok(parent);
@@ -111,7 +114,9 @@ impl AtomCollector<'_> {
     let relative = parent.invert().unwrap_or(Affine::IDENTITY) * paint.transform;
     if !relative.only_translation() {
       if let Some(bounds) = paint.paint_bounds {
-        atoms.push((bounds.top as f32, bounds.bottom as f32));
+        atoms
+          .extents
+          .push((bounds.top as f32, bounds.bottom as f32));
       }
       return Ok(parent * relative);
     }
@@ -119,24 +124,24 @@ impl AtomCollector<'_> {
     let style = &node.context.style;
 
     if style.break_before == BreakBetween::Page {
-      forced.push(y);
+      atoms.forced.push(y);
     }
     if style.break_after == BreakBetween::Page {
-      forced.push(y + layout.size.height);
+      atoms.forced.push(y + layout.size.height);
     }
     if style.break_inside == BreakInside::Avoid {
-      atoms.push((y, y + layout.size.height));
+      atoms.extents.push((y, y + layout.size.height));
     }
 
     if node.should_create_inline_layout() {
-      self.text_atoms(node, paint.node_id, layout, y, atoms, paragraphs)?;
+      self.text_atoms(node, paint.node_id, layout, y, atoms)?;
     } else if !node.has_anonymous_text_item_child() {
       match node.node.as_ref().map(|n| &n.kind) {
         Some(NodeKind::Text(_)) => {
-          self.text_atoms(node, paint.node_id, layout, y, atoms, paragraphs)?;
+          self.text_atoms(node, paint.node_id, layout, y, atoms)?;
         }
         Some(NodeKind::Image(_)) => {
-          atoms.push((y, y + layout.size.height));
+          atoms.extents.push((y, y + layout.size.height));
         }
         _ => {}
       }
@@ -152,10 +157,9 @@ impl AtomCollector<'_> {
     node_id: NodeId,
     layout: Layout,
     y: f32,
-    atoms: &mut Vec<Atom>,
-    paragraphs: &mut Vec<Paragraph>,
+    atoms: &mut Atoms,
   ) -> Result<(), PdfError> {
-    let start = atoms.len();
+    let start = atoms.extents.len();
     let owned_runs;
     let runs = match self.inline.and_then(|map| map.get(&node_id)) {
       Some(prepared) => &prepared.runs,
@@ -174,12 +178,12 @@ impl AtomCollector<'_> {
       }
     };
 
-    text_line_atoms(runs, layout, y, atoms);
+    text_line_atoms(runs, layout, y, &mut atoms.extents);
     // Box bands are indivisible but not text lines, so widow/orphan control
     // does not count them.
-    let paragraph_end = atoms.len();
-    inline_box_atoms(runs, layout, y, atoms);
-    push_paragraph(node, &atoms[start..paragraph_end], paragraphs);
+    let paragraph_end = atoms.extents.len();
+    inline_box_atoms(runs, layout, y, &mut atoms.extents);
+    atoms.push_paragraph(node, start..paragraph_end);
     Ok(())
   }
 }

--- a/takumi-pdf/src/background.rs
+++ b/takumi-pdf/src/background.rs
@@ -41,53 +41,58 @@ struct Axis {
   step: f32,
 }
 
-/// Resolves one layer's placement. An image layer carries its intrinsic
-/// sizing, which `auto`, `cover` and `contain` resolve against; a gradient has
-/// none, so those all resolve to the positioning area.
-pub(crate) fn place(
-  area: Size<f32>,
-  size: BackgroundSize,
-  position: PositionValue,
-  repeat: BackgroundRepeat,
-  intrinsic: Option<IntrinsicSizing>,
-  context: &RenderContext,
-) -> Placement {
-  let (tile, auto) = tile_size(area, size, intrinsic, context);
-  // `round` rescales the axis it applies to. An axis left `auto` follows from
-  // the image's ratio, so it has to resolve after the one it depends on.
-  let (x, y) = match auto {
-    Some((AutoBackgroundAxis::Width, ratio)) => {
-      let y = axis(area.height, tile.height, position.0.y, repeat.1, context);
-      let width =
-        auto_axis_from_intrinsic(AutoBackgroundAxis::Width, ratio, y.tile).unwrap_or(tile.width);
+impl Placement {
+  /// Resolves one layer's placement. An image layer carries its intrinsic
+  /// sizing, which `auto`, `cover` and `contain` resolve against; a gradient has
+  /// none, so those all resolve to the positioning area.
+  pub(crate) fn resolve(
+    area: Size<f32>,
+    size: BackgroundSize,
+    position: PositionValue,
+    repeat: BackgroundRepeat,
+    intrinsic: Option<IntrinsicSizing>,
+    context: &RenderContext,
+  ) -> Placement {
+    let (tile, auto) = tile_size(area, size, intrinsic, context);
+    // `round` rescales the axis it applies to. An axis left `auto` follows from
+    // the image's ratio, so it has to resolve after the one it depends on.
+    let (x, y) = match auto {
+      Some((AutoBackgroundAxis::Width, ratio)) => {
+        let y = Axis::resolve(area.height, tile.height, position.0.y, repeat.1, context);
+        let width =
+          auto_axis_from_intrinsic(AutoBackgroundAxis::Width, ratio, y.tile).unwrap_or(tile.width);
 
-      (axis(area.width, width, position.0.x, repeat.0, context), y)
+        (
+          Axis::resolve(area.width, width, position.0.x, repeat.0, context),
+          y,
+        )
+      }
+      Some((AutoBackgroundAxis::Height, ratio)) => {
+        let x = Axis::resolve(area.width, tile.width, position.0.x, repeat.0, context);
+        let height = auto_axis_from_intrinsic(AutoBackgroundAxis::Height, ratio, x.tile)
+          .unwrap_or(tile.height);
+
+        (
+          x,
+          Axis::resolve(area.height, height, position.0.y, repeat.1, context),
+        )
+      }
+      None => (
+        Axis::resolve(area.width, tile.width, position.0.x, repeat.0, context),
+        Axis::resolve(area.height, tile.height, position.0.y, repeat.1, context),
+      ),
+    };
+
+    Self {
+      tiles: repeat.0 != BackgroundRepeatStyle::NoRepeat
+        || repeat.1 != BackgroundRepeatStyle::NoRepeat,
+      tile: Size {
+        width: x.tile,
+        height: y.tile,
+      },
+      origin: (x.origin, y.origin),
+      step: (x.step, y.step),
     }
-    Some((AutoBackgroundAxis::Height, ratio)) => {
-      let x = axis(area.width, tile.width, position.0.x, repeat.0, context);
-      let height =
-        auto_axis_from_intrinsic(AutoBackgroundAxis::Height, ratio, x.tile).unwrap_or(tile.height);
-
-      (
-        x,
-        axis(area.height, height, position.0.y, repeat.1, context),
-      )
-    }
-    None => (
-      axis(area.width, tile.width, position.0.x, repeat.0, context),
-      axis(area.height, tile.height, position.0.y, repeat.1, context),
-    ),
-  };
-
-  Placement {
-    tiles: repeat.0 != BackgroundRepeatStyle::NoRepeat
-      || repeat.1 != BackgroundRepeatStyle::NoRepeat,
-    tile: Size {
-      width: x.tile,
-      height: y.tile,
-    },
-    origin: (x.origin, y.origin),
-    step: (x.step, y.step),
   }
 }
 
@@ -143,56 +148,58 @@ fn tile_size(
 /// A repeating axis starts one step before the anchor so the tiles also cover
 /// the area's leading edge. `round` rescales the tile to fit a whole number of
 /// them, and `space` keeps the tile but spreads the leftover between tiles.
-fn axis(
-  area: f32,
-  tile: f32,
-  position: PositionComponent,
-  repeat: BackgroundRepeatStyle,
-  context: &RenderContext,
-) -> Axis {
-  if tile <= 0.0 {
-    return Axis {
-      tile,
-      origin: 0.0,
-      step: area.max(1.0),
-    };
-  }
-  let anchor = position.resolve(context, area - tile);
-  let once = Axis {
-    tile,
-    origin: anchor,
-    step: area.max(tile),
-  };
-
-  match repeat {
-    BackgroundRepeatStyle::NoRepeat => once,
-    BackgroundRepeatStyle::Repeat => Axis {
-      tile,
-      origin: anchor - (anchor / tile).ceil() * tile,
-      step: tile,
-    },
-    BackgroundRepeatStyle::Round => {
-      let count = (area / tile).round().max(1.0);
-      let rounded = area / count;
-      // The position still applies, against the rescaled tile.
-      let anchor = position.resolve(context, area - rounded);
-
-      Axis {
-        tile: rounded,
-        origin: anchor - (anchor / rounded).ceil() * rounded,
-        step: rounded,
-      }
-    }
-    BackgroundRepeatStyle::Space => {
-      let count = (area / tile).floor();
-
-      if count < 2.0 {
-        return once;
-      }
-      Axis {
+impl Axis {
+  fn resolve(
+    area: f32,
+    tile: f32,
+    position: PositionComponent,
+    repeat: BackgroundRepeatStyle,
+    context: &RenderContext,
+  ) -> Self {
+    if tile <= 0.0 {
+      return Self {
         tile,
         origin: 0.0,
-        step: tile + (area - count * tile) / (count - 1.0),
+        step: area.max(1.0),
+      };
+    }
+    let anchor = position.resolve(context, area - tile);
+    let once = Self {
+      tile,
+      origin: anchor,
+      step: area.max(tile),
+    };
+
+    match repeat {
+      BackgroundRepeatStyle::NoRepeat => once,
+      BackgroundRepeatStyle::Repeat => Self {
+        tile,
+        origin: anchor - (anchor / tile).ceil() * tile,
+        step: tile,
+      },
+      BackgroundRepeatStyle::Round => {
+        let count = (area / tile).round().max(1.0);
+        let rounded = area / count;
+        // The position still applies, against the rescaled tile.
+        let anchor = position.resolve(context, area - rounded);
+
+        Self {
+          tile: rounded,
+          origin: anchor - (anchor / rounded).ceil() * rounded,
+          step: rounded,
+        }
+      }
+      BackgroundRepeatStyle::Space => {
+        let count = (area / tile).floor();
+
+        if count < 2.0 {
+          return once;
+        }
+        Self {
+          tile,
+          origin: 0.0,
+          step: tile + (area - count * tile) / (count - 1.0),
+        }
       }
     }
   }
@@ -211,7 +218,7 @@ mod tests {
     viewport::Viewport,
   };
 
-  use super::place;
+  use super::Placement;
 
   /// `round` rescales the axis it applies to, and an `auto` axis follows from
   /// the image's ratio rather than keeping the size it was asked for.
@@ -226,7 +233,7 @@ mod tests {
           .build(),
       )
       .build();
-    let placement = place(
+    let placement = Placement::resolve(
       Size {
         width: 1200.0,
         height: 630.0,

--- a/takumi-pdf/src/bands.rs
+++ b/takumi-pdf/src/bands.rs
@@ -1,19 +1,26 @@
 //! Trees drawn once per page: header and footer bands, and repeated `fixed`
 //! boxes.
 
-use std::cell::RefCell;
+use std::ops::Range;
 
-use takumi_core::{context::RenderContext, layout::node::Node, viewport::Viewport};
+use takumi_core::{
+  context::RenderContext,
+  layout::{
+    node::{Node, NodeKind},
+    tree::RenderNode,
+  },
+  viewport::Viewport,
+};
 
 use crate::{
-  counters::{has_page_counters, substitute_page_counters, substitute_target_counters},
-  emitter::{FontMap, RenderIssues},
-  interactive::{LinkTarget, collect_interactive},
+  counters::{has_page_counters, substitute_page_counters},
+  emitter::DocumentState,
+  interactive::{Interactive, LinkTarget},
   krilla::surface::Surface,
   options::{BAND_EDGE_PADDING, PdfError},
   page::PageFrame,
-  tree::{PreparedTree, RepeatedBox, RepeatedTemplate, TreeInputs, prepare_repeated, prepare_tree},
-  window::ContentWindow,
+  tree::{PreparedTree, TreeInputs, page_root},
+  window::{ContentWindow, Window},
 };
 
 /// Where a repeatable draws on the page.
@@ -68,7 +75,45 @@ enum RepeatTemplate {
   /// A band re-lays out its option node with the page's counters.
   Band(Node),
   /// A repeated box re-lays out the subtree it was taken from.
-  Fixed(RepeatedTemplate),
+  Fixed(FixedTemplate),
+}
+
+/// A repeated box's source subtree, with the context its styles resolved
+/// under, so a re-layout inherits what its ancestors gave it.
+pub(crate) struct FixedTemplate {
+  pub(crate) node: Node,
+  pub(crate) parent: RenderContext,
+  pub(crate) source_order: usize,
+}
+
+impl FixedTemplate {
+  /// The source orders the subtree occupies in the tree it was taken from.
+  fn source_orders(&self) -> Range<usize> {
+    self.source_order..self.source_order + node_count(&self.node)
+  }
+
+  /// Lays the box out again with the counters a page asks for.
+  fn prepare(
+    &self,
+    page_context: &RenderContext,
+    page: usize,
+    pages: usize,
+    page_area: Viewport,
+  ) -> Result<PreparedTree, PdfError> {
+    let mut node = self.node.clone();
+
+    substitute_page_counters(&mut node, page, pages);
+    let child = RenderNode::from_node(&self.parent, node);
+
+    PreparedTree::lay_out(page_root(page_context, child), page_area)
+  }
+}
+
+fn node_count(node: &Node) -> usize {
+  match &node.kind {
+    NodeKind::Container { children } => 1 + children.iter().map(node_count).sum::<usize>(),
+    _ => 1,
+  }
 }
 
 impl Repeatable {
@@ -82,11 +127,27 @@ impl Repeatable {
     pages: usize,
   ) -> Result<Self, PdfError> {
     Ok(Self {
-      prepared: prepare_band(inputs, template, pages, pages, viewport)?,
+      prepared: inputs.prepare_band(template, pages, pages, viewport)?,
       template: has_page_counters(template).then(|| RepeatTemplate::Band(template.clone())),
       bounds,
       links: Vec::new(),
     })
+  }
+
+  /// Wraps a repeated `fixed` box, caching its links when it never re-lays out.
+  pub(crate) fn fixed(prepared: PreparedTree, template: Option<FixedTemplate>) -> Self {
+    let links = match template {
+      Some(_) => Vec::new(),
+      None => Interactive::collect(&prepared).links,
+    };
+    let below = prepared.paints_below();
+
+    Self {
+      prepared,
+      template: template.map(RepeatTemplate::Fixed),
+      bounds: RepeatBounds::Content { below },
+      links,
+    }
   }
 
   /// Whether the band holds a counter and lays out again per page.
@@ -94,25 +155,18 @@ impl Repeatable {
     self.template.is_some()
   }
 
-  /// Wraps a repeated `fixed` box, caching its links when it never re-lays out.
-  pub(crate) fn fixed(repeat: RepeatedBox) -> Self {
-    let links = match repeat.template {
-      Some(_) => Vec::new(),
-      None => collect_interactive(&repeat.prepared).links,
-    };
-    let below = repeat.prepared.paints_below();
-
-    Self {
-      prepared: repeat.prepared,
-      template: repeat.template.map(RepeatTemplate::Fixed),
-      bounds: RepeatBounds::Content { below },
-      links,
-    }
-  }
-
   /// The height the measured layout came out at.
   pub(crate) fn height(&self) -> f32 {
     self.prepared.height
+  }
+
+  /// The source orders a repeated box's counters live at, which the content
+  /// pass leaves to the box itself.
+  pub(crate) fn source_orders(&self) -> Option<Range<usize>> {
+    match &self.template {
+      Some(RepeatTemplate::Fixed(template)) => Some(template.source_orders()),
+      _ => None,
+    }
   }
 
   /// Resolves the tree this page draws: a fresh layout with the page's
@@ -127,23 +181,15 @@ impl Repeatable {
   ) -> Result<RepeatablePage<'_>, PdfError> {
     let fresh = match &self.template {
       None => None,
-      Some(RepeatTemplate::Band(node)) => Some(prepare_band(
-        inputs,
-        node,
-        page,
-        pages,
-        frame.band_viewport,
-      )?),
-      Some(RepeatTemplate::Fixed(template)) => Some(prepare_repeated(
-        page_context,
-        template,
-        page,
-        pages,
-        frame.page_area,
-      )?),
+      Some(RepeatTemplate::Band(node)) => {
+        Some(inputs.prepare_band(node, page, pages, frame.band_viewport)?)
+      }
+      Some(RepeatTemplate::Fixed(template)) => {
+        Some(template.prepare(page_context, page, pages, frame.page_area)?)
+      }
     };
     let fresh_links = match (&fresh, &self.bounds) {
-      (Some(tree), RepeatBounds::Content { .. }) => collect_interactive(tree).links,
+      (Some(tree), RepeatBounds::Content { .. }) => Interactive::collect(tree).links,
       _ => Vec::new(),
     };
 
@@ -181,14 +227,12 @@ impl RepeatablePage<'_> {
     self.repeatable.links.iter().chain(&self.fresh_links)
   }
 
-  /// Emits the tree clipped to its bounds on the page.
+  /// Emits the tree clipped to its bounds on the page, as an artifact when the
+  /// document is tagged.
   pub(crate) fn emit(
     &self,
     frame: &PageFrame,
-    fonts: &mut FontMap,
-    artifact: bool,
-    issues: &RefCell<RenderIssues>,
-    document_lang: Option<&str>,
+    state: &DocumentState<'_>,
     surface: &mut Surface,
   ) -> Result<(), PdfError> {
     let (x, y, width, height) = self.repeatable.bounds.rect(frame, self.repeatable.height());
@@ -196,34 +240,9 @@ impl RepeatablePage<'_> {
     ContentWindow {
       clip: (x, y, width, height),
       translate: (x, y),
-      window: None,
-      x_window: None,
-      line_window: None,
-      artifact,
+      window: Window::default(),
+      artifact: state.tags.is_some(),
     }
-    .emit(
-      self
-        .tree()
-        .emitter(fonts, None, None, issues, document_lang),
-      surface,
-    )
+    .emit(self.tree().emitter(state, None, false), surface)
   }
-}
-
-/// Lays out a band template with the given counter values.
-pub(crate) fn prepare_band(
-  inputs: &TreeInputs<'_>,
-  template: &Node,
-  page: usize,
-  pages: usize,
-  viewport: Viewport,
-) -> Result<PreparedTree, PdfError> {
-  let mut node = template.clone();
-
-  substitute_page_counters(&mut node, page, pages);
-  // A band lays out per page, after the pass that resolves target counters, so
-  // its hooks name no page. They empty like any other unresolved target instead
-  // of leaving the placeholder the template put there.
-  substitute_target_counters(&mut node, None, &|_: &str| None, &mut Vec::new());
-  prepare_tree(inputs, node, viewport)
 }

--- a/takumi-pdf/src/counters.rs
+++ b/takumi-pdf/src/counters.rs
@@ -91,43 +91,74 @@ const COUNTER_HOOKS: [&str; 2] = ["pageNumber", "totalPages"];
 /// `target-counter(attr(href), page)` this stands in for.
 const TARGET_HOOK: &str = "targetPageNumber";
 
-const OTHER_STYLES: [&str; 5] = [
-  "decimal",
-  "decimal-leading-zero",
-  "lower-roman",
-  "upper-roman",
-  "trad-chinese-informal",
-];
-
-/// Whether a class names a counter style this renderer knows.
-fn is_counter_style(name: &str) -> bool {
-  name == "cjk-ideographic"
-    || OTHER_STYLES.contains(&name)
-    || DIGIT_STYLES.iter().any(|(style, _)| *style == name)
-    || ALPHABET_STYLES.iter().any(|(style, _)| *style == name)
+/// A `@counter-style` this renderer formats.
+#[derive(Clone, Copy)]
+enum CounterStyle {
+  Decimal,
+  DecimalLeadingZero,
+  LowerRoman,
+  UpperRoman,
+  /// Reading-style Chinese numerals. Blink defines `cjk-ideographic` as
+  /// `extends trad-chinese-informal`.
+  ChineseInformal,
+  /// A decimal number in another script's digits, zero first.
+  Digits(&'static [char; 10]),
+  /// Counting through an alphabet: a, b, ..., z, aa, ab, and so on.
+  Alphabet(&'static str),
 }
 
-/// Formats a page counter in a CSS `@counter-style` named style. Unknown
-/// styles fall back to `decimal`.
-fn format_counter(value: usize, style: &str) -> String {
-  if let Some((_, digits)) = DIGIT_STYLES.iter().find(|(name, _)| *name == style) {
-    return value
-      .to_string()
-      .bytes()
-      .map(|digit| digits[usize::from(digit - b'0')])
-      .collect();
-  }
-  if let Some((_, alphabet)) = ALPHABET_STYLES.iter().find(|(name, _)| *name == style) {
-    return alphabetic(value, alphabet);
+impl CounterStyle {
+  fn from_name(name: &str) -> Option<Self> {
+    if let Some((_, digits)) = DIGIT_STYLES.iter().find(|(style, _)| *style == name) {
+      return Some(Self::Digits(digits));
+    }
+    if let Some((_, alphabet)) = ALPHABET_STYLES.iter().find(|(style, _)| *style == name) {
+      return Some(Self::Alphabet(alphabet));
+    }
+    match name {
+      "decimal" => Some(Self::Decimal),
+      "decimal-leading-zero" => Some(Self::DecimalLeadingZero),
+      "lower-roman" => Some(Self::LowerRoman),
+      "upper-roman" => Some(Self::UpperRoman),
+      "trad-chinese-informal" | "cjk-ideographic" => Some(Self::ChineseInformal),
+      _ => None,
+    }
   }
 
-  match style {
-    // Blink defines cjk-ideographic as `extends trad-chinese-informal`.
-    "trad-chinese-informal" | "cjk-ideographic" => chinese_informal(value),
-    "lower-roman" => roman(value).to_ascii_lowercase(),
-    "upper-roman" => roman(value),
-    "decimal-leading-zero" => format!("{value:02}"),
-    _ => value.to_string(),
+  /// The style a hook's class list names, `decimal` when none does.
+  fn from_classes(classes: &str) -> Self {
+    classes
+      .split_whitespace()
+      .find_map(Self::from_name)
+      .unwrap_or(Self::Decimal)
+  }
+
+  fn format(self, value: usize) -> String {
+    match self {
+      Self::Digits(digits) => value
+        .to_string()
+        .bytes()
+        .map(|digit| digits[usize::from(digit - b'0')])
+        .collect(),
+      Self::Alphabet(alphabet) => alphabetic(value, alphabet),
+      Self::ChineseInformal => chinese_informal(value),
+      Self::LowerRoman => roman(value).to_ascii_lowercase(),
+      Self::UpperRoman => roman(value),
+      Self::DecimalLeadingZero => format!("{value:02}"),
+      Self::Decimal => value.to_string(),
+    }
+  }
+
+  /// Every character the style can produce.
+  fn characters(self) -> String {
+    match self {
+      Self::Digits(digits) => digits.iter().collect(),
+      Self::Alphabet(alphabet) => alphabet.to_string(),
+      Self::LowerRoman => "ivxlcdm".to_string(),
+      Self::UpperRoman => "IVXLCDM".to_string(),
+      Self::ChineseInformal => CHINESE_DIGITS.iter().collect::<String>() + "十百千",
+      Self::Decimal | Self::DecimalLeadingZero => "0123456789".to_string(),
+    }
   }
 }
 
@@ -157,7 +188,7 @@ const CHINESE_DIGITS: [char; 10] = ['零', '一', '二', '三', '四', '五', '�
 /// values fall back to positional digits.
 fn chinese_informal(value: usize) -> String {
   if value >= 10_000 {
-    return format_counter(value, "cjk-decimal");
+    return CounterStyle::Digits(&CHINESE_DIGITS).format(value);
   }
   if value == 0 {
     return CHINESE_DIGITS[0].to_string();
@@ -220,25 +251,6 @@ fn roman(value: usize) -> String {
   out
 }
 
-/// Every character a counter in `style` can produce.
-fn style_characters(style: &str) -> String {
-  if let Some((_, digits)) = DIGIT_STYLES.iter().find(|(name, _)| *name == style) {
-    return digits.iter().collect();
-  }
-  if let Some((_, alphabet)) = ALPHABET_STYLES.iter().find(|(name, _)| *name == style) {
-    return (*alphabet).to_string();
-  }
-
-  match style {
-    "lower-roman" => "ivxlcdm".to_string(),
-    "upper-roman" => "IVXLCDM".to_string(),
-    "trad-chinese-informal" | "cjk-ideographic" => {
-      CHINESE_DIGITS.iter().collect::<String>() + "十百千"
-    }
-    _ => "0123456789".to_string(),
-  }
-}
-
 /// The characters the page counters named by `classes` can produce, or nothing
 /// when no class asks for a counter.
 ///
@@ -253,8 +265,8 @@ pub fn counter_characters<'c>(classes: impl IntoIterator<Item = &'c str>) -> Str
       hooked = true;
       continue;
     }
-    if is_counter_style(class) {
-      characters.push_str(&style_characters(class));
+    if let Some(style) = CounterStyle::from_name(class) {
+      characters.push_str(&style.characters());
     }
   }
 
@@ -263,7 +275,7 @@ pub fn counter_characters<'c>(classes: impl IntoIterator<Item = &'c str>) -> Str
   }
   // A hook without a style counts in decimal, and a band can hold both: a
   // plain `pageNumber` beside a `totalPages thai` still needs its own digits.
-  style_characters("decimal") + &characters
+  CounterStyle::Decimal.characters() + &characters
 }
 
 /// The counter value a node's class hooks request, if any: `pageNumber` or
@@ -284,12 +296,8 @@ pub(crate) fn counter_text(node: &Node, page: usize, pages: usize) -> Option<Str
   } else {
     return None;
   };
-  let style = classes
-    .split_whitespace()
-    .find(|class| is_counter_style(class))
-    .unwrap_or("decimal");
 
-  Some(format_counter(value, style))
+  Some(CounterStyle::from_classes(classes).format(value))
 }
 
 /// The page a `targetPageNumber` node asks for, formatted. The target is the
@@ -306,16 +314,13 @@ fn target_counter_text(
   if !classes.split_whitespace().any(|class| class == TARGET_HOOK) {
     return None;
   }
-  let style = classes
-    .split_whitespace()
-    .find(|class| is_counter_style(class))
-    .unwrap_or("decimal");
+  let style = CounterStyle::from_classes(classes);
   let page = href
     .and_then(|href| href.strip_prefix('#'))
     .filter(|fragment| !fragment.is_empty())
     .and_then(|fragment| page_of(&percent_decode(fragment)));
 
-  Some(page.map_or_else(String::new, |page| format_counter(page, style)))
+  Some(page.map_or_else(String::new, |page| style.format(page)))
 }
 
 /// Whether a tree asks for any target page counter. Only such a tree pays for
@@ -474,6 +479,10 @@ fn write_counter(node: &mut Node, text: String) {
 mod tests {
   use super::*;
 
+  fn format_counter(value: usize, style: &str) -> String {
+    CounterStyle::from_classes(style).format(value)
+  }
+
   #[test]
   fn digit_styles_spell_the_number_in_their_own_script() {
     assert_eq!(format_counter(2026, "devanagari"), "२०२६");
@@ -511,7 +520,7 @@ mod tests {
   #[test]
   fn unknown_styles_count_in_decimal() {
     assert_eq!(format_counter(42, "no-such-style"), "42");
-    assert!(!is_counter_style("no-such-style"));
-    assert!(is_counter_style("tibetan"));
+    assert!(CounterStyle::from_name("no-such-style").is_none());
+    assert!(CounterStyle::from_name("tibetan").is_some());
   }
 }

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -49,7 +49,7 @@ use crate::svg;
 use crate::{
   background::{Placement, cycled, place},
   filter::{ColorFilter, unsupported_filter},
-  glyph::run_glyphs,
+  glyph::{run_glyphs, uncovered_error},
   inline::{InlineMap, build_inline_runs, node_inline_items},
   krilla::{
     Data,
@@ -71,6 +71,7 @@ use crate::{
   },
   shadow::{emit_inset_shadows, emit_outer_shadows},
   tags::TagCollector,
+  window::Window,
 };
 
 /// What a box left on the surface for its caller to unwind.
@@ -98,33 +99,22 @@ pub(crate) struct PendingOutline {
 /// coordinates belong in the key.
 pub(crate) type FontKey = (u64, u32, Vec<([u8; 4], u32)>);
 
-/// Scene walker state: the render tree, the stacking-context scene, and a cache
-/// of krilla fonts.
+/// Krilla fonts embedded so far, one per distinct instance.
 pub(crate) type FontMap = HashMap<FontKey, Font>;
 
 pub(crate) struct Emitter<'a> {
   pub(crate) root: &'a RenderNode,
   pub(crate) contexts: &'a [StackingContextNode],
   pub(crate) results: &'a LayoutResults,
-  pub(crate) fonts: &'a mut FontMap,
+  pub(crate) document: &'a DocumentState<'a>,
   /// Pre-built inline layouts for the content tree; band trees build on the
   /// fly.
   pub(crate) inline: Option<&'a InlineMap<'a>>,
-  /// Vertical content window `[top, bottom)` of the page being emitted;
-  /// paint wholly outside it is skipped so clipped-away content never reaches
-  /// the content stream (or text extraction).
-  pub(crate) window: Option<(f32, f32)>,
-  /// Horizontal content window `[left, right)`: a repeated table header
-  /// replays only its own table's column of the scene.
-  pub(crate) x_window: Option<(f32, f32)>,
-  /// Text-line ownership window: `[this page's cut, next page's cut)`. Wider
-  /// than `window` at the edges (first page reaches up to −∞, last to +∞) and
-  /// narrower at the bottom when a cut lands above the page's full height, so
-  /// every line is emitted on exactly one page.
-  pub(crate) line_window: Option<(f32, f32)>,
-  /// Records a marked-content identifier per source node while drawing, for
-  /// the structure tree built after emission.
-  pub(crate) tags: Option<&'a RefCell<TagCollector>>,
+  /// The page window this walk paints through.
+  pub(crate) window: Window,
+  /// Whether this walk records marked content for the structure tree. A
+  /// replayed artifact walks the same document untagged.
+  pub(crate) tagged: bool,
   /// Path from the document root to this emitter's own root. Empty for the
   /// document; an inline box's subtree emitter carries the box's path, so the
   /// nodes it tags land where the structure tree walk looks for them.
@@ -132,14 +122,6 @@ pub(crate) struct Emitter<'a> {
   /// Color transform from the `filter` properties of the enclosing stacking
   /// contexts, applied to every color this subtree paints.
   pub(crate) color_filter: Option<Rc<ColorFilter>>,
-  /// The document's default language. A node declaring a different one has
-  /// its content marked with that language, which is how a reader knows to
-  /// switch voices mid-document.
-  pub(crate) document_lang: Option<&'a str>,
-  /// What the page could not draw. Collected rather than raised on the spot:
-  /// the surface has open transforms and clips mid-page, and unwinding past
-  /// them would leave it unbalanced.
-  pub(crate) issues: &'a RefCell<RenderIssues>,
 }
 
 /// Names an image in an error: its URL, or that it came in as raw bytes.
@@ -158,6 +140,41 @@ pub(crate) struct RenderIssues {
   pub(crate) uncovered: String,
   /// The first failure worth stopping for.
   pub(crate) failure: Option<PdfError>,
+}
+
+/// What every page of one document shares while it is emitted.
+pub(crate) struct DocumentState<'a> {
+  pub(crate) fonts: RefCell<FontMap>,
+  /// Present when the document is tagged.
+  pub(crate) tags: Option<RefCell<TagCollector>>,
+  /// What the pages could not draw. Collected rather than raised on the spot:
+  /// the surface has open transforms and clips mid-page, and unwinding past
+  /// them would leave it unbalanced.
+  pub(crate) issues: RefCell<RenderIssues>,
+  /// The document's default language. A node declaring a different one has
+  /// its content marked with that language, which is how a reader knows to
+  /// switch voices mid-document.
+  pub(crate) lang: Option<&'a str>,
+}
+
+impl<'a> DocumentState<'a> {
+  pub(crate) fn new(tagged: bool, lang: Option<&'a str>) -> Self {
+    Self {
+      fonts: RefCell::new(FontMap::default()),
+      tags: tagged.then(RefCell::default),
+      issues: RefCell::default(),
+      lang,
+    }
+  }
+
+  /// The error the pages left behind, if any.
+  pub(crate) fn into_error(self) -> Option<PdfError> {
+    let issues = self.issues.into_inner();
+
+    issues
+      .failure
+      .or_else(|| uncovered_error(&issues.uncovered))
+  }
 }
 
 impl Emitter<'_> {
@@ -192,47 +209,27 @@ impl Emitter<'_> {
   }
 
   fn fail(&self, error: PdfError) {
-    let mut issues = self.issues.borrow_mut();
+    let mut issues = self.document.issues.borrow_mut();
 
     if issues.failure.is_none() {
       issues.failure = Some(error);
     }
   }
 
-  fn window_excludes(&self, top: f32, bottom: f32) -> bool {
-    self
-      .window
-      .is_some_and(|(y0, y1)| bottom <= y0 || top >= y1)
-  }
-
-  /// Whether a text line at `baseline` belongs to another page. Ownership is
-  /// keyed on the baseline (always inside the line's own box, unlike the font
-  /// ascent band, which can poke above the container a forced break cut at) and
-  /// half-open, so each line is emitted exactly once.
-  fn window_disowns_line(&self, baseline: f32) -> bool {
-    self
-      .line_window
-      .is_some_and(|(y0, y1)| baseline < y0 || baseline >= y1)
-  }
-
   /// Whether the run's line belongs to another page. The one ownership test
   /// every inline paint pass shares: glyphs, shadows, decorations, boxes and
   /// background fragments all key on it.
   fn window_disowns_run(&self, run: &PositionedInlineRun, layout: Layout, y: f32) -> bool {
-    run
-      .glyph_run
-      .glyphs
-      .first()
-      .is_some_and(|glyph| self.window_disowns_line(y + run.glyph_offset(layout).y + glyph.y))
+    run.glyph_run.glyphs.first().is_some_and(|glyph| {
+      self
+        .window
+        .disowns_line(y + run.glyph_offset(layout).y + glyph.y)
+    })
   }
 
-  fn window_excludes_bounds(&self, bounds: Option<takumi_core::scene::SceneBounds>) -> bool {
-    bounds.is_some_and(|b| {
-      self.window_excludes(b.top as f32, b.bottom as f32)
-        || self
-          .x_window
-          .is_some_and(|(x0, x1)| b.right as f32 <= x0 || b.left as f32 >= x1)
-    })
+  /// The marked-content identifiers this walk records into, if it tags.
+  fn tags(&self) -> Option<&RefCell<TagCollector>> {
+    self.tagged.then_some(self.document.tags.as_ref()?)
   }
 
   /// The marked-content tag a node's own content opens.
@@ -242,7 +239,7 @@ impl Emitter<'_> {
   /// language needs nothing: the catalog already declares it.
   fn content_tag<'t>(&self, node: &'t RenderNode) -> ContentTag<'t> {
     match node.context.style.lang.as_ref().map(Lang::as_str) {
-      Some(lang) if Some(lang) != self.document_lang => {
+      Some(lang) if Some(lang) != self.document.lang => {
         ContentTag::Span(SpanTag::empty().with_lang(Some(lang)))
       }
       _ => ContentTag::Other,
@@ -270,7 +267,7 @@ impl Emitter<'_> {
       self.color_filter = self.composed_filter(outer_filter.as_deref(), &node.context.style.filter);
     }
 
-    let (outer_window, outer_line_window) = (self.window, self.line_window);
+    let outer_window = self.window;
     let (child_frame, root_state) = match context.root() {
       Some(paint) => self.emit_box(paint, parent, surface)?,
       None => (parent, BoxState::default()),
@@ -284,7 +281,7 @@ impl Emitter<'_> {
             // the page's own clip would drop it anyway. A context's root is
             // never skipped this way, because the clip it opens decides what
             // its descendants are allowed to emit.
-            if self.window_excludes_bounds(paint.paint_bounds) {
+            if self.window.excludes_bounds(paint.paint_bounds) {
               continue;
             }
             let (_, state) = self.emit_box(paint, child_frame, surface)?;
@@ -294,7 +291,7 @@ impl Emitter<'_> {
             let excluded = self
               .contexts
               .get(*child)
-              .is_some_and(|ctx| self.window_excludes_bounds(ctx.paint_bounds()));
+              .is_some_and(|ctx| self.window.excludes_bounds(ctx.paint_bounds()));
             if !excluded {
               self.emit_context(*child, child_frame, surface)?;
             }
@@ -303,7 +300,7 @@ impl Emitter<'_> {
       }
     }
     self.finish_box(root_state, surface);
-    (self.window, self.line_window) = (outer_window, outer_line_window);
+    self.window = outer_window;
     self.color_filter = outer_filter;
     Ok(())
   }
@@ -364,7 +361,7 @@ impl Emitter<'_> {
     // reserve layout space). `slice` needs nothing — the page window slices
     // the full-box decorations, which is exactly the sliced rendering.
     let (deco_y, deco_size) = if style.box_decoration_break == BoxDecorationBreak::Clone
-      && let Some((window_top, window_bottom)) = self.window
+      && let Some((window_top, window_bottom)) = self.window.y
     {
       let top = y.max(window_top);
       let bottom = (y + layout.size.height).min(window_bottom);
@@ -436,15 +433,7 @@ impl Emitter<'_> {
       // what it cuts away must never be emitted. Only a translated frame maps
       // the box onto the window's axis.
       if relative.only_translation() {
-        let (top, bottom) = (y, y + layout.size.height);
-
-        if let Some((from, to)) = self.window {
-          self.window = Some((from.max(top), to.min(bottom)));
-        }
-        // A text line is owned by its baseline, against its own window.
-        if let Some((from, to)) = self.line_window {
-          self.line_window = Some((from.max(top), to.min(bottom)));
-        }
+        self.window.narrow(y, y + layout.size.height);
       }
       let clip_border = BorderProperties::from_context(&node.context, layout.size, layout.border);
       let path = if clip_border.is_zero() {
@@ -464,7 +453,7 @@ impl Emitter<'_> {
       }
     }
 
-    let tagged = self.tags.is_some() && has_own_content(node);
+    let tagged = self.tagged && has_own_content(node);
 
     if tagged {
       if decorative_image(node) {
@@ -475,7 +464,7 @@ impl Emitter<'_> {
       } else {
         let identifier = surface.start_tagged(self.content_tag(node));
 
-        if let Some(tags) = self.tags {
+        if let Some(tags) = self.tags() {
           tags
             .borrow_mut()
             .record(&self.tag_path(&paint.path), identifier);
@@ -522,7 +511,7 @@ impl Emitter<'_> {
       filter: self.color_filter.as_deref(),
       // An artifact opens only once something actually paints, because marked
       // content does not nest and an empty region would still have to close.
-      artifact: self.tags.is_some(),
+      artifact: self.tagged,
     };
 
     BoxPainter::new(&node.context, layout).background_color(CorePoint { x, y }, &mut device);
@@ -966,7 +955,7 @@ impl Emitter<'_> {
   /// Opens an artifact sequence around a decoration when tagging is on, so it
   /// stays out of the structure tree. Returns whether one was opened.
   fn start_artifact(&self, surface: &mut Surface) -> bool {
-    if self.tags.is_none() {
+    if !self.tagged {
       return false;
     }
     surface.start_tagged(ContentTag::Artifact(Artifact::new(
@@ -1053,7 +1042,7 @@ impl Emitter<'_> {
       &mut SurfaceDevice {
         surface,
         filter: self.color_filter.as_deref(),
-        artifact: self.tags.is_some(),
+        artifact: self.tagged,
       },
     ) {
       return;
@@ -1305,7 +1294,7 @@ impl Emitter<'_> {
     // A fragment paints only on the page that owns its line, like the glyph
     // pass, so a page cut leaves no background sliver on the neighbor page.
     for fragment in &runs.background_fragments {
-      if self.window_disowns_line(y + fragment.baseline) {
+      if self.window.disowns_line(y + fragment.baseline) {
         continue;
       }
       let Some(path) = krilla_path(&inline_background_path(fragment), x, y) else {
@@ -1369,7 +1358,11 @@ impl Emitter<'_> {
         .text
         .get(shaped.text_range.clone())
         .unwrap_or_default();
-      let glyphs = run_glyphs(shaped, run_text, &mut self.issues.borrow_mut().uncovered);
+      let glyphs = run_glyphs(
+        shaped,
+        run_text,
+        &mut self.document.issues.borrow_mut().uncovered,
+      );
 
       let color = shaped.brush.color;
       let fill = fill_from_rgba(self.filtered(color), shaped.brush.opacity);
@@ -1452,7 +1445,7 @@ impl Emitter<'_> {
     // The caller opened a marked-content region for the text around these
     // boxes. Marked content does not nest, so each box closes it, takes a
     // region of its own, and hands it back.
-    let owner_tagged = self.tags.is_some() && has_own_content(owner);
+    let owner_tagged = self.tagged && has_own_content(owner);
 
     for positioned in &runs.inline_boxes {
       let Some(ProcessedInlineSpan::Box(item)) = built.spans.get(positioned.id as usize) else {
@@ -1464,23 +1457,22 @@ impl Emitter<'_> {
       // runs beside it.
       if positioned.line_baseline.is_some_and(|baseline| {
         let absolute = y + layout.content_box_offset().y + baseline;
-        self.window_disowns_line(absolute)
+        self.window.disowns_line(absolute)
       }) {
         continue;
       }
       let Some((offset, paint)) = resolve_inline_box(positioned, item, layout) else {
         continue;
       };
-      let marker_target = (self.tags.is_some() && node.origin == NodeOrigin::Marker)
+      let marker_target = (self.tagged && node.origin == NodeOrigin::Marker)
         .then(|| self.marker_tag_target(owner))
         .flatten();
       let marker_tagged = marker_target.is_some();
 
       // A container box runs its own emitter, which tags every node it walks.
       // A replaced one paints here, so it takes one region for the whole box.
-      let box_tagged = cfg!(feature = "images")
-        && self.tags.is_some()
-        && matches!(paint, InlineBoxPaint::Replaced { .. });
+      let box_tagged =
+        cfg!(feature = "images") && self.tagged && matches!(paint, InlineBoxPaint::Replaced { .. });
 
       if owner_tagged {
         surface.end_tagged();
@@ -1488,7 +1480,7 @@ impl Emitter<'_> {
       if let Some(path) = marker_target.as_ref() {
         let identifier = surface.start_tagged(self.content_tag(node));
 
-        if let Some(tags) = self.tags {
+        if let Some(tags) = self.tags() {
           tags.borrow_mut().record_label(path, identifier);
         }
       } else if box_tagged {
@@ -1589,24 +1581,18 @@ impl Emitter<'_> {
     // The subtree root is a clone of `node`, so the box's own path is the
     // prefix that puts the subtree's nodes back on the document tree.
     let mut box_path = Vec::new();
-    let tags = self
-      .tags
-      .filter(|_| node_path(self.root, node, &mut box_path));
+    let tagged = self.tagged && node_path(self.root, node, &mut box_path);
     let tag_prefix = self.tag_path(&box_path);
     let mut emitter = Emitter {
       root: &subtree.root,
       contexts: &contexts,
       results: &subtree.results,
-      fonts: &mut *self.fonts,
+      document: self.document,
       inline: None,
-      window: None,
-      x_window: None,
-      line_window: None,
-      tags,
+      window: Window::default(),
+      tagged,
       tag_prefix,
       color_filter: self.color_filter.clone(),
-      issues: self.issues,
-      document_lang: self.document_lang,
     };
     let x = origin.0 + subtree.margin_offset.x;
     let y = origin.1 + subtree.margin_offset.y;
@@ -1629,7 +1615,7 @@ impl Emitter<'_> {
     let identifier = surface.start_tagged(self.content_tag(node));
     let mut path = Vec::new();
 
-    if let Some(tags) = self.tags
+    if let Some(tags) = self.tags()
       && node_path(self.root, node, &mut path)
     {
       tags.borrow_mut().record(&self.tag_path(&path), identifier);
@@ -1796,7 +1782,11 @@ impl Emitter<'_> {
         .text
         .get(shaped.text_range.clone())
         .unwrap_or_default();
-      let glyphs = run_glyphs(shaped, run_text, &mut self.issues.borrow_mut().uncovered);
+      let glyphs = run_glyphs(
+        shaped,
+        run_text,
+        &mut self.document.issues.borrow_mut().uncovered,
+      );
 
       let color = color.unwrap_or(shaped.brush.color);
 
@@ -1850,7 +1840,7 @@ impl Emitter<'_> {
         .collect(),
     );
 
-    if let Some(font) = self.fonts.get(&key) {
+    if let Some(font) = self.document.fonts.borrow().get(&key) {
       return Some(font.clone());
     }
     let variations: Vec<(Tag, f32)> = shaped
@@ -1864,7 +1854,7 @@ impl Emitter<'_> {
       &variations,
     )?;
 
-    self.fonts.insert(key, font.clone());
+    self.document.fonts.borrow_mut().insert(key, font.clone());
     Some(font)
   }
 }

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -47,9 +47,9 @@ use crate::paint::rasterized_image;
 #[cfg(all(feature = "svg", feature = "images"))]
 use crate::svg;
 use crate::{
-  background::{Placement, cycled, place},
+  background::{Placement, cycled},
   filter::{ColorFilter, unsupported_filter},
-  glyph::{run_glyphs, uncovered_error},
+  glyph::run_glyphs,
   inline::{InlineMap, build_inline_runs, node_inline_items},
   krilla::{
     Data,
@@ -167,13 +167,22 @@ impl<'a> DocumentState<'a> {
     }
   }
 
-  /// The error the pages left behind, if any.
+  /// The error the pages left behind, if any: what failed outright, else the
+  /// characters no font covered.
   pub(crate) fn into_error(self) -> Option<PdfError> {
     let issues = self.issues.into_inner();
 
-    issues
-      .failure
-      .or_else(|| uncovered_error(&issues.uncovered))
+    if issues.failure.is_some() || issues.uncovered.is_empty() {
+      return issues.failure;
+    }
+    let named = issues
+      .uncovered
+      .chars()
+      .map(|character| format!("{character} (U+{:04X})", character as u32))
+      .collect::<Vec<_>>()
+      .join(", ");
+
+    Some(PdfError::MissingGlyphs(named))
   }
 }
 
@@ -559,7 +568,7 @@ impl Emitter<'_> {
 
     surface.push_clip_path(&clip, &rule);
     for (index, image) in images.iter().enumerate().rev() {
-      let placement = place(
+      let placement = Placement::resolve(
         area,
         cycled(&style.background_size, index),
         cycled(&style.background_position, index),
@@ -901,7 +910,7 @@ impl Emitter<'_> {
       let mut content = builder.surface();
 
       for (index, image) in images.iter().enumerate().rev() {
-        let placement = place(
+        let placement = Placement::resolve(
           size,
           cycled(&style.mask_size, index),
           cycled(&style.mask_position, index),
@@ -1718,7 +1727,7 @@ impl Emitter<'_> {
       .enumerate()
       .rev()
     {
-      let placement = place(
+      let placement = Placement::resolve(
         area,
         cycled(&style.background_size, index),
         cycled(&style.background_position, index),

--- a/takumi-pdf/src/glyph.rs
+++ b/takumi-pdf/src/glyph.rs
@@ -4,12 +4,9 @@ use std::ops::Range;
 
 use takumi_core::layout::inline::ShapedRun;
 
-use crate::{
-  krilla::{
-    surface::Location,
-    text::{Glyph, GlyphId},
-  },
-  options::PdfError,
+use crate::krilla::{
+  surface::Location,
+  text::{Glyph, GlyphId},
 };
 
 /// The run's glyphs, each carrying the source text it maps to.
@@ -68,20 +65,6 @@ fn collect_uncovered(
       }
     }
   }
-}
-
-/// The error naming what no font covered, or `None` when everything mapped.
-pub(crate) fn uncovered_error(uncovered: &str) -> Option<PdfError> {
-  if uncovered.is_empty() {
-    return None;
-  }
-  let named = uncovered
-    .chars()
-    .map(|character| format!("{character} (U+{:04X})", character as u32))
-    .collect::<Vec<_>>()
-    .join(", ");
-
-  Some(PdfError::MissingGlyphs(named))
 }
 
 /// Per-glyph byte ranges into `run_text`, from the shaper's cluster

--- a/takumi-pdf/src/inline.rs
+++ b/takumi-pdf/src/inline.rs
@@ -29,15 +29,8 @@ pub(crate) struct PreparedInline<'c> {
 /// Inline layouts keyed by the box's layout [`NodeId`].
 pub(crate) type InlineMap<'c> = HashMap<NodeId, PreparedInline<'c>>;
 
-/// The text-bearing boxes of a prepared tree, with the resolved font style
-/// each inline layout borrows.
-pub(crate) fn collect_text_boxes<'t>(tree: &'t PreparedTree) -> Vec<TextBox<'t>> {
-  let mut boxes = Vec::new();
-
-  tree.for_each_paint(|paint| collect_text_boxes_paint(tree, paint, &mut boxes));
-  boxes
-}
-
+/// A text-bearing box of a prepared tree, with the resolved font style its
+/// inline layout borrows.
 pub(crate) struct TextBox<'t> {
   node: &'t RenderNode,
   node_id: NodeId,
@@ -45,28 +38,33 @@ pub(crate) struct TextBox<'t> {
   font_style: SizedFontStyle<'t>,
 }
 
-fn collect_text_boxes_paint<'t>(
-  tree: &'t PreparedTree,
-  paint: &NodePaint,
-  boxes: &mut Vec<TextBox<'t>>,
-) {
-  let Some(node) = tree.root.node_at_path(&paint.path) else {
-    return;
-  };
-  let Ok(layout) = tree.results.layout(paint.node_id) else {
-    return;
-  };
-  let is_text = node.should_create_inline_layout()
-    || (!node.has_anonymous_text_item_child()
-      && matches!(node.node.as_ref().map(|n| &n.kind), Some(NodeKind::Text(_))));
+impl<'t> TextBox<'t> {
+  pub(crate) fn collect(tree: &'t PreparedTree) -> Vec<Self> {
+    let mut boxes = Vec::new();
 
-  if is_text {
-    boxes.push(TextBox {
-      node,
-      node_id: paint.node_id,
-      layout,
-      font_style: SizedFontStyle::from_style(&node.context.style, &node.context),
-    });
+    tree.for_each_paint(|paint| Self::collect_paint(tree, paint, &mut boxes));
+    boxes
+  }
+
+  fn collect_paint(tree: &'t PreparedTree, paint: &NodePaint, boxes: &mut Vec<Self>) {
+    let Some(node) = tree.root.node_at_path(&paint.path) else {
+      return;
+    };
+    let Ok(layout) = tree.results.layout(paint.node_id) else {
+      return;
+    };
+    let is_text = node.should_create_inline_layout()
+      || (!node.has_anonymous_text_item_child()
+        && matches!(node.node.as_ref().map(|n| &n.kind), Some(NodeKind::Text(_))));
+
+    if is_text {
+      boxes.push(Self {
+        node,
+        node_id: paint.node_id,
+        layout,
+        font_style: SizedFontStyle::from_style(&node.context.style, &node.context),
+      });
+    }
   }
 }
 

--- a/takumi-pdf/src/interactive.rs
+++ b/takumi-pdf/src/interactive.rs
@@ -411,45 +411,47 @@ pub(crate) fn add_link_annotations<'l>(
 /// deeper headings as children, like an HTML document outline. A heading with
 /// no destination (its page is dropped by page ranges) loses its entry and its
 /// children take its place.
-pub(crate) fn build_outline(
-  headings: &[HeadingTarget],
-  destination: impl Fn(&HeadingTarget) -> Option<XyzDestination>,
-) -> Outline {
-  fn take(
-    headings: &[HeadingTarget],
-    index: &mut usize,
-    level: u8,
-    destination: &impl Fn(&HeadingTarget) -> Option<XyzDestination>,
-  ) -> Vec<OutlineNode> {
-    let mut nodes = Vec::new();
+impl Interactive {
+  pub(crate) fn outline(
+    &self,
+    destination: impl Fn(&HeadingTarget) -> Option<XyzDestination>,
+  ) -> Outline {
+    fn take(
+      headings: &[HeadingTarget],
+      index: &mut usize,
+      level: u8,
+      destination: &impl Fn(&HeadingTarget) -> Option<XyzDestination>,
+    ) -> Vec<OutlineNode> {
+      let mut nodes = Vec::new();
 
-    while let Some(heading) = headings.get(*index) {
-      if heading.level < level {
-        break;
-      }
-      *index += 1;
-      let children = take(headings, index, heading.level + 1, destination);
-
-      match destination(heading) {
-        Some(dest) => {
-          let mut node = OutlineNode::new(heading.text.clone(), dest);
-
-          for child in children {
-            node.push_child(child);
-          }
-          nodes.push(node);
+      while let Some(heading) = headings.get(*index) {
+        if heading.level < level {
+          break;
         }
-        None => nodes.extend(children),
+        *index += 1;
+        let children = take(headings, index, heading.level + 1, destination);
+
+        match destination(heading) {
+          Some(dest) => {
+            let mut node = OutlineNode::new(heading.text.clone(), dest);
+
+            for child in children {
+              node.push_child(child);
+            }
+            nodes.push(node);
+          }
+          None => nodes.extend(children),
+        }
       }
+      nodes
     }
-    nodes
-  }
 
-  let mut outline = Outline::new();
-  let mut index = 0;
+    let mut outline = Outline::new();
+    let mut index = 0;
 
-  for node in take(headings, &mut index, 1, &destination) {
-    outline.push_child(node);
+    for node in take(&self.headings, &mut index, 1, &destination) {
+      outline.push_child(node);
+    }
+    outline
   }
-  outline
 }

--- a/takumi-pdf/src/interactive.rs
+++ b/takumi-pdf/src/interactive.rs
@@ -31,6 +31,7 @@ use crate::{
   options::PT_PER_PX,
   tags::{TagCollector, text_content},
   tree::PreparedTree,
+  window::Window,
 };
 
 /// A hyperlink box in content coordinates.
@@ -109,35 +110,32 @@ fn heading_level(tag: &str) -> Option<u8> {
   }
 }
 
-/// The element paths a destination can point at: every anchor and every
-/// heading the outline lists. Their structure elements need an id so a
-/// structure destination can name them.
-pub(crate) fn destination_targets(interactive: &Interactive) -> HashSet<Vec<usize>> {
-  interactive
-    .anchors
-    .values()
-    .map(|anchor| anchor.path.clone())
-    .chain(
-      interactive
-        .headings
-        .iter()
-        .map(|heading| heading.path.clone()),
-    )
-    .collect()
-}
+impl Interactive {
+  /// Collects hyperlinks and headings from the prepared scene, in paint order.
+  pub(crate) fn collect(tree: &PreparedTree) -> Self {
+    let mut collected = Self {
+      links: Vec::new(),
+      headings: Vec::new(),
+      anchors: HashMap::new(),
+      extents: HashMap::new(),
+    };
 
-/// Collects hyperlinks and headings from the prepared scene, in paint order.
-pub(crate) fn collect_interactive(tree: &PreparedTree) -> Interactive {
-  let mut collected = Interactive {
-    links: Vec::new(),
-    headings: Vec::new(),
-    anchors: HashMap::new(),
-    extents: HashMap::new(),
-  };
+    tree.for_each_paint(|paint| collect_interactive_paint(tree, paint, &mut collected));
+    collected.headings.sort_by(|a, b| a.top.total_cmp(&b.top));
+    collected
+  }
 
-  tree.for_each_paint(|paint| collect_interactive_paint(tree, paint, &mut collected));
-  collected.headings.sort_by(|a, b| a.top.total_cmp(&b.top));
-  collected
+  /// The element paths a destination can point at: every anchor and every
+  /// heading the outline lists. Their structure elements need an id so a
+  /// structure destination can name them.
+  pub(crate) fn destination_targets(&self) -> HashSet<Vec<usize>> {
+    self
+      .anchors
+      .values()
+      .map(|anchor| anchor.path.clone())
+      .chain(self.headings.iter().map(|heading| heading.path.clone()))
+      .collect()
+  }
 }
 
 fn collect_interactive_paint(tree: &PreparedTree, paint: &NodePaint, collected: &mut Interactive) {
@@ -351,22 +349,22 @@ fn collect_inline_links(
 }
 
 /// Adds this page's slice of every link as annotations. `window` is the page's
-/// content window in content coordinates; `x_window` narrows it horizontally
-/// for a replayed table header; `offset` maps content to page coordinates.
+/// content window in content coordinates, narrowed horizontally for a
+/// replayed table header; `offset` maps content to page coordinates.
 pub(crate) fn add_link_annotations<'l>(
   page: &mut Page,
   links: impl IntoIterator<Item = &'l LinkTarget>,
-  window: (f32, f32),
-  x_window: Option<(f32, f32)>,
+  window: Window,
   offset: (f32, f32),
   tags: Option<&RefCell<TagCollector>>,
   anchor: impl Fn(&str) -> Option<XyzDestination>,
 ) {
-  let (x0, x1) = x_window.unwrap_or((f32::NEG_INFINITY, f32::INFINITY));
+  let (y0, y1) = window.y.unwrap_or((f32::NEG_INFINITY, f32::INFINITY));
+  let (x0, x1) = window.x.unwrap_or((f32::NEG_INFINITY, f32::INFINITY));
 
   for link in links {
-    let top = link.rect.top().max(window.0);
-    let bottom = link.rect.bottom().min(window.1);
+    let top = link.rect.top().max(y0);
+    let bottom = link.rect.bottom().min(y1);
     let left = link.rect.left().max(x0);
     let right = link.rect.right().min(x1);
 
@@ -375,9 +373,9 @@ pub(crate) fn add_link_annotations<'l>(
     }
     let Some(rect) = KrillaRect::from_ltrb(
       (left + offset.0) * PT_PER_PX,
-      (top - window.0 + offset.1) * PT_PER_PX,
+      (top - y0 + offset.1) * PT_PER_PX,
       (right + offset.0) * PT_PER_PX,
-      (bottom - window.0 + offset.1) * PT_PER_PX,
+      (bottom - y0 + offset.1) * PT_PER_PX,
     ) else {
       continue;
     };

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -39,7 +39,7 @@
 //! `filter: blur()` and `drop-shadow()` have no PDF equivalent. [`render`]
 //! stops and names the function.
 
-use std::{cell::RefCell, mem::take, rc::Rc};
+use std::{mem::take, rc::Rc};
 
 mod atoms;
 mod background;
@@ -87,6 +87,7 @@ mod krilla;
 mod subsetter;
 
 use takumi_core::{
+  layout::tree::RenderNode,
   style::{Affine, Color, Lang},
   viewport::{MediaTarget, Viewport},
 };
@@ -100,26 +101,23 @@ pub use crate::options::{
   XmpProperty, XmpSchema,
 };
 use crate::{
-  bands::{RepeatBounds, Repeatable, prepare_band},
-  emitter::{FontMap, RenderIssues},
-  glyph::uncovered_error,
-  inline::{build_inline_map, collect_text_boxes},
-  interactive::{add_link_annotations, build_outline, collect_interactive, destination_targets},
+  emitter::DocumentState,
+  inline::{TextBox, build_inline_map},
+  interactive::{Interactive, add_link_annotations, build_outline},
   krilla::{
     Document, SerializeSettings,
     configure::ConfigurationBuilder,
     destination::XyzDestination,
     embed::{EmbeddedFile, MimeType},
-    geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
+    geom::{Point, Size as KrillaSize, Transform},
     page::PageSettings,
-    surface::Surface,
   },
   options::{PT_PER_PX, PageSelection, build_metadata, krilla_datetime, validate_xmp_schemas},
-  page::{PageComposer, PageFrame},
-  pagination::{MAX_PAGES, paginate},
-  paint::{fill_from_rgba, rect_path},
-  tags::{TagCollector, build_tag_tree, tag_id},
-  tree::{TreeInputs, prepare_tree, tree_context},
+  page::{PageBands, PagePlan},
+  paint::paint_page_background,
+  tags::tag_id,
+  tree::{PreparedTree, TreeInputs},
+  window::Window,
 };
 
 /// Lays out a node tree without rendering and returns its size.
@@ -141,18 +139,15 @@ pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
     lang: options.lang,
   };
   let tree = match (options.page, options.viewport) {
-    (Some(page), _) => prepare_band(
-      &inputs,
+    (Some(page), _) => inputs.prepare_band(
       &options.node,
       999,
       999,
       Viewport::new((page.width as u32, None)).with_media_target(MediaTarget::Print),
     )?,
-    (None, Some(viewport)) => prepare_tree(
-      &inputs,
-      options.node,
-      viewport.with_media_target(MediaTarget::Print),
-    )?,
+    (None, Some(viewport)) => {
+      inputs.prepare(options.node, viewport.with_media_target(MediaTarget::Print))?
+    }
     (None, None) => return Err(PdfError::MissingViewport),
   };
 
@@ -164,24 +159,11 @@ pub fn measure(options: MeasureOptions<'_>) -> Result<MeasuredSize, PdfError> {
   })
 }
 
-/// Fills the page box before the page draws anything else. An unset color
-/// leaves the page empty rather than painting white, like Chromium's print
-/// path.
-fn paint_page_background(color: Option<Color>, size: (f32, f32), surface: &mut Surface) {
-  let Some(color) = color else {
-    return;
-  };
-  let Some(path) = KrillaRect::from_xywh(0.0, 0.0, size.0, size.1).and_then(rect_path) else {
-    return;
-  };
-
-  surface.set_fill(Some(fill_from_rgba(color.0, 1.0)));
-  surface.draw_path(&path);
-}
-
 /// Renders a node tree to a PDF: single-page at the viewport size, or paged
 /// when [`PdfOptions::page`] is set.
-pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
+pub fn render(mut options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
+  let attachments = take(&mut options.attachments);
+  let mut pdf = open_document(&options, attachments)?;
   let inputs = TreeInputs {
     fonts: options.fonts,
     stylesheet: options.stylesheet,
@@ -189,54 +171,113 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
     font_families: options.font_families,
     lang: options.lang,
   };
-  let mut fonts = FontMap::new();
-  let issues = RefCell::new(RenderIssues::default());
-  let document_lang = inputs.lang.as_ref().map(Lang::as_str);
-  let mut document = {
-    let mut builder = ConfigurationBuilder::new();
-    let mut validated = false;
+  let tagged = options.tagged != Tagging::Off || options.standard.requires_tagging();
+  let state = DocumentState::new(tagged, inputs.lang.as_ref().map(Lang::as_str));
+  let structural = options.tagged.names_structure_destinations();
+  let rendered = match options.page {
+    Some(page) => {
+      let bands = PageBands {
+        header: options.header.as_ref(),
+        footer: options.footer.as_ref(),
+        page_ranges: options.page_ranges.as_deref(),
+      };
+      let plan = PagePlan::solve(&inputs, page, bands, options.node, structural)?;
 
-    if let Some(archival) = options.standard.archival() {
-      builder = builder.with_archival_validator(archival);
-      validated = true;
+      plan.compose(&mut pdf, &inputs, &state, options.background_color)?;
+      Rendered::Paged(Box::new(plan))
     }
-    if let Some(accessibility) = options.tagged.accessibility() {
-      builder = builder.with_accessibility_validator(accessibility);
-      validated = true;
-    }
-    let settings = SerializeSettings {
-      producer: options
-        .producer
-        .clone()
-        .unwrap_or_else(|| PRODUCER.to_string()),
-      ..SerializeSettings::default()
-    };
+    None => {
+      // A viewport render is one page, so the ranges only have page 1 to keep.
+      PageSelection::resolve(options.page_ranges.as_deref(), 1)?;
+      let viewport = options
+        .viewport
+        .ok_or(PdfError::MissingViewport)?
+        .with_media_target(MediaTarget::Print);
+      let content = inputs.prepare(options.node, viewport)?;
+      let interactive = compose_single_page(
+        &mut pdf,
+        &content,
+        &state,
+        options.background_color,
+        structural,
+      )?;
 
-    if validated {
-      let configuration = builder.finish().map_err(|_| PdfError::InvalidStandard)?;
-
-      Document::new_with(SerializeSettings {
-        configuration,
-        ..settings
-      })
-    } else {
-      Document::new_with(settings)
+      Rendered::Single(Box::new(SinglePage {
+        content,
+        interactive,
+        structural,
+      }))
     }
   };
-  let tag_collector = (options.tagged != Tagging::Off || options.standard.requires_tagging())
-    .then(|| RefCell::new(TagCollector::default()));
+
+  if (options.outline || options.tagged.requires_outline())
+    && !rendered.interactive().headings.is_empty()
+  {
+    pdf.set_outline(build_outline(&rendered.interactive().headings, |heading| {
+      rendered.destination(heading.top, &heading.path)
+    }));
+  }
+  if let Some(collector) = &state.tags {
+    pdf.set_tag_tree(collector.borrow_mut().build_tree(
+      rendered.root(),
+      state.lang,
+      &rendered.interactive().destination_targets(),
+    ));
+  }
+  if let Some(error) = state.into_error() {
+    return Err(error);
+  }
+
+  pdf.finish().map_err(PdfError::Krilla)
+}
+
+/// A document with its validators, metadata and attachments set, before any
+/// page is drawn.
+fn open_document(
+  options: &PdfOptions<'_>,
+  attachments: Vec<Attachment>,
+) -> Result<Document, PdfError> {
+  let mut builder = ConfigurationBuilder::new();
+  let mut validated = false;
+
+  if let Some(archival) = options.standard.archival() {
+    builder = builder.with_archival_validator(archival);
+    validated = true;
+  }
+  if let Some(accessibility) = options.tagged.accessibility() {
+    builder = builder.with_accessibility_validator(accessibility);
+    validated = true;
+  }
+  let settings = SerializeSettings {
+    producer: options
+      .producer
+      .clone()
+      .unwrap_or_else(|| PRODUCER.to_string()),
+    ..SerializeSettings::default()
+  };
+  let mut document = if validated {
+    let configuration = builder.finish().map_err(|_| PdfError::InvalidStandard)?;
+
+    Document::new_with(SerializeSettings {
+      configuration,
+      ..settings
+    })
+  } else {
+    Document::new_with(settings)
+  };
+  let tagged = options.tagged != Tagging::Off || options.standard.requires_tagging();
 
   if let Some(metadata) = &options.metadata {
     validate_xmp_schemas(&metadata.xmp)?;
-    document.set_metadata(build_metadata(metadata, inputs.lang));
-  } else if tag_collector.is_some() && inputs.lang.is_some() {
+    document.set_metadata(build_metadata(metadata, options.lang));
+  } else if tagged && options.lang.is_some() {
     // Tagged standards check the document language even without metadata.
-    document.set_metadata(build_metadata(&PdfMetadata::default(), inputs.lang));
+    document.set_metadata(build_metadata(&PdfMetadata::default(), options.lang));
   }
 
   let fallback_date = options.metadata.as_ref().and_then(|m| m.creation_date);
 
-  for attachment in options.attachments {
+  for attachment in attachments {
     let mime_type = match attachment.mime_type {
       Some(mime) => Some(MimeType::new(&mime).ok_or(PdfError::InvalidMimeType(mime))?),
       None => None,
@@ -259,223 +300,98 @@ pub fn render(options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
       .embed_file(file)
       .ok_or(PdfError::DuplicateAttachment(attachment.name))?;
   }
-  match options.page {
-    Some(page) => {
-      // Bands lay out at full page width and draw inside the margin areas,
-      // like Chromium's print header and footer templates.
-      let band_viewport =
-        Viewport::new((page.width as u32, None)).with_media_target(MediaTarget::Print);
-      let bands = |pages: usize| -> Result<(Option<Repeatable>, Option<Repeatable>), PdfError> {
-        let header = options
-          .header
-          .as_ref()
-          .map(|template| {
-            Repeatable::band(
-              &inputs,
-              template,
-              band_viewport,
-              RepeatBounds::Header,
-              pages,
-            )
-          })
-          .transpose()?;
-        let footer = options
-          .footer
-          .as_ref()
-          .map(|template| {
-            Repeatable::band(
-              &inputs,
-              template,
-              band_viewport,
-              RepeatBounds::Footer,
-              pages,
-            )
-          })
-          .transpose()?;
+  Ok(document)
+}
 
-        Ok((header, footer))
-      };
-      let resolve = |header: Option<&Repeatable>, footer: Option<&Repeatable>| {
-        PageFrame::resolve(
-          &page,
-          band_viewport,
-          header.map(Repeatable::height),
-          footer.map(Repeatable::height),
-        )
-      };
-      let (mut header, mut footer) = bands(1)?;
-      let mut frame = resolve(header.as_ref(), footer.as_ref())?;
-      // A band with a counter and the cut list depend on each other: an `auto`
-      // margin takes the band's height, the band lays out with the real page
-      // numbers, and the page count is only known once the content is cut. The
-      // band is re-measured with the count each cut produced until its height
-      // stops moving, like the content counters in `paginate`.
-      let dynamic = header.as_ref().is_some_and(Repeatable::dynamic)
-        || footer.as_ref().is_some_and(Repeatable::dynamic);
-      let source = dynamic.then(|| options.node.clone());
-      let mut paginated = paginate(options.node, &inputs, &frame.geometry())?;
+/// What the pages were drawn from, which the outline and structure tree read
+/// after them.
+enum Rendered {
+  Paged(Box<PagePlan>),
+  Single(Box<SinglePage>),
+}
 
-      if let Some(source) = source {
-        const BAND_PASSES: usize = 3;
+/// A viewport render: one page at the content's size.
+struct SinglePage {
+  content: PreparedTree,
+  interactive: Interactive,
+  structural: bool,
+}
 
-        for _ in 0..BAND_PASSES {
-          let (next_header, next_footer) = bands(paginated.starts.len())?;
-          let stable = next_header.as_ref().map(Repeatable::height)
-            == header.as_ref().map(Repeatable::height)
-            && next_footer.as_ref().map(Repeatable::height)
-              == footer.as_ref().map(Repeatable::height);
-
-          header = next_header;
-          footer = next_footer;
-          if stable {
-            break;
-          }
-          frame = resolve(header.as_ref(), footer.as_ref())?;
-          paginated = paginate(source.clone(), &inputs, &frame.geometry())?;
-        }
-      }
-
-      if paginated.starts.len() >= MAX_PAGES {
-        return Err(PdfError::TooManyPages(paginated.starts.len()));
-      }
-      let selection =
-        PageSelection::resolve(options.page_ranges.as_deref(), paginated.starts.len())?;
-      let repeatables: Vec<Repeatable> = header
-        .into_iter()
-        .chain(
-          take(&mut paginated.repeated)
-            .into_iter()
-            .map(Repeatable::fixed),
-        )
-        .chain(footer)
-        .collect();
-      let text_boxes = collect_text_boxes(&paginated.content);
-      let inline_map = build_inline_map(&text_boxes)?;
-      let mut composer = PageComposer {
-        frame: &frame,
-        paginated: &paginated,
-        inputs: &inputs,
-        page_context: tree_context(&inputs, frame.page_area),
-        inline_map: &inline_map,
-        fonts: &mut fonts,
-        issues: &issues,
-        tag_collector: tag_collector.as_ref(),
-        document_lang,
-        background: options.background_color,
-        structural: options.tagged.names_structure_destinations(),
-        selection: &selection,
-      };
-
-      for slice in paginated.pages() {
-        if !selection.keeps(slice.index) {
-          continue;
-        }
-        composer.compose(&mut document, &repeatables, &slice)?;
-      }
-
-      let interactive = &paginated.interactive;
-
-      if (options.outline || options.tagged.requires_outline()) && !interactive.headings.is_empty()
-      {
-        document.set_outline(build_outline(&interactive.headings, |heading| {
-          composer.destination(heading.top, &heading.path)
-        }));
-      }
-      if let Some(collector) = &tag_collector {
-        document.set_tag_tree(build_tag_tree(
-          &paginated.content.root,
-          inputs.lang.as_ref().map(Lang::as_str),
-          &mut collector.borrow_mut(),
-          &destination_targets(interactive),
-        ));
-      }
-    }
-    None => {
-      // A viewport render is one page, so the ranges only have page 1 to keep.
-      PageSelection::resolve(options.page_ranges.as_deref(), 1)?;
-      let viewport = options
-        .viewport
-        .ok_or(PdfError::MissingViewport)?
-        .with_media_target(MediaTarget::Print);
-      let content = prepare_tree(&inputs, options.node, viewport)?;
-      let page_size = KrillaSize::from_wh(content.width * PT_PER_PX, content.height * PT_PER_PX)
-        .ok_or(PdfError::InvalidPageSize)?;
-      let text_boxes = collect_text_boxes(&content);
-      let inline_map = build_inline_map(&text_boxes)?;
-      let mut page = document.start_page_with(PageSettings::new(page_size));
-      let mut surface = page.surface();
-
-      surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
-      paint_page_background(
-        options.background_color,
-        (content.width, content.height),
-        &mut surface,
-      );
-
-      let mut emitter = content.emitter(
-        &mut fonts,
-        Some(&inline_map),
-        tag_collector.as_ref(),
-        &issues,
-        document_lang,
-      );
-
-      emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
-      surface.pop();
-      surface.finish();
-      let interactive = collect_interactive(&content);
-      let structural = options.tagged.names_structure_destinations();
-      let destination = |top: f32, path: &[usize]| {
-        let dest = XyzDestination::new(0, Point::from_xy(0.0, top.max(0.0) * PT_PER_PX));
-
-        Some(match structural {
-          true => dest.with_structure(tag_id(path)),
-          false => dest,
-        })
-      };
-
-      add_link_annotations(
-        &mut page,
-        &interactive.links,
-        (0.0, content.height),
-        None,
-        (0.0, 0.0),
-        tag_collector.as_ref(),
-        |id| {
-          interactive
-            .anchors
-            .get(id)
-            .and_then(|anchor| destination(anchor.top, &anchor.path))
-        },
-      );
-      page.finish();
-      if (options.outline || options.tagged.requires_outline()) && !interactive.headings.is_empty()
-      {
-        document.set_outline(build_outline(&interactive.headings, |heading| {
-          destination(heading.top, &heading.path)
-        }));
-      }
-      if let Some(collector) = &tag_collector {
-        document.set_tag_tree(build_tag_tree(
-          &content.root,
-          inputs.lang.as_ref().map(Lang::as_str),
-          &mut collector.borrow_mut(),
-          &destination_targets(&interactive),
-        ));
-      }
+impl Rendered {
+  fn root(&self) -> &RenderNode {
+    match self {
+      Self::Paged(plan) => &plan.paginated.content.root,
+      Self::Single(page) => &page.content.root,
     }
   }
 
-  let issues = issues.into_inner();
-
-  if let Some(error) = issues
-    .failure
-    .or_else(|| uncovered_error(&issues.uncovered))
-  {
-    return Err(error);
+  fn interactive(&self) -> &Interactive {
+    match self {
+      Self::Paged(plan) => &plan.paginated.interactive,
+      Self::Single(page) => &page.interactive,
+    }
   }
 
-  document.finish().map_err(PdfError::Krilla)
+  fn destination(&self, top: f32, path: &[usize]) -> Option<XyzDestination> {
+    match self {
+      Self::Paged(plan) => plan.destination(top, path),
+      Self::Single(page) => Some(single_page_destination(top, path, page.structural)),
+    }
+  }
+}
+
+fn single_page_destination(top: f32, path: &[usize], structural: bool) -> XyzDestination {
+  let dest = XyzDestination::new(0, Point::from_xy(0.0, top.max(0.0) * PT_PER_PX));
+
+  match structural {
+    true => dest.with_structure(tag_id(path)),
+    false => dest,
+  }
+}
+
+/// Draws a viewport render's one page and returns its interactive targets.
+fn compose_single_page(
+  pdf: &mut Document,
+  content: &PreparedTree,
+  state: &DocumentState<'_>,
+  background: Option<Color>,
+  structural: bool,
+) -> Result<Interactive, PdfError> {
+  let page_size = KrillaSize::from_wh(content.width * PT_PER_PX, content.height * PT_PER_PX)
+    .ok_or(PdfError::InvalidPageSize)?;
+  let text_boxes = TextBox::collect(content);
+  let inline_map = build_inline_map(&text_boxes)?;
+  let mut page = pdf.start_page_with(PageSettings::new(page_size));
+  let mut surface = page.surface();
+
+  surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
+  paint_page_background(background, (content.width, content.height), &mut surface);
+
+  let mut emitter = content.emitter(state, Some(&inline_map), true);
+
+  emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
+  surface.pop();
+  surface.finish();
+  let interactive = Interactive::collect(content);
+
+  add_link_annotations(
+    &mut page,
+    &interactive.links,
+    Window {
+      y: Some((0.0, content.height)),
+      ..Window::default()
+    },
+    (0.0, 0.0),
+    state.tags.as_ref(),
+    |id| {
+      interactive
+        .anchors
+        .get(id)
+        .map(|anchor| single_page_destination(anchor.top, &anchor.path, structural))
+    },
+  );
+  page.finish();
+  Ok(interactive)
 }
 
 #[cfg(test)]
@@ -484,9 +400,18 @@ mod tests {
 
   use super::*;
   use crate::{
+    atoms::Atoms,
     options::BAND_EDGE_PADDING,
-    pagination::{Atom, page_starts},
+    pagination::{Atom, MAX_PAGES, Paragraph, page_starts},
   };
+
+  fn atoms(extents: &[Atom], forced: &[f32], paragraphs: Vec<Paragraph>) -> Atoms {
+    Atoms {
+      extents: extents.to_vec(),
+      forced: forced.to_vec(),
+      paragraphs,
+    }
+  }
 
   const A4: (f32, f32) = (PageOptions::A4.width, PageOptions::A4.height);
 
@@ -548,7 +473,7 @@ mod tests {
 
   #[test]
   fn content_taller_than_a_render_allows_stops_counting() {
-    let starts = page_starts(&mut [], &mut Vec::new(), &[], &[], 2_000_000.0, 10.0);
+    let starts = page_starts(Atoms::default(), &[], 2_000_000.0, 10.0);
 
     assert_eq!(starts.len(), MAX_PAGES, "the page count runs unbounded");
   }
@@ -556,27 +481,23 @@ mod tests {
   #[test]
   fn page_starts_without_atoms_cuts_at_window() {
     assert_eq!(
-      page_starts(&mut [], &mut Vec::new(), &[], &[], 250.0, 100.0),
+      page_starts(Atoms::default(), &[], 250.0, 100.0),
       vec![0.0, 100.0, 200.0]
     );
   }
 
   #[test]
   fn page_starts_pushes_straddling_atom_to_next_page() {
-    let mut atoms = [(90.0, 110.0)];
-
     assert_eq!(
-      page_starts(&mut atoms, &mut Vec::new(), &[], &[], 250.0, 100.0),
+      page_starts(atoms(&[(90.0, 110.0)], &[], Vec::new()), &[], 250.0, 100.0),
       vec![0.0, 90.0, 190.0]
     );
   }
 
   #[test]
   fn page_starts_hard_cuts_atom_taller_than_window() {
-    let mut atoms = [(0.0, 300.0)];
-
     assert_eq!(
-      page_starts(&mut atoms, &mut Vec::new(), &[], &[], 300.0, 100.0),
+      page_starts(atoms(&[(0.0, 300.0)], &[], Vec::new()), &[], 300.0, 100.0),
       vec![0.0, 100.0, 200.0]
     );
   }
@@ -588,15 +509,14 @@ mod tests {
     let lines: Vec<Atom> = (0..6)
       .map(|i| (50.0 + i as f32 * 10.0, 60.0 + i as f32 * 10.0))
       .collect();
-    let mut atoms = lines.clone();
-    let paragraphs = [pagination::Paragraph {
-      lines,
+    let paragraphs = vec![Paragraph {
+      lines: lines.clone(),
       before: 2,
       after: 2,
     }];
 
     assert_eq!(
-      page_starts(&mut atoms, &mut Vec::new(), &paragraphs, &[], 110.0, 100.0),
+      page_starts(atoms(&lines, &[], paragraphs), &[], 110.0, 100.0),
       vec![0.0, 90.0],
       "the cut moves from 100 to 90 so two lines reach the next page"
     );
@@ -609,15 +529,14 @@ mod tests {
     let lines: Vec<Atom> = (0..4)
       .map(|i| (90.0 + i as f32 * 10.0, 100.0 + i as f32 * 10.0))
       .collect();
-    let mut atoms = lines.clone();
-    let paragraphs = [pagination::Paragraph {
-      lines,
+    let paragraphs = vec![Paragraph {
+      lines: lines.clone(),
       before: 2,
       after: 2,
     }];
 
     assert_eq!(
-      page_starts(&mut atoms, &mut Vec::new(), &paragraphs, &[], 140.0, 100.0),
+      page_starts(atoms(&lines, &[], paragraphs), &[], 140.0, 100.0),
       vec![0.0, 90.0],
       "one line before the cut violates orphans, so the paragraph starts the next page"
     );
@@ -630,15 +549,14 @@ mod tests {
     let lines: Vec<Atom> = (0..3)
       .map(|i| (80.0 + i as f32 * 10.0, 90.0 + i as f32 * 10.0))
       .collect();
-    let mut atoms = lines.clone();
-    let paragraphs = [pagination::Paragraph {
-      lines,
+    let paragraphs = vec![Paragraph {
+      lines: lines.clone(),
       before: 2,
       after: 2,
     }];
 
     assert_eq!(
-      page_starts(&mut atoms, &mut Vec::new(), &paragraphs, &[], 110.0, 100.0),
+      page_starts(atoms(&lines, &[], paragraphs), &[], 110.0, 100.0),
       vec![0.0, 100.0],
       "backing up past the orphans floor is worse than a lone widow"
     );
@@ -650,15 +568,14 @@ mod tests {
     let lines: Vec<Atom> = (0..30)
       .map(|i| (i as f32 * 10.0, 10.0 + i as f32 * 10.0))
       .collect();
-    let mut atoms = lines.clone();
-    let paragraphs = [pagination::Paragraph {
-      lines,
+    let paragraphs = vec![Paragraph {
+      lines: lines.clone(),
       before: 20,
       after: 20,
     }];
 
     assert_eq!(
-      page_starts(&mut atoms, &mut Vec::new(), &paragraphs, &[], 300.0, 100.0),
+      page_starts(atoms(&lines, &[], paragraphs), &[], 300.0, 100.0),
       vec![0.0, 100.0, 200.0],
       "a paragraph that can never satisfy 20/20 still paginates at the window"
     );
@@ -666,10 +583,8 @@ mod tests {
 
   #[test]
   fn page_starts_honors_forced_cuts() {
-    let mut forced = vec![40.0, 150.0];
-
     assert_eq!(
-      page_starts(&mut [], &mut forced, &[], &[], 250.0, 100.0),
+      page_starts(atoms(&[], &[40.0, 150.0], Vec::new()), &[], 250.0, 100.0),
       vec![0.0, 40.0, 140.0, 150.0]
     );
   }

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -586,10 +586,10 @@ mod tests {
     );
   }
 
-  /// `widows` past the paragraph's line count cannot be honored at all, so
-  /// the cut stays where the window put it.
+  /// `widows` past the paragraph's line count resolves to the orphans floor,
+  /// like any other unsatisfiable widows value, instead of underflowing.
   #[test]
-  fn page_starts_ignores_widows_past_the_line_count() {
+  fn page_starts_floors_widows_past_the_line_count() {
     let lines: Vec<Atom> = (0..3)
       .map(|i| (80.0 + i as f32 * 10.0, 90.0 + i as f32 * 10.0))
       .collect();
@@ -601,7 +601,7 @@ mod tests {
 
     assert_eq!(
       atoms(&lines, &[], paragraphs).page_starts(&[], 110.0, 100.0),
-      vec![0.0, 100.0]
+      vec![0.0, 90.0]
     );
   }
 

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -586,6 +586,25 @@ mod tests {
     );
   }
 
+  /// `widows` past the paragraph's line count cannot be honored at all, so
+  /// the cut stays where the window put it.
+  #[test]
+  fn page_starts_ignores_widows_past_the_line_count() {
+    let lines: Vec<Atom> = (0..3)
+      .map(|i| (80.0 + i as f32 * 10.0, 90.0 + i as f32 * 10.0))
+      .collect();
+    let paragraphs = vec![Paragraph {
+      lines: lines.clone(),
+      before: 1,
+      after: 5,
+    }];
+
+    assert_eq!(
+      atoms(&lines, &[], paragraphs).page_starts(&[], 110.0, 100.0),
+      vec![0.0, 100.0]
+    );
+  }
+
   #[test]
   fn page_starts_honors_forced_cuts() {
     assert_eq!(

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -103,7 +103,7 @@ pub use crate::options::{
 use crate::{
   emitter::DocumentState,
   inline::{TextBox, build_inline_map},
-  interactive::{Interactive, add_link_annotations, build_outline},
+  interactive::{Interactive, add_link_annotations},
   krilla::{
     Document, SerializeSettings,
     configure::ConfigurationBuilder,
@@ -194,28 +194,26 @@ pub fn render(mut options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
         .ok_or(PdfError::MissingViewport)?
         .with_media_target(MediaTarget::Print);
       let content = inputs.prepare(options.node, viewport)?;
-      let interactive = compose_single_page(
+      let page = SinglePage::compose(
         &mut pdf,
-        &content,
+        content,
         &state,
         options.background_color,
         structural,
       )?;
 
-      Rendered::Single(Box::new(SinglePage {
-        content,
-        interactive,
-        structural,
-      }))
+      Rendered::Single(Box::new(page))
     }
   };
 
   if (options.outline || options.tagged.requires_outline())
     && !rendered.interactive().headings.is_empty()
   {
-    pdf.set_outline(build_outline(&rendered.interactive().headings, |heading| {
-      rendered.destination(heading.top, &heading.path)
-    }));
+    pdf.set_outline(
+      rendered
+        .interactive()
+        .outline(|heading| rendered.destination(heading.top, &heading.path)),
+    );
   }
   if let Some(collector) = &state.tags {
     pdf.set_tag_tree(collector.borrow_mut().build_tree(
@@ -335,63 +333,70 @@ impl Rendered {
   fn destination(&self, top: f32, path: &[usize]) -> Option<XyzDestination> {
     match self {
       Self::Paged(plan) => plan.destination(top, path),
-      Self::Single(page) => Some(single_page_destination(top, path, page.structural)),
+      Self::Single(page) => Some(page.destination(top, path)),
     }
   }
 }
 
-fn single_page_destination(top: f32, path: &[usize], structural: bool) -> XyzDestination {
-  let dest = XyzDestination::new(0, Point::from_xy(0.0, top.max(0.0) * PT_PER_PX));
+impl SinglePage {
+  /// Draws the one page and collects its interactive targets.
+  fn compose(
+    pdf: &mut Document,
+    content: PreparedTree,
+    state: &DocumentState<'_>,
+    background: Option<Color>,
+    structural: bool,
+  ) -> Result<Self, PdfError> {
+    let page_size = KrillaSize::from_wh(content.width * PT_PER_PX, content.height * PT_PER_PX)
+      .ok_or(PdfError::InvalidPageSize)?;
+    let text_boxes = TextBox::collect(&content);
+    let inline_map = build_inline_map(&text_boxes)?;
+    let mut page = pdf.start_page_with(PageSettings::new(page_size));
+    let mut surface = page.surface();
 
-  match structural {
-    true => dest.with_structure(tag_id(path)),
-    false => dest,
+    surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
+    paint_page_background(background, (content.width, content.height), &mut surface);
+
+    let mut emitter = content.emitter(state, Some(&inline_map), true);
+
+    emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
+    surface.pop();
+    surface.finish();
+    let rendered = Self {
+      interactive: Interactive::collect(&content),
+      content,
+      structural,
+    };
+
+    add_link_annotations(
+      &mut page,
+      &rendered.interactive.links,
+      Window {
+        y: Some((0.0, rendered.content.height)),
+        ..Window::default()
+      },
+      (0.0, 0.0),
+      state.tags.as_ref(),
+      |id| {
+        rendered
+          .interactive
+          .anchors
+          .get(id)
+          .map(|anchor| rendered.destination(anchor.top, &anchor.path))
+      },
+    );
+    page.finish();
+    Ok(rendered)
   }
-}
 
-/// Draws a viewport render's one page and returns its interactive targets.
-fn compose_single_page(
-  pdf: &mut Document,
-  content: &PreparedTree,
-  state: &DocumentState<'_>,
-  background: Option<Color>,
-  structural: bool,
-) -> Result<Interactive, PdfError> {
-  let page_size = KrillaSize::from_wh(content.width * PT_PER_PX, content.height * PT_PER_PX)
-    .ok_or(PdfError::InvalidPageSize)?;
-  let text_boxes = TextBox::collect(content);
-  let inline_map = build_inline_map(&text_boxes)?;
-  let mut page = pdf.start_page_with(PageSettings::new(page_size));
-  let mut surface = page.surface();
+  fn destination(&self, top: f32, path: &[usize]) -> XyzDestination {
+    let dest = XyzDestination::new(0, Point::from_xy(0.0, top.max(0.0) * PT_PER_PX));
 
-  surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
-  paint_page_background(background, (content.width, content.height), &mut surface);
-
-  let mut emitter = content.emitter(state, Some(&inline_map), true);
-
-  emitter.emit_context(0, Affine::IDENTITY, &mut surface)?;
-  surface.pop();
-  surface.finish();
-  let interactive = Interactive::collect(content);
-
-  add_link_annotations(
-    &mut page,
-    &interactive.links,
-    Window {
-      y: Some((0.0, content.height)),
-      ..Window::default()
-    },
-    (0.0, 0.0),
-    state.tags.as_ref(),
-    |id| {
-      interactive
-        .anchors
-        .get(id)
-        .map(|anchor| single_page_destination(anchor.top, &anchor.path, structural))
-    },
-  );
-  page.finish();
-  Ok(interactive)
+    match self.structural {
+      true => dest.with_structure(tag_id(path)),
+      false => dest,
+    }
+  }
 }
 
 #[cfg(test)]
@@ -402,7 +407,7 @@ mod tests {
   use crate::{
     atoms::Atoms,
     options::BAND_EDGE_PADDING,
-    pagination::{Atom, MAX_PAGES, Paragraph, page_starts},
+    pagination::{Atom, MAX_PAGES, Paragraph},
   };
 
   fn atoms(extents: &[Atom], forced: &[f32], paragraphs: Vec<Paragraph>) -> Atoms {
@@ -473,7 +478,7 @@ mod tests {
 
   #[test]
   fn content_taller_than_a_render_allows_stops_counting() {
-    let starts = page_starts(Atoms::default(), &[], 2_000_000.0, 10.0);
+    let starts = Atoms::default().page_starts(&[], 2_000_000.0, 10.0);
 
     assert_eq!(starts.len(), MAX_PAGES, "the page count runs unbounded");
   }
@@ -481,7 +486,7 @@ mod tests {
   #[test]
   fn page_starts_without_atoms_cuts_at_window() {
     assert_eq!(
-      page_starts(Atoms::default(), &[], 250.0, 100.0),
+      Atoms::default().page_starts(&[], 250.0, 100.0),
       vec![0.0, 100.0, 200.0]
     );
   }
@@ -489,7 +494,7 @@ mod tests {
   #[test]
   fn page_starts_pushes_straddling_atom_to_next_page() {
     assert_eq!(
-      page_starts(atoms(&[(90.0, 110.0)], &[], Vec::new()), &[], 250.0, 100.0),
+      atoms(&[(90.0, 110.0)], &[], Vec::new()).page_starts(&[], 250.0, 100.0),
       vec![0.0, 90.0, 190.0]
     );
   }
@@ -497,7 +502,7 @@ mod tests {
   #[test]
   fn page_starts_hard_cuts_atom_taller_than_window() {
     assert_eq!(
-      page_starts(atoms(&[(0.0, 300.0)], &[], Vec::new()), &[], 300.0, 100.0),
+      atoms(&[(0.0, 300.0)], &[], Vec::new()).page_starts(&[], 300.0, 100.0),
       vec![0.0, 100.0, 200.0]
     );
   }
@@ -516,7 +521,7 @@ mod tests {
     }];
 
     assert_eq!(
-      page_starts(atoms(&lines, &[], paragraphs), &[], 110.0, 100.0),
+      atoms(&lines, &[], paragraphs).page_starts(&[], 110.0, 100.0),
       vec![0.0, 90.0],
       "the cut moves from 100 to 90 so two lines reach the next page"
     );
@@ -536,7 +541,7 @@ mod tests {
     }];
 
     assert_eq!(
-      page_starts(atoms(&lines, &[], paragraphs), &[], 140.0, 100.0),
+      atoms(&lines, &[], paragraphs).page_starts(&[], 140.0, 100.0),
       vec![0.0, 90.0],
       "one line before the cut violates orphans, so the paragraph starts the next page"
     );
@@ -556,7 +561,7 @@ mod tests {
     }];
 
     assert_eq!(
-      page_starts(atoms(&lines, &[], paragraphs), &[], 110.0, 100.0),
+      atoms(&lines, &[], paragraphs).page_starts(&[], 110.0, 100.0),
       vec![0.0, 100.0],
       "backing up past the orphans floor is worse than a lone widow"
     );
@@ -575,7 +580,7 @@ mod tests {
     }];
 
     assert_eq!(
-      page_starts(atoms(&lines, &[], paragraphs), &[], 300.0, 100.0),
+      atoms(&lines, &[], paragraphs).page_starts(&[], 300.0, 100.0),
       vec![0.0, 100.0, 200.0],
       "a paragraph that can never satisfy 20/20 still paginates at the window"
     );
@@ -584,7 +589,7 @@ mod tests {
   #[test]
   fn page_starts_honors_forced_cuts() {
     assert_eq!(
-      page_starts(atoms(&[], &[40.0, 150.0], Vec::new()), &[], 250.0, 100.0),
+      atoms(&[], &[40.0, 150.0], Vec::new()).page_starts(&[], 250.0, 100.0),
       vec![0.0, 40.0, 140.0, 150.0]
     );
   }

--- a/takumi-pdf/src/page.rs
+++ b/takumi-pdf/src/page.rs
@@ -1,32 +1,33 @@
 //! One page: its resolved geometry, and the emit walk that draws it.
 
-use std::cell::RefCell;
-
 use takumi_core::{
   context::RenderContext,
   geometry::Rect,
+  layout::node::Node,
   style::Color,
   viewport::{MediaTarget, Viewport},
 };
 
+use std::mem::take;
+
 use crate::{
-  bands::{Repeatable, RepeatablePage},
-  emitter::{FontMap, RenderIssues},
-  inline::InlineMap,
+  bands::{RepeatBounds, Repeatable, RepeatablePage},
+  emitter::DocumentState,
+  inline::{InlineMap, TextBox, build_inline_map},
   interactive::add_link_annotations,
   krilla::{
     Document,
     destination::XyzDestination,
-    geom::{Point, Rect as KrillaRect, Size as KrillaSize, Transform},
+    geom::{Point, Size as KrillaSize, Transform},
     page::PageSettings,
     surface::Surface,
   },
-  options::{PT_PER_PX, PageOptions, PageSelection, PdfError},
-  pagination::{PageGeometry, PageSlice, Paginated, header_replays},
-  paint::{fill_from_rgba, rect_path},
-  tags::{TagCollector, tag_id},
+  options::{PT_PER_PX, PageOptions, PageRange, PageSelection, PdfError},
+  pagination::{MAX_PAGES, PageSlice, Paginated},
+  paint::paint_page_background,
+  tags::tag_id,
   tree::TreeInputs,
-  window::ContentWindow,
+  window::{ContentWindow, Window},
 };
 
 /// Page geometry resolved once: everything derived from [`PageOptions`] and
@@ -83,37 +84,32 @@ impl PageFrame {
     })
   }
 
-  /// What a pagination pass lays out against.
-  pub(crate) fn geometry(&self) -> PageGeometry {
-    PageGeometry {
-      viewport: Viewport::new((self.content_width as u32, None))
-        .with_media_target(MediaTarget::Print),
-      page_area: self.page_area,
-      window_height: self.window_height,
-    }
+  /// The content column: content width, unbounded height.
+  pub(crate) fn column(&self) -> Viewport {
+    Viewport::new((self.content_width as u32, None)).with_media_target(MediaTarget::Print)
   }
 }
 
-/// Draws the paginated content one page at a time: background, the repeatables
-/// under the content, the content window, the repeatables over it, then the
-/// link annotations.
-pub(crate) struct PageComposer<'c, 'g> {
-  pub(crate) frame: &'c PageFrame,
-  pub(crate) paginated: &'c Paginated,
-  pub(crate) inputs: &'c TreeInputs<'g>,
-  pub(crate) page_context: RenderContext,
-  pub(crate) inline_map: &'c InlineMap<'c>,
-  pub(crate) fonts: &'c mut FontMap,
-  pub(crate) issues: &'c RefCell<RenderIssues>,
-  pub(crate) tag_collector: Option<&'c RefCell<TagCollector>>,
-  pub(crate) document_lang: Option<&'c str>,
-  pub(crate) background: Option<Color>,
-  /// Whether destinations name tag-tree structure elements.
-  pub(crate) structural: bool,
-  pub(crate) selection: &'c PageSelection,
+/// What a paged render takes from its options besides the content.
+pub(crate) struct PageBands<'o> {
+  pub(crate) header: Option<&'o Node>,
+  pub(crate) footer: Option<&'o Node>,
+  pub(crate) page_ranges: Option<&'o [PageRange]>,
 }
 
-impl PageComposer<'_, '_> {
+/// The paginated document: its geometry, its cut content, and which pages
+/// the render keeps.
+pub(crate) struct PagePlan {
+  pub(crate) frame: PageFrame,
+  pub(crate) paginated: Paginated,
+  pub(crate) selection: PageSelection,
+  /// Whether destinations name tag-tree structure elements.
+  pub(crate) structural: bool,
+  /// In draw order: the header band, the repeated boxes, the footer band.
+  pub(crate) repeatables: Vec<Repeatable>,
+}
+
+impl PagePlan {
   /// The destination a link or outline entry jumps to: the page `top` falls
   /// on, at its position inside that page. `None` when the page is dropped by
   /// [`crate::PdfOptions::page_ranges`].
@@ -133,73 +129,190 @@ impl PageComposer<'_, '_> {
     })
   }
 
+  /// Lays the bands out, resolves the page frame around them, and cuts the
+  /// content into pages.
+  pub(crate) fn solve(
+    inputs: &TreeInputs<'_>,
+    page: PageOptions,
+    bands: PageBands<'_>,
+    node: Node,
+    structural: bool,
+  ) -> Result<Self, PdfError> {
+    // Bands lay out at full page width and draw inside the margin areas,
+    // like Chromium's print header and footer templates.
+    let band_viewport =
+      Viewport::new((page.width as u32, None)).with_media_target(MediaTarget::Print);
+    let measure_bands =
+      |pages: usize| -> Result<(Option<Repeatable>, Option<Repeatable>), PdfError> {
+        let band = |template: Option<&Node>, bounds| {
+          template
+            .map(|template| Repeatable::band(inputs, template, band_viewport, bounds, pages))
+            .transpose()
+        };
+
+        Ok((
+          band(bands.header, RepeatBounds::Header)?,
+          band(bands.footer, RepeatBounds::Footer)?,
+        ))
+      };
+    let resolve = |header: Option<&Repeatable>, footer: Option<&Repeatable>| {
+      PageFrame::resolve(
+        &page,
+        band_viewport,
+        header.map(Repeatable::height),
+        footer.map(Repeatable::height),
+      )
+    };
+    let (mut header, mut footer) = measure_bands(1)?;
+    let mut frame = resolve(header.as_ref(), footer.as_ref())?;
+    // A band with a counter and the cut list depend on each other: an `auto`
+    // margin takes the band's height, the band lays out with the real page
+    // numbers, and the page count is only known once the content is cut. The
+    // band is re-measured with the count each cut produced until its height
+    // stops moving, like the content counters in `Paginated::build`.
+    let dynamic = header.as_ref().is_some_and(Repeatable::dynamic)
+      || footer.as_ref().is_some_and(Repeatable::dynamic);
+    let source = dynamic.then(|| node.clone());
+    let mut paginated = Paginated::build(node, inputs, &frame)?;
+
+    if let Some(source) = source {
+      const BAND_PASSES: usize = 3;
+
+      for _ in 0..BAND_PASSES {
+        let (next_header, next_footer) = measure_bands(paginated.starts.len())?;
+        let stable = next_header.as_ref().map(Repeatable::height)
+          == header.as_ref().map(Repeatable::height)
+          && next_footer.as_ref().map(Repeatable::height)
+            == footer.as_ref().map(Repeatable::height);
+
+        header = next_header;
+        footer = next_footer;
+        if stable {
+          break;
+        }
+        frame = resolve(header.as_ref(), footer.as_ref())?;
+        paginated = Paginated::build(source.clone(), inputs, &frame)?;
+      }
+    }
+
+    if paginated.starts.len() >= MAX_PAGES {
+      return Err(PdfError::TooManyPages(paginated.starts.len()));
+    }
+    let selection = PageSelection::resolve(bands.page_ranges, paginated.starts.len())?;
+    let repeatables = header
+      .into_iter()
+      .chain(take(&mut paginated.repeated))
+      .chain(footer)
+      .collect();
+
+    Ok(Self {
+      frame,
+      paginated,
+      selection,
+      structural,
+      repeatables,
+    })
+  }
+
+  /// Draws every kept page.
+  pub(crate) fn compose(
+    &self,
+    pdf: &mut Document,
+    inputs: &TreeInputs<'_>,
+    state: &DocumentState<'_>,
+    background: Option<Color>,
+  ) -> Result<(), PdfError> {
+    let text_boxes = TextBox::collect(&self.paginated.content);
+    let inline_map = build_inline_map(&text_boxes)?;
+    let composer = PageComposer {
+      plan: self,
+      inputs,
+      page_context: inputs.context(self.frame.page_area),
+      inline_map: &inline_map,
+      state,
+      background,
+    };
+
+    for slice in self.paginated.pages() {
+      if !self.selection.keeps(slice.index) {
+        continue;
+      }
+      composer.compose(pdf, &self.repeatables, &slice)?;
+    }
+    Ok(())
+  }
+
+  /// Where `href="#id"` lands, or `None` when nothing carries that id or its
+  /// page is dropped.
+  pub(crate) fn anchor_destination(&self, id: &str) -> Option<XyzDestination> {
+    let anchor = self.paginated.interactive.anchors.get(id)?;
+
+    self.destination(anchor.top, &anchor.path)
+  }
+}
+
+/// Draws the paginated content one page at a time: background, the repeatables
+/// under the content, the content window, the repeatables over it, then the
+/// link annotations.
+pub(crate) struct PageComposer<'c, 'g> {
+  pub(crate) plan: &'c PagePlan,
+  pub(crate) inputs: &'c TreeInputs<'g>,
+  pub(crate) page_context: RenderContext,
+  pub(crate) inline_map: &'c InlineMap<'c>,
+  pub(crate) state: &'c DocumentState<'c>,
+  pub(crate) background: Option<Color>,
+}
+
+impl PageComposer<'_, '_> {
   /// Draws one page. `repeatables` are in draw order: the header band, the
   /// repeated boxes, the footer band.
   pub(crate) fn compose(
-    &mut self,
-    document: &mut Document,
+    &self,
+    pdf: &mut Document,
     repeatables: &[Repeatable],
     slice: &PageSlice,
   ) -> Result<(), PdfError> {
-    let pages = self.paginated.starts.len();
+    let frame = &self.plan.frame;
+    let paginated = &self.plan.paginated;
+    let pages = paginated.starts.len();
     let resolved = repeatables
       .iter()
       .map(|repeatable| {
         repeatable.for_page(
           self.inputs,
           &self.page_context,
-          self.frame,
+          frame,
           slice.index + 1,
           pages,
         )
       })
       .collect::<Result<Vec<_>, _>>()?;
-    let mut pdf_page = document.start_page_with(PageSettings::new(self.frame.page_size));
+    let mut pdf_page = pdf.start_page_with(PageSettings::new(frame.page_size));
     let mut surface = pdf_page.surface();
 
     surface.push_transform(&Transform::from_scale(PT_PER_PX, PT_PER_PX));
-    self.paint_background(&mut surface);
+    paint_page_background(self.background, frame.size, &mut surface);
     for repeatable in resolved.iter().filter(|page| page.draws_before_content()) {
-      repeatable.emit(
-        self.frame,
-        self.fonts,
-        self.tag_collector.is_some(),
-        self.issues,
-        self.document_lang,
-        &mut surface,
-      )?;
+      repeatable.emit(frame, self.state, &mut surface)?;
     }
     self.emit_content(slice, &mut surface)?;
     for repeatable in resolved.iter().filter(|page| !page.draws_before_content()) {
-      repeatable.emit(
-        self.frame,
-        self.fonts,
-        self.tag_collector.is_some(),
-        self.issues,
-        self.document_lang,
-        &mut surface,
-      )?;
+      repeatable.emit(frame, self.state, &mut surface)?;
     }
     surface.pop();
     surface.finish();
+    let anchor = |id: &str| self.plan.anchor_destination(id);
+
     add_link_annotations(
       &mut pdf_page,
-      &self.paginated.interactive.links,
-      (slice.start, slice.start + slice.paint_height),
-      None,
-      (
-        self.frame.margin.left,
-        self.frame.margin.top + slice.reserved,
-      ),
-      self.tag_collector,
-      |id| {
-        self
-          .paginated
-          .interactive
-          .anchors
-          .get(id)
-          .and_then(|anchor| self.destination(anchor.top, &anchor.path))
+      &paginated.interactive.links,
+      Window {
+        y: Some((slice.start, slice.start + slice.paint_height)),
+        ..Window::default()
       },
+      (frame.margin.left, frame.margin.top + slice.reserved),
+      self.state.tags.as_ref(),
+      anchor,
     );
     // A repeated box sits at the same place on every page, so its links are
     // added per page against the page area rather than the content window.
@@ -208,152 +321,97 @@ impl PageComposer<'_, '_> {
     add_link_annotations(
       &mut pdf_page,
       resolved.iter().flat_map(RepeatablePage::links),
-      (0.0, self.frame.window_height),
-      None,
-      (self.frame.margin.left, self.frame.margin.top),
-      None,
-      |id| {
-        self
-          .paginated
-          .interactive
-          .anchors
-          .get(id)
-          .and_then(|anchor| self.destination(anchor.top, &anchor.path))
+      Window {
+        y: Some((0.0, frame.window_height)),
+        ..Window::default()
       },
+      (frame.margin.left, frame.margin.top),
+      None,
+      anchor,
     );
     // A replayed table header is an artifact like a repeated box, so its
     // links annotate per page and stay out of the structure.
-    for (offset, index) in self.replays(slice) {
-      let band = &self.paginated.headers[index];
+    for &(offset, index) in &slice.replays {
+      let band = &paginated.headers[index];
 
       add_link_annotations(
         &mut pdf_page,
-        &self.paginated.interactive.links,
-        (band.top, band.bottom),
-        Some((band.left, band.right)),
-        (self.frame.margin.left, self.frame.margin.top + offset),
+        &paginated.interactive.links,
+        band.window(),
+        (frame.margin.left, frame.margin.top + offset),
         None,
-        |id| {
-          self
-            .paginated
-            .interactive
-            .anchors
-            .get(id)
-            .and_then(|anchor| self.destination(anchor.top, &anchor.path))
-        },
+        anchor,
       );
     }
     pdf_page.finish();
     Ok(())
   }
 
-  /// The header bands this page replays, with each band's window offset.
-  fn replays(&self, slice: &PageSlice) -> Vec<(f32, usize)> {
-    header_replays(
-      &self.paginated.headers,
-      slice.start,
-      self.frame.window_height,
-    )
-    .1
-  }
-
-  /// Fills the page box before anything else draws. An unset color leaves the
-  /// page empty rather than painting white, like Chromium's print path.
-  fn paint_background(&self, surface: &mut Surface) {
-    let Some(color) = self.background else {
-      return;
-    };
-    let Some(path) =
-      KrillaRect::from_xywh(0.0, 0.0, self.frame.size.0, self.frame.size.1).and_then(rect_path)
-    else {
-      return;
-    };
-
-    surface.set_fill(Some(fill_from_rgba(color.0, 1.0)));
-    surface.draw_path(&path);
-  }
-
   /// Emits the content column through this page's window: clipped to the paint
   /// height and translated so the slice lands at the content origin, below any
   /// repeated table headers.
-  fn emit_content(&mut self, slice: &PageSlice, surface: &mut Surface) -> Result<(), PdfError> {
+  fn emit_content(&self, slice: &PageSlice, surface: &mut Surface) -> Result<(), PdfError> {
+    let frame = &self.plan.frame;
+    let paginated = &self.plan.paginated;
+
     // Paint stops at the next cut: the region between a raised cut and the
     // page's full height belongs to the next page and stays blank, exactly
     // like browser print fragmentation.
     ContentWindow {
       clip: (
-        self.frame.margin.left,
-        self.frame.margin.top + slice.reserved,
-        self.frame.content_width,
+        frame.margin.left,
+        frame.margin.top + slice.reserved,
+        frame.content_width,
         slice.paint_height,
       ),
       translate: (
-        self.frame.margin.left,
-        self.frame.margin.top + slice.reserved - slice.start,
+        frame.margin.left,
+        frame.margin.top + slice.reserved - slice.start,
       ),
-      window: Some((slice.start, slice.start + slice.paint_height)),
-      x_window: None,
-      line_window: Some((
-        if slice.index == 0 {
-          f32::NEG_INFINITY
-        } else {
-          slice.start
-        },
-        slice.end,
-      )),
+      window: Window {
+        y: Some((slice.start, slice.start + slice.paint_height)),
+        x: None,
+        lines: Some((
+          if slice.index == 0 {
+            f32::NEG_INFINITY
+          } else {
+            slice.start
+          },
+          slice.end,
+        )),
+      },
       artifact: false,
     }
     .emit(
-      self.paginated.content.emitter(
-        self.fonts,
-        Some(self.inline_map),
-        self.tag_collector,
-        self.issues,
-        self.document_lang,
-      ),
+      paginated
+        .content
+        .emitter(self.state, Some(self.inline_map), true),
       surface,
     )?;
-    if slice.reserved > 0.0 {
-      self.emit_repeated_headers(slice, surface)?;
-    }
-    Ok(())
-  }
+    // Each repeating table header band replays at the top of the window. The
+    // first occurrence carried the tags, so a replay is an artifact. Clipping
+    // to the table keeps content beside it out of the replay.
+    for &(offset, index) in &slice.replays {
+      let band = &paginated.headers[index];
 
-  /// Replays each repeating table header band at the top of the window. The
-  /// first occurrence carried the tags, so a replay is an artifact.
-  fn emit_repeated_headers(
-    &mut self,
-    slice: &PageSlice,
-    surface: &mut Surface,
-  ) -> Result<(), PdfError> {
-    for (offset, index) in self.replays(slice) {
-      let band = &self.paginated.headers[index];
-
-      // Clipping to the table keeps content beside it out of the replay.
       ContentWindow {
         clip: (
-          self.frame.margin.left + band.left,
-          self.frame.margin.top + offset,
+          frame.margin.left + band.left,
+          frame.margin.top + offset,
           band.right - band.left,
           band.height(),
         ),
-        translate: (
-          self.frame.margin.left,
-          self.frame.margin.top + offset - band.top,
-        ),
-        window: Some((band.top, band.bottom)),
-        x_window: Some((band.left, band.right)),
-        line_window: Some((f32::NEG_INFINITY, band.bottom)),
+        translate: (frame.margin.left, frame.margin.top + offset - band.top),
+        window: Window {
+          lines: Some((f32::NEG_INFINITY, band.bottom)),
+          ..band.window()
+        },
         artifact: true,
       }
       .emit(
-        self.paginated.content.emitter(
-          self.fonts,
-          Some(self.inline_map),
-          None,
-          self.issues,
-          self.document_lang,
-        ),
+        paginated
+          .content
+          .emitter(self.state, Some(self.inline_map), false),
         surface,
       )?;
     }

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -65,7 +65,7 @@ impl Paragraph {
     } else if after < self.after {
       // Blink's resolution: `max(line_count - widows, orphans)`. The orphans
       // floor wins; a floor at the current cut accepts the widow violation.
-      let line_number = (lines.len() - self.after).max(self.before);
+      let line_number = lines.len().saturating_sub(self.after).max(self.before);
 
       if line_number >= before {
         return cut;

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -1,27 +1,26 @@
 //! Cutting the content column into pages without splitting unsplittable atoms.
 
-use std::ops::Range;
-
 use takumi_core::{
   geometry::transformed_rect_extents,
   layout::node::Node,
   scene::NodePaint,
   style::{GridPlacement, GridPlacementSpan},
-  viewport::Viewport,
 };
 
 use crate::{
+  atoms::Atoms,
+  bands::Repeatable,
   counters::{
     BoxPages, FlowCounters, has_page_counters, has_target_counters, substitute_target_counters,
   },
-  inline::{build_inline_map, collect_text_boxes},
-  interactive::{Interactive, collect_interactive},
+  inline::{TextBox, build_inline_map},
+  interactive::Interactive,
   options::PdfError,
-  tree::{PreparedTree, RepeatedBox, TreeInputs, prepare_paged_tree},
+  page::PageFrame,
+  tree::{PreparedTree, TreeInputs},
+  window::Window,
 };
 
-/// Unsplittable vertical extents in content coordinates: text lines, images,
-/// and transformed subtrees (which cannot be windowed without distortion).
 /// An unsplittable box as `(top, bottom)` in content coordinates. Both are
 /// finite: they come from resolved layout, which is what lets the cut search
 /// sort and bisect them.
@@ -46,14 +45,43 @@ impl Paragraph {
   fn bottom(&self) -> f32 {
     self.lines.last().map_or(0.0, |line| line.1)
   }
+
+  /// Where a cut through the paragraph must move up to honor its minimums, or
+  /// `cut` unchanged. A proposal at or above `floor` (the top of the current
+  /// page) drops the constraint instead, like browsers do.
+  fn cut_for_minimums(&self, cut: f32, floor: f32) -> f32 {
+    let lines = &self.lines;
+    // The atom pass keeps the cut off line interiors; the half point absorbs a
+    // cut sitting exactly on a line edge.
+    let before = lines.partition_point(|(_, bottom)| *bottom <= cut + 0.5);
+
+    if before == 0 || before >= lines.len() {
+      return cut;
+    }
+    let after = lines.len() - before;
+
+    let proposed = if before < self.before {
+      lines[0].0
+    } else if after < self.after {
+      // Blink's resolution: `max(line_count - widows, orphans)`. The orphans
+      // floor wins; a floor at the current cut accepts the widow violation.
+      let line_number = (lines.len() - self.after).max(self.before);
+
+      if line_number >= before {
+        return cut;
+      }
+      lines[line_number].0
+    } else {
+      return cut;
+    };
+
+    if proposed <= floor {
+      return cut;
+    }
+    cut.min(proposed)
+  }
 }
 
-/// Page start offsets for slicing `total` height into windows of `window`
-/// height. Each cut moves up to the top of any atom straddling it, repeated
-/// until no atom straddles (a raised cut can land inside another atom). An
-/// atom taller than the window can never fit a page, so it does not push cuts
-/// at all — matching browsers, where `break-inside: avoid` is dropped for
-/// boxes taller than the fragmentainer.
 /// How many pages one render may cut its content into. A document tall enough
 /// to pass this is not a document anyone reads; it is a way to spend a
 /// renderer's memory.
@@ -84,152 +112,159 @@ impl HeaderBand {
     self.bottom - self.top
   }
 
+  /// The band's own extent as a paint window.
+  pub(crate) fn window(&self) -> Window {
+    Window {
+      y: Some((self.top, self.bottom)),
+      x: Some((self.left, self.right)),
+      lines: None,
+    }
+  }
+
   /// Whether a page starting at `y` shows this header again.
-  pub(crate) fn repeats_at(&self, y: f32) -> bool {
+  fn repeats_at(&self, y: f32) -> bool {
     self.bottom <= y + 0.5 && y + 0.5 < self.table_bottom
   }
-}
 
-/// The bands a page starting at `y` replays, each with the window offset its
-/// strip paints at. Bands whose source ranges overlap vertically sit side by
-/// side, so they share one strip instead of stacking; only bands below one
-/// another (nested continuations) stack.
-pub(crate) fn header_replays(
-  headers: &[HeaderBand],
-  y: f32,
-  window: f32,
-) -> (f32, Vec<(f32, usize)>) {
-  let mut slots = Vec::new();
-  let mut offset = 0.0_f32;
-  let mut strip: Option<(f32, f32)> = None;
+  /// Every table header band eligible to repeat: css-tables-3 §repeated-headers
+  /// admits a header of at most a quarter of the fragmentainer.
+  fn collect(tree: &PreparedTree, window: f32) -> Vec<Self> {
+    let mut bands = Vec::new();
 
-  for (index, band) in headers.iter().enumerate() {
-    if !band.repeats_at(y) {
-      continue;
+    tree.for_each_paint(|paint| Self::collect_paint(tree, paint, &mut bands));
+    bands.retain(|band| band.height() > 0.0 && band.height() <= window / 4.0);
+    bands.sort_by(|a, b| a.top.total_cmp(&b.top));
+    bands
+  }
+
+  fn collect_paint(tree: &PreparedTree, paint: &NodePaint, bands: &mut Vec<Self>) {
+    let Some(node) = tree.root.node_at_path(&paint.path) else {
+      return;
+    };
+    let Some((start, end)) = node.table_header_lines else {
+      return;
+    };
+    // Cell extents are measured in the table's own space, so anything beyond a
+    // translation would disagree with the transformed band; such a table is a
+    // monolithic atom anyway.
+    let transform = paint.transform;
+
+    if (transform.a - 1.0).abs() > 1e-3
+      || (transform.d - 1.0).abs() > 1e-3
+      || transform.b.abs() > 1e-3
+      || transform.c.abs() > 1e-3
+    {
+      return;
     }
-    match &mut strip {
-      Some((bottom, height)) if band.top < *bottom => {
-        slots.push((offset, index));
-        *bottom = bottom.max(band.bottom);
-        *height = height.max(band.height());
-      }
-      _ => {
-        if let Some((_, height)) = strip.take() {
-          offset += height;
-        }
-        slots.push((offset, index));
-        strip = Some((band.bottom, band.height()));
-      }
-    }
-  }
-  let reserved = offset + strip.map_or(0.0, |(_, height)| height);
-
-  // A band stack this tall starves the page; the headers stop repeating
-  // rather than squeezing the body out.
-  if reserved > window / 2.0 {
-    (0.0, Vec::new())
-  } else {
-    (reserved, slots)
-  }
-}
-
-/// Every table header band eligible to repeat: css-tables-3 §repeated-headers
-/// admits a header of at most a quarter of the fragmentainer.
-fn collect_repeating_headers(tree: &PreparedTree, window: f32) -> Vec<HeaderBand> {
-  let mut bands = Vec::new();
-
-  tree.for_each_paint(|paint| collect_headers_paint(tree, paint, &mut bands));
-  bands.retain(|band| band.height() > 0.0 && band.height() <= window / 4.0);
-  bands.sort_by(|a, b| a.top.total_cmp(&b.top));
-  bands
-}
-
-fn collect_headers_paint(tree: &PreparedTree, paint: &NodePaint, bands: &mut Vec<HeaderBand>) {
-  let Some(node) = tree.root.node_at_path(&paint.path) else {
-    return;
-  };
-  let Some((start, end)) = node.table_header_lines else {
-    return;
-  };
-  // Cell extents are measured in the table's own space, so anything beyond a
-  // translation would disagree with the transformed band; such a table is a
-  // monolithic atom anyway.
-  let transform = paint.transform;
-
-  if (transform.a - 1.0).abs() > 1e-3
-    || (transform.d - 1.0).abs() > 1e-3
-    || transform.b.abs() > 1e-3
-    || transform.c.abs() > 1e-3
-  {
-    return;
-  }
-  let Ok(layout) = tree.results.layout(paint.node_id) else {
-    return;
-  };
-  let Some((table_left, table_top, table_right, table_bottom)) = transformed_rect_extents(
-    takumi_core::geometry::Point { x: 0.0, y: 0.0 },
-    layout.size,
-    paint.transform,
-  ) else {
-    return;
-  };
-  let Some(rows) = node.children.as_deref() else {
-    return;
-  };
-  let Ok(children) = tree.results.box_children(paint.node_id) else {
-    return;
-  };
-  let content_top = table_top + layout.border.top + layout.padding.top;
-  let mut header_top = f32::MAX;
-  let mut header_bottom = f32::MIN;
-  let mut body_top = f32::MAX;
-
-  for ordered in children.iter() {
-    let Some(child) = rows.get(ordered.render_index) else {
-      continue;
+    let Ok(layout) = tree.results.layout(paint.node_id) else {
+      return;
     };
-    let GridPlacement::Line(line) = child.context.style.grid_row_start else {
-      continue;
+    let Some((table_left, table_top, table_right, table_bottom)) = transformed_rect_extents(
+      takumi_core::geometry::Point { x: 0.0, y: 0.0 },
+      layout.size,
+      paint.transform,
+    ) else {
+      return;
     };
-    let Ok(cell) = tree.results.layout(ordered.node_id) else {
-      continue;
+    let Some(rows) = node.children.as_deref() else {
+      return;
     };
+    let Ok(children) = tree.results.box_children(paint.node_id) else {
+      return;
+    };
+    let content_top = table_top + layout.border.top + layout.padding.top;
+    let mut header_top = f32::MAX;
+    let mut header_bottom = f32::MIN;
+    let mut body_top = f32::MAX;
 
-    if line >= start && line < end {
-      // A header cell whose rowspan reaches into the body would replay body
-      // area with the band; such a table does not repeat.
-      let GridPlacement::Span(GridPlacementSpan::Span(rowspan)) = child.context.style.grid_row_end
-      else {
-        return;
+    for ordered in children.iter() {
+      let Some(child) = rows.get(ordered.render_index) else {
+        continue;
+      };
+      let GridPlacement::Line(line) = child.context.style.grid_row_start else {
+        continue;
+      };
+      let Ok(cell) = tree.results.layout(ordered.node_id) else {
+        continue;
       };
 
-      if line.saturating_add(rowspan as i16) > end {
-        return;
+      if line >= start && line < end {
+        // A header cell whose rowspan reaches into the body would replay body
+        // area with the band; such a table does not repeat.
+        let GridPlacement::Span(GridPlacementSpan::Span(rowspan)) =
+          child.context.style.grid_row_end
+        else {
+          return;
+        };
+
+        if line.saturating_add(rowspan as i16) > end {
+          return;
+        }
+        header_top = header_top.min(content_top + cell.location.y);
+        header_bottom = header_bottom.max(content_top + cell.location.y + cell.size.height);
+      } else if line >= end {
+        body_top = body_top.min(content_top + cell.location.y);
       }
-      header_top = header_top.min(content_top + cell.location.y);
-      header_bottom = header_bottom.max(content_top + cell.location.y + cell.size.height);
-    } else if line >= end {
-      body_top = body_top.min(content_top + cell.location.y);
+    }
+
+    // The band starts at the header cells, not the table edge: a top caption
+    // sits between the two and must not repeat. It runs to the first body row,
+    // so the `border-spacing` strip repeats with it, as Blink reserves it.
+    let band_bottom = if body_top < f32::MAX {
+      body_top.max(header_bottom)
+    } else {
+      header_bottom
+    };
+
+    if header_top < f32::MAX && band_bottom > header_top {
+      bands.push(Self {
+        top: header_top,
+        bottom: band_bottom,
+        table_bottom,
+        left: table_left,
+        right: table_right,
+      });
     }
   }
 
-  // The band starts at the header cells, not the table edge: a top caption
-  // sits between the two and must not repeat. It runs to the first body row,
-  // so the `border-spacing` strip repeats with it, as Blink reserves it.
-  let band_bottom = if body_top < f32::MAX {
-    body_top.max(header_bottom)
-  } else {
-    header_bottom
-  };
+  /// The bands a page starting at `y` replays, each with the window offset its
+  /// strip paints at, and the window height they take together. Bands whose
+  /// source ranges overlap vertically sit side by side, so they share one
+  /// strip instead of stacking; only bands below one another (nested
+  /// continuations) stack.
+  pub(crate) fn replays(headers: &[Self], y: f32, window: f32) -> (f32, Vec<(f32, usize)>) {
+    let mut slots = Vec::new();
+    let mut offset = 0.0_f32;
+    let mut strip: Option<(f32, f32)> = None;
 
-  if header_top < f32::MAX && band_bottom > header_top {
-    bands.push(HeaderBand {
-      top: header_top,
-      bottom: band_bottom,
-      table_bottom,
-      left: table_left,
-      right: table_right,
-    });
+    for (index, band) in headers.iter().enumerate() {
+      if !band.repeats_at(y) {
+        continue;
+      }
+      match &mut strip {
+        Some((bottom, height)) if band.top < *bottom => {
+          slots.push((offset, index));
+          *bottom = bottom.max(band.bottom);
+          *height = height.max(band.height());
+        }
+        _ => {
+          if let Some((_, height)) = strip.take() {
+            offset += height;
+          }
+          slots.push((offset, index));
+          strip = Some((band.bottom, band.height()));
+        }
+      }
+    }
+    let reserved = offset + strip.map_or(0.0, |(_, height)| height);
+
+    // A band stack this tall starves the page; the headers stop repeating
+    // rather than squeezing the body out.
+    if reserved > window / 2.0 {
+      (0.0, Vec::new())
+    } else {
+      (reserved, slots)
+    }
   }
 }
 
@@ -237,7 +272,7 @@ fn collect_headers_paint(tree: &PreparedTree, paint: &NodePaint, bands: &mut Vec
 /// on every page and the interactive targets the pages draw from.
 pub(crate) struct Paginated {
   pub(crate) content: PreparedTree,
-  pub(crate) repeated: Vec<RepeatedBox>,
+  pub(crate) repeated: Vec<Repeatable>,
   pub(crate) starts: Vec<f32>,
   pub(crate) interactive: Interactive,
   pub(crate) headers: Vec<HeaderBand>,
@@ -254,9 +289,105 @@ pub(crate) struct PageSlice {
   pub(crate) paint_height: f32,
   /// Window height repeated table headers take above the content.
   pub(crate) reserved: f32,
+  /// The header bands this page replays, with each band's window offset.
+  pub(crate) replays: Vec<(f32, usize)>,
 }
 
 impl Paginated {
+  /// Lays the content out and cuts it into pages, refilling the counters it
+  /// holds until the numbers stop moving. A counter inside a repeated box is
+  /// left to that box, which lays out again per page with its own numbers.
+  pub(crate) fn build(
+    mut node: Node,
+    inputs: &TreeInputs<'_>,
+    frame: &PageFrame,
+  ) -> Result<Self, PdfError> {
+    if !has_page_counters(&node) && !has_target_counters(&node) {
+      return Self::build_once(node, inputs, frame);
+    }
+    let mut previous: Vec<String> = Vec::new();
+    let mut passes = 0;
+
+    loop {
+      let paginated = Self::build_once(node.clone(), inputs, frame)?;
+      let pages = paginated.starts.len();
+      let mut written = Vec::new();
+
+      passes += 1;
+      if pages < MAX_PAGES {
+        paginated.substitute_counters(&mut node, &mut written);
+      }
+      if written == previous {
+        return Ok(paginated);
+      }
+      previous = written;
+      // The numbers are still moving, and this was the last pass allowed. They
+      // are laid out once more so the page shows the numbers it was cut with.
+      if passes == COUNTER_PASSES {
+        return Self::build_once(node, inputs, frame);
+      }
+    }
+  }
+
+  fn build_once(node: Node, inputs: &TreeInputs<'_>, frame: &PageFrame) -> Result<Self, PdfError> {
+    let (content, repeated) = inputs.prepare_paged(node, frame)?;
+    let text_boxes = TextBox::collect(&content);
+    let inline_map = build_inline_map(&text_boxes)?;
+    let mut atoms = content.atom_collector(Some(&inline_map)).collect()?;
+    let headers = HeaderBand::collect(&content, frame.window_height);
+
+    // A repeating header is monolithic: a cut through it would show a partial
+    // header once and the full band again on the next page.
+    atoms
+      .extents
+      .extend(headers.iter().map(|band| (band.top, band.bottom)));
+    let starts = page_starts(atoms, &headers, content.height, frame.window_height);
+    let interactive = Interactive::collect(&content);
+
+    Ok(Self {
+      content,
+      repeated,
+      starts,
+      interactive,
+      headers,
+      window: frame.window_height,
+    })
+  }
+
+  /// Fills both kinds of counter from this laid-out pass, collecting what it
+  /// wrote so the caller can see whether the numbers moved.
+  fn substitute_counters(&self, node: &mut Node, written: &mut Vec<String>) {
+    let pages = self.starts.len();
+    let page_at = |top: &f32| self.page_index(*top) + 1;
+    // `fill_root` wraps the tree in a page-wide box, which takes preorder 0.
+    let page_of = self
+      .interactive
+      .extents
+      .iter()
+      .filter_map(|(order, extent)| {
+        let pages = BoxPages {
+          start: page_at(&extent.top),
+          next: extent.flow_bottom.as_ref().map(page_at),
+        };
+
+        Some((order.checked_sub(1)?, pages))
+      })
+      .collect();
+    let repeated: Vec<_> = self
+      .repeated
+      .iter()
+      .filter_map(Repeatable::source_orders)
+      .map(|orders| orders.start.saturating_sub(1)..orders.end.saturating_sub(1))
+      .collect();
+
+    FlowCounters::new(&page_of, pages, &repeated).substitute(node, None, written);
+
+    let anchors = &self.interactive.anchors;
+    let target_page = |id: &str| anchors.get(id).map(|anchor| page_at(&anchor.top));
+
+    substitute_target_counters(node, None, &target_page, written);
+  }
+
   /// 0-based index of the page `top` falls on.
   pub(crate) fn page_index(&self, top: f32) -> usize {
     self
@@ -267,13 +398,13 @@ impl Paginated {
 
   /// Window height repeated headers take on the page starting at `start`.
   pub(crate) fn reserved_at(&self, start: f32) -> f32 {
-    header_replays(&self.headers, start, self.window).0
+    HeaderBand::replays(&self.headers, start, self.window).0
   }
 
   pub(crate) fn pages(&self) -> impl Iterator<Item = PageSlice> + '_ {
     self.starts.iter().enumerate().map(|(index, &start)| {
       let end = self.starts.get(index + 1).copied().unwrap_or(f32::INFINITY);
-      let reserved = self.reserved_at(start);
+      let (reserved, replays) = HeaderBand::replays(&self.headers, start, self.window);
 
       PageSlice {
         index,
@@ -281,143 +412,31 @@ impl Paginated {
         end,
         paint_height: (end - start).min(self.window - reserved),
         reserved,
+        replays,
       }
     })
   }
 }
 
-/// What a pagination pass lays out against: the content column, the page area a
-/// repeated box positions in, and the height one page shows.
-pub(crate) struct PageGeometry {
-  pub(crate) viewport: Viewport,
-  pub(crate) page_area: Viewport,
-  pub(crate) window_height: f32,
-}
-
-/// Lays the content out and cuts it into pages, refilling the counters it holds
-/// until the numbers stop moving. A counter inside a repeated box is left to
-/// that box, which lays out again per page with its own numbers.
-pub(crate) fn paginate(
-  mut node: Node,
-  inputs: &TreeInputs<'_>,
-  geometry: &PageGeometry,
-) -> Result<Paginated, PdfError> {
-  if !has_page_counters(&node) && !has_target_counters(&node) {
-    return paginate_once(node, inputs, geometry);
-  }
-  let mut previous: Vec<String> = Vec::new();
-  let mut passes = 0;
-
-  loop {
-    let paginated = paginate_once(node.clone(), inputs, geometry)?;
-    let pages = paginated.starts.len();
-    let mut written = Vec::new();
-
-    passes += 1;
-    if pages < MAX_PAGES {
-      substitute_counters(&mut node, &paginated, &mut written);
-    }
-    if written == previous {
-      return Ok(paginated);
-    }
-    previous = written;
-    // The numbers are still moving, and this was the last pass allowed. They
-    // are laid out once more so the page shows the numbers it was cut with.
-    if passes == COUNTER_PASSES {
-      return paginate_once(node, inputs, geometry);
-    }
-  }
-}
-
-/// Fills both kinds of counter from one laid-out pass, collecting what it wrote
-/// so the caller can see whether the numbers moved.
-fn substitute_counters(node: &mut Node, paginated: &Paginated, written: &mut Vec<String>) {
-  let pages = paginated.starts.len();
-  let page_at = |top: &f32| paginated.page_index(*top) + 1;
-  // `fill_root` wraps the tree in a page-wide box, which takes preorder 0.
-  let page_of = paginated
-    .interactive
-    .extents
-    .iter()
-    .filter_map(|(order, extent)| {
-      let pages = BoxPages {
-        start: page_at(&extent.top),
-        next: extent.flow_bottom.as_ref().map(page_at),
-      };
-
-      Some((order.checked_sub(1)?, pages))
-    })
-    .collect();
-  let repeated: Vec<Range<usize>> = paginated
-    .repeated
-    .iter()
-    .filter_map(|repeat| repeat.template.as_ref())
-    .map(|template| {
-      let orders = template.source_orders();
-
-      orders.start.saturating_sub(1)..orders.end.saturating_sub(1)
-    })
-    .collect();
-
-  FlowCounters::new(&page_of, pages, &repeated).substitute(node, None, written);
-
-  let anchors = &paginated.interactive.anchors;
-  let target_page = |id: &str| anchors.get(id).map(|anchor| page_at(&anchor.top));
-
-  substitute_target_counters(node, None, &target_page, written);
-}
-
-fn paginate_once(
-  node: Node,
-  inputs: &TreeInputs<'_>,
-  geometry: &PageGeometry,
-) -> Result<Paginated, PdfError> {
-  let (content, repeated) =
-    prepare_paged_tree(inputs, node, geometry.viewport, geometry.page_area)?;
-  let text_boxes = collect_text_boxes(&content);
-  let inline_map = build_inline_map(&text_boxes)?;
-  let mut atoms = Vec::new();
-  let mut forced = Vec::new();
-  let mut paragraphs = Vec::new();
-
-  content
-    .atom_collector(Some(&inline_map))
-    .collect(&mut atoms, &mut forced, &mut paragraphs)?;
-
-  let headers = collect_repeating_headers(&content, geometry.window_height);
-
-  // A repeating header is monolithic: a cut through it would show a partial
-  // header once and the full band again on the next page.
-  atoms.extend(headers.iter().map(|band| (band.top, band.bottom)));
-  let starts = page_starts(
-    &mut atoms,
-    &mut forced,
-    &paragraphs,
-    &headers,
-    content.height,
-    geometry.window_height,
-  );
-  let interactive = collect_interactive(&content);
-
-  Ok(Paginated {
-    content,
-    repeated,
-    starts,
-    interactive,
-    headers,
-    window: geometry.window_height,
-  })
-}
-
+/// Page start offsets for slicing `total` height into windows of `window`
+/// height. Each cut moves up to the top of any atom straddling it, repeated
+/// until no atom straddles (a raised cut can land inside another atom). An
+/// atom taller than the window can never fit a page, so it does not push cuts
+/// at all — matching browsers, where `break-inside: avoid` is dropped for
+/// boxes taller than the fragmentainer.
 pub(crate) fn page_starts(
-  atoms: &mut [Atom],
-  forced: &mut Vec<f32>,
-  paragraphs: &[Paragraph],
+  mut atoms: Atoms,
   headers: &[HeaderBand],
   total: f32,
   window: f32,
 ) -> Vec<f32> {
-  atoms.sort_by(|a, b| a.0.total_cmp(&b.0));
+  let Atoms {
+    extents,
+    forced,
+    paragraphs,
+  } = &mut atoms;
+
+  extents.sort_by(|a, b| a.0.total_cmp(&b.0));
   forced.retain(|cut| *cut > 1.0 && *cut < total - 1.0);
   forced.sort_by(f32::total_cmp);
 
@@ -438,7 +457,7 @@ pub(crate) fn page_starts(
   let mut y0 = 0.0_f32;
 
   loop {
-    let limit = y0 + window - header_replays(headers, y0, window).0;
+    let limit = y0 + window - HeaderBand::replays(headers, y0, window).0;
 
     if let Some(cut) = forced.iter().copied().find(|cut| *cut > y0 + 1.0)
       && cut <= limit
@@ -453,19 +472,19 @@ pub(crate) fn page_starts(
     let mut cut = limit;
 
     loop {
-      // `atoms` is sorted by top, and an atom that fits the window can only
+      // `extents` is sorted by top, and an atom that fits the window can only
       // straddle the cut if it starts within one window of it, so the scan
       // walks back from the cut and stops there instead of reading every atom.
-      let straddling = atoms.partition_point(|(top, _)| *top < cut);
+      let straddling = extents.partition_point(|(top, _)| *top < cut);
       let mut pushed_up = cut;
 
-      for &(top, bottom) in atoms[..straddling].iter().rev() {
+      for &(top, bottom) in extents[..straddling].iter().rev() {
         if top <= cut - window {
           break;
         }
         // An atom moves to the next page only when it fits the capacity that
         // page actually offers under its repeated headers.
-        if bottom > cut && bottom - top <= window - header_replays(headers, top, window).0 {
+        if bottom > cut && bottom - top <= window - HeaderBand::replays(headers, top, window).0 {
           pushed_up = pushed_up.min(top);
         }
       }
@@ -476,7 +495,7 @@ pub(crate) fn page_starts(
         if prefix_max_bottom[i] <= pushed_up {
           break;
         }
-        pushed_up = pushed_up.min(widow_orphan_cut(by_top[i], pushed_up, y0 + 1.0));
+        pushed_up = pushed_up.min(by_top[i].cut_for_minimums(pushed_up, y0 + 1.0));
       }
 
       if pushed_up >= cut {
@@ -502,39 +521,4 @@ pub(crate) fn page_starts(
     }
   }
   starts
-}
-
-/// Where a cut through `paragraph` must move up to honor its minimums, or
-/// `cut` unchanged. A proposal at or above `floor` (the top of the current
-/// page) drops the constraint instead, like browsers do.
-fn widow_orphan_cut(paragraph: &Paragraph, cut: f32, floor: f32) -> f32 {
-  let lines = &paragraph.lines;
-  // The atom pass keeps the cut off line interiors; the half point absorbs a
-  // cut sitting exactly on a line edge.
-  let before = lines.partition_point(|(_, bottom)| *bottom <= cut + 0.5);
-
-  if before == 0 || before >= lines.len() {
-    return cut;
-  }
-  let after = lines.len() - before;
-
-  let proposed = if before < paragraph.before {
-    lines[0].0
-  } else if after < paragraph.after {
-    // Blink's resolution: `max(line_count - widows, orphans)`. The orphans
-    // floor wins; a floor at the current cut accepts the widow violation.
-    let line_number = (lines.len() - paragraph.after).max(paragraph.before);
-
-    if line_number >= before {
-      return cut;
-    }
-    lines[line_number].0
-  } else {
-    return cut;
-  };
-
-  if proposed <= floor {
-    return cut;
-  }
-  cut.min(proposed)
 }

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -341,7 +341,7 @@ impl Paginated {
     atoms
       .extents
       .extend(headers.iter().map(|band| (band.top, band.bottom)));
-    let starts = page_starts(atoms, &headers, content.height, frame.window_height);
+    let starts = atoms.page_starts(&headers, content.height, frame.window_height);
     let interactive = Interactive::collect(&content);
 
     Ok(Self {
@@ -424,101 +424,98 @@ impl Paginated {
 /// atom taller than the window can never fit a page, so it does not push cuts
 /// at all — matching browsers, where `break-inside: avoid` is dropped for
 /// boxes taller than the fragmentainer.
-pub(crate) fn page_starts(
-  mut atoms: Atoms,
-  headers: &[HeaderBand],
-  total: f32,
-  window: f32,
-) -> Vec<f32> {
-  let Atoms {
-    extents,
-    forced,
-    paragraphs,
-  } = &mut atoms;
+impl Atoms {
+  pub(crate) fn page_starts(mut self, headers: &[HeaderBand], total: f32, window: f32) -> Vec<f32> {
+    let Self {
+      extents,
+      forced,
+      paragraphs,
+    } = &mut self;
 
-  extents.sort_by(|a, b| a.0.total_cmp(&b.0));
-  forced.retain(|cut| *cut > 1.0 && *cut < total - 1.0);
-  forced.sort_by(f32::total_cmp);
+    extents.sort_by(|a, b| a.0.total_cmp(&b.0));
+    forced.retain(|cut| *cut > 1.0 && *cut < total - 1.0);
+    forced.sort_by(f32::total_cmp);
 
-  // The prefix max of bottoms lets the back-scan stop early even when a
-  // paragraph spans several pages.
-  let mut by_top: Vec<&Paragraph> = paragraphs.iter().collect();
+    // The prefix max of bottoms lets the back-scan stop early even when a
+    // paragraph spans several pages.
+    let mut by_top: Vec<&Paragraph> = paragraphs.iter().collect();
 
-  by_top.sort_by(|a, b| a.top().total_cmp(&b.top()));
+    by_top.sort_by(|a, b| a.top().total_cmp(&b.top()));
 
-  let mut prefix_max_bottom = Vec::with_capacity(by_top.len());
-  let mut running = f32::MIN;
+    let mut prefix_max_bottom = Vec::with_capacity(by_top.len());
+    let mut running = f32::MIN;
 
-  for paragraph in &by_top {
-    running = running.max(paragraph.bottom());
-    prefix_max_bottom.push(running);
-  }
-  let mut starts = vec![0.0_f32];
-  let mut y0 = 0.0_f32;
-
-  loop {
-    let limit = y0 + window - HeaderBand::replays(headers, y0, window).0;
-
-    if let Some(cut) = forced.iter().copied().find(|cut| *cut > y0 + 1.0)
-      && cut <= limit
-    {
-      starts.push(cut);
-      y0 = cut;
-      continue;
+    for paragraph in &by_top {
+      running = running.max(paragraph.bottom());
+      prefix_max_bottom.push(running);
     }
-    if limit >= total {
-      break;
-    }
-    let mut cut = limit;
+    let mut starts = vec![0.0_f32];
+    let mut y0 = 0.0_f32;
 
     loop {
-      // `extents` is sorted by top, and an atom that fits the window can only
-      // straddle the cut if it starts within one window of it, so the scan
-      // walks back from the cut and stops there instead of reading every atom.
-      let straddling = extents.partition_point(|(top, _)| *top < cut);
-      let mut pushed_up = cut;
+      let limit = y0 + window - HeaderBand::replays(headers, y0, window).0;
 
-      for &(top, bottom) in extents[..straddling].iter().rev() {
-        if top <= cut - window {
-          break;
-        }
-        // An atom moves to the next page only when it fits the capacity that
-        // page actually offers under its repeated headers.
-        if bottom > cut && bottom - top <= window - HeaderBand::replays(headers, top, window).0 {
-          pushed_up = pushed_up.min(top);
-        }
+      if let Some(cut) = forced.iter().copied().find(|cut| *cut > y0 + 1.0)
+        && cut <= limit
+      {
+        starts.push(cut);
+        y0 = cut;
+        continue;
       }
-
-      let straddling = by_top.partition_point(|paragraph| paragraph.top() < pushed_up);
-
-      for i in (0..straddling).rev() {
-        if prefix_max_bottom[i] <= pushed_up {
-          break;
-        }
-        pushed_up = pushed_up.min(by_top[i].cut_for_minimums(pushed_up, y0 + 1.0));
-      }
-
-      if pushed_up >= cut {
+      if limit >= total {
         break;
       }
-      if pushed_up <= y0 + 1.0 {
-        cut = limit;
+      let mut cut = limit;
+
+      loop {
+        // `extents` is sorted by top, and an atom that fits the window can only
+        // straddle the cut if it starts within one window of it, so the scan
+        // walks back from the cut and stops there instead of reading every atom.
+        let straddling = extents.partition_point(|(top, _)| *top < cut);
+        let mut pushed_up = cut;
+
+        for &(top, bottom) in extents[..straddling].iter().rev() {
+          if top <= cut - window {
+            break;
+          }
+          // An atom moves to the next page only when it fits the capacity that
+          // page actually offers under its repeated headers.
+          if bottom > cut && bottom - top <= window - HeaderBand::replays(headers, top, window).0 {
+            pushed_up = pushed_up.min(top);
+          }
+        }
+
+        let straddling = by_top.partition_point(|paragraph| paragraph.top() < pushed_up);
+
+        for i in (0..straddling).rev() {
+          if prefix_max_bottom[i] <= pushed_up {
+            break;
+          }
+          pushed_up = pushed_up.min(by_top[i].cut_for_minimums(pushed_up, y0 + 1.0));
+        }
+
+        if pushed_up >= cut {
+          break;
+        }
+        if pushed_up <= y0 + 1.0 {
+          cut = limit;
+          break;
+        }
+        cut = pushed_up;
+      }
+
+      // The page cap is what bounds this loop; a cut that did not move would
+      // spin forever without it, so refuse that too rather than lean on the cap.
+      if cut <= y0 {
         break;
       }
-      cut = pushed_up;
-    }
+      starts.push(cut);
+      y0 = cut;
 
-    // The page cap is what bounds this loop; a cut that did not move would
-    // spin forever without it, so refuse that too rather than lean on the cap.
-    if cut <= y0 {
-      break;
+      if starts.len() >= MAX_PAGES {
+        break;
+      }
     }
-    starts.push(cut);
-    y0 = cut;
-
-    if starts.len() >= MAX_PAGES {
-      break;
-    }
+    starts
   }
-  starts
 }

--- a/takumi-pdf/src/paint.rs
+++ b/takumi-pdf/src/paint.rs
@@ -5,7 +5,7 @@ use takumi_core::resources::image::{ImageError, ImageSource, RenderedImage};
 use takumi_core::{
   context::RenderContext,
   geometry::{ComputedLayout as Layout, PathCommand},
-  style::{BlendMode, ComputedStyle, Overflow, ResolvedGradientStop},
+  style::{BlendMode, Color, ComputedStyle, Overflow, ResolvedGradientStop},
 };
 
 use crate::{
@@ -265,6 +265,21 @@ pub(crate) const fn krilla_blend(mode: BlendMode) -> KrillaBlendMode {
     BlendMode::Luminosity => KrillaBlendMode::Luminosity,
     _ => KrillaBlendMode::Normal,
   }
+}
+
+/// Fills the page box before the page draws anything else. An unset color
+/// leaves the page empty rather than painting white, like Chromium's print
+/// path.
+pub(crate) fn paint_page_background(color: Option<Color>, size: (f32, f32), surface: &mut Surface) {
+  let Some(color) = color else {
+    return;
+  };
+  let Some(path) = KrillaRect::from_xywh(0.0, 0.0, size.0, size.1).and_then(rect_path) else {
+    return;
+  };
+
+  surface.set_fill(Some(fill_from_rgba(color.0, 1.0)));
+  surface.draw_path(&path);
 }
 
 pub(crate) fn pop_transforms(surface: &mut Surface, pushed: usize) {

--- a/takumi-pdf/src/shadow.rs
+++ b/takumi-pdf/src/shadow.rs
@@ -39,7 +39,7 @@ pub(crate) fn emit_outer_shadows(
   border.append_mask_commands(&mut element, size, CorePoint::ZERO);
 
   for shadow in shadows.iter().rev() {
-    for band in bands(shadow) {
+    for band in Band::of(shadow) {
       let mut commands = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
       let (shape, spread_size) = border.outset_shadow_box(size, band.spread);
 
@@ -73,7 +73,7 @@ pub(crate) fn emit_inset_shadows(
   };
 
   for shadow in shadows.iter().rev() {
-    for band in bands(shadow) {
+    for band in Band::of(shadow) {
       let mut commands = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT * 2);
 
       // The filled region is the padding box minus the hole the shadow casts
@@ -112,39 +112,41 @@ struct Band {
   alpha: f32,
 }
 
-/// A sharp shadow is one band at full alpha. A blurred one is a stack from the
-/// outermost, faintest band inward, with each band's alpha chosen so the fills
-/// composite to the coverage the blur would have had at that distance.
-fn bands(shadow: &SizedShadow) -> Vec<Band> {
-  if shadow.blur_radius <= 0.0 {
-    return vec![Band {
+impl Band {
+  /// A sharp shadow is one band at full alpha. A blurred one is a stack from the
+  /// outermost, faintest band inward, with each band's alpha chosen so the fills
+  /// composite to the coverage the blur would have had at that distance.
+  fn of(shadow: &SizedShadow) -> Vec<Self> {
+    if shadow.blur_radius <= 0.0 {
+      return vec![Band {
+        spread: shadow.spread_radius,
+        alpha: 1.0,
+      }];
+    }
+    // The shifted, unblurred shape is fully opaque; the blur only fades outward
+    // from its edge, so that core is the last band drawn.
+    let mut bands = Vec::with_capacity(BLUR_BANDS + 1);
+    let mut covered = 0.0;
+
+    for index in 0..BLUR_BANDS {
+      // Walk inward: the outermost band sits a full blur radius out and is the
+      // faintest, the innermost sits at the sharp edge and is opaque.
+      let t = (index as f32 + 1.0) / BLUR_BANDS as f32;
+      let target = coverage(1.0 - t);
+      let alpha = ((target - covered) / (1.0 - covered)).clamp(0.0, 1.0);
+
+      covered = target;
+      bands.push(Band {
+        spread: shadow.spread_radius + shadow.blur_radius * (1.0 - t),
+        alpha,
+      });
+    }
+    bands.push(Band {
       spread: shadow.spread_radius,
       alpha: 1.0,
-    }];
-  }
-  // The shifted, unblurred shape is fully opaque; the blur only fades outward
-  // from its edge, so that core is the last band drawn.
-  let mut bands = Vec::with_capacity(BLUR_BANDS + 1);
-  let mut covered = 0.0;
-
-  for index in 0..BLUR_BANDS {
-    // Walk inward: the outermost band sits a full blur radius out and is the
-    // faintest, the innermost sits at the sharp edge and is opaque.
-    let t = (index as f32 + 1.0) / BLUR_BANDS as f32;
-    let target = coverage(1.0 - t);
-    let alpha = ((target - covered) / (1.0 - covered)).clamp(0.0, 1.0);
-
-    covered = target;
-    bands.push(Band {
-      spread: shadow.spread_radius + shadow.blur_radius * (1.0 - t),
-      alpha,
     });
+    bands
   }
-  bands.push(Band {
-    spread: shadow.spread_radius,
-    alpha: 1.0,
-  });
-  bands
 }
 
 /// Coverage a Gaussian blur leaves `distance` blur radii outside the shape.
@@ -195,7 +197,7 @@ fn fill(commands: &[PathCommand], color: Color, alpha: f32, at: (f32, f32), surf
 mod tests {
   use takumi_core::{shadow::SizedShadow, style::Color};
 
-  use super::{bands, coverage};
+  use super::{Band, coverage};
 
   #[test]
   fn a_blurred_shadow_has_an_opaque_core() {
@@ -206,7 +208,7 @@ mod tests {
       spread_radius: 2.0,
       color: Color([0, 0, 0, 255]),
     };
-    let bands = bands(&shadow);
+    let bands = Band::of(&shadow);
     let core = bands.last().expect("a band");
 
     assert_eq!(core.alpha, 1.0);

--- a/takumi-pdf/src/tags.rs
+++ b/takumi-pdf/src/tags.rs
@@ -71,10 +71,40 @@ impl TagCollector {
   fn take_annotations(&mut self, path: &[usize]) -> Vec<Identifier> {
     self.annotations.remove(path).unwrap_or_default()
   }
+
+  /// Walks the source tree in logical order and builds the structure tree from
+  /// the recorded identifiers.
+  pub(crate) fn build_tree(
+    &mut self,
+    root: &RenderNode,
+    lang: Option<&str>,
+    targets: &HashSet<Vec<usize>>,
+  ) -> TagTree {
+    let mut tree = TagTree::new().with_lang(lang.map(str::to_string));
+    let mut top = Vec::new();
+    let mut pending = Vec::new();
+    let mut walk = Walk {
+      collector: self,
+      headings: Vec::new(),
+      targets,
+    };
+
+    build_node(
+      root,
+      &mut Vec::new(),
+      &mut walk,
+      &mut top,
+      &mut pending,
+      Nesting::default(),
+    );
+    flush_paragraph(&mut pending, &mut top);
+    for group in top {
+      tree.push(group);
+    }
+    tree
+  }
 }
 
-/// Walks the source tree in logical order and builds the structure tree from
-/// the recorded identifiers.
 /// The id a destination uses to name the structure element built from `path`.
 pub(crate) fn tag_id(path: &[usize]) -> TagId {
   let mut bytes = Vec::with_capacity(path.len() * 3 + 1);
@@ -85,36 +115,6 @@ pub(crate) fn tag_id(path: &[usize]) -> TagId {
     bytes.extend_from_slice(index.to_string().as_bytes());
   }
   TagId::from(bytes)
-}
-
-pub(crate) fn build_tag_tree(
-  root: &RenderNode,
-  lang: Option<&str>,
-  collector: &mut TagCollector,
-  targets: &HashSet<Vec<usize>>,
-) -> TagTree {
-  let mut tree = TagTree::new().with_lang(lang.map(str::to_string));
-  let mut top = Vec::new();
-  let mut pending = Vec::new();
-  let mut walk = Walk {
-    collector,
-    headings: Vec::new(),
-    targets,
-  };
-
-  build_node(
-    root,
-    &mut Vec::new(),
-    &mut walk,
-    &mut top,
-    &mut pending,
-    Nesting::default(),
-  );
-  flush_paragraph(&mut pending, &mut top);
-  for group in top {
-    tree.push(group);
-  }
-  tree
 }
 
 /// Drains a run of bare-content identifiers into a single `P`. Bare content

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -1,6 +1,6 @@
 //! Layout of an independent node tree: the main content or a header/footer band.
 
-use std::{cell::RefCell, collections::HashMap, ops::Range, rc::Rc, sync::Arc};
+use std::{collections::HashMap, rc::Rc, sync::Arc};
 
 use takumi_core::{
   Fonts,
@@ -21,11 +21,13 @@ use takumi_core::{
 
 use crate::{
   atoms::AtomCollector,
-  counters::{has_page_counters, substitute_page_counters},
-  emitter::{Emitter, FontMap, RenderIssues},
+  bands::{FixedTemplate, Repeatable},
+  counters::{has_page_counters, substitute_page_counters, substitute_target_counters},
+  emitter::{DocumentState, Emitter},
   inline::InlineMap,
   options::PdfError,
-  tags::TagCollector,
+  page::PageFrame,
+  window::Window,
 };
 
 /// Shared inputs for laying out an independent node tree: the main content or
@@ -38,6 +40,90 @@ pub(crate) struct TreeInputs<'g> {
   pub(crate) lang: Option<Lang>,
 }
 
+impl TreeInputs<'_> {
+  pub(crate) fn context(&self, viewport: Viewport) -> RenderContext {
+    RenderContext::builder()
+      .fonts(
+        self
+          .fonts
+          .snapshot_with_fallbacks(self.font_families.as_ref()),
+      )
+      .sizing(SizingContext::builder().viewport(viewport).build())
+      .images(self.images.clone())
+      .stylesheet(self.stylesheet.clone())
+      .style(Box::new(ComputedStyle {
+        lang: self.lang,
+        font_family: self.font_families.clone().unwrap_or_default(),
+        ..Default::default()
+      }))
+      .build()
+  }
+
+  pub(crate) fn prepare(&self, node: Node, viewport: Viewport) -> Result<PreparedTree, PdfError> {
+    let node = fill_root(node, viewport);
+    let root = RenderNode::from_node(&self.context(viewport), node);
+
+    PreparedTree::lay_out(root, viewport)
+  }
+
+  /// Lays out a band template with the given counter values.
+  pub(crate) fn prepare_band(
+    &self,
+    template: &Node,
+    page: usize,
+    pages: usize,
+    viewport: Viewport,
+  ) -> Result<PreparedTree, PdfError> {
+    let mut node = template.clone();
+
+    substitute_page_counters(&mut node, page, pages);
+    // A band lays out per page, after the pass that resolves target counters, so
+    // its hooks name no page. They empty like any other unresolved target instead
+    // of leaving the placeholder the template put there.
+    substitute_target_counters(&mut node, None, &|_: &str| None, &mut Vec::new());
+    self.prepare(node, viewport)
+  }
+
+  /// The content column, plus the `fixed` subtrees attached to the initial
+  /// containing block. Those repeat on every page, so they lay out against the
+  /// page area instead of the column.
+  pub(crate) fn prepare_paged(
+    &self,
+    node: Node,
+    frame: &PageFrame,
+  ) -> Result<(PreparedTree, Vec<Repeatable>), PdfError> {
+    let viewport = frame.column();
+    let node = fill_root(node, viewport);
+    // A repeated box holding a counter lays out again per page, from the subtree
+    // its preorder position names in the tree it was taken from.
+    let source = has_page_counters(&node).then(|| node.clone());
+    let mut root = RenderNode::from_node(&self.context(viewport), node);
+    let repeated = take_repeating_fixed(&mut root);
+    let content = PreparedTree::lay_out(root, viewport)?;
+    let page_context = self.context(frame.page_area);
+    let repeated = repeated
+      .into_iter()
+      .map(|(node, parent)| {
+        let template = source
+          .as_ref()
+          .zip(node.source_order())
+          .and_then(|(source, index)| Some((index, node_in_source_order(source, index)?)))
+          .filter(|(_, template)| has_page_counters(template))
+          .map(|(source_order, template)| FixedTemplate {
+            node: template.clone(),
+            parent,
+            source_order,
+          });
+        let prepared = PreparedTree::lay_out(page_root(&page_context, node), frame.page_area)?;
+
+        Ok(Repeatable::fixed(prepared, template))
+      })
+      .collect::<Result<Vec<_>, PdfError>>()?;
+
+    Ok((content, repeated))
+  }
+}
+
 /// A node tree taken through layout and scene building, ready to emit.
 pub(crate) struct PreparedTree {
   pub(crate) root: RenderNode,
@@ -48,6 +134,38 @@ pub(crate) struct PreparedTree {
 }
 
 impl PreparedTree {
+  pub(crate) fn lay_out(root: RenderNode, viewport: Viewport) -> Result<Self, PdfError> {
+    let mut tree = LayoutTree::from_render_node(&root);
+
+    tree.compute_layout(viewport.into());
+
+    let results = tree.into_results();
+    let root_layout = results.layout(NodeId::ROOT)?;
+    let width = viewport
+      .size
+      .width
+      .map_or(root_layout.size.width, |w| w as f32);
+    let height = viewport
+      .size
+      .height
+      .map_or(root_layout.size.height, |h| h as f32);
+    let contexts = build_stacking_contexts(
+      &root,
+      &results,
+      NodeId::ROOT,
+      Affine::IDENTITY,
+      (Some(width), Some(height)),
+    )?;
+
+    Ok(Self {
+      root,
+      results,
+      contexts,
+      width,
+      height,
+    })
+  }
+
   /// The size the caller's own node laid out at, which is what `measure`
   /// reports. [`fill_root`] wraps that node in a page-wide box, so the root's
   /// size only ever gives the page back.
@@ -118,26 +236,20 @@ impl PreparedTree {
 
   pub(crate) fn emitter<'a>(
     &'a self,
-    fonts: &'a mut FontMap,
+    state: &'a DocumentState<'a>,
     inline: Option<&'a InlineMap<'a>>,
-    tags: Option<&'a RefCell<TagCollector>>,
-    issues: &'a RefCell<RenderIssues>,
-    document_lang: Option<&'a str>,
+    tagged: bool,
   ) -> Emitter<'a> {
     Emitter {
-      color_filter: None,
-      issues,
-      document_lang,
       root: &self.root,
       contexts: &self.contexts,
       results: &self.results,
-      fonts,
+      document: state,
       inline,
-      window: None,
-      x_window: None,
-      line_window: None,
-      tags,
+      window: Window::default(),
+      tagged: tagged && state.tags.is_some(),
       tag_prefix: Vec::new(),
+      color_filter: None,
     }
   }
 }
@@ -156,123 +268,6 @@ fn fill_root(node: Node, viewport: Viewport) -> Node {
   }
 
   Node::container([node]).with_style(style)
-}
-
-pub(crate) fn prepare_tree(
-  inputs: &TreeInputs<'_>,
-  node: Node,
-  viewport: Viewport,
-) -> Result<PreparedTree, PdfError> {
-  let node = fill_root(node, viewport);
-  let context = tree_context(inputs, viewport);
-  let root = RenderNode::from_node(&context, node);
-
-  lay_out(root, viewport)
-}
-
-pub(crate) fn tree_context(inputs: &TreeInputs<'_>, viewport: Viewport) -> RenderContext {
-  RenderContext::builder()
-    .fonts(
-      inputs
-        .fonts
-        .snapshot_with_fallbacks(inputs.font_families.as_ref()),
-    )
-    .sizing(SizingContext::builder().viewport(viewport).build())
-    .images(inputs.images.clone())
-    .stylesheet(inputs.stylesheet.clone())
-    .style(Box::new(ComputedStyle {
-      lang: inputs.lang,
-      font_family: inputs.font_families.clone().unwrap_or_default(),
-      ..Default::default()
-    }))
-    .build()
-}
-
-/// A `fixed` box repeated on every page: its layout, and the subtree it lays
-/// out again from when it holds a page counter.
-pub(crate) struct RepeatedBox {
-  pub(crate) prepared: PreparedTree,
-  pub(crate) template: Option<RepeatedTemplate>,
-}
-
-/// A repeated box's source subtree, with the context its styles resolved
-/// under, so a re-layout inherits what its ancestors gave it.
-pub(crate) struct RepeatedTemplate {
-  node: Node,
-  parent: RenderContext,
-  source_order: usize,
-}
-
-impl RepeatedTemplate {
-  /// The source orders the subtree occupies in the tree it was taken from.
-  pub(crate) fn source_orders(&self) -> Range<usize> {
-    self.source_order..self.source_order + node_count(&self.node)
-  }
-}
-
-fn node_count(node: &Node) -> usize {
-  match &node.kind {
-    NodeKind::Container { children } => 1 + children.iter().map(node_count).sum::<usize>(),
-    _ => 1,
-  }
-}
-
-/// The tree, plus the `fixed` subtrees attached to the initial containing
-/// block. Those repeat on every page, so they lay out against the page area
-/// instead of the content column.
-pub(crate) fn prepare_paged_tree(
-  inputs: &TreeInputs<'_>,
-  node: Node,
-  viewport: Viewport,
-  page_area: Viewport,
-) -> Result<(PreparedTree, Vec<RepeatedBox>), PdfError> {
-  let node = fill_root(node, viewport);
-  // A repeated box holding a counter lays out again per page, from the subtree
-  // its preorder position names in the tree it was taken from.
-  let source = has_page_counters(&node).then(|| node.clone());
-  let context = tree_context(inputs, viewport);
-  let mut root = RenderNode::from_node(&context, node);
-  let repeated = take_repeating_fixed(&mut root);
-  let content = lay_out(root, viewport)?;
-  let page_context = tree_context(inputs, page_area);
-  let repeated = repeated
-    .into_iter()
-    .map(|(node, parent)| {
-      let template = source
-        .as_ref()
-        .zip(node.source_order())
-        .and_then(|(source, index)| Some((index, node_in_source_order(source, index)?)))
-        .filter(|(_, template)| has_page_counters(template))
-        .map(|(source_order, template)| RepeatedTemplate {
-          node: template.clone(),
-          parent,
-          source_order,
-        });
-
-      Ok(RepeatedBox {
-        prepared: lay_out(page_root(&page_context, node), page_area)?,
-        template,
-      })
-    })
-    .collect::<Result<Vec<_>, PdfError>>()?;
-
-  Ok((content, repeated))
-}
-
-/// Lays a repeated box out again with the counters a page asks for.
-pub(crate) fn prepare_repeated(
-  page_context: &RenderContext,
-  template: &RepeatedTemplate,
-  page: usize,
-  pages: usize,
-  page_area: Viewport,
-) -> Result<PreparedTree, PdfError> {
-  let mut node = template.node.clone();
-
-  substitute_page_counters(&mut node, page, pages);
-  let child = RenderNode::from_node(&template.parent, node);
-
-  lay_out(page_root(page_context, child), page_area)
 }
 
 /// The node at a source order, counted the way the render tree numbers the
@@ -324,7 +319,7 @@ fn take_repeating_fixed(node: &mut RenderNode) -> Vec<(RenderNode, RenderContext
 
 /// The page area a repeated box positions against. Taffy gives a layout root
 /// the origin, so the box has to be a child of one to see its own insets.
-fn page_root(context: &RenderContext, child: RenderNode) -> RenderNode {
+pub(crate) fn page_root(context: &RenderContext, child: RenderNode) -> RenderNode {
   let area = Node::container([]).with_style(
     Style::default()
       .with(StyleDeclaration::display(Display::Block))
@@ -335,36 +330,4 @@ fn page_root(context: &RenderContext, child: RenderNode) -> RenderNode {
 
   root.children = Some(Box::new([child]));
   root
-}
-
-fn lay_out(root: RenderNode, viewport: Viewport) -> Result<PreparedTree, PdfError> {
-  let mut tree = LayoutTree::from_render_node(&root);
-
-  tree.compute_layout(viewport.into());
-
-  let results = tree.into_results();
-  let root_layout = results.layout(NodeId::ROOT)?;
-  let width = viewport
-    .size
-    .width
-    .map_or(root_layout.size.width, |w| w as f32);
-  let height = viewport
-    .size
-    .height
-    .map_or(root_layout.size.height, |h| h as f32);
-  let contexts = build_stacking_contexts(
-    &root,
-    &results,
-    NodeId::ROOT,
-    Affine::IDENTITY,
-    (Some(width), Some(height)),
-  )?;
-
-  Ok(PreparedTree {
-    root,
-    results,
-    contexts,
-    width,
-    height,
-  })
 }

--- a/takumi-pdf/src/window.rs
+++ b/takumi-pdf/src/window.rs
@@ -1,4 +1,7 @@
-//! A clipped, translated window through which a prepared tree emits onto a page.
+//! The page window a prepared tree emits through: what it paints, what it
+//! owns, and the clip and translation that put it on the page.
+
+use takumi_core::{scene::SceneBounds, style::Affine};
 
 use crate::{
   emitter::Emitter,
@@ -11,19 +14,69 @@ use crate::{
   options::PdfError,
   paint::rect_path,
 };
-use takumi_core::style::Affine;
+
+/// The content windows one emit walk filters by, in content coordinates.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Window {
+  /// Vertical paint window `[top, bottom)`. Paint wholly outside it is
+  /// skipped, so clipped-away content never reaches the content stream (or
+  /// text extraction).
+  pub(crate) y: Option<(f32, f32)>,
+  /// Horizontal paint window `[left, right)`: a repeated table header replays
+  /// only its own table's column of the scene.
+  pub(crate) x: Option<(f32, f32)>,
+  /// Text-line ownership window `[this page's cut, next page's cut)`. Wider
+  /// than `y` at the edges (first page reaches up to −∞, last to +∞) and
+  /// narrower at the bottom when a cut lands above the page's full height, so
+  /// every line is emitted on exactly one page.
+  pub(crate) lines: Option<(f32, f32)>,
+}
+
+impl Window {
+  pub(crate) fn excludes(&self, top: f32, bottom: f32) -> bool {
+    self.y.is_some_and(|(y0, y1)| bottom <= y0 || top >= y1)
+  }
+
+  pub(crate) fn excludes_bounds(&self, bounds: Option<SceneBounds>) -> bool {
+    bounds.is_some_and(|b| {
+      self.excludes(b.top as f32, b.bottom as f32)
+        || self
+          .x
+          .is_some_and(|(x0, x1)| b.right as f32 <= x0 || b.left as f32 >= x1)
+    })
+  }
+
+  /// Whether a text line at `baseline` belongs to another page. Ownership is
+  /// keyed on the baseline (always inside the line's own box, unlike the font
+  /// ascent band, which can poke above the container a forced break cut at) and
+  /// half-open, so each line is emitted exactly once.
+  pub(crate) fn disowns_line(&self, baseline: f32) -> bool {
+    self
+      .lines
+      .is_some_and(|(y0, y1)| baseline < y0 || baseline >= y1)
+  }
+
+  /// Narrows both vertical windows to a box that clips its overflow. A clip
+  /// keeps content off the page but not out of the text layer, so what it
+  /// cuts away must never be emitted.
+  pub(crate) fn narrow(&mut self, top: f32, bottom: f32) {
+    for window in [&mut self.y, &mut self.lines] {
+      if let Some((from, to)) = window {
+        *window = Some((from.max(top), to.min(bottom)));
+      }
+    }
+  }
+}
 
 /// One windowed emit: the page-space clip, the content translation, the
-/// content windows the emitter filters by, and whether the content is a
-/// repeated artifact.
+/// window the emitter filters by, and whether the content is a repeated
+/// artifact.
 pub(crate) struct ContentWindow {
   /// Clip rect on the page, as `(x, y, width, height)`.
   pub(crate) clip: (f32, f32, f32, f32),
   /// Translation from content to page coordinates.
   pub(crate) translate: (f32, f32),
-  pub(crate) window: Option<(f32, f32)>,
-  pub(crate) x_window: Option<(f32, f32)>,
-  pub(crate) line_window: Option<(f32, f32)>,
+  pub(crate) window: Window,
   /// A repeated occurrence is an artifact: the first one carried the tags.
   /// `Other` stays valid below PDF 2.0, where the header/footer artifact
   /// subtypes do not exist yet.
@@ -53,8 +106,6 @@ impl ContentWindow {
       self.translate.1,
     ));
     emitter.window = self.window;
-    emitter.x_window = self.x_window;
-    emitter.line_window = self.line_window;
     emitter.emit_context(0, Affine::IDENTITY, surface)?;
     surface.pop();
     surface.pop();


### PR DESCRIPTION
## Why
The page walk threaded fonts, tag collector, issues and language as four loose parameters, kept three window pairs on the emitter, and spread the repeated-box and page-geometry logic over six small types and a 250-line `render`. Every new page feature had to touch all of them.

## What
One `DocumentState` and one `Window` travel through the walk, `PagePlan` and `SinglePage` each compose and address their own pages, and the leftover free functions become methods on the types they build (`Atoms::page_starts`, `CounterStyle`, `Interactive::collect`, `HeaderBand::replays`). Pure refactor: every PDF golden is byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page background rendering, including transparent or unset background handling.
  * Improved repeated headers and fixed page elements during PDF layout.
* **Bug Fixes**
  * Improved pagination when headers and footers change size based on page count.
  * Added safeguards against excessive page generation and pagination edge cases.
  * Improved counter formatting, including Roman, alphabetic, digit, and Chinese styles.
* **Refactor**
  * Streamlined document rendering, layout, tagging, links, and text processing for more consistent PDF output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->