### PR TITLE
Core: clip animation frames that start outside the canvas

### DIFF
--- a/.tegami/frame-outside-canvas.md
+++ b/.tegami/frame-outside-canvas.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: patch
+---
+
+### Clip animation frames that start outside the canvas
+
+A GIF or WebP frame whose origin lies beyond the logical screen no longer panics the decoder. The frame is clipped away instead, as browsers do.

--- a/.tegami/webp-frame-cap.md
+++ b/.tegami/webp-frame-cap.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: patch
+---
+
+### Report a capped WebP animation as unfinished
+
+A WebP stream cut at the frame cap now reports the same unfinished flag as APNG and GIF instead of claiming it ended.

--- a/takumi-core/src/resources/image_decoder/gif.rs
+++ b/takumi-core/src/resources/image_decoder/gif.rs
@@ -117,8 +117,12 @@ pub(crate) fn gif_frame_infos(bytes: &[u8]) -> ImageResult<Box<[FrameInfo]>> {
 /// unclamped pixel stride.
 #[cfg(feature = "gif")]
 fn clamped_span(rect: Rect<u32>, canvas_width: u32, canvas_height: u32) -> (u32, usize, usize) {
-  let rows = rect.bottom.min(canvas_height).saturating_sub(rect.top);
   let cols = rect.right.min(canvas_width).saturating_sub(rect.left) as usize;
+  let rows = if cols == 0 {
+    0
+  } else {
+    rect.bottom.min(canvas_height).saturating_sub(rect.top)
+  };
   let stride = (rect.right - rect.left) as usize;
   (rows, cols, stride)
 }
@@ -362,6 +366,22 @@ pub(crate) fn decode_gif_frames(
 mod tests {
   use super::*;
   use crate::resources::image_decoder::rgba_to_buffer;
+
+  #[cfg(feature = "gif")]
+  #[test]
+  fn frames_starting_outside_the_canvas_clear_nothing() {
+    let mut canvas = vec![255_u8; 4 * 4 * 4];
+    let rect = Rect {
+      left: 6,
+      right: 8,
+      top: 3,
+      bottom: 5,
+    };
+
+    clear_rect(&mut canvas, (4, 4), rect);
+    blit_frame(&mut canvas, (4, 4), rect, &[0; 2 * 2 * 4]);
+    assert!(canvas.iter().all(|byte| *byte == 255));
+  }
 
   #[cfg(feature = "gif")]
   fn rgba_patch(width: u16, height: u16, rgba: [u8; 4]) -> Vec<u8> {

--- a/takumi-core/src/resources/image_decoder/webp.rs
+++ b/takumi-core/src/resources/image_decoder/webp.rs
@@ -299,7 +299,7 @@ pub(crate) fn decode_webp_frames(
 
     match decoder.read_frame(&mut canvas) {
       Ok(_) => {}
-      Err(WebPDecodingError::NoMoreFrames) => break,
+      Err(WebPDecodingError::NoMoreFrames) => return Ok(true),
       Err(error) if index == 0 => return Err(webp_decode_error(error)),
       Err(_) => return Ok(true),
     }
@@ -319,7 +319,7 @@ pub(crate) fn decode_webp_frames(
     pushed += 1;
   }
 
-  Ok(true)
+  Ok(false)
 }
 
 /// The first frame, for the still-image decode paths.

--- a/takumi-core/src/resources/image_decoder/webp.rs
+++ b/takumi-core/src/resources/image_decoder/webp.rs
@@ -396,18 +396,36 @@ pub(crate) fn decode_webp_frame_alone(
   let buffer = if covers_canvas(rect, (canvas_width, canvas_height)) {
     frame
   } else {
-    let mut canvas = vec![0; canvas_width as usize * canvas_height as usize * 4];
-    let stride = canvas_width as usize * 4;
-    for row in 0..rect.3.min(canvas_height.saturating_sub(rect.1)) {
-      let source = row as usize * rect.2 as usize * 4;
-      let target = (rect.1 + row) as usize * stride + rect.0 as usize * 4;
-      let span = rect.2.min(canvas_width.saturating_sub(rect.0)) as usize * 4;
-      canvas[target..target + span].copy_from_slice(&frame.data()[source..source + span]);
-    }
-    ImageBuffer::from_premultiplied_rgba(canvas, canvas_width, canvas_height)?
+    place_on_canvas(&frame, rect, (canvas_width, canvas_height))?
   };
 
   fit_to_target(buffer, target).ok()
+}
+
+/// Copies `frame` onto a cleared canvas at `rect`, clipping the part that
+/// falls outside.
+#[cfg(feature = "webp")]
+fn place_on_canvas(
+  frame: &ImageBuffer,
+  rect: (u32, u32, u32, u32),
+  (canvas_width, canvas_height): (u32, u32),
+) -> Option<ImageBuffer> {
+  let mut canvas = vec![0; canvas_width as usize * canvas_height as usize * 4];
+  let stride = canvas_width as usize * 4;
+  let span = rect.2.min(canvas_width.saturating_sub(rect.0)) as usize * 4;
+  let rows = if span == 0 {
+    0
+  } else {
+    rect.3.min(canvas_height.saturating_sub(rect.1))
+  };
+
+  for row in 0..rows {
+    let source = row as usize * rect.2 as usize * 4;
+    let target = (rect.1 + row) as usize * stride + rect.0 as usize * 4;
+
+    canvas[target..target + span].copy_from_slice(&frame.data()[source..source + span]);
+  }
+  ImageBuffer::from_premultiplied_rgba(canvas, canvas_width, canvas_height)
 }
 
 /// Wraps one frame's bitstream in a RIFF container so the still decoder can
@@ -483,6 +501,15 @@ pub(super) fn decode_webp_scaled(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[cfg(feature = "webp")]
+  #[test]
+  fn frames_starting_outside_the_canvas_place_nothing() {
+    let frame = ImageBuffer::from_premultiplied_rgba(vec![255; 2 * 2 * 4], 2, 2).unwrap();
+    let placed = place_on_canvas(&frame, (6, 3, 2, 2), (4, 4)).unwrap();
+
+    assert!(placed.data().iter().all(|byte| *byte == 0));
+  }
   use crate::resources::{
     image_decoder::{decode_bitmap_scaled, decode_image},
     image_resampler::resample_premultiplied,


### PR DESCRIPTION
## Why
A GIF or WebP animation frame whose origin lies beyond the logical screen made the decoder slice past the end of the canvas and panic.

## What
A frame that starts outside the canvas clips to zero rows before any indexing, so it paints nothing, as browsers do. A second commit makes the WebP frame loop report a capped stream as unfinished, matching the APNG and GIF loops.