### PR TITLE
Core: name the values the paint helpers pass around

### DIFF
--- a/.tegami/named-values.md
+++ b/.tegami/named-values.md
@@ -1,0 +1,9 @@
+---
+packages:
+  takumi-core:
+    type: minor
+---
+
+### Name the values the paint helpers pass around
+
+`BorderStyle::dash_pattern` returns a `BorderDash`. `resolve_inline_runs`, `inline_background_path`, `glyph_outlines`, and `run_decorations` are methods on `BuiltInlineLayout`, `InlineBackgroundFragment`, and `ShapedRun`.

--- a/takumi-core/src/layout/background.rs
+++ b/takumi-core/src/layout/background.rs
@@ -89,10 +89,20 @@ fn resolve_intrinsic_size(image: &BackgroundImage, context: &RenderContext) -> I
   source.intrinsic_sizing().scale(&context.sizing)
 }
 
+/// One axis of the positioning and painting areas.
 struct AxisArea {
   area: u32,
   paint: u32,
   offset: i32,
+  /// The `background-position` component on this axis.
+  position: PositionComponent,
+  axis: Axis,
+}
+
+#[derive(Clone, Copy)]
+enum Axis {
+  X,
+  Y,
 }
 
 impl AxisArea {
@@ -100,19 +110,10 @@ impl AxisArea {
   fn tiles(
     &self,
     repeat: BackgroundRepeatStyle,
-    pos: PositionValue,
     tile_size: u32,
     sizing: &SizingContext,
-    is_x: bool,
   ) -> (SmallVec<[i32; 1]>, u32) {
-    let anchor = |tile: u32| {
-      self.offset
-        + if is_x {
-          resolve_position_component_x(pos, tile, self.area, sizing)
-        } else {
-          resolve_position_component_y(pos, tile, self.area, sizing)
-        }
-    };
+    let anchor = |tile: u32| self.offset + self.position_offset(tile, sizing);
     let shift = |mut positions: SmallVec<[i32; 1]>| {
       if self.offset != 0 {
         positions.iter_mut().for_each(|x| *x += self.offset);
@@ -184,40 +185,20 @@ fn calculate_available_space(area_size: u32, tile_size: u32) -> i32 {
     .saturating_sub_unsigned(tile_size)
 }
 
-/// Resolves the x component of a `background-position`.
-fn resolve_position_component_x(
-  comp: PositionValue,
-  tile_w: u32,
-  area_w: u32,
-  sizing: &SizingContext,
-) -> i32 {
-  let available = calculate_available_space(area_w, tile_w);
-  match comp.0.x {
-    PositionComponent::KeywordX(PositionKeywordX::Left) => 0,
-    PositionComponent::KeywordX(PositionKeywordX::Center) => available / 2,
-    PositionComponent::KeywordX(PositionKeywordX::Right) => available,
-    PositionComponent::KeywordY(_) => available / 2,
-    PositionComponent::Length(length) => {
-      resolve_length_to_position_component(length, available, sizing)
-    }
-  }
-}
+impl AxisArea {
+  /// Resolves the `background-position` component against the free space on this axis.
+  fn position_offset(&self, tile: u32, sizing: &SizingContext) -> i32 {
+    let available = calculate_available_space(self.area, tile);
 
-/// Resolves the y component of a `background-position`.
-fn resolve_position_component_y(
-  comp: PositionValue,
-  tile_h: u32,
-  area_h: u32,
-  sizing: &SizingContext,
-) -> i32 {
-  let available = calculate_available_space(area_h, tile_h);
-  match comp.0.y {
-    PositionComponent::KeywordY(PositionKeywordY::Top) => 0,
-    PositionComponent::KeywordY(PositionKeywordY::Center) => available / 2,
-    PositionComponent::KeywordY(PositionKeywordY::Bottom) => available,
-    PositionComponent::KeywordX(_) => available / 2,
-    PositionComponent::Length(length) => {
-      resolve_length_to_position_component(length, available, sizing)
+    match (self.position, self.axis) {
+      (PositionComponent::KeywordX(PositionKeywordX::Left), Axis::X)
+      | (PositionComponent::KeywordY(PositionKeywordY::Top), Axis::Y) => 0,
+      (PositionComponent::KeywordX(PositionKeywordX::Right), Axis::X)
+      | (PositionComponent::KeywordY(PositionKeywordY::Bottom), Axis::Y) => available,
+      (PositionComponent::Length(length), _) => {
+        resolve_length_to_position_component(length, available, sizing)
+      }
+      _ => available / 2,
     }
   }
 }
@@ -278,22 +259,20 @@ impl BackgroundLayerInput<'_> {
       area: self.area.width,
       paint: self.paint.width,
       offset: self.origin_offset.x,
+      position: style.pos.0.x,
+      axis: Axis::X,
     };
     let axis_y = AxisArea {
       area: self.area.height,
       paint: self.paint.height,
       offset: self.origin_offset.y,
+      position: style.pos.0.y,
+      axis: Axis::Y,
     };
 
     let (xs, ys, tile_w, tile_h) = match resolved_size.auto_axis {
       Some(AutoBackgroundAxis::Width) => {
-        let (ys, tile_h) = axis_y.tiles(
-          style.repeat.1,
-          style.pos,
-          resolved_size.height,
-          &self.context.sizing,
-          false,
-        );
+        let (ys, tile_h) = axis_y.tiles(style.repeat.1, resolved_size.height, &self.context.sizing);
         let tile_w = if style.repeat.1 == BackgroundRepeatStyle::Round {
           resolve_auto_axis_from_intrinsic(
             AutoBackgroundAxis::Width,
@@ -304,23 +283,11 @@ impl BackgroundLayerInput<'_> {
         } else {
           resolved_size.width
         };
-        let (xs, tile_w) = axis_x.tiles(
-          style.repeat.0,
-          style.pos,
-          tile_w,
-          &self.context.sizing,
-          true,
-        );
+        let (xs, tile_w) = axis_x.tiles(style.repeat.0, tile_w, &self.context.sizing);
         (xs, ys, tile_w, tile_h)
       }
       Some(AutoBackgroundAxis::Height) => {
-        let (xs, tile_w) = axis_x.tiles(
-          style.repeat.0,
-          style.pos,
-          resolved_size.width,
-          &self.context.sizing,
-          true,
-        );
+        let (xs, tile_w) = axis_x.tiles(style.repeat.0, resolved_size.width, &self.context.sizing);
         let tile_h = if style.repeat.0 == BackgroundRepeatStyle::Round {
           resolve_auto_axis_from_intrinsic(
             AutoBackgroundAxis::Height,
@@ -331,30 +298,12 @@ impl BackgroundLayerInput<'_> {
         } else {
           resolved_size.height
         };
-        let (ys, tile_h) = axis_y.tiles(
-          style.repeat.1,
-          style.pos,
-          tile_h,
-          &self.context.sizing,
-          false,
-        );
+        let (ys, tile_h) = axis_y.tiles(style.repeat.1, tile_h, &self.context.sizing);
         (xs, ys, tile_w, tile_h)
       }
       None => {
-        let (xs, tile_w) = axis_x.tiles(
-          style.repeat.0,
-          style.pos,
-          resolved_size.width,
-          &self.context.sizing,
-          true,
-        );
-        let (ys, tile_h) = axis_y.tiles(
-          style.repeat.1,
-          style.pos,
-          resolved_size.height,
-          &self.context.sizing,
-          false,
-        );
+        let (xs, tile_w) = axis_x.tiles(style.repeat.0, resolved_size.width, &self.context.sizing);
+        let (ys, tile_h) = axis_y.tiles(style.repeat.1, resolved_size.height, &self.context.sizing);
         (xs, ys, tile_w, tile_h)
       }
     };
@@ -407,7 +356,7 @@ impl BackgroundLayersInput<'_> {
 
 #[cfg(test)]
 mod tests {
-  use super::{resolve_position_component_x, resolve_position_component_y};
+  use super::{Axis, AxisArea};
   use crate::{
     style::{
       Length, PositionComponent, PositionKeywordX, PositionKeywordY, PositionValue, SizingContext,
@@ -434,11 +383,25 @@ mod tests {
     ));
 
     assert_eq!(
-      resolve_position_component_x(position, 150, 100, &sizing),
+      AxisArea {
+        area: 100,
+        paint: 100,
+        offset: 0,
+        position: position.0.x,
+        axis: Axis::X
+      }
+      .position_offset(150, &sizing),
       -50
     );
     assert_eq!(
-      resolve_position_component_y(position, 150, 100, &sizing),
+      AxisArea {
+        area: 100,
+        paint: 100,
+        offset: 0,
+        position: position.0.y,
+        axis: Axis::Y
+      }
+      .position_offset(150, &sizing),
       -50
     );
   }
@@ -452,11 +415,25 @@ mod tests {
     ));
 
     assert_eq!(
-      resolve_position_component_x(position, 140, 100, &sizing),
+      AxisArea {
+        area: 100,
+        paint: 100,
+        offset: 0,
+        position: position.0.x,
+        axis: Axis::X
+      }
+      .position_offset(140, &sizing),
       -10
     );
     assert_eq!(
-      resolve_position_component_y(position, 140, 100, &sizing),
+      AxisArea {
+        area: 100,
+        paint: 100,
+        offset: 0,
+        position: position.0.y,
+        axis: Axis::Y
+      }
+      .position_offset(140, &sizing),
       -30
     );
   }

--- a/takumi-core/src/layout/border.rs
+++ b/takumi-core/src/layout/border.rs
@@ -1073,14 +1073,17 @@ impl BorderProperties {
 
 impl BorderStyle {
   /// Returns a dash interval and round-cap flag for this style.
-  pub fn dash_pattern(self, width: f32, length: f32, closed: bool) -> Option<([f32; 2], bool)> {
+  pub fn dash_pattern(self, width: f32, length: f32, closed: bool) -> Option<BorderDash> {
     if !matches!(self, BorderStyle::Dashed | BorderStyle::Dotted) || width <= 0.0 || length <= 0.0 {
       return None;
     }
 
     if self == BorderStyle::Dashed {
       let (dash, gap) = compute_dashed_intervals(width, length, closed)?;
-      return Some(([dash, gap], false));
+      return Some(BorderDash {
+        intervals: [dash, gap],
+        round_cap: false,
+      });
     }
 
     let per_dot_length = width * 2.0;
@@ -1089,8 +1092,20 @@ impl BorderStyle {
     } else {
       select_best_dash_gap(length, width, width, closed) + width - DOTTED_ENDPOINT_EPSILON
     };
-    Some(([0.0, gap], true))
+    Some(BorderDash {
+      intervals: [0.0, gap],
+      round_cap: true,
+    })
   }
+}
+
+/// The stroke dash of a `dashed`/`dotted` border or outline side.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BorderDash {
+  /// Dash and gap lengths.
+  pub intervals: [f32; 2],
+  /// Whether dots are drawn with round caps.
+  pub round_cap: bool,
 }
 
 fn compute_dashed_intervals(width: f32, length: f32, closed: bool) -> Option<(f32, f32)> {
@@ -1157,7 +1172,7 @@ impl PaintedSide {
       _ => false,
     };
 
-    self.color.mix(
+    self.color.mix_rgb(
       if lighten {
         Color::white()
       } else {

--- a/takumi-core/src/layout/inline/background.rs
+++ b/takumi-core/src/layout/inline/background.rs
@@ -282,70 +282,72 @@ impl DecorationAccumulator {
   }
 }
 
-/// The rounded-rect contour an [`InlineBackgroundFragment`] fills, with quarter-ellipse corners.
-pub fn inline_background_path(fragment: &InlineBackgroundFragment) -> Vec<PathCommand> {
-  const KAPPA: f32 = 4.0 / 3.0 * (std::f32::consts::SQRT_2 - 1.0);
+impl InlineBackgroundFragment {
+  /// The rounded-rect contour the fragment fills, with quarter-ellipse corners.
+  pub fn path(&self) -> Vec<PathCommand> {
+    const KAPPA: f32 = 4.0 / 3.0 * (std::f32::consts::SQRT_2 - 1.0);
 
-  let InlineBackgroundFragment {
-    x,
-    y,
-    width,
-    height,
-    radii,
-    ..
-  } = *fragment;
-  let point = |x, y| Point { x, y };
-  let [tl, tr, br, bl] = radii.map(|(rx, ry)| {
-    if rx > 0.0 && ry > 0.0 {
-      (rx, ry)
-    } else {
-      (0.0, 0.0)
+    let InlineBackgroundFragment {
+      x,
+      y,
+      width,
+      height,
+      radii,
+      ..
+    } = *self;
+    let point = |x, y| Point { x, y };
+    let [tl, tr, br, bl] = radii.map(|(rx, ry)| {
+      if rx > 0.0 && ry > 0.0 {
+        (rx, ry)
+      } else {
+        (0.0, 0.0)
+      }
+    });
+    if [tl, tr, br, bl] == [(0.0, 0.0); 4] {
+      return vec![
+        PathCommand::MoveTo(point(x, y)),
+        PathCommand::LineTo(point(x + width, y)),
+        PathCommand::LineTo(point(x + width, y + height)),
+        PathCommand::LineTo(point(x, y + height)),
+        PathCommand::Close,
+      ];
     }
-  });
-  if [tl, tr, br, bl] == [(0.0, 0.0); 4] {
-    return vec![
-      PathCommand::MoveTo(point(x, y)),
-      PathCommand::LineTo(point(x + width, y)),
-      PathCommand::LineTo(point(x + width, y + height)),
-      PathCommand::LineTo(point(x, y + height)),
-      PathCommand::Close,
-    ];
-  }
-  let mut path = Vec::with_capacity(9);
+    let mut path = Vec::with_capacity(9);
 
-  path.push(PathCommand::MoveTo(point(x + tl.0, y)));
-  path.push(PathCommand::LineTo(point(x + width - tr.0, y)));
-  if tr.0 > 0.0 {
-    path.push(PathCommand::CubicTo(
-      point(x + width - tr.0 + tr.0 * KAPPA, y),
-      point(x + width, y + tr.1 - tr.1 * KAPPA),
-      point(x + width, y + tr.1),
-    ));
+    path.push(PathCommand::MoveTo(point(x + tl.0, y)));
+    path.push(PathCommand::LineTo(point(x + width - tr.0, y)));
+    if tr.0 > 0.0 {
+      path.push(PathCommand::CubicTo(
+        point(x + width - tr.0 + tr.0 * KAPPA, y),
+        point(x + width, y + tr.1 - tr.1 * KAPPA),
+        point(x + width, y + tr.1),
+      ));
+    }
+    path.push(PathCommand::LineTo(point(x + width, y + height - br.1)));
+    if br.0 > 0.0 {
+      path.push(PathCommand::CubicTo(
+        point(x + width, y + height - br.1 + br.1 * KAPPA),
+        point(x + width - br.0 + br.0 * KAPPA, y + height),
+        point(x + width - br.0, y + height),
+      ));
+    }
+    path.push(PathCommand::LineTo(point(x + bl.0, y + height)));
+    if bl.0 > 0.0 {
+      path.push(PathCommand::CubicTo(
+        point(x + bl.0 - bl.0 * KAPPA, y + height),
+        point(x, y + height - bl.1 + bl.1 * KAPPA),
+        point(x, y + height - bl.1),
+      ));
+    }
+    path.push(PathCommand::LineTo(point(x, y + tl.1)));
+    if tl.0 > 0.0 {
+      path.push(PathCommand::CubicTo(
+        point(x, y + tl.1 - tl.1 * KAPPA),
+        point(x + tl.0 - tl.0 * KAPPA, y),
+        point(x + tl.0, y),
+      ));
+    }
+    path.push(PathCommand::Close);
+    path
   }
-  path.push(PathCommand::LineTo(point(x + width, y + height - br.1)));
-  if br.0 > 0.0 {
-    path.push(PathCommand::CubicTo(
-      point(x + width, y + height - br.1 + br.1 * KAPPA),
-      point(x + width - br.0 + br.0 * KAPPA, y + height),
-      point(x + width - br.0, y + height),
-    ));
-  }
-  path.push(PathCommand::LineTo(point(x + bl.0, y + height)));
-  if bl.0 > 0.0 {
-    path.push(PathCommand::CubicTo(
-      point(x + bl.0 - bl.0 * KAPPA, y + height),
-      point(x, y + height - bl.1 + bl.1 * KAPPA),
-      point(x, y + height - bl.1),
-    ));
-  }
-  path.push(PathCommand::LineTo(point(x, y + tl.1)));
-  if tl.0 > 0.0 {
-    path.push(PathCommand::CubicTo(
-      point(x, y + tl.1 - tl.1 * KAPPA),
-      point(x + tl.0 - tl.0 * KAPPA, y),
-      point(x + tl.0, y),
-    ));
-  }
-  path.push(PathCommand::Close);
-  path
 }

--- a/takumi-core/src/layout/inline/decorations.rs
+++ b/takumi-core/src/layout/inline/decorations.rs
@@ -28,69 +28,74 @@ pub struct DecorationRect {
   pub line: TextDecorationLines,
 }
 
-/// The active decoration lines for a glyph run, in border-box space.
-pub fn glyph_outlines<'g>(
-  glyph_run: &ShapedRun,
-  resolved_glyphs: &'g HashMap<u32, Arc<ResolvedGlyph>>,
-  origin: Point<f32>,
-  baseline_shift: f32,
-) -> Vec<(Point<f32>, &'g [PathCommand])> {
-  glyph_run
-    .glyphs
-    .iter()
-    .filter_map(|glyph| {
-      let ResolvedGlyph::Outline(outline) = resolved_glyphs.get(&glyph.id)?.as_ref() else {
-        return None;
-      };
+impl ShapedRun {
+  /// The active decoration lines for a glyph run, in border-box space.
+  pub fn glyph_outlines<'g>(
+    &self,
+    resolved_glyphs: &'g HashMap<u32, Arc<ResolvedGlyph>>,
+    origin: Point<f32>,
+    baseline_shift: f32,
+  ) -> Vec<(Point<f32>, &'g [PathCommand])> {
+    self
+      .glyphs
+      .iter()
+      .filter_map(|glyph| {
+        let ResolvedGlyph::Outline(outline) = resolved_glyphs.get(&glyph.id)?.as_ref() else {
+          return None;
+        };
 
-      Some((
-        Point {
-          x: origin.x + glyph.x,
-          y: origin.y + glyph.y + baseline_shift,
-        },
-        outline.paths(),
-      ))
-    })
-    .collect()
-}
+        Some((
+          Point {
+            x: origin.x + glyph.x,
+            y: origin.y + glyph.y + baseline_shift,
+          },
+          outline.paths(),
+        ))
+      })
+      .collect()
+  }
 
-/// The rectangles a run's `text-decoration` paints.
-pub fn run_decorations(
-  glyph_run: &ShapedRun,
-  resolved_glyphs: &HashMap<u32, Arc<ResolvedGlyph>>,
-  layout: ComputedLayout,
-  baseline_shift: f32,
-  transform: Affine,
-) -> Vec<DecorationRect> {
-  let mut out = Vec::new();
-  let brush = &glyph_run.brush;
-  let lines = brush.decoration_line;
-  if lines.is_empty() {
-    return out;
-  }
-  let metrics = &glyph_run.metrics;
-  // A fully trimmed run must not snap up to a 1px decoration.
-  if glyph_run.decorated_advance() <= 0.0 {
-    return out;
-  }
-  let start_x = layout.border.left + layout.padding.left + glyph_run.offset;
-  let snapped_start_x = start_x.floor();
-  let width = (start_x + glyph_run.decorated_advance()).ceil() - snapped_start_x;
-  if width <= 0.0 {
-    return out;
-  }
-  let baseline = glyph_run.baseline + baseline_shift;
-  let top = layout.border.top + layout.padding.top;
-  // Blink floors every decoration at 1px (`TextDecorationInfo::ResolvedThickness`).
-  let thickness = |from_font: f32| {
-    match brush.decoration_thickness {
-      SizedTextDecorationThickness::Value(value) => value,
-      SizedTextDecorationThickness::FromFont => from_font,
+  /// The rectangles the run's `text-decoration` paints.
+  pub fn decorations(
+    &self,
+    resolved_glyphs: &HashMap<u32, Arc<ResolvedGlyph>>,
+    layout: ComputedLayout,
+    baseline_shift: f32,
+    transform: Affine,
+  ) -> Vec<DecorationRect> {
+    let mut out = Vec::new();
+    let brush = &self.brush;
+    let lines = brush.decoration_line;
+    if lines.is_empty() {
+      return out;
     }
-    .max(1.0)
-  };
-  let mut emit =
-    |x: f32, span_width: f32, y_offset: f32, height: f32, over: bool, line: TextDecorationLines| {
+    let metrics = &self.metrics;
+    // A fully trimmed run must not snap up to a 1px decoration.
+    if self.decorated_advance() <= 0.0 {
+      return out;
+    }
+    let start_x = layout.border.left + layout.padding.left + self.offset;
+    let snapped_start_x = start_x.floor();
+    let width = (start_x + self.decorated_advance()).ceil() - snapped_start_x;
+    if width <= 0.0 {
+      return out;
+    }
+    let baseline = self.baseline + baseline_shift;
+    let top = layout.border.top + layout.padding.top;
+    // Blink floors every decoration at 1px (`TextDecorationInfo::ResolvedThickness`).
+    let thickness = |from_font: f32| {
+      match brush.decoration_thickness {
+        SizedTextDecorationThickness::Value(value) => value,
+        SizedTextDecorationThickness::FromFont => from_font,
+      }
+      .max(1.0)
+    };
+    let mut emit = |x: f32,
+                    span_width: f32,
+                    y_offset: f32,
+                    height: f32,
+                    over: bool,
+                    line: TextDecorationLines| {
       if height <= 0.0 || span_width <= 0.0 {
         return;
       }
@@ -105,66 +110,66 @@ pub fn run_decorations(
       });
     };
 
-  if lines.contains(TextDecorationLines::UNDERLINE) {
-    let y_offset = baseline + glyph_run.underline_offset_from_baseline();
-    let height = thickness(metrics.underline_size);
-    // `skip-ink` cuts the line where the glyphs cross it. The pieces carry the
-    // same transform, so a backend paints them exactly as it paints one line.
-    let spans = if brush.decoration_skip_ink == TextDecorationSkipInk::None {
-      [(snapped_start_x, snapped_start_x + width)]
-        .into_iter()
-        .collect()
-    } else {
-      // The band runs from the content box, so the glyphs have to as well.
-      let outlines = glyph_outlines(
-        glyph_run,
-        resolved_glyphs,
-        Point {
-          x: layout.border.left + layout.padding.left,
-          y: 0.0,
-        },
-        baseline_shift,
-      );
+    if lines.contains(TextDecorationLines::UNDERLINE) {
+      let y_offset = baseline + self.underline_offset_from_baseline();
+      let height = thickness(metrics.underline_size);
+      // `skip-ink` cuts the line where the glyphs cross it. The pieces carry the
+      // same transform, so a backend paints them exactly as it paints one line.
+      let spans = if brush.decoration_skip_ink == TextDecorationSkipInk::None {
+        [(snapped_start_x, snapped_start_x + width)]
+          .into_iter()
+          .collect()
+      } else {
+        // The band runs from the content box, so the glyphs have to as well.
+        let outlines = self.glyph_outlines(
+          resolved_glyphs,
+          Point {
+            x: layout.border.left + layout.padding.left,
+            y: 0.0,
+          },
+          baseline_shift,
+        );
 
-      skip_ink_spans(
-        outlines.iter().copied(),
-        snapped_start_x,
-        snapped_start_x + width,
-        y_offset,
-        y_offset + height,
-      )
-    };
+        skip_ink_spans(
+          outlines.iter().copied(),
+          snapped_start_x,
+          snapped_start_x + width,
+          y_offset,
+          y_offset + height,
+        )
+      };
 
-    for (start, end) in spans {
+      for (start, end) in spans {
+        emit(
+          start,
+          end - start,
+          y_offset,
+          height,
+          false,
+          TextDecorationLines::UNDERLINE,
+        );
+      }
+    }
+    if lines.contains(TextDecorationLines::OVERLINE) {
       emit(
-        start,
-        end - start,
-        y_offset,
-        height,
+        snapped_start_x,
+        width,
+        baseline - metrics.ascent - metrics.underline_offset,
+        thickness(metrics.underline_size),
         false,
-        TextDecorationLines::UNDERLINE,
+        TextDecorationLines::OVERLINE,
       );
     }
+    if lines.contains(TextDecorationLines::LINE_THROUGH) {
+      emit(
+        snapped_start_x,
+        width,
+        baseline - metrics.strikethrough_offset,
+        thickness(metrics.strikethrough_size),
+        true,
+        TextDecorationLines::LINE_THROUGH,
+      );
+    }
+    out
   }
-  if lines.contains(TextDecorationLines::OVERLINE) {
-    emit(
-      snapped_start_x,
-      width,
-      baseline - metrics.ascent - metrics.underline_offset,
-      thickness(metrics.underline_size),
-      false,
-      TextDecorationLines::OVERLINE,
-    );
-  }
-  if lines.contains(TextDecorationLines::LINE_THROUGH) {
-    emit(
-      snapped_start_x,
-      width,
-      baseline - metrics.strikethrough_offset,
-      thickness(metrics.strikethrough_size),
-      true,
-      TextDecorationLines::LINE_THROUGH,
-    );
-  }
-  out
 }

--- a/takumi-core/src/layout/inline/mod.rs
+++ b/takumi-core/src/layout/inline/mod.rs
@@ -32,14 +32,14 @@ mod text_fit;
 mod truncation;
 
 pub use self::{
-  background::{InlineBackgroundFragment, inline_background_path},
-  decorations::{DecorationRect, glyph_outlines, run_decorations},
+  background::InlineBackgroundFragment,
+  decorations::DecorationRect,
   items::{DecorationLink, InlineBoxItem, InlineItem, ProcessedInlineSpan, collect_inline_items},
   metrics::VisualInlineBox,
   outline::{InlineOutlineRect, outline_island_contour, outline_islands},
   runs::{
     InlineRunLayout, MeasuredInlineBox, MeasuredInlineRun, PositionedGlyph, PositionedInlineRun,
-    RunMetrics, ShapedRun, resolve_inline_runs,
+    RunMetrics, ShapedRun,
   },
 };
 pub(crate) use self::{
@@ -1134,7 +1134,7 @@ mod tests {
       border: crate::geometry::Rect::default(),
       padding: crate::geometry::Rect::default(),
     };
-    let decorations = run_decorations(&run, &HashMap::new(), layout, 0.0, Affine::IDENTITY);
+    let decorations = run.decorations(&HashMap::new(), layout, 0.0, Affine::IDENTITY);
 
     assert_eq!(decorations.len(), 0);
   }
@@ -1189,7 +1189,7 @@ mod tests {
       border: Rect::default(),
       padding: Rect::default(),
     };
-    let runs = resolve_inline_runs(&built, &render_node.context, layout).unwrap();
+    let runs = built.resolve_runs(&render_node.context, layout).unwrap();
 
     let trailing: Vec<(f32, f32)> = runs
       .runs
@@ -1271,7 +1271,7 @@ mod tests {
       border: crate::geometry::Rect::default(),
       padding: crate::geometry::Rect::default(),
     };
-    let runs = resolve_inline_runs(&built, &render_node.context, layout).unwrap();
+    let runs = built.resolve_runs(&render_node.context, layout).unwrap();
 
     let heights: Vec<f32> = runs.background_fragments.iter().map(|f| f.height).collect();
 
@@ -1332,7 +1332,7 @@ mod tests {
       border: crate::geometry::Rect::default(),
       padding: crate::geometry::Rect::default(),
     };
-    let runs = resolve_inline_runs(&built, &render_node.context, layout).unwrap();
+    let runs = built.resolve_runs(&render_node.context, layout).unwrap();
     let fragment = runs
       .background_fragments
       .first()

--- a/takumi-core/src/layout/inline/runs.rs
+++ b/takumi-core/src/layout/inline/runs.rs
@@ -274,250 +274,252 @@ pub struct InlineRunLayout {
   pub background_fragments: Vec<InlineBackgroundFragment>,
 }
 
-/// Walks `built` once, resolving every glyph run, inline box, and outline rect into
-/// backend-agnostic positioned drawables.
-pub fn resolve_inline_runs(
-  built: &BuiltInlineLayout<'_>,
-  context: &RenderContext,
-  layout: ComputedLayout,
-) -> Result<InlineRunLayout, FontError> {
-  let BuiltInlineLayout {
-    layout: inline_layout,
-    spans,
-    positioned_floats,
-    line_scales,
-    ..
-  } = built;
-  let line_vertical_metrics = built.line_metrics();
-  let line_states = built.line_states();
-
-  let need_outline = spans.iter().any(|span| match span {
-    ProcessedInlineSpan::Text { style, .. } => {
-      style.outline_width > 0.0 && style.outline_style.is_rendered()
-    }
-    ProcessedInlineSpan::DirectionMark { .. }
-    | ProcessedInlineSpan::Box(_)
-    | ProcessedInlineSpan::Spacer { .. } => false,
-  });
-
-  let mut runs = Vec::new();
-  let mut outline_rects = Vec::new();
-  let mut decoration_coverage = DecorationAccumulator::default();
-  let mut positioned_inline_boxes: HashMap<u64, VisualInlineBox> = HashMap::new();
-
-  for (line_index, line) in inline_layout.lines().enumerate() {
-    let Some(setup) = LineSetup::new(
-      &line,
-      layout,
-      &line_vertical_metrics,
+impl BuiltInlineLayout<'_> {
+  /// Resolves every glyph run, inline box, and outline rect into backend-agnostic positioned
+  /// drawables.
+  pub fn resolve_runs(
+    &self,
+    context: &RenderContext,
+    layout: ComputedLayout,
+  ) -> Result<InlineRunLayout, FontError> {
+    let BuiltInlineLayout {
+      layout: inline_layout,
+      spans,
+      positioned_floats,
       line_scales,
-      line_index,
-    ) else {
-      continue;
-    };
-    let mut static_inline_prefix = 0.0_f32;
+      ..
+    } = self;
+    let line_vertical_metrics = self.line_metrics();
+    let line_states = self.line_states();
 
-    let items: Vec<_> = line.items().collect();
-    let run_trailing_whitespace = distribute_trailing_whitespace(&items, &line);
+    let need_outline = spans.iter().any(|span| match span {
+      ProcessedInlineSpan::Text { style, .. } => {
+        style.outline_width > 0.0 && style.outline_style.is_rendered()
+      }
+      ProcessedInlineSpan::DirectionMark { .. }
+      | ProcessedInlineSpan::Box(_)
+      | ProcessedInlineSpan::Spacer { .. } => false,
+    });
 
-    for (item_index, item) in items.into_iter().enumerate() {
-      match item {
-        PositionedLayoutItem::GlyphRun(glyph_run) => {
-          let run = glyph_run.run();
-          // A run carrying only the direction mark paints nothing; a run the
-          // mark's cluster merged into (emoji sequences) paints as the first
-          // real span.
-          let mut brush = glyph_run.style().brush;
-          if brush.is_direction_mark {
-            if glyph_run.advance() == 0.0 {
+    let mut runs = Vec::new();
+    let mut outline_rects = Vec::new();
+    let mut decoration_coverage = DecorationAccumulator::default();
+    let mut positioned_inline_boxes: HashMap<u64, VisualInlineBox> = HashMap::new();
+
+    for (line_index, line) in inline_layout.lines().enumerate() {
+      let Some(setup) = LineSetup::new(
+        &line,
+        layout,
+        &line_vertical_metrics,
+        line_scales,
+        line_index,
+      ) else {
+        continue;
+      };
+      let mut static_inline_prefix = 0.0_f32;
+
+      let items: Vec<_> = line.items().collect();
+      let run_trailing_whitespace = distribute_trailing_whitespace(&items, &line);
+
+      for (item_index, item) in items.into_iter().enumerate() {
+        match item {
+          PositionedLayoutItem::GlyphRun(glyph_run) => {
+            let run = glyph_run.run();
+            // A run carrying only the direction mark paints nothing; a run the
+            // mark's cluster merged into (emoji sequences) paints as the first
+            // real span.
+            let mut brush = glyph_run.style().brush;
+            if brush.is_direction_mark {
+              if glyph_run.advance() == 0.0 {
+                continue;
+              }
+              brush.is_direction_mark = false;
+            }
+
+            let font = FontRef::from_index(run.font().data.as_ref(), run.font().index)
+              .map_err(|_| FontError::InvalidFontIndex)?;
+            let glyph_ids = glyph_run.positioned_glyphs().map(|glyph| glyph.id);
+            let resolved_glyphs = context
+              .fonts()
+              .with_context(|fonts| fonts.resolve_glyphs(&glyph_run, font, glyph_ids));
+
+            if need_outline && let Some(span_id) = brush.source_span_id {
+              outline_rects.push(scale_outline_rect(
+                InlineOutlineRect {
+                  span_id,
+                  line_index,
+                  x: layout.border.left + layout.padding.left + glyph_run.offset(),
+                  y: layout.border.top
+                    + layout.padding.top
+                    + glyph_run.baseline()
+                    + setup.baseline_shift
+                    - setup.resolved_metrics.resolved_ascent,
+                  width: glyph_run.advance(),
+                  height: setup.resolved_metrics.resolved_line_height,
+                },
+                setup.state,
+                static_inline_prefix,
+              ));
+            }
+
+            let metrics = run.metrics();
+
+            if let Some(span_id) = brush.source_span_id
+              && let Some(ProcessedInlineSpan::Text {
+                decorations: Some(chain),
+                ..
+              }) = spans.get(span_id as usize)
+            {
+              // The run's leaded box, like Blink's inline box fragment
+              // (`InlineBoxState::ComputeTextMetrics` adds the line-height
+              // leading to the font height).
+              let (above, below) =
+                brush.line_box_contribution(metrics.line_height, metrics.ascent, metrics.descent);
+              let rect = scale_outline_rect(
+                InlineOutlineRect {
+                  span_id,
+                  line_index,
+                  x: layout.border.left + layout.padding.left + glyph_run.offset(),
+                  y: layout.border.top
+                    + layout.padding.top
+                    + glyph_run.baseline()
+                    + setup.baseline_shift
+                    - above,
+                  width: glyph_run.advance(),
+                  height: above + below,
+                },
+                setup.state,
+                static_inline_prefix,
+              );
+
+              decoration_coverage.cover(
+                Some(chain),
+                line_index,
+                rect.x,
+                rect.x + rect.width,
+                &CoverExtent::Run {
+                  font_size: run.font_size(),
+                  top: rect.y,
+                  bottom: rect.y + rect.height,
+                  baseline: rect.y + above * setup.state.scale,
+                },
+              );
+            }
+            let glyphs: Vec<PositionedGlyph> = glyph_run
+              .positioned_glyphs()
+              .map(|g| PositionedGlyph {
+                id: g.id,
+                x: g.x,
+                y: g.y,
+              })
+              .collect();
+            let cluster_ranges = glyph_cluster_ranges(&glyph_run, &glyphs);
+            let synthesis = run_synthesis(&glyph_run);
+            let shaped = ShapedRun {
+              glyphs,
+              offset: glyph_run.offset(),
+              baseline: glyph_run.baseline(),
+              advance: glyph_run.advance(),
+              trailing_whitespace: run_trailing_whitespace[item_index],
+              brush,
+              metrics: RunMetrics {
+                ascent: metrics.ascent,
+                descent: metrics.descent,
+                underline_offset: metrics.underline_offset,
+                underline_size: metrics.underline_size,
+                strikethrough_offset: metrics.strikethrough_offset,
+                strikethrough_size: metrics.strikethrough_size,
+              },
+              font_size: run.font_size(),
+              font_index: run.font().index,
+              text_range: run.text_range(),
+              cluster_ranges,
+              variations: run_variations(&glyph_run),
+              synthetic_bold: synthesis.embolden,
+              synthetic_skew: synthesis.skew,
+              font_data: run.font().data.clone(),
+            };
+
+            runs.push(PositionedInlineRun {
+              glyph_run: shaped,
+              resolved_glyphs,
+              line_scale: setup.state,
+              static_inline_prefix,
+              baseline_shift: setup.baseline_shift,
+            });
+          }
+          PositionedLayoutItem::InlineBox(inline_box) => {
+            if inline_box.kind != InlineBoxKind::InFlow {
               continue;
             }
-            brush.is_direction_mark = false;
-          }
+            let Some(inline_box) =
+              resolve_visual_inline_box(inline_box, Some(line_states[line_index]), spans)
+            else {
+              continue;
+            };
+            let inline_box = VisualInlineBox {
+              x: scale_text_fit_x(
+                inline_box.layout_x,
+                setup.line_scale_origin_x,
+                setup.state.scale,
+                static_inline_prefix,
+                setup.state.alignment_correction,
+              ),
+              ..inline_box
+            };
+            // A spacer or atomic box inside a decorated span stretches the
+            // span's fragment horizontally; runs set its height, like Blink's
+            // box metrics ignoring atomic descendants. The line extent is the
+            // last resort so padding-only coverage still paints.
+            let chain = match spans.get(inline_box.id as usize) {
+              Some(ProcessedInlineSpan::Box(item)) => item.decorations.as_ref(),
+              Some(ProcessedInlineSpan::Spacer { decorations, .. }) => decorations.as_ref(),
+              _ => None,
+            };
 
-          let font = FontRef::from_index(run.font().data.as_ref(), run.font().index)
-            .map_err(|_| FontError::InvalidFontIndex)?;
-          let glyph_ids = glyph_run.positioned_glyphs().map(|glyph| glyph.id);
-          let resolved_glyphs = context
-            .fonts()
-            .with_context(|fonts| fonts.resolve_glyphs(&glyph_run, font, glyph_ids));
+            if chain.is_some() {
+              let x0 = layout.border.left + layout.padding.left + inline_box.x;
+              let origin_y = setup.state.layout_origin.y;
+              let content_top = layout.border.top + layout.padding.top;
+              let line_y =
+                |value: f32| origin_y + (content_top + value - origin_y) * setup.state.scale;
 
-          if need_outline && let Some(span_id) = brush.source_span_id {
-            outline_rects.push(scale_outline_rect(
-              InlineOutlineRect {
-                span_id,
+              decoration_coverage.cover(
+                chain,
                 line_index,
-                x: layout.border.left + layout.padding.left + glyph_run.offset(),
-                y: layout.border.top
-                  + layout.padding.top
-                  + glyph_run.baseline()
-                  + setup.baseline_shift
-                  - setup.resolved_metrics.resolved_ascent,
-                width: glyph_run.advance(),
-                height: setup.resolved_metrics.resolved_line_height,
-              },
-              setup.state,
-              static_inline_prefix,
-            ));
+                x0,
+                x0 + inline_box.width,
+                &CoverExtent::Line {
+                  top: line_y(setup.resolved_metrics.resolved_line_top),
+                  bottom: line_y(setup.resolved_metrics.resolved_line_bottom),
+                  baseline: line_y(setup.resolved_metrics.resolved_baseline),
+                },
+              );
+            }
+            positioned_inline_boxes.insert(inline_box.id, inline_box);
+            static_inline_prefix += inline_box.layout_advance;
           }
-
-          let metrics = run.metrics();
-
-          if let Some(span_id) = brush.source_span_id
-            && let Some(ProcessedInlineSpan::Text {
-              decorations: Some(chain),
-              ..
-            }) = spans.get(span_id as usize)
-          {
-            // The run's leaded box, like Blink's inline box fragment
-            // (`InlineBoxState::ComputeTextMetrics` adds the line-height
-            // leading to the font height).
-            let (above, below) =
-              brush.line_box_contribution(metrics.line_height, metrics.ascent, metrics.descent);
-            let rect = scale_outline_rect(
-              InlineOutlineRect {
-                span_id,
-                line_index,
-                x: layout.border.left + layout.padding.left + glyph_run.offset(),
-                y: layout.border.top
-                  + layout.padding.top
-                  + glyph_run.baseline()
-                  + setup.baseline_shift
-                  - above,
-                width: glyph_run.advance(),
-                height: above + below,
-              },
-              setup.state,
-              static_inline_prefix,
-            );
-
-            decoration_coverage.cover(
-              Some(chain),
-              line_index,
-              rect.x,
-              rect.x + rect.width,
-              &CoverExtent::Run {
-                font_size: run.font_size(),
-                top: rect.y,
-                bottom: rect.y + rect.height,
-                baseline: rect.y + above * setup.state.scale,
-              },
-            );
-          }
-          let glyphs: Vec<PositionedGlyph> = glyph_run
-            .positioned_glyphs()
-            .map(|g| PositionedGlyph {
-              id: g.id,
-              x: g.x,
-              y: g.y,
-            })
-            .collect();
-          let cluster_ranges = glyph_cluster_ranges(&glyph_run, &glyphs);
-          let synthesis = run_synthesis(&glyph_run);
-          let shaped = ShapedRun {
-            glyphs,
-            offset: glyph_run.offset(),
-            baseline: glyph_run.baseline(),
-            advance: glyph_run.advance(),
-            trailing_whitespace: run_trailing_whitespace[item_index],
-            brush,
-            metrics: RunMetrics {
-              ascent: metrics.ascent,
-              descent: metrics.descent,
-              underline_offset: metrics.underline_offset,
-              underline_size: metrics.underline_size,
-              strikethrough_offset: metrics.strikethrough_offset,
-              strikethrough_size: metrics.strikethrough_size,
-            },
-            font_size: run.font_size(),
-            font_index: run.font().index,
-            text_range: run.text_range(),
-            cluster_ranges,
-            variations: run_variations(&glyph_run),
-            synthetic_bold: synthesis.embolden,
-            synthetic_skew: synthesis.skew,
-            font_data: run.font().data.clone(),
-          };
-
-          runs.push(PositionedInlineRun {
-            glyph_run: shaped,
-            resolved_glyphs,
-            line_scale: setup.state,
-            static_inline_prefix,
-            baseline_shift: setup.baseline_shift,
-          });
-        }
-        PositionedLayoutItem::InlineBox(inline_box) => {
-          if inline_box.kind != InlineBoxKind::InFlow {
-            continue;
-          }
-          let Some(inline_box) =
-            resolve_visual_inline_box(inline_box, Some(line_states[line_index]), spans)
-          else {
-            continue;
-          };
-          let inline_box = VisualInlineBox {
-            x: scale_text_fit_x(
-              inline_box.layout_x,
-              setup.line_scale_origin_x,
-              setup.state.scale,
-              static_inline_prefix,
-              setup.state.alignment_correction,
-            ),
-            ..inline_box
-          };
-          // A spacer or atomic box inside a decorated span stretches the
-          // span's fragment horizontally; runs set its height, like Blink's
-          // box metrics ignoring atomic descendants. The line extent is the
-          // last resort so padding-only coverage still paints.
-          let chain = match spans.get(inline_box.id as usize) {
-            Some(ProcessedInlineSpan::Box(item)) => item.decorations.as_ref(),
-            Some(ProcessedInlineSpan::Spacer { decorations, .. }) => decorations.as_ref(),
-            _ => None,
-          };
-
-          if chain.is_some() {
-            let x0 = layout.border.left + layout.padding.left + inline_box.x;
-            let origin_y = setup.state.layout_origin.y;
-            let content_top = layout.border.top + layout.padding.top;
-            let line_y =
-              |value: f32| origin_y + (content_top + value - origin_y) * setup.state.scale;
-
-            decoration_coverage.cover(
-              chain,
-              line_index,
-              x0,
-              x0 + inline_box.width,
-              &CoverExtent::Line {
-                top: line_y(setup.resolved_metrics.resolved_line_top),
-                bottom: line_y(setup.resolved_metrics.resolved_line_bottom),
-                baseline: line_y(setup.resolved_metrics.resolved_baseline),
-              },
-            );
-          }
-          positioned_inline_boxes.insert(inline_box.id, inline_box);
-          static_inline_prefix += inline_box.layout_advance;
         }
       }
     }
+
+    for inline_box in positioned_floats {
+      let Some(inline_box) = resolve_visual_inline_box(inline_box.clone(), None, spans) else {
+        continue;
+      };
+      positioned_inline_boxes.insert(inline_box.id, inline_box);
+    }
+
+    let mut inline_boxes: Vec<_> = positioned_inline_boxes.into_values().collect();
+    inline_boxes.sort_by_key(|inline_box| inline_box.id);
+
+    Ok(InlineRunLayout {
+      runs,
+      inline_boxes,
+      outline_rects,
+      background_fragments: decoration_coverage.into_fragments(),
+    })
   }
-
-  for inline_box in positioned_floats {
-    let Some(inline_box) = resolve_visual_inline_box(inline_box.clone(), None, spans) else {
-      continue;
-    };
-    positioned_inline_boxes.insert(inline_box.id, inline_box);
-  }
-
-  let mut inline_boxes: Vec<_> = positioned_inline_boxes.into_values().collect();
-  inline_boxes.sort_by_key(|inline_box| inline_box.id);
-
-  Ok(InlineRunLayout {
-    runs,
-    inline_boxes,
-    outline_rects,
-    background_fragments: decoration_coverage.into_fragments(),
-  })
 }
 
 /// A measured glyph run: its text (borrowed from the layout) and local bounding box, with text-fit

--- a/takumi-core/src/layout/table.rs
+++ b/takumi-core/src/layout/table.rs
@@ -83,16 +83,6 @@ impl CellAlignment {
   }
 }
 
-impl Display {
-  fn table_group_order(self) -> u8 {
-    match self {
-      Display::TableHeaderGroup => 0,
-      Display::TableFooterGroup => 2,
-      _ => 1,
-    }
-  }
-}
-
 /// The table's children sorted into their roles, rows flattened in render order: header rows first,
 /// then body, then footer.
 struct TableSlots {
@@ -104,6 +94,14 @@ struct TableSlots {
 }
 
 impl TableSlots {
+  fn group_order(display: Display) -> u8 {
+    match display {
+      Display::TableHeaderGroup => 0,
+      Display::TableFooterGroup => 2,
+      _ => 1,
+    }
+  }
+
   /// Extracts rows without CSS anonymous table-box fixup.
   fn collect(table: &mut RenderNode) -> Self {
     let mut captions = Vec::new();
@@ -117,7 +115,7 @@ impl TableSlots {
         Display::TableCaption => captions.push(child),
         Display::TableRow => groups.push((1, index, vec![child])),
         Display::TableHeaderGroup | Display::TableRowGroup | Display::TableFooterGroup => {
-          let order = child.context.style.display.table_group_order();
+          let order = Self::group_order(child.context.style.display);
           let rows = child.children.take().map_or_else(Vec::new, Vec::from);
 
           groups.push((

--- a/takumi-core/src/painter.rs
+++ b/takumi-core/src/painter.rs
@@ -363,8 +363,8 @@ pub fn paint_border<D: PaintDevice>(
         &StrokeStyle {
           color,
           width,
-          dash: dash.map(|(intervals, _)| intervals),
-          round_cap: dash.is_some_and(|(_, round)| round),
+          dash: dash.map(|dash| dash.intervals),
+          round_cap: dash.is_some_and(|dash| dash.round_cap),
         },
         at,
       );

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -3,6 +3,7 @@
 //! This module provides types and utilities for managing image resources,
 //! including loading states, error handling, and image processing operations.
 
+use super::image_decoder::DecodeTarget;
 #[cfg(feature = "svg")]
 use std::borrow::Cow;
 #[cfg(feature = "svg")]
@@ -267,7 +268,7 @@ impl AnimatedFormat {
     bytes: &[u8],
     skip: usize,
     limit: Option<usize>,
-    target: Option<(u32, u32, ImageScalingAlgorithm)>,
+    target: Option<DecodeTarget>,
     push: impl FnMut(Arc<ImageBuffer>),
   ) -> Result<bool, image::ImageError> {
     match self {
@@ -284,7 +285,7 @@ impl AnimatedFormat {
     self,
     bytes: &[u8],
     index: usize,
-    target: (u32, u32, ImageScalingAlgorithm),
+    target: DecodeTarget,
   ) -> Option<ImageBuffer> {
     match self {
       Self::Gif => decode_gif_frame_alone(bytes, index, Some(target)),
@@ -422,11 +423,16 @@ impl AnimatedSource {
   ) -> Arc<ImageBuffer> {
     let timing = self.timing();
     let index = self.frame_index_at(timing, time_ms);
-    let target = cover_target((self.inner.width, self.inner.height), (width, height));
+    let (width, height) = cover_target((self.inner.width, self.inner.height), (width, height));
+    let target = DecodeTarget {
+      width,
+      height,
+      algorithm,
+    };
 
     self
-      .decode_frame(index, target, algorithm)
-      .or_else(|| self.decode_frame(0, target, algorithm))
+      .decode_frame(index, target)
+      .or_else(|| self.decode_frame(0, target))
       .unwrap_or_else(|| {
         log::warn!("Failed to decode any frame of an animated image, drawing nothing.");
         Arc::new(ImageBuffer::transparent_pixel())
@@ -436,30 +442,25 @@ impl AnimatedSource {
   /// Decodes a single frame by stream index, resampled to `target`. A frame
   /// that depends on earlier ones is reached by replaying them, since disposal
   /// is stateful.
-  fn decode_frame(
-    &self,
-    index: usize,
-    (target_width, target_height): (u32, u32),
-    algorithm: ImageScalingAlgorithm,
-  ) -> Option<Arc<ImageBuffer>> {
+  fn decode_frame(&self, index: usize, target: DecodeTarget) -> Option<Arc<ImageBuffer>> {
     if self.stands_alone(index)
-      && let Some(frame) = self.inner.format.decode_frame_alone(
-        &self.inner.bytes,
-        index,
-        (target_width, target_height, algorithm),
-      )
+      && let Some(frame) = self
+        .inner
+        .format
+        .decode_frame_alone(&self.inner.bytes, index, target)
     {
       return Some(Arc::new(frame));
     }
 
     let mut frame = None;
-    if let Err(error) = self.inner.format.decode_frames(
-      &self.inner.bytes,
-      index,
-      Some(1),
-      Some((target_width, target_height, algorithm)),
-      |decoded| frame = Some(decoded),
-    ) {
+    if let Err(error) =
+      self
+        .inner
+        .format
+        .decode_frames(&self.inner.bytes, index, Some(1), Some(target), |decoded| {
+          frame = Some(decoded)
+        })
+    {
       log::warn!("Failed to decode frame {index} of an animated image: {error}");
     }
 
@@ -1766,7 +1767,15 @@ mod tests {
 
       for index in 1..3 {
         let seeked = animated_format
-          .decode_frame_alone(&bytes, index, (4, 4, ImageScalingAlgorithm::Auto))
+          .decode_frame_alone(
+            &bytes,
+            index,
+            DecodeTarget {
+              width: 4,
+              height: 4,
+              algorithm: ImageScalingAlgorithm::Auto,
+            },
+          )
           .unwrap_or_else(|| panic!("{format} frame {index} should seek"));
 
         let mut replayed = None;
@@ -1817,7 +1826,15 @@ mod tests {
 
     assert!(
       AnimatedFormat::WebP
-        .decode_frame_alone(&bytes, 1, (4, 4, ImageScalingAlgorithm::Auto))
+        .decode_frame_alone(
+          &bytes,
+          1,
+          DecodeTarget {
+            width: 4,
+            height: 4,
+            algorithm: ImageScalingAlgorithm::Auto
+          }
+        )
         .is_none()
     );
   }

--- a/takumi-core/src/resources/image_decoder/gif.rs
+++ b/takumi-core/src/resources/image_decoder/gif.rs
@@ -1,6 +1,7 @@
 //! GIF sizing and timelines, composited the way browsers and the `image` crate do; stubs when the
 //! decoder is compiled out.
 
+use super::DecodeTarget;
 use std::sync::Arc;
 #[cfg(feature = "gif")]
 use std::{io::Cursor, mem::take};
@@ -20,8 +21,8 @@ use super::{
   invalid_buffer_error, pixel_budget_error,
 };
 #[cfg(feature = "gif")]
-use crate::{geometry::Rect, resources::image_resampler::resample_premultiplied};
-use crate::{resources::image_buffer::ImageBuffer, style::ImageScalingAlgorithm};
+use crate::geometry::Rect;
+use crate::resources::image_buffer::ImageBuffer;
 
 pub(crate) fn is_gif(bytes: &[u8]) -> bool {
   matches!(detect_image_format(bytes), Some(DetectedImageFormat::Gif))
@@ -160,12 +161,12 @@ pub(crate) fn decode_gif_frames(
   bytes: &[u8],
   skip: usize,
   limit: Option<usize>,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
   mut push: impl FnMut(Arc<ImageBuffer>),
 ) -> ImageResult<bool> {
   let mut decoder = gif_decoder(bytes)?;
   let (width, height) = (decoder.width() as u32, decoder.height() as u32);
-  let target = target.filter(|&(w, h, _)| w < width || h < height);
+  let target = target.filter(|target| target.shrinks(width, height));
 
   // GIF alpha is 0 or 255, so the canvas is valid premultiplied RGBA as-is:
   // blits copy opaque pixels (premultiply is identity) and cleared pixels are
@@ -225,13 +226,8 @@ pub(crate) fn decode_gif_frames(
         blit_frame(&mut canvas, (width, height), rect, &scratch);
         if !keep {
           None
-        } else if let Some((w, h, algorithm)) = target {
-          Some(resample_premultiplied(
-            &canvas,
-            (width, height),
-            (w, h),
-            algorithm,
-          ))
+        } else if let Some(target) = target {
+          Some(target.resample(&canvas, (width, height)))
         } else if last_needed {
           // The canvas is never read again: emit it without cloning.
           Some(ImageBuffer::from_premultiplied_rgba(
@@ -252,9 +248,7 @@ pub(crate) fn decode_gif_frames(
           let mut out = canvas.clone();
           blit_frame(&mut out, (width, height), rect, &scratch);
           match target {
-            Some((w, h, algorithm)) => {
-              resample_premultiplied(&out, (width, height), (w, h), algorithm)
-            }
+            Some(target) => target.resample(&out, (width, height)),
             None => ImageBuffer::from_premultiplied_rgba(out, width, height),
           }
         });
@@ -283,7 +277,7 @@ pub(crate) fn decode_gif_frames(
 pub(crate) fn decode_gif_frame_alone(
   bytes: &[u8],
   index: usize,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
 ) -> Option<ImageBuffer> {
   let mut decoder = gif_decoder(bytes).ok()?;
   let (canvas_width, canvas_height) = (decoder.width() as u32, decoder.height() as u32);
@@ -334,7 +328,7 @@ pub(crate) fn gif_frame_infos(_bytes: &[u8]) -> ImageResult<Box<[FrameInfo]>> {
 pub(crate) fn decode_gif_frame_alone(
   _bytes: &[u8],
   _index: usize,
-  _target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  _target: Option<DecodeTarget>,
 ) -> Option<ImageBuffer> {
   None
 }
@@ -344,7 +338,7 @@ pub(crate) fn decode_gif_frames(
   _bytes: &[u8],
   _skip: usize,
   _limit: Option<usize>,
-  _target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  _target: Option<DecodeTarget>,
   _push: impl FnMut(Arc<ImageBuffer>),
 ) -> ImageResult<bool> {
   Err(format_compiled_out_error())

--- a/takumi-core/src/resources/image_decoder/mod.rs
+++ b/takumi-core/src/resources/image_decoder/mod.rs
@@ -286,20 +286,37 @@ pub(super) fn covers_canvas(rect: (u32, u32, u32, u32), canvas: (u32, u32)) -> b
   x == 0 && y == 0 && width == canvas.0 && height == canvas.1
 }
 
+/// The size decoded frames resample down to, and how.
+#[derive(Clone, Copy)]
+pub(crate) struct DecodeTarget {
+  pub(crate) width: u32,
+  pub(crate) height: u32,
+  pub(crate) algorithm: ImageScalingAlgorithm,
+}
+
+impl DecodeTarget {
+  /// Whether a `width` by `height` canvas is larger than the target on either axis.
+  pub(super) fn shrinks(self, width: u32, height: u32) -> bool {
+    self.width < width || self.height < height
+  }
+
+  /// Resamples a premultiplied `source`-sized canvas to the target.
+  pub(super) fn resample(self, data: &[u8], source: (u32, u32)) -> Option<ImageBuffer> {
+    resample_premultiplied(data, source, (self.width, self.height), self.algorithm)
+  }
+}
+
 /// Resamples a full-canvas buffer down to `target`, or hands it back untouched.
 pub(super) fn fit_to_target(
   buffer: ImageBuffer,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
 ) -> ImageResult<ImageBuffer> {
-  let Some((width, height, algorithm)) = target else {
+  let Some(target) = target.filter(|target| target.shrinks(buffer.width(), buffer.height())) else {
     return Ok(buffer);
   };
-  if width >= buffer.width() && height >= buffer.height() {
-    return Ok(buffer);
-  }
 
-  let source = (buffer.width(), buffer.height());
-  resample_premultiplied(buffer.data(), source, (width, height), algorithm)
+  target
+    .resample(buffer.data(), (buffer.width(), buffer.height()))
     .ok_or_else(invalid_buffer_error)
 }
 

--- a/takumi-core/src/resources/image_decoder/png.rs
+++ b/takumi-core/src/resources/image_decoder/png.rs
@@ -1,5 +1,6 @@
 //! PNG stills, streamed downscaling, and APNG timelines.
 
+use super::DecodeTarget;
 use std::{io::Cursor, sync::Arc};
 
 use image::{ImageError, ImageFormat, ImageResult, codecs::png::PngDecoder, error::DecodingError};
@@ -14,7 +15,7 @@ use super::{
 use crate::{
   resources::{
     image_buffer::{ImageBuffer, premultiply_rgba_in_place},
-    image_resampler::{StreamResampler, resample_premultiplied},
+    image_resampler::StreamResampler,
   },
   style::ImageScalingAlgorithm,
 };
@@ -208,7 +209,7 @@ fn apng_reader(bytes: &[u8]) -> ImageResult<png::Reader<Cursor<&[u8]>>> {
 pub(crate) fn decode_apng_frame_alone(
   bytes: &[u8],
   index: usize,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
 ) -> Option<ImageBuffer> {
   let mut reader = apng_reader(bytes).ok()?;
   let (canvas_width, canvas_height) = (reader.info().width, reader.info().height);
@@ -255,12 +256,12 @@ pub(crate) fn decode_apng_frames(
   bytes: &[u8],
   skip: usize,
   limit: Option<usize>,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
   mut push: impl FnMut(Arc<ImageBuffer>),
 ) -> ImageResult<bool> {
   let mut reader = apng_reader(bytes)?;
   let (width, height) = (reader.info().width, reader.info().height);
-  let target = target.filter(|&(w, h, _)| w < width || h < height);
+  let target = target.filter(|target| target.shrinks(width, height));
   let channels = match reader.output_color_type() {
     (ColorType::Rgba, BitDepth::Eight) => 4,
     (ColorType::GrayscaleAlpha, BitDepth::Eight) => 2,
@@ -410,20 +411,12 @@ impl ApngCanvas {
     }
   }
 
-  fn to_buffer(
-    &self,
-    target: Option<(u32, u32, ImageScalingAlgorithm)>,
-  ) -> ImageResult<ImageBuffer> {
+  fn to_buffer(&self, target: Option<DecodeTarget>) -> ImageResult<ImageBuffer> {
     let mut premultiplied = self.pixels.clone();
     premultiply_rgba_in_place(&mut premultiplied);
 
     match target {
-      Some((width, height, algorithm)) => resample_premultiplied(
-        &premultiplied,
-        (self.width, self.height),
-        (width, height),
-        algorithm,
-      ),
+      Some(target) => target.resample(&premultiplied, (self.width, self.height)),
       None => ImageBuffer::from_premultiplied_rgba(premultiplied, self.width, self.height),
     }
     .ok_or_else(invalid_buffer_error)
@@ -454,6 +447,7 @@ fn blend_over(target: &mut [u8], source: [u8; 4]) {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::resources::image_resampler::resample_premultiplied;
   use image::RgbaImage;
 
   use crate::resources::image_decoder::{decode_bitmap_scaled, decode_image};

--- a/takumi-core/src/resources/image_decoder/webp.rs
+++ b/takumi-core/src/resources/image_decoder/webp.rs
@@ -1,6 +1,7 @@
 //! WebP stills and animations: libwebp on native targets, `image-webp` on
 //! wasm, and header-only sizing when the decoder is compiled out.
 
+use super::DecodeTarget;
 #[cfg(feature = "webp")]
 use std::{io::Cursor, sync::Arc};
 
@@ -24,8 +25,6 @@ use super::{
 #[cfg(not(feature = "webp"))]
 use super::{format_compiled_out_error, header_dimensions};
 use crate::resources::image_buffer::ImageBuffer;
-#[cfg(feature = "webp")]
-use crate::style::ImageScalingAlgorithm;
 
 #[cfg(all(target_arch = "wasm32", feature = "webp"))]
 pub(super) fn webp_dimensions(bytes: &[u8]) -> ImageResult<(u32, u32)> {
@@ -266,13 +265,13 @@ pub(crate) fn decode_webp_frames(
   bytes: &[u8],
   skip: usize,
   limit: Option<usize>,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
   mut push: impl FnMut(Arc<ImageBuffer>),
 ) -> ImageResult<bool> {
   let mut decoder = WebPDecoder::new(Cursor::new(bytes)).map_err(webp_decode_error)?;
   let (width, height) = decoder.dimensions();
   check_pixel_budget(width, height)?;
-  let target = target.filter(|&(w, h, _)| w < width || h < height);
+  let target = target.filter(|target| target.shrinks(width, height));
 
   let has_alpha = decoder.has_alpha();
   let mut canvas = vec![
@@ -336,7 +335,7 @@ fn decode_animated_webp_first_frame(bytes: &[u8]) -> ImageResult<ImageBuffer> {
 pub(crate) fn decode_webp_frame_alone(
   bytes: &[u8],
   index: usize,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
 ) -> Option<ImageBuffer> {
   let read_24 = |bytes: &[u8], offset: usize| {
     Some(u32::from_le_bytes([
@@ -450,7 +449,7 @@ fn webp_canvas_to_buffer(
   width: u32,
   height: u32,
   has_alpha: bool,
-  target: Option<(u32, u32, ImageScalingAlgorithm)>,
+  target: Option<DecodeTarget>,
 ) -> ImageResult<ImageBuffer> {
   let rgba = if has_alpha {
     canvas.to_vec()
@@ -490,6 +489,7 @@ pub(super) fn decode_webp_scaled(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::style::ImageScalingAlgorithm;
 
   #[cfg(feature = "webp")]
   #[test]

--- a/takumi-core/src/resources/image_decoder/webp.rs
+++ b/takumi-core/src/resources/image_decoder/webp.rs
@@ -1,6 +1,7 @@
 //! WebP stills and animations: libwebp on native targets, `image-webp` on
 //! wasm, and header-only sizing when the decoder is compiled out.
 
+#[cfg(feature = "webp")]
 use super::DecodeTarget;
 #[cfg(feature = "webp")]
 use std::{io::Cursor, sync::Arc};

--- a/takumi-core/src/style/properties/color.rs
+++ b/takumi-core/src/style/properties/color.rs
@@ -608,7 +608,7 @@ impl Color {
   }
 
   /// Mixes `amount` of `target` into the colour, keeping this alpha.
-  pub(crate) fn mix(self, target: Color, amount: f32) -> Self {
+  pub(crate) fn mix_rgb(self, target: Color, amount: f32) -> Self {
     let amount = amount.clamp(0.0, 1.0);
     let inverse = 1.0 - amount;
 

--- a/takumi-core/src/svg_vector.rs
+++ b/takumi-core/src/svg_vector.rs
@@ -188,7 +188,7 @@ pub struct SvgGradientStop {
 
 /// Flattens `tree` into vector ops in SVG canvas coordinates.
 pub(crate) fn flatten(tree: &Tree, raster_scale: f32) -> Vec<SvgOp> {
-  Flattener::new(raster_scale).group(tree.root())
+  Flattener::new(raster_scale).flatten(tree.root())
 }
 
 /// One op list being written, at one raster scale.
@@ -213,7 +213,7 @@ impl Flattener {
     nested.ops
   }
 
-  fn group(mut self, group: &Group) -> Vec<SvgOp> {
+  fn flatten(mut self, group: &Group) -> Vec<SvgOp> {
     self.push_group(group);
     self.ops
   }

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -20,7 +20,6 @@ use takumi_core::{
     decoration::{ClipBox, OutlineGeometry},
     inline::{
       BuiltInlineLayout, InlineRunLayout, PositionedInlineRun, ProcessedInlineSpan, ShapedRun,
-      inline_background_path, run_decorations,
     },
     inline_box::{InlineBoxPaint, InlineSubtree, resolve_inline_box},
     node::NodeKind,
@@ -1275,7 +1274,7 @@ impl Emitter<'_> {
       if self.window.disowns_line(y + fragment.baseline) {
         continue;
       }
-      let Some(path) = krilla_path(&inline_background_path(fragment), x, y) else {
+      let Some(path) = krilla_path(&fragment.path(), x, y) else {
         continue;
       };
 
@@ -1313,8 +1312,7 @@ impl Emitter<'_> {
         continue;
       }
       let offset = run.glyph_offset(layout);
-      let decorations = run_decorations(
-        shaped,
+      let decorations = shaped.decorations(
         &run.resolved_glyphs,
         layout,
         run.baseline_shift,

--- a/takumi-pdf/src/inline.rs
+++ b/takumi-pdf/src/inline.rs
@@ -9,7 +9,7 @@ use takumi_core::{
   layout::{
     inline::{
       BuiltInlineLayout, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineRunLayout,
-      collect_inline_items, create_inline_layout, resolve_inline_runs,
+      collect_inline_items, create_inline_layout,
     },
     node::{NodeKind, TextData},
     tree::RenderNode,
@@ -175,7 +175,9 @@ pub(crate) fn build_inline_runs<'c>(
     context,
     InlineLayoutMode::Draw,
   ));
-  let runs = resolve_inline_runs(&built, context, layout).map_err(PdfError::Font)?;
+  let runs = built
+    .resolve_runs(context, layout)
+    .map_err(PdfError::Font)?;
 
   Ok(Some((built, runs)))
 }

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -373,12 +373,12 @@ fn draw_side_pattern_border(
 
 fn compute_side_stroke(width: f32, style: BorderStyle, length: f32, closed: bool) -> Stroke {
   let mut stroke = Stroke::new(width);
-  if let Some((intervals, round_cap)) = style.dash_pattern(width, length, closed) {
-    if round_cap {
+  if let Some(dash) = style.dash_pattern(width, length, closed) {
+    if dash.round_cap {
       stroke.cap = Cap::Round;
     }
     stroke.dash = Some(DashPattern {
-      intervals,
+      intervals: dash.intervals,
       offset: 0.0,
     });
   }

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -17,8 +17,7 @@ use crate::{
   draw_outset_box_shadow,
   layout::inline::{
     BuiltInlineLayout, InlineBoxItem, InlineOutlineRect, InlineRunLayout, PositionedInlineRun,
-    ProcessedInlineSpan, ShapedRun, VisualInlineBox, glyph_outlines, inline_background_path,
-    outline_island_contour, outline_islands, resolve_inline_runs,
+    ProcessedInlineSpan, ShapedRun, VisualInlineBox, outline_island_contour, outline_islands,
   },
   painter::StrokeStyle,
   rasterize_layers,
@@ -91,12 +90,7 @@ fn draw_underline_with_skip_ink(
   let content_offset = options.layout.content_box_offset();
   let run_start_x = content_offset.x + glyph_run.offset;
   let line_top = content_offset.y + options.offset;
-  let outlines = glyph_outlines(
-    glyph_run,
-    resolved_glyphs,
-    content_offset,
-    options.baseline_shift,
-  );
+  let outlines = glyph_run.glyph_outlines(resolved_glyphs, content_offset, options.baseline_shift);
 
   for (start_x, end_x) in skip_ink_spans(
     outlines.iter().copied(),
@@ -436,11 +430,11 @@ pub(crate) fn draw_inline_layout(
   font_style: &SizedFontStyle,
 ) -> Result<Vec<VisualInlineBox>> {
   let spans = &built.spans;
-  let resolved = resolve_inline_runs(built, context, layout)?;
+  let resolved = built.resolve_runs(context, layout)?;
 
   // Inline-span backgrounds fill under every glyph of the formatting context.
   for fragment in &resolved.background_fragments {
-    let path = inline_background_path(fragment);
+    let path = fragment.path();
     let (mask, placement) = render_mask(
       &path,
       Some(context.transform),

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -928,9 +928,13 @@ fn dash_attrs(
   closed: bool,
 ) -> (Option<String>, Option<&'static str>) {
   match style.dash_pattern(width, length, closed) {
-    Some(([dash, gap], round_cap)) => (
-      Some(format!("{} {}", Num(dash), Num(gap))),
-      round_cap.then_some("round"),
+    Some(dash) => (
+      Some(format!(
+        "{} {}",
+        Num(dash.intervals[0]),
+        Num(dash.intervals[1])
+      )),
+      dash.round_cap.then_some("round"),
     ),
     None => (None, None),
   }

--- a/takumi-svg/src/text.rs
+++ b/takumi-svg/src/text.rs
@@ -16,8 +16,7 @@ use takumi_core::{
     inline::{
       DecorationRect, InlineItem, InlineLayoutMode, InlineLayoutRequest, InlineOutlineRect,
       InlineRunLayout, PositionedInlineRun, ProcessedInlineSpan, ShapedRun, collect_inline_items,
-      create_inline_layout, inline_background_path, outline_island_contour, outline_islands,
-      resolve_inline_runs, run_decorations,
+      create_inline_layout, outline_island_contour, outline_islands,
     },
     node::TextData,
     tree::RenderNode,
@@ -93,7 +92,7 @@ pub(crate) fn emit_text(
     InlineLayoutMode::Draw,
   ));
 
-  let runs = resolve_inline_runs(&built, context, layout).map_err(font_error)?;
+  let runs = built.resolve_runs(context, layout).map_err(font_error)?;
   emit_runs(
     doc,
     &runs,
@@ -130,7 +129,7 @@ pub(crate) fn emit_inline_content(
     InlineLayoutMode::Draw,
   ));
 
-  let runs = resolve_inline_runs(&built, context, layout).map_err(font_error)?;
+  let runs = built.resolve_runs(context, layout).map_err(font_error)?;
   emit_runs(
     doc,
     &runs,
@@ -161,7 +160,7 @@ fn emit_runs(
   // Inline-span backgrounds fill under every glyph of the formatting context.
   for fragment in &runs.background_fragments {
     let data = path_data(
-      &inline_background_path(fragment),
+      &fragment.path(),
       [1.0, 0.0, 0.0, 1.0, frame.origin_x, frame.origin_y],
     );
 
@@ -198,8 +197,7 @@ fn emit_runs(
     .runs
     .iter()
     .map(|run| {
-      run_decorations(
-        &run.glyph_run,
+      run.glyph_run.decorations(
         &run.resolved_glyphs,
         frame.layout,
         run.baseline_shift,


### PR DESCRIPTION
## Why
The decoders passed a `(u32, u32, ImageScalingAlgorithm)` tuple through every frame path, `dash_pattern` returned a tuple with a bare bool, the tile resolver took an `is_x` flag, and four inline paint helpers were free functions over a type they only read.

## What
`DecodeTarget` carries the resample size and algorithm with a `resample` method, `BorderDash` names the dash and cap, `AxisArea` knows its axis and position component, and the inline helpers are methods on `BuiltInlineLayout`, `InlineBackgroundFragment`, and `ShapedRun`. `Color::mix` is `mix_rgb` and `Flattener::group` is `flatten`. Pure refactor, goldens byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `BorderDash` type with named access to dash intervals and round-cap settings.
  * Added methods for resolving inline runs, creating inline background paths, and calculating glyph outlines and decorations.

* **Improvements**
  * Unified image scaling targets across GIF, PNG/APNG, and WebP decoding.
  * Improved RGB color mixing for 3D border shading.

* **Documentation**
  * Documented named value types used by painting and inline-layout helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->