### PR TITLE
Core: build gradient tables through ColorLut

### DIFF
--- a/.tegami/gradient-lut.md
+++ b/.tegami/gradient-lut.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Build gradient tables through ColorLut
+
+Gradient tiles carry one `lut: ColorLut` instead of `color_lut` and its dithering companions. `resolve_stops_along_axis` is `ResolvedGradientStop::resolve`, `build_color_lut_with_interpolation` is `ColorLut::new`, and the overlay fast path is `GradientOverlayTile::overlay_unconstrained`.

--- a/.tegami/gradient-lut.md
+++ b/.tegami/gradient-lut.md
@@ -6,4 +6,4 @@ packages:
 
 ### Build gradient tables through ColorLut
 
-Gradient tiles carry one `lut: ColorLut` instead of `color_lut` and its dithering companions. `resolve_stops_along_axis` is `ResolvedGradientStop::resolve`, `build_color_lut_with_interpolation` is `ColorLut::new`, and the overlay fast path is `GradientOverlayTile::overlay_unconstrained`.
+Gradient tiles carry one `lut: ColorLut`. `ResolvedGradientStop::resolve` and `ColorLut::new` replace the free functions.

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -69,10 +69,7 @@ pub mod paint {
     },
     conic_gradient::{ConicGradientRowState, ConicGradientTile},
     filter::compose_transfer_table,
-    gradient_utils::{
-      GradientOverlayTile, build_color_lut_with_interpolation,
-      overlay_gradient_tile_fast_normal_unconstrained, resolve_stops_along_axis,
-    },
+    gradient_utils::{ColorLut, GradientOverlayTile},
     linear_gradient::{
       LinearGradientFastPath, LinearGradientFastPathKind, LinearGradientRowState,
       LinearGradientTile,

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -1,18 +1,18 @@
 use std::fmt::{self, Display};
 
-use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Srgb, parse_color};
+use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Rgba8, Srgb, parse_color};
 use cssparser::{
   Parser, Token,
   color::{parse_hash_color, parse_named_color},
   match_ignore_ascii_case,
 };
+use tiny_skia::{ColorU8, PremultipliedColorU8};
 
 use crate::style::tw::{Namespace, extract_arbitrary_value};
 use crate::style::{
   Animatable, Color as CurrentColor, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
   FromCssStr, MakeComputed, ParseResult, PercentageNumber, SizingContext, ToCss,
-  math::fast_div_255, properties::gradient_utils::interpolate_with_color_space,
-  tw::TailwindPropertyParser, unexpected_token,
+  math::fast_div_255, tw::TailwindPropertyParser, unexpected_token,
 };
 
 fn is_cylindrical_color_space(color_space: ColorSpaceTag) -> bool {
@@ -212,8 +212,7 @@ impl Animatable for ColorInput {
       // a legacy sRGB one, and those interpolate in sRGB with premultiplied alpha.
       // Oklab is for colours a legacy space cannot express.
       // https://www.w3.org/TR/css-color-4/#interpolation-space
-      _ => ColorInput::Value(interpolate_with_color_space(
-        from.resolve(current_color),
+      _ => ColorInput::Value(from.resolve(current_color).interpolate(
         to.resolve(current_color),
         progress,
         ColorSpaceTag::Srgb,
@@ -519,6 +518,98 @@ impl Color {
   /// Creates a new white color.
   pub const fn white() -> Self {
     Color([255, 255, 255, 255])
+  }
+
+  /// Premultiplies the straight-alpha colour into a `tiny_skia`
+  /// [`PremultipliedColorU8`].
+  pub(crate) fn premultiplied(self) -> PremultipliedColorU8 {
+    let [r, g, b, a] = self.0;
+    let premul_r = fast_div_255(r as u32 * a as u32);
+    let premul_g = fast_div_255(g as u32 * a as u32);
+    let premul_b = fast_div_255(b as u32 * a as u32);
+
+    PremultipliedColorU8::from_rgba(premul_r, premul_g, premul_b, a)
+      .unwrap_or(PremultipliedColorU8::TRANSPARENT)
+  }
+
+  /// Interpolates toward `other` in sRGB with premultiplied alpha.
+  pub(crate) fn lerp_premultiplied(self, other: Color, t: f32) -> Color {
+    if t <= f32::EPSILON {
+      return self;
+    }
+
+    if t >= 1.0 - f32::EPSILON {
+      return other;
+    }
+
+    let [r1, g1, b1, a1] = self.0;
+    let [r2, g2, b2, a2] = other.0;
+    let premul_1 = [
+      fast_div_255(r1 as u32 * a1 as u32),
+      fast_div_255(g1 as u32 * a1 as u32),
+      fast_div_255(b1 as u32 * a1 as u32),
+      a1,
+    ];
+    let premul_2 = [
+      fast_div_255(r2 as u32 * a2 as u32),
+      fast_div_255(g2 as u32 * a2 as u32),
+      fast_div_255(b2 as u32 * a2 as u32),
+      a2,
+    ];
+
+    let mut result = [0u8; 4];
+    for i in 0..4 {
+      result[i] = (premul_1[i] as f32 * (1.0 - t) + premul_2[i] as f32 * t)
+        .round()
+        .clamp(0.0, 255.0) as u8;
+    }
+
+    let premul = PremultipliedColorU8::from_rgba(
+      result[0].min(result[3]),
+      result[1].min(result[3]),
+      result[2].min(result[3]),
+      result[3],
+    )
+    .unwrap_or(PremultipliedColorU8::TRANSPARENT);
+    let demul: ColorU8 = premul.demultiply();
+    Color([demul.red(), demul.green(), demul.blue(), demul.alpha()])
+  }
+
+  /// Interpolates toward `other` in the given color space and hue direction.
+  pub(crate) fn interpolate(
+    self,
+    other: Color,
+    t: f32,
+    color_space: ColorSpaceTag,
+    hue_direction: HueDirection,
+  ) -> Color {
+    if self == other {
+      return self;
+    }
+
+    if color_space == ColorSpaceTag::Srgb && hue_direction == HueDirection::Shorter {
+      return self.lerp_premultiplied(other, t);
+    }
+
+    if t <= f32::EPSILON {
+      return self;
+    }
+
+    if t >= 1.0 - f32::EPSILON {
+      return other;
+    }
+
+    let dynamic_1 =
+      DynamicColor::from_alpha_color(AlphaColor::<Srgb>::from(Rgba8::from_u8_array(self.0)));
+    let dynamic_2 =
+      DynamicColor::from_alpha_color(AlphaColor::<Srgb>::from(Rgba8::from_u8_array(other.0)));
+
+    let mixed = dynamic_1
+      .interpolate(dynamic_2, color_space, hue_direction)
+      .eval(t);
+    let rgba = mixed.to_alpha_color::<Srgb>().to_rgba8().to_u8_array();
+
+    Color(rgba)
   }
 
   /// Mixes `amount` of `target` into the colour, keeping this alpha.

--- a/takumi-core/src/style/properties/conic_gradient.rs
+++ b/takumi-core/src/style/properties/conic_gradient.rs
@@ -5,17 +5,15 @@ use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 
 use super::gradient_utils::{
-  GradientLutHiEntry, GradientOverlayTile, adaptive_lut_size_with_visible_samples,
-  build_color_lut_hi_with_interpolation, build_color_lut_with_interpolation, compute_repeat_setup,
-  gradient_tile_accessors, parse_gradient_stops, quantize_dithered, resolve_stops_along_axis,
+  ColorLut, GradientOverlayTile, LutAxis, gradient_tile_accessors, parse_gradient_stops,
   write_gradient_css,
 };
 use crate::{
   math,
   style::{
     Angle, Color, ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop,
-    Length, MakeComputed, ParseResult, PositionValue, SizingContext, StopPosition, ToCss,
-    unexpected_token,
+    Length, MakeComputed, ParseResult, PositionValue, ResolvedGradientStop, SizingContext,
+    StopPosition, ToCss, unexpected_token,
   },
 };
 
@@ -75,13 +73,8 @@ pub struct ConicGradientTile {
   pub angle_to_lut_scale: f32,
   /// Whether every LUT entry has alpha = 255.
   pub fully_opaque: bool,
-  /// Pre-computed color lookup table for fast gradient sampling.
-  /// Maps normalized angle [0.0, 1.0] (fraction of full turn) to color.
-  pub color_lut: Vec<PremultipliedColorU8>,
-  /// The LUT in premultiplied 8.8 fixed point, read by dithered sampling.
-  pub(crate) color_lut_hi: Vec<GradientLutHiEntry>,
-  /// Whether any LUT entry carries a fraction dithering can move.
-  pub(crate) lut_dither_active: bool,
+  /// Pre-computed colour samples around the turn.
+  pub lut: ColorLut,
 }
 
 /// Per-row sampling state for incremental angle stepping.
@@ -188,39 +181,21 @@ impl ConicGradientTile {
     let start_turns = start_rad / TAU;
 
     // Resolve stop percentages against one full turn (360deg).
-    let resolved_stops = resolve_stops_along_axis(&gradient.stops, 360.0, sizing, current_color);
-
-    let (repeating, repeat_start_deg, repeat_period_deg, lut_axis_length_deg, lut_resolved_stops) =
-      compute_repeat_setup(gradient.repeating, resolved_stops, 360.0);
-
-    let lut_size = adaptive_lut_size_with_visible_samples(
-      Self::visible_angle_samples(width, height, cx, cy),
-      lut_axis_length_deg,
-      &lut_resolved_stops,
-    );
-    let color_lut = build_color_lut_with_interpolation(
-      &lut_resolved_stops,
-      lut_axis_length_deg,
-      lut_size,
-      gradient.interpolation,
-    );
-    let (color_lut_hi, lut_dither_active) = build_color_lut_hi_with_interpolation(
-      &lut_resolved_stops,
-      lut_axis_length_deg,
-      lut_size,
-      gradient.interpolation,
-      dither,
-    );
-    let lut_len = color_lut.len();
-    let angle_to_lut_scale = if repeating && repeat_period_deg > 1e-6 && lut_len > 1 {
-      (lut_len - 1) as f32 / repeat_period_deg
+    let resolved_stops =
+      ResolvedGradientStop::resolve(&gradient.stops, 360.0, sizing, current_color);
+    let axis = LutAxis::new(gradient.repeating, resolved_stops, 360.0);
+    let lut_size = axis.lut_size_covering(Self::visible_angle_samples(width, height, cx, cy));
+    let lut = axis.lut(lut_size, gradient.interpolation, dither);
+    let lut_len = lut.len();
+    let angle_to_lut_scale = if axis.repeating && axis.repeat_period > 1e-6 && lut_len > 1 {
+      (lut_len - 1) as f32 / axis.repeat_period
     } else if lut_len == 0 {
       0.0
     } else {
       lut_len as f32 / TAU
     };
 
-    let fully_opaque = color_lut.iter().all(|p| p.alpha() == u8::MAX);
+    let fully_opaque = lut.colors().iter().all(|p| p.alpha() == u8::MAX);
 
     ConicGradientTile {
       width,
@@ -230,14 +205,12 @@ impl ConicGradientTile {
       start_rad,
       start_turns,
       turns_to_lut_scale: lut_len as f32,
-      repeating,
-      repeat_start_deg,
-      repeat_period_deg,
+      repeating: axis.repeating,
+      repeat_start_deg: axis.repeat_start,
+      repeat_period_deg: axis.repeat_period,
       angle_to_lut_scale,
       fully_opaque,
-      color_lut,
-      color_lut_hi,
-      lut_dither_active,
+      lut,
     }
   }
 
@@ -250,7 +223,7 @@ impl ConicGradientTile {
     }
 
     let adjusted = self.adjusted_turns(dx, dy);
-    self.lut_index_for_adjusted_turns(adjusted, self.color_lut.len())
+    self.lut_index_for_adjusted_turns(adjusted, self.lut.len())
   }
 }
 
@@ -261,20 +234,20 @@ impl GradientOverlayTile for ConicGradientTile {
 
   #[inline(always)]
   fn sample_pixel(&self, x: u32, y: u32) -> PremultipliedColorU8 {
-    match self.color_lut.len() {
+    match self.lut.len() {
       0 => PremultipliedColorU8::TRANSPARENT,
-      1 => self.color_lut[0],
-      _ => self.color_lut[self.pixel_lut_index(x, y)],
+      1 => self.lut.sample(0),
+      _ => self.lut.sample(self.pixel_lut_index(x, y)),
     }
   }
 
   #[inline(always)]
   fn sample_pixel_dithered(&self, x: u32, y: u32) -> PremultipliedColorU8 {
-    if !self.lut_dither_active {
+    if !self.lut.dither_active() {
       return self.sample_pixel(x, y);
     }
 
-    quantize_dithered(self.color_lut_hi[self.pixel_lut_index(x, y)], x, y)
+    self.lut.sample_dithered(self.pixel_lut_index(x, y), x, y)
   }
 
   #[inline(always)]

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
-use color::{AlphaColor, ColorSpaceTag, DynamicColor, HueDirection, Rgba8, Srgb};
+use color::{ColorSpaceTag, HueDirection};
 use cssparser::{Parser, Token};
 use smallvec::SmallVec;
-use tiny_skia::{ColorU8, PremultipliedColorU8};
+use tiny_skia::PremultipliedColorU8;
 
 use crate::{
   geometry::Point,
@@ -34,24 +34,6 @@ const DITHER_NOISE_88: [[i16; 8]; 8] = [
 
 /// A gradient LUT entry in premultiplied 8.8 fixed point.
 pub(crate) type GradientLutHiEntry = [u16; 4];
-
-/// Quantizes an 8.8 sample to 8-bit with the Bayer noise for pixel `(x, y)`.
-///
-/// The bias stays in `[0, 252]`, so no channel can underflow, overflow, or
-/// round past its alpha; the entry's premultiplied ordering survives as-is.
-#[inline(always)]
-pub(crate) fn quantize_dithered(entry: GradientLutHiEntry, x: u32, y: u32) -> PremultipliedColorU8 {
-  let bias = (128 + DITHER_NOISE_88[(y & 7) as usize][(x & 7) as usize] as i32) as u32;
-  let channel = |value: u16| ((value as u32 + bias) >> 8) as u8;
-
-  PremultipliedColorU8::from_rgba(
-    channel(entry[0]),
-    channel(entry[1]),
-    channel(entry[2]),
-    channel(entry[3]),
-  )
-  .unwrap_or(PremultipliedColorU8::TRANSPARENT)
-}
 
 #[cfg(test)]
 pub(crate) fn red_blue_stops(
@@ -85,22 +67,22 @@ macro_rules! gradient_tile_accessors {
 
     #[inline(always)]
     fn lut_len(&self) -> usize {
-      self.color_lut.len()
+      self.lut.len()
     }
 
     #[inline(always)]
     fn sample_at(&self, lut_idx: usize) -> PremultipliedColorU8 {
-      self.color_lut[lut_idx]
+      self.lut.sample(lut_idx)
     }
 
     #[inline(always)]
     fn sample_dithered_at(&self, lut_idx: usize, x: u32, y: u32) -> PremultipliedColorU8 {
-      $crate::style::properties::gradient_utils::quantize_dithered(self.color_lut_hi[lut_idx], x, y)
+      self.lut.sample_dithered(lut_idx, x, y)
     }
 
     #[inline(always)]
     fn dither_active(&self) -> bool {
-      self.lut_dither_active
+      self.lut.dither_active()
     }
 
     #[inline(always)]
@@ -111,30 +93,6 @@ macro_rules! gradient_tile_accessors {
 }
 
 pub(crate) use gradient_tile_accessors;
-
-/// Computes the repeating origin/period and the stops/axis length used to build the LUT.
-pub(crate) fn compute_repeat_setup(
-  repeating: bool,
-  resolved_stops: SmallVec<[ResolvedGradientStop; 4]>,
-  fallback_axis: f32,
-) -> (bool, f32, f32, f32, SmallVec<[ResolvedGradientStop; 4]>) {
-  if repeating && let (Some(first), Some(last)) = (resolved_stops.first(), resolved_stops.last()) {
-    let repeat_start = first.position;
-    let repeat_period = (last.position - first.position).max(0.0);
-    if repeat_period > 1e-6 {
-      let shifted = resolved_stops
-        .iter()
-        .map(|stop| ResolvedGradientStop {
-          color: stop.color,
-          position: stop.position - repeat_start,
-        })
-        .collect();
-      return (true, repeat_start, repeat_period, repeat_period, shifted);
-    }
-  }
-
-  (false, 0.0, 0.0, fallback_axis, resolved_stops)
-}
 
 /// Color functions whose presence flips an unspecified gradient interpolation
 /// space from sRGB to Oklab; every other stop syntax is a legacy sRGB form.
@@ -252,97 +210,6 @@ pub(crate) fn write_gradient_css<W: fmt::Write>(
   dest.write_char(')')
 }
 
-/// Premultiplies a straight-alpha [`Color`] into a `tiny_skia`
-/// [`PremultipliedColorU8`].
-pub(crate) fn color_to_premultiplied(color: Color) -> PremultipliedColorU8 {
-  let [r, g, b, a] = color.0;
-  let premul_r = fast_div_255(r as u32 * a as u32);
-  let premul_g = fast_div_255(g as u32 * a as u32);
-  let premul_b = fast_div_255(b as u32 * a as u32);
-
-  PremultipliedColorU8::from_rgba(premul_r, premul_g, premul_b, a)
-    .unwrap_or(PremultipliedColorU8::TRANSPARENT)
-}
-
-pub(crate) fn interpolate_rgba(c1: Color, c2: Color, t: f32) -> Color {
-  if t <= f32::EPSILON {
-    return c1;
-  }
-
-  if t >= 1.0 - f32::EPSILON {
-    return c2;
-  }
-
-  let [r1, g1, b1, a1] = c1.0;
-  let [r2, g2, b2, a2] = c2.0;
-  let premul_1 = [
-    fast_div_255(r1 as u32 * a1 as u32),
-    fast_div_255(g1 as u32 * a1 as u32),
-    fast_div_255(b1 as u32 * a1 as u32),
-    a1,
-  ];
-  let premul_2 = [
-    fast_div_255(r2 as u32 * a2 as u32),
-    fast_div_255(g2 as u32 * a2 as u32),
-    fast_div_255(b2 as u32 * a2 as u32),
-    a2,
-  ];
-
-  let mut result = [0u8; 4];
-  for i in 0..4 {
-    result[i] = (premul_1[i] as f32 * (1.0 - t) + premul_2[i] as f32 * t)
-      .round()
-      .clamp(0.0, 255.0) as u8;
-  }
-
-  let premul = PremultipliedColorU8::from_rgba(
-    result[0].min(result[3]),
-    result[1].min(result[3]),
-    result[2].min(result[3]),
-    result[3],
-  )
-  .unwrap_or(PremultipliedColorU8::TRANSPARENT);
-  let demul: ColorU8 = premul.demultiply();
-  Color([demul.red(), demul.green(), demul.blue(), demul.alpha()])
-}
-
-/// Interpolates two colors in the given color space and hue direction.
-pub(crate) fn interpolate_with_color_space(
-  c1: Color,
-  c2: Color,
-  t: f32,
-  color_space: ColorSpaceTag,
-  hue_direction: HueDirection,
-) -> Color {
-  if c1 == c2 {
-    return c1;
-  }
-
-  if color_space == ColorSpaceTag::Srgb && hue_direction == HueDirection::Shorter {
-    return interpolate_rgba(c1, c2, t);
-  }
-
-  if t <= f32::EPSILON {
-    return c1;
-  }
-
-  if t >= 1.0 - f32::EPSILON {
-    return c2;
-  }
-
-  let dynamic_1 =
-    DynamicColor::from_alpha_color(AlphaColor::<Srgb>::from(Rgba8::from_u8_array(c1.0)));
-  let dynamic_2 =
-    DynamicColor::from_alpha_color(AlphaColor::<Srgb>::from(Rgba8::from_u8_array(c2.0)));
-
-  let mixed = dynamic_1
-    .interpolate(dynamic_2, color_space, hue_direction)
-    .eval(t);
-  let rgba = mixed.to_alpha_color::<Srgb>().to_rgba8().to_u8_array();
-
-  Color(rgba)
-}
-
 /// Interpolates two premultiplied colors directly in premultiplied RGBA space.
 pub(crate) fn interpolate_rgba_premultiplied(
   c1: PremultipliedColorU8,
@@ -411,84 +278,84 @@ pub trait GradientOverlayTile {
   fn fully_opaque(&self) -> bool {
     false
   }
-}
 
-/// Overlays a gradient tile onto `data` with source-over blending, no clip.
-pub fn overlay_gradient_tile_fast_normal_unconstrained<T: GradientOverlayTile>(
-  data: &mut [u8],
-  bottom_width: u32,
-  bottom_height: u32,
-  tile: &T,
-  offset: Point<f32>,
-) {
-  let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
-    compute_overlay_bounds_raw(
-      bottom_width,
-      bottom_height,
-      offset,
-      tile.width(),
-      tile.height(),
-    )
-  else {
-    return;
-  };
+  /// Overlays the tile onto `data` with source-over blending, no clip.
+  fn overlay_unconstrained(
+    &self,
+    data: &mut [u8],
+    bottom_width: u32,
+    bottom_height: u32,
+    offset: Point<f32>,
+  ) {
+    let Some((offset_x, offset_y, dest_x_min, dest_x_max, dest_y_min, dest_y_max)) =
+      compute_overlay_bounds_raw(
+        bottom_width,
+        bottom_height,
+        offset,
+        self.width(),
+        self.height(),
+      )
+    else {
+      return;
+    };
 
-  let lut_len = tile.lut_len();
-  if lut_len == 0 {
-    return;
-  }
-
-  let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(data);
-  let row_pixels = bottom_width as usize;
-  let dest_x_min_usize = dest_x_min as usize;
-  let dest_x_max_usize = dest_x_max as usize;
-  let fully_opaque = tile.fully_opaque();
-  let dither = tile.dither_active();
-  let sample = |lut_idx: usize, src_x: u32, src_y: u32| {
-    if dither {
-      tile.sample_dithered_at(lut_idx, src_x, src_y)
-    } else {
-      tile.sample_at(lut_idx)
+    let lut_len = self.lut_len();
+    if lut_len == 0 {
+      return;
     }
-  };
 
-  for dest_y in dest_y_min..dest_y_max {
-    let src_y = (dest_y - offset_y) as u32;
-    let src_x_start = (dest_x_min - offset_x) as u32;
-    let mut row_state = tile.begin_row(src_x_start, src_y, lut_len);
-    let row_start = dest_y as usize * row_pixels;
-    let row = &mut pixels[row_start + dest_x_min_usize..row_start + dest_x_max_usize];
-
-    if fully_opaque {
-      for (i, dst) in row.iter_mut().enumerate() {
-        let lut_idx = tile.next_lut_index(&mut row_state);
-        debug_assert!(lut_idx < lut_len);
-        let pixel = sample(lut_idx, src_x_start + i as u32, src_y);
-        *dst = [pixel.red(), pixel.green(), pixel.blue(), pixel.alpha()];
+    let pixels: &mut [[u8; 4]] = bytemuck::cast_slice_mut(data);
+    let row_pixels = bottom_width as usize;
+    let dest_x_min_usize = dest_x_min as usize;
+    let dest_x_max_usize = dest_x_max as usize;
+    let fully_opaque = self.fully_opaque();
+    let dither = self.dither_active();
+    let sample = |lut_idx: usize, src_x: u32, src_y: u32| {
+      if dither {
+        self.sample_dithered_at(lut_idx, src_x, src_y)
+      } else {
+        self.sample_at(lut_idx)
       }
-    } else {
-      const CHUNK: usize = 256;
-      let mut buf = [[0u8; 4]; CHUNK];
-      let mut remaining = row;
-      let mut src_x = src_x_start;
-      while !remaining.is_empty() {
-        let n = remaining.len().min(CHUNK);
-        let (chunk, rest) = remaining.split_at_mut(n);
-        remaining = rest;
-        for slot in buf.iter_mut().take(n) {
-          let lut_idx = tile.next_lut_index(&mut row_state);
+    };
+
+    for dest_y in dest_y_min..dest_y_max {
+      let src_y = (dest_y - offset_y) as u32;
+      let src_x_start = (dest_x_min - offset_x) as u32;
+      let mut row_state = self.begin_row(src_x_start, src_y, lut_len);
+      let row_start = dest_y as usize * row_pixels;
+      let row = &mut pixels[row_start + dest_x_min_usize..row_start + dest_x_max_usize];
+
+      if fully_opaque {
+        for (i, dst) in row.iter_mut().enumerate() {
+          let lut_idx = self.next_lut_index(&mut row_state);
           debug_assert!(lut_idx < lut_len);
-          let pixel = sample(lut_idx, src_x, src_y);
-          src_x += 1;
-          *slot = [pixel.red(), pixel.green(), pixel.blue(), pixel.alpha()];
+          let pixel = sample(lut_idx, src_x_start + i as u32, src_y);
+          *dst = [pixel.red(), pixel.green(), pixel.blue(), pixel.alpha()];
         }
-        for (dst, &src) in chunk.iter_mut().zip(buf[..n].iter()) {
-          let src_a = src[3];
-          let inv_src_a = (u8::MAX - src_a) as u32;
-          dst[0] = src[0].saturating_add(fast_div_255(dst[0] as u32 * inv_src_a));
-          dst[1] = src[1].saturating_add(fast_div_255(dst[1] as u32 * inv_src_a));
-          dst[2] = src[2].saturating_add(fast_div_255(dst[2] as u32 * inv_src_a));
-          dst[3] = src_a.saturating_add(fast_div_255(dst[3] as u32 * inv_src_a));
+      } else {
+        const CHUNK: usize = 256;
+        let mut buf = [[0u8; 4]; CHUNK];
+        let mut remaining = row;
+        let mut src_x = src_x_start;
+        while !remaining.is_empty() {
+          let n = remaining.len().min(CHUNK);
+          let (chunk, rest) = remaining.split_at_mut(n);
+          remaining = rest;
+          for slot in buf.iter_mut().take(n) {
+            let lut_idx = self.next_lut_index(&mut row_state);
+            debug_assert!(lut_idx < lut_len);
+            let pixel = sample(lut_idx, src_x, src_y);
+            src_x += 1;
+            *slot = [pixel.red(), pixel.green(), pixel.blue(), pixel.alpha()];
+          }
+          for (dst, &src) in chunk.iter_mut().zip(buf[..n].iter()) {
+            let src_a = src[3];
+            let inv_src_a = (u8::MAX - src_a) as u32;
+            dst[0] = src[0].saturating_add(fast_div_255(dst[0] as u32 * inv_src_a));
+            dst[1] = src[1].saturating_add(fast_div_255(dst[1] as u32 * inv_src_a));
+            dst[2] = src[2].saturating_add(fast_div_255(dst[2] as u32 * inv_src_a));
+            dst[3] = src_a.saturating_add(fast_div_255(dst[3] as u32 * inv_src_a));
+          }
         }
       }
     }
@@ -662,13 +529,11 @@ fn build_lut<T: Copy>(
       return interpolate_srgb(from_color(left_stop.color), from_color(right_stop.color), t);
     }
 
-    from_color(interpolate_with_color_space(
-      left_stop.color,
-      right_stop.color,
-      t,
-      color_space,
-      hue_direction,
-    ))
+    from_color(
+      left_stop
+        .color
+        .interpolate(right_stop.color, t, color_space, hue_direction),
+    )
   };
 
   let mut lut: Vec<T> = (0..lut_size).map(&mut write_sample).collect();
@@ -678,24 +543,6 @@ fn build_lut<T: Copy>(
   }
 
   lut
-}
-
-/// Builds a pre-computed high-precision color lookup table for a gradient.
-/// This allows O(1) color sampling instead of O(n) search + interpolation per pixel.
-pub fn build_color_lut_with_interpolation(
-  resolved_stops: &[ResolvedGradientStop],
-  axis_length: f32,
-  lut_size: usize,
-  interpolation: ColorInterpolationMethod,
-) -> Vec<PremultipliedColorU8> {
-  build_lut(
-    resolved_stops,
-    axis_length,
-    lut_size,
-    interpolation,
-    color_to_premultiplied,
-    interpolate_rgba_premultiplied,
-  )
 }
 
 fn color_to_premultiplied_hi(color: Color) -> GradientLutHiEntry {
@@ -722,204 +569,324 @@ fn interpolate_hi(
   entry
 }
 
-/// Builds the premultiplied 8.8 LUT dithered sampling reads, plus whether any
-/// entry carries a fraction dithering can move. Empty unless `dither`.
-pub(crate) fn build_color_lut_hi_with_interpolation(
-  resolved_stops: &[ResolvedGradientStop],
-  axis_length: f32,
-  lut_size: usize,
-  interpolation: ColorInterpolationMethod,
-  dither: bool,
-) -> (Vec<GradientLutHiEntry>, bool) {
-  if !dither {
-    return (Vec::new(), false);
+/// Precomputed gradient samples: 8-bit for plain reads and, when dithering,
+/// premultiplied 8.8 for dithered ones.
+#[derive(Debug, Clone, Default)]
+pub struct ColorLut {
+  colors: Vec<PremultipliedColorU8>,
+  hi: Vec<GradientLutHiEntry>,
+  dither_active: bool,
+}
+
+impl ColorLut {
+  /// Samples `stops` along the axis into `size` entries, snapping stop
+  /// positions onto exact entries. The 8.8 table is built only with `dither`.
+  pub fn new(
+    stops: &[ResolvedGradientStop],
+    axis_length: f32,
+    size: usize,
+    interpolation: ColorInterpolationMethod,
+    dither: bool,
+  ) -> Self {
+    let colors = build_lut(
+      stops,
+      axis_length,
+      size,
+      interpolation,
+      Color::premultiplied,
+      interpolate_rgba_premultiplied,
+    );
+    let hi = if dither {
+      build_lut(
+        stops,
+        axis_length,
+        size,
+        interpolation,
+        color_to_premultiplied_hi,
+        interpolate_hi,
+      )
+    } else {
+      Vec::new()
+    };
+    let dither_active = stops.len() > 1
+      && hi
+        .iter()
+        .any(|entry| entry.iter().any(|channel| channel & 0xFF != 0));
+
+    Self {
+      colors,
+      hi,
+      dither_active,
+    }
   }
 
-  let lut = build_lut(
-    resolved_stops,
-    axis_length,
-    lut_size,
-    interpolation,
-    color_to_premultiplied_hi,
-    interpolate_hi,
-  );
+  /// The 8-bit entries.
+  pub fn colors(&self) -> &[PremultipliedColorU8] {
+    &self.colors
+  }
 
-  let dither_active = resolved_stops.len() > 1
-    && lut
-      .iter()
-      .any(|entry| entry.iter().any(|channel| channel & 0xFF != 0));
+  /// Number of entries.
+  pub fn len(&self) -> usize {
+    self.colors.len()
+  }
 
-  (lut, dither_active)
+  /// Whether the table has no entries.
+  pub fn is_empty(&self) -> bool {
+    self.colors.is_empty()
+  }
+
+  /// Whether any entry carries a fraction dithering can move.
+  pub fn dither_active(&self) -> bool {
+    self.dither_active
+  }
+
+  /// The entry at `index`.
+  #[inline(always)]
+  pub fn sample(&self, index: usize) -> PremultipliedColorU8 {
+    self.colors[index]
+  }
+
+  /// The entry at `index` quantized with the Bayer noise for pixel `(x, y)`.
+  ///
+  /// The bias stays in `[0, 252]`, so no channel can underflow, overflow, or
+  /// round past its alpha; the entry's premultiplied ordering survives as-is.
+  #[inline(always)]
+  pub fn sample_dithered(&self, index: usize, x: u32, y: u32) -> PremultipliedColorU8 {
+    let entry = self.hi[index];
+    let bias = (128 + DITHER_NOISE_88[(y & 7) as usize][(x & 7) as usize] as i32) as u32;
+    let channel = |value: u16| ((value as u32 + bias) >> 8) as u8;
+
+    PremultipliedColorU8::from_rgba(
+      channel(entry[0]),
+      channel(entry[1]),
+      channel(entry[2]),
+      channel(entry[3]),
+    )
+    .unwrap_or(PremultipliedColorU8::TRANSPARENT)
+  }
 }
 
-/// Calculates an adaptive LUT size based on the gradient axis length.
-pub(crate) fn adaptive_lut_size(
-  axis_length: f32,
-  resolved_stops: &[ResolvedGradientStop],
-) -> usize {
-  adaptive_lut_size_with_visible_samples(
-    (axis_length.ceil() as usize)
-      .saturating_add(1)
-      .max(MIN_GRADIENT_LUT_SIZE),
-    axis_length,
-    resolved_stops,
-  )
+/// The stop run a LUT samples. A repeating gradient shifts its stops to start
+/// at zero and samples one period; any other samples the whole axis.
+pub(crate) struct LutAxis {
+  pub(crate) repeating: bool,
+  /// First resolved stop position, the repeating origin.
+  pub(crate) repeat_start: f32,
+  pub(crate) repeat_period: f32,
+  /// The length the LUT covers.
+  pub(crate) length: f32,
+  pub(crate) stops: SmallVec<[ResolvedGradientStop; 4]>,
 }
 
-/// LUT size that covers `visible_samples` and the tightest stop interval.
-pub(crate) fn adaptive_lut_size_with_visible_samples(
-  visible_samples: usize,
-  axis_length: f32,
-  resolved_stops: &[ResolvedGradientStop],
-) -> usize {
-  let visible_samples = visible_samples.max(MIN_GRADIENT_LUT_SIZE);
+impl LutAxis {
+  pub(crate) fn new(
+    repeating: bool,
+    stops: SmallVec<[ResolvedGradientStop; 4]>,
+    axis_length: f32,
+  ) -> Self {
+    if repeating && let (Some(first), Some(last)) = (stops.first(), stops.last()) {
+      let repeat_start = first.position;
+      let repeat_period = (last.position - first.position).max(0.0);
+      if repeat_period > 1e-6 {
+        let shifted = stops
+          .iter()
+          .map(|stop| ResolvedGradientStop {
+            color: stop.color,
+            position: stop.position - repeat_start,
+          })
+          .collect();
+        return Self {
+          repeating: true,
+          repeat_start,
+          repeat_period,
+          length: repeat_period,
+          stops: shifted,
+        };
+      }
+    }
 
-  let min_interval = resolved_stops
-    .windows(2)
-    .map(|stops| stops[1].position - stops[0].position)
-    .filter(|interval| *interval > f32::EPSILON)
-    .fold(f32::INFINITY, f32::min);
+    Self {
+      repeating: false,
+      repeat_start: 0.0,
+      repeat_period: 0.0,
+      length: axis_length,
+      stops,
+    }
+  }
 
-  let segment_aware_size = if min_interval.is_finite() {
-    ((axis_length / min_interval).ceil() as usize)
-      .saturating_add(resolved_stops.len())
-      .saturating_add(1)
-      .max(MIN_GRADIENT_LUT_SIZE)
-  } else {
-    resolved_stops
-      .len()
-      .saturating_add(1)
-      .max(MIN_GRADIENT_LUT_SIZE)
-  };
+  /// A LUT size with one entry per pixel of the axis.
+  pub(crate) fn lut_size(&self) -> usize {
+    self.lut_size_covering(
+      (self.length.ceil() as usize)
+        .saturating_add(1)
+        .max(MIN_GRADIENT_LUT_SIZE),
+    )
+  }
 
-  let size = visible_samples
-    .max(segment_aware_size)
-    .max(resolved_stops.len().saturating_mul(2))
-    .max(MIN_GRADIENT_LUT_SIZE);
-  size.min(MAX_GRADIENT_LUT_SIZE)
+  /// A LUT size that covers `visible_samples` and the tightest stop interval.
+  pub(crate) fn lut_size_covering(&self, visible_samples: usize) -> usize {
+    let visible_samples = visible_samples.max(MIN_GRADIENT_LUT_SIZE);
+
+    let min_interval = self
+      .stops
+      .windows(2)
+      .map(|stops| stops[1].position - stops[0].position)
+      .filter(|interval| *interval > f32::EPSILON)
+      .fold(f32::INFINITY, f32::min);
+
+    let segment_aware_size = if min_interval.is_finite() {
+      ((self.length / min_interval).ceil() as usize)
+        .saturating_add(self.stops.len())
+        .saturating_add(1)
+        .max(MIN_GRADIENT_LUT_SIZE)
+    } else {
+      self
+        .stops
+        .len()
+        .saturating_add(1)
+        .max(MIN_GRADIENT_LUT_SIZE)
+    };
+
+    let size = visible_samples
+      .max(segment_aware_size)
+      .max(self.stops.len().saturating_mul(2))
+      .max(MIN_GRADIENT_LUT_SIZE);
+    size.min(MAX_GRADIENT_LUT_SIZE)
+  }
+
+  pub(crate) fn lut(
+    &self,
+    size: usize,
+    interpolation: ColorInterpolationMethod,
+    dither: bool,
+  ) -> ColorLut {
+    ColorLut::new(&self.stops, self.length, size, interpolation, dither)
+  }
+}
+
+impl ResolvedGradientStop {
+  /// Resolves stop positions to pixels along the axis, filling unspecified ones.
+  pub fn resolve(
+    stops: &[GradientStop],
+    axis_size_px: f32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) -> SmallVec<[Self; 4]> {
+    let mut resolved: SmallVec<[ResolvedGradientStop; 4]> = SmallVec::new();
+    let mut last_position = 0.0;
+
+    for (i, step) in stops.iter().enumerate() {
+      match step {
+        GradientStop::ColorHint {
+          color,
+          hint: Some(hint),
+        } => {
+          let position = hint.0.to_px(sizing, axis_size_px).max(last_position);
+
+          last_position = position;
+
+          resolved.push(ResolvedGradientStop {
+            color: color.resolve(current_color),
+            position,
+          });
+        }
+        GradientStop::ColorHint { color, hint: None } => {
+          resolved.push(ResolvedGradientStop {
+            color: color.resolve(current_color),
+            position: UNDEFINED_POSITION,
+          });
+        }
+        GradientStop::Hint(hint) => {
+          let Some(before) = resolved.last() else {
+            continue;
+          };
+
+          let Some(after_color) = stops.get(i + 1).and_then(|stop| match stop {
+            GradientStop::ColorHint { color, hint: _ } => Some(color.resolve(current_color)),
+            GradientStop::Hint(_) => None,
+          }) else {
+            continue;
+          };
+
+          let interpolated_color = before.color.lerp_premultiplied(after_color, 0.5);
+
+          let position = hint.0.to_px(sizing, axis_size_px).max(last_position);
+
+          resolved.push(ResolvedGradientStop {
+            color: interpolated_color,
+            position,
+          });
+
+          last_position = position;
+        }
+      }
+    }
+
+    // If there are no color stops, return an empty vector
+    if resolved.is_empty() {
+      return resolved;
+    }
+
+    // if there is only one stop, treat it as pure color image
+    if resolved.len() == 1 {
+      if let Some(first_stop) = resolved.first_mut() {
+        first_stop.position = axis_size_px;
+      }
+
+      return resolved;
+    }
+
+    if let Some(first_stop) = resolved.first_mut()
+      && first_stop.position == UNDEFINED_POSITION
+    {
+      first_stop.position = 0.0;
+    }
+
+    if let Some(last_stop) = resolved.last_mut()
+      && last_stop.position == UNDEFINED_POSITION
+    {
+      last_stop.position = axis_size_px;
+    }
+
+    // Distribute unspecified or non-increasing positions in pixel domain
+    let mut i = 1usize;
+    while i < resolved.len() - 1 {
+      // if the position is defined and valid, skip it
+      if resolved[i].position != UNDEFINED_POSITION {
+        i += 1;
+        continue;
+      }
+
+      let last_defined_position = resolved.get(i - 1).map(|s| s.position).unwrap_or(0.0);
+
+      // try to find next defined position
+      let next_index = resolved
+        .iter()
+        .skip(i + 1)
+        .position(|s| s.position != UNDEFINED_POSITION)
+        .map(|idx| i + 1 + idx)
+        .unwrap_or(resolved.len() - 1);
+
+      let next_position = resolved[next_index].position;
+
+      // number of segments between last defined and next position
+      let segments_count = (next_index - i + 1) as f32;
+      let step_for_each_segment = (next_position - last_defined_position) / segments_count;
+
+      // distribute the step evenly between the stops
+      for j in i..next_index {
+        let offset = (j - i + 1) as f32;
+        resolved[j].position = last_defined_position + step_for_each_segment * offset;
+      }
+
+      i = next_index + 1;
+    }
+
+    resolved
+  }
 }
 
 const UNDEFINED_POSITION: f32 = -1.0;
-
-/// Resolves stop positions to pixels along the axis, filling unspecified ones.
-pub fn resolve_stops_along_axis(
-  stops: &[GradientStop],
-  axis_size_px: f32,
-  sizing: &SizingContext,
-  current_color: Color,
-) -> SmallVec<[ResolvedGradientStop; 4]> {
-  let mut resolved: SmallVec<[ResolvedGradientStop; 4]> = SmallVec::new();
-  let mut last_position = 0.0;
-
-  for (i, step) in stops.iter().enumerate() {
-    match step {
-      GradientStop::ColorHint {
-        color,
-        hint: Some(hint),
-      } => {
-        let position = hint.0.to_px(sizing, axis_size_px).max(last_position);
-
-        last_position = position;
-
-        resolved.push(ResolvedGradientStop {
-          color: color.resolve(current_color),
-          position,
-        });
-      }
-      GradientStop::ColorHint { color, hint: None } => {
-        resolved.push(ResolvedGradientStop {
-          color: color.resolve(current_color),
-          position: UNDEFINED_POSITION,
-        });
-      }
-      GradientStop::Hint(hint) => {
-        let Some(before) = resolved.last() else {
-          continue;
-        };
-
-        let Some(after_color) = stops.get(i + 1).and_then(|stop| match stop {
-          GradientStop::ColorHint { color, hint: _ } => Some(color.resolve(current_color)),
-          GradientStop::Hint(_) => None,
-        }) else {
-          continue;
-        };
-
-        let interpolated_color = interpolate_rgba(before.color, after_color, 0.5);
-
-        let position = hint.0.to_px(sizing, axis_size_px).max(last_position);
-
-        resolved.push(ResolvedGradientStop {
-          color: interpolated_color,
-          position,
-        });
-
-        last_position = position;
-      }
-    }
-  }
-
-  // If there are no color stops, return an empty vector
-  if resolved.is_empty() {
-    return resolved;
-  }
-
-  // if there is only one stop, treat it as pure color image
-  if resolved.len() == 1 {
-    if let Some(first_stop) = resolved.first_mut() {
-      first_stop.position = axis_size_px;
-    }
-
-    return resolved;
-  }
-
-  if let Some(first_stop) = resolved.first_mut()
-    && first_stop.position == UNDEFINED_POSITION
-  {
-    first_stop.position = 0.0;
-  }
-
-  if let Some(last_stop) = resolved.last_mut()
-    && last_stop.position == UNDEFINED_POSITION
-  {
-    last_stop.position = axis_size_px;
-  }
-
-  // Distribute unspecified or non-increasing positions in pixel domain
-  let mut i = 1usize;
-  while i < resolved.len() - 1 {
-    // if the position is defined and valid, skip it
-    if resolved[i].position != UNDEFINED_POSITION {
-      i += 1;
-      continue;
-    }
-
-    let last_defined_position = resolved.get(i - 1).map(|s| s.position).unwrap_or(0.0);
-
-    // try to find next defined position
-    let next_index = resolved
-      .iter()
-      .skip(i + 1)
-      .position(|s| s.position != UNDEFINED_POSITION)
-      .map(|idx| i + 1 + idx)
-      .unwrap_or(resolved.len() - 1);
-
-    let next_position = resolved[next_index].position;
-
-    // number of segments between last defined and next position
-    let segments_count = (next_index - i + 1) as f32;
-    let step_for_each_segment = (next_position - last_defined_position) / segments_count;
-
-    // distribute the step evenly between the stops
-    for j in i..next_index {
-      let offset = (j - i + 1) as f32;
-      resolved[j].position = last_defined_position + step_for_each_segment * offset;
-    }
-
-    i = next_index + 1;
-  }
-
-  resolved
-}
 
 #[cfg(test)]
 mod tests {
@@ -954,7 +921,7 @@ mod tests {
 
     assert!(width.is_some());
 
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &stops,
       width.unwrap_or_default() as f32,
       &sizing,
@@ -1007,7 +974,7 @@ mod tests {
       .viewport(Viewport::new((40, 40)))
       .build();
 
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &stops,
       sizing.viewport.size.width.unwrap_or_default() as f32,
       &sizing,
@@ -1051,7 +1018,7 @@ mod tests {
       .viewport(Viewport::new((40, 40)))
       .build();
 
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &stops,
       sizing.viewport.size.width.unwrap_or_default() as f32,
       &sizing,
@@ -1070,7 +1037,7 @@ mod tests {
     assert_eq!(
       resolved[1],
       ResolvedGradientStop {
-        color: interpolate_rgba(Color([255, 0, 0, 255]), Color([0, 0, 255, 255]), 0.5),
+        color: Color([255, 0, 0, 255]).lerp_premultiplied(Color([0, 0, 255, 255]), 0.5),
         position: sizing.viewport.size.width.unwrap_or_default() as f32 * 0.1,
       },
     );
@@ -1101,7 +1068,7 @@ mod tests {
       },
     ];
 
-    let size = adaptive_lut_size(256.0, &resolved);
+    let size = LutAxis::new(false, resolved.iter().cloned().collect(), 256.0).lut_size();
 
     assert!(size > 1025);
     assert!(size <= MAX_GRADIENT_LUT_SIZE);
@@ -1128,7 +1095,7 @@ mod tests {
       },
     ];
 
-    let lut = build_color_lut_with_interpolation(
+    let lut = ColorLut::new(
       &resolved,
       16.0,
       17,
@@ -1136,10 +1103,13 @@ mod tests {
         color_space: ColorSpaceTag::Srgb,
         hue_direction: HueDirection::Shorter,
       },
-    );
+      false,
+    )
+    .colors()
+    .to_vec();
 
-    assert_eq!(lut[7], color_to_premultiplied(Color([255, 0, 0, 255])));
-    assert_eq!(lut[8], color_to_premultiplied(Color([0, 0, 255, 255])));
+    assert_eq!(lut[7], Color::premultiplied(Color([255, 0, 0, 255])));
+    assert_eq!(lut[8], Color::premultiplied(Color([0, 0, 255, 255])));
   }
 
   #[test]
@@ -1159,8 +1129,8 @@ mod tests {
       },
     ];
 
-    let lut_size = adaptive_lut_size(32.0, &resolved);
-    let lut = build_color_lut_with_interpolation(
+    let lut_size = LutAxis::new(false, resolved.iter().cloned().collect(), 32.0).lut_size();
+    let lut = ColorLut::new(
       &resolved,
       32.0,
       lut_size,
@@ -1168,17 +1138,20 @@ mod tests {
         color_space: ColorSpaceTag::Srgb,
         hue_direction: HueDirection::Shorter,
       },
-    );
+      false,
+    )
+    .colors()
+    .to_vec();
     let stop_indices = assign_stop_sample_indices(&resolved, 32.0, lut.len());
 
     assert!(stop_indices[0] < stop_indices[1]);
     assert_eq!(
       lut[stop_indices[0]],
-      color_to_premultiplied(resolved[0].color)
+      Color::premultiplied(resolved[0].color)
     );
     assert_eq!(
       lut[stop_indices[1]],
-      color_to_premultiplied(resolved[1].color)
+      Color::premultiplied(resolved[1].color)
     );
   }
 
@@ -1195,7 +1168,7 @@ mod tests {
       },
     ];
 
-    let lut = build_color_lut_with_interpolation(
+    let lut = ColorLut::new(
       &resolved,
       10.0,
       33,
@@ -1203,7 +1176,10 @@ mod tests {
         color_space: ColorSpaceTag::Srgb,
         hue_direction: HueDirection::Shorter,
       },
-    );
+      false,
+    )
+    .colors()
+    .to_vec();
 
     for pair in lut.windows(2) {
       assert!(pair[0].red() <= pair[1].red());
@@ -1216,7 +1192,7 @@ mod tests {
 
   #[test]
   fn test_interpolate_rgba_uses_premultiplied_alpha() {
-    let mixed = interpolate_rgba(Color([255, 255, 255, 255]), Color([0, 0, 0, 0]), 0.5);
+    let mixed = Color([255, 255, 255, 255]).lerp_premultiplied(Color([0, 0, 0, 0]), 0.5);
     assert_eq!(mixed, Color([255, 255, 255, 128]));
   }
 
@@ -1241,8 +1217,15 @@ mod tests {
   #[test]
   fn stop_snapping_survives_more_stops_than_lut() {
     let stops = evenly_spaced_stops(9000, 256.0);
-    let lut =
-      build_color_lut_with_interpolation(&stops, 256.0, 8193, ColorInterpolationMethod::default());
+    let lut = ColorLut::new(
+      &stops,
+      256.0,
+      8193,
+      ColorInterpolationMethod::default(),
+      false,
+    )
+    .colors()
+    .to_vec();
 
     assert_eq!(lut.len(), 8193);
   }

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -8,10 +8,8 @@ use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 
 use super::gradient_utils::{
-  GradientLutHiEntry, GradientOverlayTile, adaptive_lut_size,
-  adaptive_lut_size_with_visible_samples, build_color_lut_hi_with_interpolation,
-  build_color_lut_with_interpolation, compute_repeat_setup, gradient_tile_accessors,
-  parse_gradient_stops, quantize_dithered, resolve_stops_along_axis, write_gradient_css,
+  ColorLut, GradientOverlayTile, LutAxis, gradient_tile_accessors, parse_gradient_stops,
+  write_gradient_css,
 };
 use crate::style::{
   Animatable, Color, ColorInterpolationMethod, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
@@ -68,13 +66,8 @@ pub struct LinearGradientTile {
   pub position_to_lut_scale: f32,
   /// Whether every sampled pixel in this gradient is fully opaque.
   pub fully_opaque: bool,
-  /// Pre-computed color lookup table for fast gradient sampling.
-  /// Maps normalized position [0.0, 1.0] to color.
-  pub color_lut: Vec<PremultipliedColorU8>,
-  /// The LUT in premultiplied 8.8 fixed point, read by dithered sampling.
-  pub(crate) color_lut_hi: Vec<GradientLutHiEntry>,
-  /// Whether any LUT entry carries a fraction dithering can move.
-  pub(crate) lut_dither_active: bool,
+  /// Pre-computed colour samples along the axis.
+  pub lut: ColorLut,
   /// Precomputed axis samples for fast horizontal/vertical fills.
   pub axis_aligned_fast_path: Option<LinearGradientFastPathData>,
 }
@@ -169,9 +162,9 @@ impl LinearGradientTile {
     let projection = self.projection_at(x as f32, y as f32);
     if self.repeating && self.repeat_period > 1e-6 {
       let wrapped = (projection - self.repeat_start).rem_euclid(self.repeat_period);
-      ((wrapped * self.position_to_lut_scale).round() as usize).min(self.color_lut.len() - 1)
+      ((wrapped * self.position_to_lut_scale).round() as usize).min(self.lut.len() - 1)
     } else {
-      self.lut_index_for_projection_with_len(projection, self.color_lut.len())
+      self.lut_index_for_projection_with_len(projection, self.lut.len())
     }
   }
 
@@ -205,7 +198,7 @@ impl LinearGradientTile {
   fn build_axis_samples(&self, kind: LinearGradientFastPathKind) -> Box<[PremultipliedColorU8]> {
     // An axis-aligned projection ignores the cross axis, so sampling the
     // dithered variants at small cross coordinates hits every noise phase.
-    match (kind, self.lut_dither_active) {
+    match (kind, self.lut.dither_active()) {
       (LinearGradientFastPathKind::Horizontal, false) => {
         (0..self.width).map(|x| self.sample_pixel(x, 0)).collect()
       }
@@ -252,52 +245,26 @@ impl LinearGradientTile {
     let axis_length = 2.0 * max_extent;
     let projection_bias = max_extent - cx * dir_x - cy * dir_y;
 
-    let resolved_stops = resolve_stops_along_axis(
+    let resolved_stops = ResolvedGradientStop::resolve(
       &gradient.stops,
       axis_length.max(1e-6),
       sizing,
       current_color,
     );
-
-    let (repeating, repeat_start, repeat_period, lut_axis_length, lut_resolved_stops) =
-      compute_repeat_setup(gradient.repeating, resolved_stops, axis_length);
-
-    let visible_lut_samples = match axis_aligned_kind {
-      Some(LinearGradientFastPathKind::Horizontal) => width as usize + 1,
-      Some(LinearGradientFastPathKind::Vertical) => height as usize + 1,
-      None => (lut_axis_length.ceil() as usize).saturating_add(1),
+    let axis = LutAxis::new(gradient.repeating, resolved_stops, axis_length);
+    let lut_size = match axis_aligned_kind {
+      Some(LinearGradientFastPathKind::Horizontal) => axis.lut_size_covering(width as usize + 1),
+      Some(LinearGradientFastPathKind::Vertical) => axis.lut_size_covering(height as usize + 1),
+      None => axis.lut_size(),
     };
-    let lut_size = if axis_aligned_kind.is_some() {
-      adaptive_lut_size_with_visible_samples(
-        visible_lut_samples,
-        lut_axis_length,
-        &lut_resolved_stops,
-      )
-    } else {
-      adaptive_lut_size(lut_axis_length, &lut_resolved_stops)
-    };
-    let color_lut = build_color_lut_with_interpolation(
-      &lut_resolved_stops,
-      lut_axis_length,
-      lut_size,
-      gradient.interpolation,
-    );
-    let (color_lut_hi, lut_dither_active) = build_color_lut_hi_with_interpolation(
-      &lut_resolved_stops,
-      lut_axis_length,
-      lut_size,
-      gradient.interpolation,
-      dither,
-    );
-    let lut_len = color_lut.len();
-    let position_to_lut_scale = if lut_axis_length.abs() <= f32::EPSILON || lut_len <= 1 {
+    let lut = axis.lut(lut_size, gradient.interpolation, dither);
+    let lut_len = lut.len();
+    let position_to_lut_scale = if axis.length.abs() <= f32::EPSILON || lut_len <= 1 {
       0.0
     } else {
-      (lut_len - 1) as f32 / lut_axis_length
+      (lut_len - 1) as f32 / axis.length
     };
-    let fully_opaque = lut_resolved_stops
-      .iter()
-      .all(|stop| stop.color.0[3] == u8::MAX);
+    let fully_opaque = axis.stops.iter().all(|stop| stop.color.0[3] == u8::MAX);
 
     let mut tile = LinearGradientTile {
       width,
@@ -305,15 +272,13 @@ impl LinearGradientTile {
       dir_x,
       dir_y,
       axis_length,
-      repeating,
-      repeat_start,
-      repeat_period,
+      repeating: axis.repeating,
+      repeat_start: axis.repeat_start,
+      repeat_period: axis.repeat_period,
       projection_bias,
       position_to_lut_scale,
       fully_opaque,
-      color_lut,
-      color_lut_hi,
-      lut_dither_active,
+      lut,
       axis_aligned_fast_path: None,
     };
 
@@ -323,7 +288,7 @@ impl LinearGradientTile {
       tile.axis_aligned_fast_path = Some(LinearGradientFastPathData {
         kind,
         axis_samples: tile.build_axis_samples(kind),
-        dithered: tile.lut_dither_active,
+        dithered: tile.lut.dither_active(),
       });
     }
 
@@ -338,20 +303,20 @@ impl GradientOverlayTile for LinearGradientTile {
 
   #[inline(always)]
   fn sample_pixel(&self, x: u32, y: u32) -> PremultipliedColorU8 {
-    match self.color_lut.len() {
+    match self.lut.len() {
       0 => PremultipliedColorU8::TRANSPARENT,
-      1 => self.color_lut[0],
-      _ => self.color_lut[self.pixel_lut_index(x, y)],
+      1 => self.lut.sample(0),
+      _ => self.lut.sample(self.pixel_lut_index(x, y)),
     }
   }
 
   #[inline(always)]
   fn sample_pixel_dithered(&self, x: u32, y: u32) -> PremultipliedColorU8 {
-    if !self.lut_dither_active {
+    if !self.lut.dither_active() {
       return self.sample_pixel(x, y);
     }
 
-    quantize_dithered(self.color_lut_hi[self.pixel_lut_index(x, y)], x, y)
+    self.lut.sample_dithered(self.pixel_lut_index(x, y), x, y)
   }
 
   #[inline(always)]
@@ -1552,7 +1517,7 @@ mod tests {
       .viewport(Viewport::new((200, 100)))
       .build();
 
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &gradient.stops,
       sizing.viewport.size.width.unwrap_or_default() as f32,
       &sizing,
@@ -1583,7 +1548,7 @@ mod tests {
       .viewport(Viewport::new((200, 100)))
       .build();
 
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &gradient.stops,
       sizing.viewport.size.width.unwrap_or_default() as f32,
       &sizing,

--- a/takumi-core/src/style/properties/radial_gradient.rs
+++ b/takumi-core/src/style/properties/radial_gradient.rs
@@ -5,15 +5,13 @@ use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 
 use super::gradient_utils::{
-  GradientLutHiEntry, GradientOverlayTile, adaptive_lut_size_with_visible_samples,
-  build_color_lut_hi_with_interpolation, build_color_lut_with_interpolation, compute_repeat_setup,
-  gradient_tile_accessors, parse_gradient_stops, quantize_dithered, resolve_stops_along_axis,
+  ColorLut, GradientOverlayTile, LutAxis, gradient_tile_accessors, parse_gradient_stops,
   write_gradient_css,
 };
 use crate::style::{
   Color, ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop, Length,
-  MakeComputed, ParseResult, PositionValue, SizingContext, StopPosition, ToCss,
-  declare_enum_from_css_impl, unexpected_token,
+  MakeComputed, ParseResult, PositionValue, ResolvedGradientStop, SizingContext, StopPosition,
+  ToCss, declare_enum_from_css_impl, unexpected_token,
 };
 
 /// Radii of the ellipse through `corner`, as Blink's `EllipseRadius`
@@ -149,13 +147,8 @@ pub struct RadialGradientTile {
   pub position_to_lut_scale: f32,
   /// Whether every LUT entry has alpha = 255.
   pub fully_opaque: bool,
-  /// Pre-computed color lookup table for fast gradient sampling.
-  /// Maps axis-space distance to color.
-  pub color_lut: Vec<PremultipliedColorU8>,
-  /// The LUT in premultiplied 8.8 fixed point, read by dithered sampling.
-  pub(crate) color_lut_hi: Vec<GradientLutHiEntry>,
-  /// Whether any LUT entry carries a fraction dithering can move.
-  pub(crate) lut_dither_active: bool,
+  /// Pre-computed colour samples along the radius.
+  pub lut: ColorLut,
 }
 
 /// Per-row sampling state for incremental distance stepping.
@@ -172,7 +165,7 @@ impl RadialGradientTile {
   /// Color of the outermost LUT entry, used outside the gradient ellipse.
   #[inline(always)]
   pub fn outer_sample(&self) -> Option<PremultipliedColorU8> {
-    self.color_lut.last().copied()
+    self.lut.colors().last().copied()
   }
 
   /// Span of `x` within a row that falls inside the gradient ellipse.
@@ -293,44 +286,24 @@ impl RadialGradientTile {
     };
 
     let radius_scale = radius_x.max(radius_y);
-    let resolved_stops = resolve_stops_along_axis(
+    let resolved_stops = ResolvedGradientStop::resolve(
       &gradient.stops,
       radius_scale.max(1e-6),
       sizing,
       current_color,
     );
-
-    let (repeating, repeat_start, repeat_period, lut_axis_length, lut_resolved_stops) =
-      compute_repeat_setup(gradient.repeating, resolved_stops, radius_scale);
-
-    // Pre-compute color lookup table with adaptive size.
-    let lut_size = adaptive_lut_size_with_visible_samples(
-      (radius_scale.ceil() as usize).saturating_add(1),
-      lut_axis_length,
-      &lut_resolved_stops,
-    );
-    let color_lut = build_color_lut_with_interpolation(
-      &lut_resolved_stops,
-      lut_axis_length,
-      lut_size,
-      gradient.interpolation,
-    );
-    let lut_len = color_lut.len();
+    let axis = LutAxis::new(gradient.repeating, resolved_stops, radius_scale);
+    let lut_size = axis.lut_size_covering((radius_scale.ceil() as usize).saturating_add(1));
+    let lut = axis.lut(lut_size, gradient.interpolation, dither);
+    let lut_len = lut.len();
     let inv_radius_x = radius_x.max(1e-6).recip();
     let inv_radius_y = radius_y.max(1e-6).recip();
-    let position_to_lut_scale = if lut_axis_length.abs() <= f32::EPSILON || lut_len <= 1 {
+    let position_to_lut_scale = if axis.length.abs() <= f32::EPSILON || lut_len <= 1 {
       0.0
     } else {
-      (lut_len - 1) as f32 / lut_axis_length
+      (lut_len - 1) as f32 / axis.length
     };
-    let fully_opaque = color_lut.iter().all(|p| p.alpha() == u8::MAX);
-    let (color_lut_hi, lut_dither_active) = build_color_lut_hi_with_interpolation(
-      &lut_resolved_stops,
-      lut_axis_length,
-      lut_size,
-      gradient.interpolation,
-      dither,
-    );
+    let fully_opaque = lut.colors().iter().all(|p| p.alpha() == u8::MAX);
 
     RadialGradientTile {
       width,
@@ -340,14 +313,12 @@ impl RadialGradientTile {
       inv_radius_x,
       inv_radius_y,
       radius_scale,
-      repeating,
-      repeat_start,
-      repeat_period,
+      repeating: axis.repeating,
+      repeat_start: axis.repeat_start,
+      repeat_period: axis.repeat_period,
       position_to_lut_scale,
       fully_opaque,
-      color_lut,
-      color_lut_hi,
-      lut_dither_active,
+      lut,
     }
   }
 
@@ -357,7 +328,7 @@ impl RadialGradientTile {
     let dy = (y as f32 - self.cy) * self.inv_radius_y;
     let distance_px = (dx * dx + dy * dy).sqrt() * self.radius_scale;
 
-    self.lut_index_for_distance_px_with_len(distance_px, self.color_lut.len())
+    self.lut_index_for_distance_px_with_len(distance_px, self.lut.len())
   }
 }
 
@@ -368,20 +339,20 @@ impl GradientOverlayTile for RadialGradientTile {
 
   #[inline(always)]
   fn sample_pixel(&self, x: u32, y: u32) -> PremultipliedColorU8 {
-    match self.color_lut.len() {
+    match self.lut.len() {
       0 => PremultipliedColorU8::TRANSPARENT,
-      1 => self.color_lut[0],
-      _ => self.color_lut[self.pixel_lut_index(x, y)],
+      1 => self.lut.sample(0),
+      _ => self.lut.sample(self.pixel_lut_index(x, y)),
     }
   }
 
   #[inline(always)]
   fn sample_pixel_dithered(&self, x: u32, y: u32) -> PremultipliedColorU8 {
-    if !self.lut_dither_active {
+    if !self.lut.dither_active() {
       return self.sample_pixel(x, y);
     }
 
-    quantize_dithered(self.color_lut_hi[self.pixel_lut_index(x, y)], x, y)
+    self.lut.sample_dithered(self.pixel_lut_index(x, y), x, y)
   }
 
   #[inline(always)]
@@ -787,7 +758,7 @@ mod tests {
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((200, 100)))
       .build();
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &gradient.stops,
       sizing.viewport.size.width.unwrap_or_default() as f32,
       &sizing,
@@ -821,7 +792,7 @@ mod tests {
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((200, 100)))
       .build();
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &gradient.stops,
       sizing.viewport.size.width.unwrap_or_default() as f32,
       &sizing,

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -26,7 +26,7 @@ use takumi_core::{
     node::NodeKind,
     tree::{LayoutResults, NodeOrigin, RenderNode},
   },
-  paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile, resolve_stops_along_axis},
+  paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile},
   painter::{
     BoxPainter, BoxShadows, FillShape, PaintDevice, StrokeStyle, paint_border,
     paint_run_decorations,
@@ -718,7 +718,7 @@ impl Emitter<'_> {
       BackgroundImage::Linear(gradient) => {
         let tile =
           LinearGradientTile::new(gradient, w as u32, h as u32, sizing, current_color, false);
-        let resolved = self.filtered_stops(resolve_stops_along_axis(
+        let resolved = self.filtered_stops(ResolvedGradientStop::resolve(
           &gradient.stops,
           tile.axis_length.max(1e-6),
           sizing,
@@ -760,7 +760,7 @@ impl Emitter<'_> {
       BackgroundImage::Radial(gradient) => {
         let tile =
           RadialGradientTile::new(gradient, w as u32, h as u32, sizing, current_color, false);
-        let resolved = self.filtered_stops(resolve_stops_along_axis(
+        let resolved = self.filtered_stops(ResolvedGradientStop::resolve(
           &gradient.stops,
           tile.radius_scale.max(1e-6),
           sizing,
@@ -799,7 +799,7 @@ impl Emitter<'_> {
       BackgroundImage::Conic(gradient) => {
         let tile =
           ConicGradientTile::new(gradient, w as u32, h as u32, sizing, current_color, false);
-        let lut_len = tile.color_lut.len();
+        let lut_len = tile.lut.len();
         if lut_len == 0 {
           return None;
         }
@@ -809,7 +809,7 @@ impl Emitter<'_> {
             let t = i as f32 / SWEEP_STOPS as f32;
             let index =
               tile.lut_index_for_adjusted_angle_with_len(t * core::f32::consts::TAU, lut_len);
-            let color = tile.color_lut[index].demultiply();
+            let color = tile.lut.sample(index).demultiply();
 
             krilla_stop(
               t,

--- a/takumi-raster/src/canvas/gradient.rs
+++ b/takumi-raster/src/canvas/gradient.rs
@@ -4,7 +4,6 @@ use takumi_core::{
   geometry::{Point, Size},
   paint::{
     GradientOverlayTile, LinearGradientFastPathKind, LinearGradientTile, RadialGradientTile,
-    overlay_gradient_tile_fast_normal_unconstrained,
   },
 };
 use tiny_skia::PixmapMut;
@@ -59,13 +58,7 @@ pub(crate) fn overlay_gradient_tile<T>(
 
   if mode == BlendMode::Normal && combined_mask.is_none() {
     let bottom_data: &mut [u8] = bytemuck::cast_slice_mut(pixmap.pixels_mut());
-    overlay_gradient_tile_fast_normal_unconstrained(
-      bottom_data,
-      bottom_width,
-      bottom_height,
-      gradient,
-      offset,
-    );
+    gradient.overlay_unconstrained(bottom_data, bottom_width, bottom_height, offset);
     return;
   }
 
@@ -217,13 +210,7 @@ fn overlay_gradient_tile_with_fast_path<T>(
       return;
     }
 
-    overlay_gradient_tile_fast_normal_unconstrained(
-      bottom_data,
-      bottom_width,
-      bottom_height,
-      gradient,
-      offset,
-    );
+    gradient.overlay_unconstrained(bottom_data, bottom_width, bottom_height, offset);
     return;
   }
 

--- a/takumi-svg/src/gradient.rs
+++ b/takumi-svg/src/gradient.rs
@@ -18,10 +18,7 @@ use takumi_core::{
   context::RenderContext,
   geometry::{Point, Size},
   layout::background::{BackgroundLayerInput, LayerTileStyle},
-  paint::{
-    ConicGradientTile, LinearGradientTile, RadialGradientTile, build_color_lut_with_interpolation,
-    resolve_stops_along_axis,
-  },
+  paint::{ColorLut, ConicGradientTile, LinearGradientTile, RadialGradientTile},
   style::{
     BackgroundImage, BackgroundRepeat, BackgroundSize, BlendMode, ColorInterpolationMethod,
     ConicGradient, LinearGradient, PositionValue, RadialGradient, ResolvedGradientStop,
@@ -246,7 +243,7 @@ impl<'a, 'd> LayerEmitter<'a, 'd> {
       self.context.current_color,
       false,
     );
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &gradient.stops,
       tile.axis_length.max(1e-6),
       &self.context.sizing,
@@ -295,7 +292,7 @@ impl<'a, 'd> LayerEmitter<'a, 'd> {
       self.context.current_color,
       false,
     );
-    let resolved = resolve_stops_along_axis(
+    let resolved = ResolvedGradientStop::resolve(
       &gradient.stops,
       tile.radius_scale.max(1e-6),
       &self.context.sizing,
@@ -344,7 +341,7 @@ impl<'a, 'd> LayerEmitter<'a, 'd> {
       self.context.current_color,
       false,
     );
-    let lut_len = tile.color_lut.len();
+    let lut_len = tile.lut.len();
     if lut_len == 0 {
       return Ok(());
     }
@@ -363,7 +360,7 @@ impl<'a, 'd> LayerEmitter<'a, 'd> {
       let mid = (a0 + a1) / 2.0;
       let adjusted = (mid - tile.start_rad).rem_euclid(TAU);
       let idx = tile.lut_index_for_adjusted_angle_with_len(adjusted, lut_len);
-      let color = tile.color_lut[idx].demultiply();
+      let color = tile.lut.sample(idx).demultiply();
       let fill = Rgba([color.red(), color.green(), color.blue(), color.alpha()]);
       if fill.0[3] == 0 {
         continue;
@@ -470,12 +467,14 @@ fn lut_svg_stops(
   axis_length: f32,
   interpolation: ColorInterpolationMethod,
 ) -> Vec<GradientStop> {
-  let lut = build_color_lut_with_interpolation(
+  let lut = ColorLut::new(
     resolved,
     axis_length.max(1e-6),
     GRADIENT_LUT_STOPS,
     interpolation,
+    false,
   );
+  let lut = lut.colors();
   if lut.len() <= 1 {
     return svg_stops(resolved, 0.0, axis_length);
   }


### PR DESCRIPTION
## Why
Every gradient tile rebuilt the same five-step pipeline out of 23 free functions, and carried the 8-bit table, the 8.8 table, and the dither flag as three separate fields that only make sense together.

## What
`ColorLut` owns the sampled tables and the dithered read, `LutAxis` owns the repeat shift and the size heuristics, `ResolvedGradientStop::resolve` resolves stops, and `Color` gained `interpolate`, `lerp_premultiplied`, and `premultiplied`. The overlay fast path is a default method on `GradientOverlayTile`. Pure refactor, goldens byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved rendering quality for linear, radial, and conic gradients.
  * Updated color interpolation to provide smoother, more consistent transitions.
  * Refined gradient sampling and dithering for cleaner visual results.
  * Improved adaptive sampling across gradients with repeating or complex color stops.
  * Applied consistent gradient rendering behavior across raster, PDF, and SVG outputs.
  * Updated gradient color handling to produce more accurate sampled colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->