### PR TITLE
Core: hang the border helpers on their types

### DIFF
--- a/.tegami/border-methods.md
+++ b/.tegami/border-methods.md
@@ -6,4 +6,4 @@ packages:
 
 ### Move the border helpers onto their types
 
-`side_bands` is `BorderProperties::side_bands`, `border_dash_pattern` is `BorderStyle::dash_pattern`, `inset_size` is `Size::inset`, and `rect_offset` is `Rect::top_left`.
+`side_bands`, `border_dash_pattern`, `inset_size`, and `rect_offset` are now methods on `BorderProperties`, `BorderStyle`, `Size`, and `Rect`.

--- a/.tegami/border-methods.md
+++ b/.tegami/border-methods.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Move the border helpers onto their types
+
+`side_bands` is `BorderProperties::side_bands`, `border_dash_pattern` is `BorderStyle::dash_pattern`, `inset_size` is `Size::inset`, and `rect_offset` is `Rect::top_left`.

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -88,6 +88,14 @@ impl Size<f32> {
     width: 0.0,
     height: 0.0,
   };
+
+  /// Shrinks by `inset` on each edge, clamped to zero.
+  pub fn inset(self, inset: Rect<f32>) -> Self {
+    Size {
+      width: (self.width - inset.left - inset.right).max(0.0),
+      height: (self.height - inset.top - inset.bottom).max(0.0),
+    }
+  }
 }
 
 impl<U, T: Add<U>> Add<Size<U>> for Size<T> {
@@ -181,6 +189,24 @@ impl Rect<f32> {
     top: 0.0,
     bottom: 0.0,
   };
+
+  /// The top-left corner as a point.
+  pub fn top_left(self) -> Point<f32> {
+    Point {
+      x: self.left,
+      y: self.top,
+    }
+  }
+
+  /// Per-side `self - rhs`, clamped to zero.
+  pub(crate) fn saturating_sub(self, rhs: Self) -> Self {
+    Rect {
+      top: (self.top - rhs.top).max(0.0),
+      right: (self.right - rhs.right).max(0.0),
+      bottom: (self.bottom - rhs.bottom).max(0.0),
+      left: (self.left - rhs.left).max(0.0),
+    }
+  }
 }
 
 impl<T> Size<T> {

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -502,7 +502,7 @@ impl BorderProperties {
     let inner_right = (outer_right - self.width.right).max(inner_left);
     let inner_bottom = (outer_bottom - self.width.bottom).max(inner_top);
 
-    let inner_size = inset_size(border_box, self.width);
+    let inner_size = border_box.inset(self.width);
     let mut inner_border = *self;
     inner_border.inset_by_border_width();
     let inner_radii = inner_border.scaled_corner_radii(inner_size);
@@ -898,14 +898,6 @@ impl BorderProperties {
   }
 }
 
-/// Top-left corner of a rect as a point.
-pub fn rect_offset(rect: Rect<f32>) -> Point<f32> {
-  Point {
-    x: rect.left,
-    y: rect.top,
-  }
-}
-
 /// The corner point where a side's clip polygon meets the inner contour.
 ///
 /// Convex corners miter along the line from the outer corner through the inner
@@ -945,7 +937,7 @@ fn side_clip_inner_corner(
   line_intersection(outer, inner, chord_x, chord_y).unwrap_or(inner)
 }
 
-pub(crate) fn line_intersection(
+fn line_intersection(
   a0: Point<f32>,
   a1: Point<f32>,
   b0: Point<f32>,
@@ -1022,7 +1014,7 @@ fn corner_arc_length(shape: Superellipse, radius_x: f32, radius_y: f32) -> f32 {
   contour_arc_length(&corner_contour(shape), radius_x, radius_y)
 }
 
-pub(crate) fn approximate_quarter_ellipse_arc_length(radius_x: f32, radius_y: f32) -> f32 {
+fn approximate_quarter_ellipse_arc_length(radius_x: f32, radius_y: f32) -> f32 {
   if radius_x <= 0.0 || radius_y <= 0.0 {
     return 0.0;
   }
@@ -1033,24 +1025,6 @@ pub(crate) fn approximate_quarter_ellipse_arc_length(radius_x: f32, radius_y: f3
   let h = (diff * diff) / (sum * sum);
   let circumference = PI * sum * (1.0 + (3.0 * h) / (10.0 + (4.0 - 3.0 * h).sqrt()));
   circumference / 4.0
-}
-
-/// Shrinks a size by the given inset on each edge, clamped to zero.
-pub fn inset_size(size: Size<f32>, inset: Rect<f32>) -> Size<f32> {
-  Size {
-    width: (size.width - inset.left - inset.right).max(0.0),
-    height: (size.height - inset.top - inset.bottom).max(0.0),
-  }
-}
-
-/// Per-side `lhs - rhs`, clamped to zero.
-pub(crate) fn subtract_rect(lhs: Rect<f32>, rhs: Rect<f32>) -> Rect<f32> {
-  Rect {
-    top: (lhs.top - rhs.top).max(0.0),
-    right: (lhs.right - rhs.right).max(0.0),
-    bottom: (lhs.bottom - rhs.bottom).max(0.0),
-    left: (lhs.left - rhs.left).max(0.0),
-  }
 }
 
 const DASHED_THICK_WIDTH_THRESHOLD: f32 = 3.0;
@@ -1097,74 +1071,73 @@ pub(crate) enum BorderPaint {
   Sides,
 }
 
-/// Decides how `border` paints. See [`BorderPaint`].
-pub(crate) fn border_paint(border: &BorderProperties) -> BorderPaint {
-  let Some(color) = border.has_uniform_visible_color() else {
-    return BorderPaint::Sides;
-  };
-  let width = border.width.top;
+impl BorderProperties {
+  /// Decides how the border paints. See [`BorderPaint`].
+  pub(crate) fn paint(&self) -> BorderPaint {
+    let Some(color) = self.has_uniform_visible_color() else {
+      return BorderPaint::Sides;
+    };
+    let width = self.width.top;
 
-  for style in [BorderStyle::Dashed, BorderStyle::Dotted] {
-    if border.is_uniform_all_sides_style(style) {
-      return BorderPaint::Stroked {
-        color,
-        width,
-        style,
-      };
+    for style in [BorderStyle::Dashed, BorderStyle::Dotted] {
+      if self.is_uniform_all_sides_style(style) {
+        return BorderPaint::Stroked {
+          color,
+          width,
+          style,
+        };
+      }
     }
-  }
-  if border.is_uniform_all_sides_style(BorderStyle::Double) {
-    return BorderPaint::Double { color, width };
-  }
-  // Only a solid side fills as part of one ring: a dashed or dotted side breaks
-  // the ring into segments, and the 3D bevels shade each side differently.
-  if !border.visible_sides_match(BorderStyle::Solid) {
-    return BorderPaint::Sides;
-  }
-  // A zero-width side leaves the ring's two contours sharing an edge, which
-  // antialiasing leaks a hairline through. Sides share no edges.
-  if [
-    border.width.top,
-    border.width.right,
-    border.width.bottom,
-    border.width.left,
-  ]
-  .iter()
-  .any(|width| *width <= 0.0)
-  {
-    return BorderPaint::Sides;
-  }
+    if self.is_uniform_all_sides_style(BorderStyle::Double) {
+      return BorderPaint::Double { color, width };
+    }
+    // Only a solid side fills as part of one ring: a dashed or dotted side breaks
+    // the ring into segments, and the 3D bevels shade each side differently.
+    if !self.visible_sides_match(BorderStyle::Solid) {
+      return BorderPaint::Sides;
+    }
+    // A zero-width side leaves the ring's two contours sharing an edge, which
+    // antialiasing leaks a hairline through. Sides share no edges.
+    if [
+      self.width.top,
+      self.width.right,
+      self.width.bottom,
+      self.width.left,
+    ]
+    .iter()
+    .any(|width| *width <= 0.0)
+    {
+      return BorderPaint::Sides;
+    }
 
-  BorderPaint::Ring { color }
+    BorderPaint::Ring { color }
+  }
 }
 
-/// The dash pattern for a stroked `dashed`/`dotted` border or outline side,
-/// shared by every backend: `([dash, gap], round_cap)`, or `None` for a solid
-/// stroke (non-dash style, or a segment too short to dash). `length` is the side
-/// length (or the ring perimeter when `closed`). Dash/gap adjust by width and
-/// length so the pattern fits the side evenly.
-pub fn border_dash_pattern(
-  width: f32,
-  style: BorderStyle,
-  length: f32,
-  closed: bool,
-) -> Option<([f32; 2], bool)> {
-  if !matches!(style, BorderStyle::Dashed | BorderStyle::Dotted) || width <= 0.0 || length <= 0.0 {
-    return None;
-  }
+impl BorderStyle {
+  /// The dash pattern for a stroked `dashed`/`dotted` border or outline side,
+  /// shared by every backend: `([dash, gap], round_cap)`, or `None` for a solid
+  /// stroke (non-dash style, or a segment too short to dash). `length` is the
+  /// side length (or the ring perimeter when `closed`). Dash/gap adjust by
+  /// width and length so the pattern fits the side evenly.
+  pub fn dash_pattern(self, width: f32, length: f32, closed: bool) -> Option<([f32; 2], bool)> {
+    if !matches!(self, BorderStyle::Dashed | BorderStyle::Dotted) || width <= 0.0 || length <= 0.0 {
+      return None;
+    }
 
-  if style == BorderStyle::Dashed {
-    let (dash, gap) = compute_dashed_intervals(width, length, closed)?;
-    return Some(([dash, gap], false));
-  }
+    if self == BorderStyle::Dashed {
+      let (dash, gap) = compute_dashed_intervals(width, length, closed)?;
+      return Some(([dash, gap], false));
+    }
 
-  let per_dot_length = width * 2.0;
-  let gap = if length < per_dot_length {
-    per_dot_length
-  } else {
-    select_best_dash_gap(length, width, width, closed) + width - DOTTED_ENDPOINT_EPSILON
-  };
-  Some(([0.0, gap], true))
+    let per_dot_length = width * 2.0;
+    let gap = if length < per_dot_length {
+      per_dot_length
+    } else {
+      select_best_dash_gap(length, width, width, closed) + width - DOTTED_ENDPOINT_EPSILON
+    };
+    Some(([0.0, gap], true))
+  }
 }
 
 fn compute_dashed_intervals(width: f32, length: f32, closed: bool) -> Option<(f32, f32)> {
@@ -1222,94 +1195,84 @@ fn select_best_dash_gap(length: f32, dash: f32, gap: f32, closed: bool) -> f32 {
   }
 }
 
-/// Lightens or darkens a side color for `inset`/`outset` 3D border shading.
-pub(crate) fn shade_3d_border_color(color: Color, side: BorderSide, style: BorderStyle) -> Color {
-  let lighten = match style {
-    BorderStyle::Outset => matches!(side, BorderSide::Top | BorderSide::Left),
-    BorderStyle::Inset => matches!(side, BorderSide::Right | BorderSide::Bottom),
-    _ => false,
-  };
+impl PaintedSide {
+  /// The side's colour lightened or darkened for `inset`/`outset` 3D shading.
+  fn shaded(&self, style: BorderStyle) -> Color {
+    let lighten = match style {
+      BorderStyle::Outset => matches!(self.side, BorderSide::Top | BorderSide::Left),
+      BorderStyle::Inset => matches!(self.side, BorderSide::Right | BorderSide::Bottom),
+      _ => false,
+    };
 
-  mix_color(
-    color,
-    if lighten {
-      Color::white()
-    } else {
-      Color::black()
-    },
-    0.35,
-  )
-}
-
-/// The strips a side fills, outermost first.
-///
-/// A dashed or dotted side has none: it strokes a centerline instead. The 3D
-/// bevels shade their strips, which is the only thing that separates them from
-/// a plain `solid` side.
-pub fn side_bands(border: &BorderProperties, side: PaintedSide) -> SmallVec<[SideBand; 2]> {
-  let mut bands = SmallVec::new();
-  let color = side.color;
-  let shaded = |style| shade_3d_border_color(color, side.side, style);
-
-  match side.style {
-    BorderStyle::Dashed | BorderStyle::Dotted => {}
-    BorderStyle::Double => {
-      let width = border.width.map(|value| value / 3.0);
-
-      bands.push(SideBand {
-        inset: Rect::ZERO,
-        width,
-        color,
-      });
-      bands.push(SideBand {
-        inset: border.width.map(|value| value * (2.0 / 3.0)),
-        width,
-        color,
-      });
-    }
-    BorderStyle::Inset | BorderStyle::Outset => bands.push(SideBand {
-      inset: Rect::ZERO,
-      width: border.width,
-      color: shaded(side.style),
-    }),
-    BorderStyle::Groove | BorderStyle::Ridge => {
-      let outer_width = border.width.map(|value| value / 2.0);
-      let (outer, inner) = match side.style {
-        BorderStyle::Groove => (BorderStyle::Inset, BorderStyle::Outset),
-        _ => (BorderStyle::Outset, BorderStyle::Inset),
-      };
-
-      bands.push(SideBand {
-        inset: Rect::ZERO,
-        width: outer_width,
-        color: shaded(outer),
-      });
-      bands.push(SideBand {
-        inset: outer_width,
-        width: subtract_rect(border.width, outer_width),
-        color: shaded(inner),
-      });
-    }
-    _ => bands.push(SideBand {
-      inset: Rect::ZERO,
-      width: border.width,
-      color,
-    }),
+    self.color.mix(
+      if lighten {
+        Color::white()
+      } else {
+        Color::black()
+      },
+      0.35,
+    )
   }
-
-  bands
 }
 
-pub(crate) fn mix_color(color: Color, target: Color, amount: f32) -> Color {
-  let amount = amount.clamp(0.0, 1.0);
-  let inverse = 1.0 - amount;
+impl BorderProperties {
+  /// The strips a side fills, outermost first.
+  ///
+  /// A dashed or dotted side has none: it strokes a centerline instead. The 3D
+  /// bevels shade their strips, which is the only thing that separates them
+  /// from a plain `solid` side.
+  pub fn side_bands(&self, side: PaintedSide) -> SmallVec<[SideBand; 2]> {
+    let mut bands = SmallVec::new();
+    let color = side.color;
 
-  Color([
-    (color.0[0] as f32 * inverse + target.0[0] as f32 * amount).round() as u8,
-    (color.0[1] as f32 * inverse + target.0[1] as f32 * amount).round() as u8,
-    (color.0[2] as f32 * inverse + target.0[2] as f32 * amount).round() as u8,
-    color.0[3],
-  ])
+    match side.style {
+      BorderStyle::Dashed | BorderStyle::Dotted => {}
+      BorderStyle::Double => {
+        let width = self.width.map(|value| value / 3.0);
+
+        bands.push(SideBand {
+          inset: Rect::ZERO,
+          width,
+          color,
+        });
+        bands.push(SideBand {
+          inset: self.width.map(|value| value * (2.0 / 3.0)),
+          width,
+          color,
+        });
+      }
+      BorderStyle::Inset | BorderStyle::Outset => bands.push(SideBand {
+        inset: Rect::ZERO,
+        width: self.width,
+        color: side.shaded(side.style),
+      }),
+      BorderStyle::Groove | BorderStyle::Ridge => {
+        let outer_width = self.width.map(|value| value / 2.0);
+        let (outer, inner) = match side.style {
+          BorderStyle::Groove => (BorderStyle::Inset, BorderStyle::Outset),
+          _ => (BorderStyle::Outset, BorderStyle::Inset),
+        };
+
+        bands.push(SideBand {
+          inset: Rect::ZERO,
+          width: outer_width,
+          color: side.shaded(outer),
+        });
+        bands.push(SideBand {
+          inset: outer_width,
+          width: self.width.saturating_sub(outer_width),
+          color: side.shaded(inner),
+        });
+      }
+      _ => bands.push(SideBand {
+        inset: Rect::ZERO,
+        width: self.width,
+        color,
+      }),
+    }
+
+    bands
+  }
 }
 
 #[cfg(test)]

--- a/takumi-core/src/painter.rs
+++ b/takumi-core/src/painter.rs
@@ -9,7 +9,7 @@ use crate::{
   context::RenderContext,
   geometry::{ComputedLayout, PathCommand, Point, Rect, Size},
   layout::{
-    border::{BorderPaint, BorderProperties, border_dash_pattern, border_paint},
+    border::{BorderPaint, BorderProperties},
     decoration::{ClipBox, OutlineGeometry, outline_paint},
     inline::DecorationRect,
   },
@@ -307,7 +307,7 @@ pub fn paint_border<D: PaintDevice>(
 ) -> bool {
   let at = Affine::translation(origin.x, origin.y);
 
-  match border_paint(border) {
+  match border.paint() {
     BorderPaint::Sides => return false,
     // A transparent ring is a fill nobody sees, and painting it would only
     // lengthen the output.
@@ -383,7 +383,7 @@ pub fn paint_border<D: PaintDevice>(
       center.append_mask_commands(&mut commands, center_size, Point { x: half, y: half });
 
       let perimeter = center.approximate_rounded_rect_perimeter(center_size);
-      let dash = border_dash_pattern(width, style, perimeter, true);
+      let dash = style.dash_pattern(width, perimeter, true);
 
       device.stroke_shape(
         &FillShape::Path {

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -521,6 +521,19 @@ impl Color {
     Color([255, 255, 255, 255])
   }
 
+  /// Mixes `amount` of `target` into the colour, keeping this alpha.
+  pub(crate) fn mix(self, target: Color, amount: f32) -> Self {
+    let amount = amount.clamp(0.0, 1.0);
+    let inverse = 1.0 - amount;
+
+    Color([
+      (self.0[0] as f32 * inverse + target.0[0] as f32 * amount).round() as u8,
+      (self.0[1] as f32 * inverse + target.0[1] as f32 * amount).round() as u8,
+      (self.0[2] as f32 * inverse + target.0[2] as f32 * amount).round() as u8,
+      self.0[3],
+    ])
+  }
+
   /// Apply opacity to alpha channel
   pub(crate) fn with_opacity(mut self, opacity: u8) -> Self {
     self.0[3] = fast_div_255(self.0[3] as u32 * opacity as u32);

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -15,7 +15,7 @@ use takumi_core::{
   font_style::SizedFontStyle,
   geometry::{ComputedLayout as Layout, NodeId, Point as CorePoint, Size},
   layout::{
-    border::{BorderProperties, inset_size, rect_offset, side_bands},
+    border::BorderProperties,
     clip::clip_shape_commands,
     decoration::{ClipBox, OutlineGeometry},
     inline::{
@@ -1072,7 +1072,7 @@ impl Emitter<'_> {
     }
 
     for side in sides {
-      for band in side_bands(border, side) {
+      for band in border.side_bands(side) {
         let mut strip = *border;
 
         strip.width = band.width;
@@ -1083,8 +1083,8 @@ impl Emitter<'_> {
         strip.append_side_clip_polygon_commands_at(
           side.side,
           &mut polygon,
-          inset_size(size, band.inset),
-          rect_offset(band.inset),
+          size.inset(band.inset),
+          band.inset.top_left(),
         );
         if let Some(path) = krilla_path(&polygon, x, y) {
           surface.set_fill(Some(fill_from_rgba(self.filtered(band.color), 1.0)));

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -1,9 +1,6 @@
 use takumi_core::{
   geometry::{Point, Rect, Size},
-  layout::border::{
-    BorderProperties, BorderSide, PaintedSide, border_dash_pattern, inset_size, rect_offset,
-    side_bands,
-  },
+  layout::border::{BorderProperties, BorderSide, PaintedSide},
 };
 
 use crate::{
@@ -136,7 +133,7 @@ fn draw_visible_side(
     draw_side_pattern_border(border, paint, side.side, border_box, side.color, side.style);
     return;
   }
-  for band in side_bands(&border, side) {
+  for band in border.side_bands(side) {
     draw_side_band(
       border, paint, side.side, border_box, band.inset, band.width, band.color,
     );
@@ -162,11 +159,7 @@ fn draw_uniform_double(
   let mut inner = border;
   inner.width = stripe_width;
   inner.expand_by(inset.map(|value| -value));
-  inner.append_border_ring_commands_at(
-    &mut paths,
-    inset_size(border_box, inset),
-    rect_offset(inset),
-  );
+  inner.append_border_ring_commands_at(&mut paths, border_box.inset(inset), inset.top_left());
 
   let (mask, placement) = render_mask(
     &paths,
@@ -203,8 +196,8 @@ fn draw_uniform_pattern(
   let mut center_rect = border;
   center_rect.expand_by(half_width.map(|v| -v));
 
-  let center_size = inset_size(border_box, half_width);
-  let center_offset = rect_offset(half_width);
+  let center_size = border_box.inset(half_width);
+  let center_offset = half_width.top_left();
 
   let mut paths = Vec::with_capacity(BorderProperties::PATH_COMMANDS_AMOUNT);
   center_rect.append_mask_commands(&mut paths, center_size, center_offset);
@@ -247,11 +240,11 @@ fn draw_side_band(
   let mut band = border;
   band.width = width;
 
-  let band_box = inset_size(border_box, inset);
+  let band_box = border_box.inset(inset);
   if band_box.width <= 0.0 || band_box.height <= 0.0 {
     return;
   }
-  let offset = rect_offset(inset);
+  let offset = inset.top_left();
   band.expand_by(inset.map(|value| -value));
 
   if band.is_zero() {
@@ -380,7 +373,7 @@ fn draw_side_pattern_border(
 
 fn compute_side_stroke(width: f32, style: BorderStyle, length: f32, closed: bool) -> Stroke {
   let mut stroke = Stroke::new(width);
-  if let Some((intervals, round_cap)) = border_dash_pattern(width, style, length, closed) {
+  if let Some((intervals, round_cap)) = style.dash_pattern(width, length, closed) {
     if round_cap {
       stroke.cap = Cap::Round;
     }

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -8,10 +8,7 @@ use takumi_core::{
   error::Result,
   geometry::{ComputedLayout as Layout, NodeId, Point, Size},
   layout::{
-    border::{
-      BorderProperties, BorderSide, PaintedSide, border_dash_pattern, inset_size, rect_offset,
-      side_bands,
-    },
+    border::{BorderProperties, BorderSide, PaintedSide},
     decoration::{ClipBox, OutlineGeometry},
     inline::{InlineBoxItem, VisualInlineBox},
     inline_box::{InlineBoxPaint, resolve_inline_box},
@@ -854,7 +851,7 @@ pub(crate) fn emit_borders(
         emit_side_pattern(border, side, geom, doc)?;
       }
       _ => {
-        for band in side_bands(border, side) {
+        for band in border.side_bands(side) {
           let mut strip = *border;
 
           strip.width = band.width;
@@ -864,8 +861,8 @@ pub(crate) fn emit_borders(
           strip.append_side_clip_polygon_commands_at(
             side.side,
             &mut polygon,
-            inset_size(size, band.inset),
-            rect_offset(band.inset),
+            size.inset(band.inset),
+            band.inset.top_left(),
           );
           doc.path(&path_data(&polygon, matrix), Rgba(band.color.0), false)?;
         }
@@ -972,7 +969,7 @@ pub(crate) fn paint_outline(pending: &PendingOutline, doc: &mut SvgDocument) -> 
 }
 
 /// SVG `stroke-dasharray`/`stroke-linecap` for a `dashed`/`dotted` border or
-/// outline, computed from the shared [`border_dash_pattern`] so the intervals
+/// outline, computed from the shared [`BorderStyle::dash_pattern`] so the intervals
 /// match the raster backend.
 fn dash_attrs(
   width: f32,
@@ -980,7 +977,7 @@ fn dash_attrs(
   length: f32,
   closed: bool,
 ) -> (Option<String>, Option<&'static str>) {
-  match border_dash_pattern(width, style, length, closed) {
+  match style.dash_pattern(width, length, closed) {
     Some(([dash, gap], round_cap)) => (
       Some(format!("{} {}", Num(dash), Num(gap))),
       round_cap.then_some("round"),


### PR DESCRIPTION
## Why
`border.rs` exported seven free functions whose first argument was a border, a style, a size, or a rect, so the three backends called them as loose helpers instead of through the types they describe.

## What
`BorderProperties::side_bands` and `paint`, `BorderStyle::dash_pattern`, `PaintedSide::shaded`, `Color::mix`, `Size::inset`, and `Rect::top_left` and `saturating_sub` replace them. Pure refactor, goldens byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the organization and consistency of border, geometry, color, and rendering APIs.
  - Border-related operations are now grouped with the components they operate on, making the toolkit easier to use and maintain.
  - Updated PDF, raster, and SVG rendering integrations to use the streamlined APIs.

- **Bug Fixes**
  - Preserved existing border rendering behavior across supported output formats while updating internal border calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->