### PR TITLE
Core: hide layout helpers no backend reads

### DIFF
--- a/.tegami/api-prune.md
+++ b/.tegami/api-prune.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Drop unused paint re-exports
+
+`takumi_core::paint` no longer re-exports the tile position helpers, the gradient row states, or `LinearGradientFastPath`; a few layout helpers are crate-private now.

--- a/takumi-core/src/context.rs
+++ b/takumi-core/src/context.rs
@@ -92,7 +92,7 @@ pub struct RenderContext {
   /// The style after inheritance.
   pub style: Box<ComputedStyle>,
   /// Whether this box is a cell of a table that collapses its borders.
-  pub collapsed_borders: bool,
+  pub(crate) collapsed_borders: bool,
   /// Whether a min-content measurement reports the widest run it could not break instead of the
   /// zero width it wrapped against.
   pub(crate) intrinsic_min_content: bool,

--- a/takumi-core/src/font_style.rs
+++ b/takumi-core/src/font_style.rs
@@ -221,7 +221,7 @@ pub struct SizedFontStyle<'s> {
   /// Outline line style.
   pub outline_style: BorderStyle,
   /// Text stroke color.
-  pub text_stroke_color: Color,
+  pub(crate) text_stroke_color: Color,
   pub(crate) text_decoration_color: Color,
   pub(crate) text_decoration_thickness: SizedTextDecorationThickness,
   pub(crate) text_underline_offset: f32,

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -342,7 +342,7 @@ pub enum AvailableSpace {
 
 impl AvailableSpace {
   /// The definite amount of space, or `None` for indefinite space.
-  pub fn into_option(self) -> Option<f32> {
+  pub(crate) fn into_option(self) -> Option<f32> {
     match self {
       Self::Definite(space) => Some(space),
       _ => None,

--- a/takumi-core/src/layout/background.rs
+++ b/takumi-core/src/layout/background.rs
@@ -6,7 +6,7 @@ use crate::{
   context::RenderContext,
   geometry::{ComputedLayout as Layout, Point, Size},
   layout::node::resolve_image,
-  paint::{
+  style::properties::background_repeat::{
     collect_repeat_tile_positions, collect_spaced_tile_positions, collect_stretched_tile_positions,
   },
   style::{

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -72,7 +72,7 @@ impl BorderProperties {
   pub const PATH_COMMANDS_AMOUNT: usize = 14;
 
   /// Resolves the border radius from the context and layout.
-  pub fn resolve_radius_part(
+  pub(crate) fn resolve_radius_part(
     context: &RenderContext,
     border_box: Size<f32>,
   ) -> Sides<SpacePair<f32>> {
@@ -150,7 +150,7 @@ impl BorderProperties {
   }
 
   /// True if a side with this style and width is rendered.
-  pub fn is_side_visible(style: BorderStyle, width: f32) -> bool {
+  fn is_side_visible(style: BorderStyle, width: f32) -> bool {
     style.is_rendered() && width > 0.0
   }
 

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -1345,7 +1345,7 @@ impl RenderNode {
   }
 
   /// True if this node is laid out as an inline-level box (atomic inline or float).
-  pub fn participates_as_inline_box(&self) -> bool {
+  pub(crate) fn participates_as_inline_box(&self) -> bool {
     self.is_inline_atomic_container() || self.context.style.float != Float::None
   }
 

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -60,17 +60,10 @@ mod svg_vector;
 /// raster and SVG renderers.
 pub mod paint {
   pub use crate::style::properties::{
-    background_repeat::{
-      collect_repeat_tile_positions, collect_spaced_tile_positions,
-      collect_stretched_tile_positions,
-    },
-    conic_gradient::{ConicGradientRowState, ConicGradientTile},
+    conic_gradient::ConicGradientTile,
     filter::compose_transfer_table,
     gradient_utils::{ColorLut, GradientOverlayTile},
-    linear_gradient::{
-      LinearGradientFastPath, LinearGradientFastPathKind, LinearGradientRowState,
-      LinearGradientTile,
-    },
+    linear_gradient::{LinearGradientFastPathKind, LinearGradientTile},
     radial_gradient::{RadialGradientRowState, RadialGradientTile},
   };
 }

--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -64,7 +64,7 @@ pub mod paint {
     filter::compose_transfer_table,
     gradient_utils::{ColorLut, GradientOverlayTile},
     linear_gradient::{LinearGradientFastPathKind, LinearGradientTile},
-    radial_gradient::{RadialGradientRowState, RadialGradientTile},
+    radial_gradient::RadialGradientTile,
   };
 }
 

--- a/takumi-core/src/shadow.rs
+++ b/takumi-core/src/shadow.rs
@@ -20,7 +20,7 @@ pub struct SizedShadow {
 
 impl SizedShadow {
   /// Creates a new [`SizedShadow`] from a [`BoxShadow`].
-  pub fn from_box_shadow(
+  pub(crate) fn from_box_shadow(
     shadow: BoxShadow,
     sizing: &SizingContext,
     current_color: Color,

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -11,7 +11,7 @@ use crate::style::{
 
 /// Tile origins along one axis for `background-repeat: repeat`: the first origin
 /// at or before 0, then one per `tile_size` up to `area_size`.
-pub fn collect_repeat_tile_positions(
+pub(crate) fn collect_repeat_tile_positions(
   area_size: u32,
   tile_size: u32,
   origin: i32,
@@ -39,7 +39,7 @@ pub fn collect_repeat_tile_positions(
 
 /// Tile origins for `background-repeat: space`: whole tiles spread to the edges
 /// with equal gaps between them, or a single centered tile when only one fits.
-pub fn collect_spaced_tile_positions(area_size: u32, tile_size: u32) -> SmallVec<[i32; 1]> {
+pub(crate) fn collect_spaced_tile_positions(area_size: u32, tile_size: u32) -> SmallVec<[i32; 1]> {
   if tile_size == 0 {
     return SmallVec::default();
   }
@@ -59,7 +59,7 @@ pub fn collect_spaced_tile_positions(area_size: u32, tile_size: u32) -> SmallVec
 
 /// Tile origins for `background-repeat: round`, with the tile rescaled so a whole
 /// number fit the area. Returns the origins and the rounded tile size.
-pub fn collect_stretched_tile_positions(
+pub(crate) fn collect_stretched_tile_positions(
   area_size: u32,
   tile_size: u32,
 ) -> (SmallVec<[i32; 1]>, u32) {

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -646,7 +646,7 @@ impl ColorLut {
 
   /// The entry at `index` quantized with the Bayer noise for pixel `(x, y)`.
   #[inline(always)]
-  pub fn sample_dithered(&self, index: usize, x: u32, y: u32) -> PremultipliedColorU8 {
+  pub(crate) fn sample_dithered(&self, index: usize, x: u32, y: u32) -> PremultipliedColorU8 {
     let entry = self.hi[index];
     let bias = (128 + DITHER_NOISE_88[(y & 7) as usize][(x & 7) as usize] as i32) as u32;
     let channel = |value: u16| ((value as u32 + bias) >> 8) as u8;


### PR DESCRIPTION
## Why
`takumi_core::paint` re-exported tile position helpers, gradient row states, and a fast-path type that no backend names, and several layout helpers were `pub` although only core reads them.

## What
The re-exports are gone and the helpers are `pub(crate)`. Anything the `takumi` prelude exposes (`Node`, `StyleSheet`, `GenericFamily`) stays as it was.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Restricted several internal layout, rendering, shadow, gradient, and background helpers from public access.
  * Removed selected unused paint-related re-exports from the public API.
  * No functional behavior changes were made; affected capabilities remain available internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->