### PR TITLE
Core: walk inline items once for paint, measure, and bounds

### DIFF
--- a/takumi-core/src/layout/inline/metrics.rs
+++ b/takumi-core/src/layout/inline/metrics.rs
@@ -303,8 +303,6 @@ pub(crate) fn resolved_line_metrics_for_apply(
 /// Resolved metrics and parent context for a single inline line.
 pub(crate) struct ResolvedInlineLineState {
   pub(crate) adjusted_metrics: LineMetrics,
-  /// Vertical shift applied to the baseline.
-  pub baseline_shift: f32,
   pub(crate) parent_x_height: Option<f32>,
   pub(crate) parent_text_metrics: Option<(f32, f32)>,
 }
@@ -326,7 +324,6 @@ pub(crate) fn resolve_inline_line_states(
     ))
     .map(|(line, resolved)| ResolvedInlineLineState {
       adjusted_metrics: resolved_line_metrics_for_apply(line.metrics(), resolved),
-      baseline_shift: resolved.baseline_shift,
       parent_x_height: effective_parent_x_height_for_line(&line, parent_font_metrics),
       parent_text_metrics: effective_parent_text_metrics_for_line(&line, parent_font_metrics),
     })
@@ -376,8 +373,6 @@ pub struct VisualInlineBox {
   /// Baseline of the in-flow line that owns this box, relative to the inline formatting context's
   /// content-box top edge.
   pub line_baseline: Option<f32>,
-  pub(crate) layout_x: f32,
-  pub(crate) layout_advance: f32,
 }
 
 /// Resolve a positioned inline box into its painted geometry.
@@ -399,8 +394,6 @@ pub(crate) fn resolve_visual_inline_box(
         width: inline_box.width,
         height: 0.0,
         line_baseline: line_state.map(|state| state.adjusted_metrics.baseline),
-        layout_x: inline_box.x,
-        layout_advance: inline_box.width,
       });
     }
     _ => return None,
@@ -420,7 +413,5 @@ pub(crate) fn resolve_visual_inline_box(
     width: item.paint_width,
     height: item.paint_height,
     line_baseline,
-    layout_x: positioned.x,
-    layout_advance: positioned.width,
   })
 }

--- a/takumi-core/src/layout/inline/mod.rs
+++ b/takumi-core/src/layout/inline/mod.rs
@@ -14,10 +14,10 @@ use crate::{
   },
 };
 use parley::{
-  IndentOptions, InlineBox, InlineBoxKind, Line, PositionedInlineBox, PositionedLayoutItem,
-  TextStyle, TreeBuilder,
+  GlyphRun, IndentOptions, InlineBox, InlineBoxKind, Line, PositionedInlineBox,
+  PositionedLayoutItem, TextStyle, TreeBuilder,
 };
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, convert::Infallible, rc::Rc};
 use xxhash_rust::xxh3::Xxh3;
 
 mod background;
@@ -42,6 +42,14 @@ pub use self::{
     RunMetrics, ShapedRun,
   },
 };
+use self::{
+  breaking::distribute_trailing_whitespace,
+  items::inline_box_kind,
+  metrics::text_line_box_contribution,
+  runs::measured_run_text,
+  text_fit::{text_fit_is_applicable, text_fit_line_scales},
+  truncation::make_ellipsis_layout,
+};
 pub(crate) use self::{
   breaking::{break_lines, create_inline_constraint},
   items::InlineContentKind,
@@ -50,13 +58,6 @@ pub(crate) use self::{
     resolve_inline_line_metrics, resolve_inline_line_states, resolve_visual_inline_box,
   },
   text_fit::{LineScaleState, scale_text_fit_x, text_fit_line_alignment_correction},
-};
-use self::{
-  items::inline_box_kind,
-  metrics::text_line_box_contribution,
-  runs::measured_run_text,
-  text_fit::{text_fit_is_applicable, text_fit_line_scales},
-  truncation::make_ellipsis_layout,
 };
 
 /// Inputs for building an inline layout.
@@ -216,104 +217,77 @@ impl BuiltInlineLayout<'_> {
     &self,
     layout: ComputedLayout,
   ) -> (Vec<MeasuredInlineRun<'_>>, Vec<MeasuredInlineBox>) {
-    let line_vertical_metrics = self.line_metrics();
-    let line_states = self.line_states();
-
     let mut runs = Vec::new();
     let mut inline_boxes = Vec::new();
 
-    for (line_index, line) in self.layout.lines().enumerate() {
-      let Some(setup) = LineSetup::new(
-        &line,
-        layout,
-        &line_vertical_metrics,
-        &self.line_scales,
-        line_index,
-      ) else {
-        continue;
-      };
+    let Ok(()) = self.walk_items::<Infallible>(layout, |line, item| {
+      let setup = &line.setup;
       let line_scale_origin_y = setup.resolved_metrics.resolved_baseline;
-      let mut static_inline_prefix = 0.0_f32;
 
-      for item in line.items() {
-        match item {
-          PositionedLayoutItem::GlyphRun(glyph_run) => {
-            let span_id = glyph_run.style().brush.source_span_id;
-            let text = measured_run_text(&self.text, &self.spans, &glyph_run, span_id);
-            if text.is_empty()
-              || (glyph_run.style().brush.is_direction_mark && glyph_run.advance() == 0.0)
-            {
-              continue;
-            }
-
-            let metrics = glyph_run.run().metrics();
-            let mut x = glyph_run.offset();
-            let mut y = glyph_run.baseline() + setup.baseline_shift - metrics.ascent;
-            let mut width = glyph_run.advance();
-            let mut height = metrics.ascent + metrics.descent;
-            if (setup.state.scale - 1.0).abs() > f32::EPSILON {
-              x = scale_text_fit_x(
-                x,
-                setup.line_scale_origin_x,
-                setup.state.scale,
-                static_inline_prefix,
-                setup.state.alignment_correction,
-              );
-              y = line_scale_origin_y + (y - line_scale_origin_y) * setup.state.scale;
-              width *= setup.state.scale;
-              height *= setup.state.scale;
-            }
-
-            let link = span_id.and_then(|span_id| match self.spans.get(span_id as usize) {
-              Some(ProcessedInlineSpan::Text { link, .. }) => link.as_deref(),
-              _ => None,
-            });
-
-            runs.push(MeasuredInlineRun {
-              text,
-              x,
-              y,
-              width,
-              height,
-              link,
-            });
+      match item {
+        PlacedItem::Run {
+          glyph_run,
+          static_inline_prefix,
+          ..
+        } => {
+          let span_id = glyph_run.style().brush.source_span_id;
+          let text = measured_run_text(&self.text, &self.spans, &glyph_run, span_id);
+          if text.is_empty()
+            || (glyph_run.style().brush.is_direction_mark && glyph_run.advance() == 0.0)
+          {
+            return Ok(());
           }
-          PositionedLayoutItem::InlineBox(positioned_box) => {
-            if positioned_box.kind != InlineBoxKind::InFlow {
-              continue;
-            }
-            let Some(resolved) =
-              resolve_visual_inline_box(positioned_box, Some(line_states[line_index]), &self.spans)
-            else {
-              continue;
-            };
 
-            let x = scale_text_fit_x(
-              resolved.x,
+          let metrics = glyph_run.run().metrics();
+          let mut x = glyph_run.offset();
+          let mut y = glyph_run.baseline() + setup.baseline_shift - metrics.ascent;
+          let mut width = glyph_run.advance();
+          let mut height = metrics.ascent + metrics.descent;
+          if (setup.state.scale - 1.0).abs() > f32::EPSILON {
+            x = scale_text_fit_x(
+              x,
               setup.line_scale_origin_x,
               setup.state.scale,
               static_inline_prefix,
               setup.state.alignment_correction,
             );
-            static_inline_prefix += resolved.width;
-
-            // A padding spacer advances the line but is not a measured box.
-            if matches!(
-              self.spans.get(resolved.id as usize),
-              Some(ProcessedInlineSpan::Spacer { .. })
-            ) {
-              continue;
-            }
-            inline_boxes.push(MeasuredInlineBox {
-              x,
-              y: resolved.y,
-              width: resolved.width,
-              height: resolved.height,
-            });
+            y = line_scale_origin_y + (y - line_scale_origin_y) * setup.state.scale;
+            width *= setup.state.scale;
+            height *= setup.state.scale;
           }
+
+          let link = span_id.and_then(|span_id| match self.spans.get(span_id as usize) {
+            Some(ProcessedInlineSpan::Text { link, .. }) => link.as_deref(),
+            _ => None,
+          });
+
+          runs.push(MeasuredInlineRun {
+            text,
+            x,
+            y,
+            width,
+            height,
+            link,
+          });
+        }
+        PlacedItem::Box(inline_box) => {
+          // A padding spacer advances the line but is not a measured box.
+          if matches!(
+            self.spans.get(inline_box.id as usize),
+            Some(ProcessedInlineSpan::Spacer { .. })
+          ) {
+            return Ok(());
+          }
+          inline_boxes.push(MeasuredInlineBox {
+            x: inline_box.x,
+            y: inline_box.y,
+            width: inline_box.width,
+            height: inline_box.height,
+          });
         }
       }
-    }
+      Ok(())
+    });
 
     for positioned_box in &self.positioned_floats {
       inline_boxes.push(MeasuredInlineBox {
@@ -1030,6 +1004,96 @@ impl LineSetup {
       line_scale_origin_x,
       resolved_metrics,
     })
+  }
+}
+
+/// A line under an item walk: its index, setup, and resolved state.
+pub(crate) struct WalkedLine {
+  pub(crate) index: usize,
+  pub(crate) setup: LineSetup,
+  pub(crate) state: ResolvedInlineLineState,
+}
+
+/// One item placed on a walked line, with the static advance of the boxes before it.
+pub(crate) enum PlacedItem<'a> {
+  Run {
+    glyph_run: GlyphRun<'a, InlineBrush>,
+    static_inline_prefix: f32,
+    /// The line-end whitespace advance this run carries.
+    trailing_whitespace: f32,
+  },
+  /// An in-flow box, its `x` already scaled for text-fit.
+  Box(VisualInlineBox),
+}
+
+impl BuiltInlineLayout<'_> {
+  /// Visits every glyph run and in-flow box line by line, resolving the line
+  /// state and text-fit prefix each visitor would otherwise track itself.
+  pub(crate) fn walk_items<E>(
+    &self,
+    layout: ComputedLayout,
+    mut visit: impl FnMut(&WalkedLine, PlacedItem<'_>) -> Result<(), E>,
+  ) -> Result<(), E> {
+    let line_vertical_metrics = self.line_metrics();
+    let line_states = self.line_states();
+
+    for (index, line) in self.layout.lines().enumerate() {
+      let Some(setup) = LineSetup::new(
+        &line,
+        layout,
+        &line_vertical_metrics,
+        &self.line_scales,
+        index,
+      ) else {
+        continue;
+      };
+      let walked = WalkedLine {
+        index,
+        setup,
+        state: line_states[index],
+      };
+      let items: Vec<_> = line.items().collect();
+      let trailing_whitespace = distribute_trailing_whitespace(&items, &line);
+      let mut static_inline_prefix = 0.0_f32;
+
+      for (item_index, item) in items.into_iter().enumerate() {
+        match item {
+          PositionedLayoutItem::GlyphRun(glyph_run) => visit(
+            &walked,
+            PlacedItem::Run {
+              glyph_run,
+              static_inline_prefix,
+              trailing_whitespace: trailing_whitespace[item_index],
+            },
+          )?,
+          PositionedLayoutItem::InlineBox(inline_box) => {
+            if inline_box.kind != InlineBoxKind::InFlow {
+              continue;
+            }
+            let Some(resolved) =
+              resolve_visual_inline_box(inline_box, Some(walked.state), &self.spans)
+            else {
+              continue;
+            };
+            let inline_box = VisualInlineBox {
+              x: scale_text_fit_x(
+                resolved.x,
+                walked.setup.line_scale_origin_x,
+                walked.setup.state.scale,
+                static_inline_prefix,
+                walked.setup.state.alignment_correction,
+              ),
+              ..resolved
+            };
+
+            visit(&walked, PlacedItem::Box(inline_box))?;
+            static_inline_prefix += resolved.width;
+          }
+        }
+      }
+    }
+
+    Ok(())
   }
 }
 

--- a/takumi-core/src/layout/inline/runs.rs
+++ b/takumi-core/src/layout/inline/runs.rs
@@ -9,18 +9,17 @@ use crate::{
   },
   style::{Affine, Color, TextUnderlinePosition},
 };
-use parley::{GlyphRun, InlineBoxKind, PositionedLayoutItem};
+use parley::GlyphRun;
 use skrifa::{FontRef, MetadataProvider, raw::TableProvider};
 use std::{collections::HashMap, ops::Range, sync::Arc};
 
 use super::{
-  BuiltInlineLayout, InlineBrush, LineSetup,
+  BuiltInlineLayout, InlineBrush, PlacedItem,
   background::{CoverExtent, DecorationAccumulator, InlineBackgroundFragment},
-  breaking::distribute_trailing_whitespace,
   items::ProcessedInlineSpan,
   metrics::{VisualInlineBox, resolve_visual_inline_box},
   outline::{InlineOutlineRect, scale_outline_rect},
-  text_fit::{LineScaleState, scale_text_fit_x},
+  text_fit::LineScaleState,
 };
 
 /// A shaped glyph positioned within its run, in run-local coordinates.
@@ -283,15 +282,10 @@ impl BuiltInlineLayout<'_> {
     layout: ComputedLayout,
   ) -> Result<InlineRunLayout, FontError> {
     let BuiltInlineLayout {
-      layout: inline_layout,
       spans,
       positioned_floats,
-      line_scales,
       ..
     } = self;
-    let line_vertical_metrics = self.line_metrics();
-    let line_states = self.line_states();
-
     let need_outline = spans.iter().any(|span| match span {
       ProcessedInlineSpan::Text { style, .. } => {
         style.outline_width > 0.0 && style.outline_style.is_rendered()
@@ -306,202 +300,175 @@ impl BuiltInlineLayout<'_> {
     let mut decoration_coverage = DecorationAccumulator::default();
     let mut positioned_inline_boxes: HashMap<u64, VisualInlineBox> = HashMap::new();
 
-    for (line_index, line) in inline_layout.lines().enumerate() {
-      let Some(setup) = LineSetup::new(
-        &line,
-        layout,
-        &line_vertical_metrics,
-        line_scales,
-        line_index,
-      ) else {
-        continue;
-      };
-      let mut static_inline_prefix = 0.0_f32;
+    self.walk_items(layout, |line, item| {
+      let setup = &line.setup;
+      let line_index = line.index;
 
-      let items: Vec<_> = line.items().collect();
-      let run_trailing_whitespace = distribute_trailing_whitespace(&items, &line);
-
-      for (item_index, item) in items.into_iter().enumerate() {
-        match item {
-          PositionedLayoutItem::GlyphRun(glyph_run) => {
-            let run = glyph_run.run();
-            // A run carrying only the direction mark paints nothing; a run the
-            // mark's cluster merged into (emoji sequences) paints as the first
-            // real span.
-            let mut brush = glyph_run.style().brush;
-            if brush.is_direction_mark {
-              if glyph_run.advance() == 0.0 {
-                continue;
-              }
-              brush.is_direction_mark = false;
+      match item {
+        PlacedItem::Run {
+          glyph_run,
+          static_inline_prefix,
+          trailing_whitespace,
+        } => {
+          let run = glyph_run.run();
+          // A run carrying only the direction mark paints nothing; a run the
+          // mark's cluster merged into (emoji sequences) paints as the first
+          // real span.
+          let mut brush = glyph_run.style().brush;
+          if brush.is_direction_mark {
+            if glyph_run.advance() == 0.0 {
+              return Ok(());
             }
+            brush.is_direction_mark = false;
+          }
 
-            let font = FontRef::from_index(run.font().data.as_ref(), run.font().index)
-              .map_err(|_| FontError::InvalidFontIndex)?;
-            let glyph_ids = glyph_run.positioned_glyphs().map(|glyph| glyph.id);
-            let resolved_glyphs = context
-              .fonts()
-              .with_context(|fonts| fonts.resolve_glyphs(&glyph_run, font, glyph_ids));
+          let font = FontRef::from_index(run.font().data.as_ref(), run.font().index)
+            .map_err(|_| FontError::InvalidFontIndex)?;
+          let glyph_ids = glyph_run.positioned_glyphs().map(|glyph| glyph.id);
+          let resolved_glyphs = context
+            .fonts()
+            .with_context(|fonts| fonts.resolve_glyphs(&glyph_run, font, glyph_ids));
 
-            if need_outline && let Some(span_id) = brush.source_span_id {
-              outline_rects.push(scale_outline_rect(
-                InlineOutlineRect {
-                  span_id,
-                  line_index,
-                  x: layout.border.left + layout.padding.left + glyph_run.offset(),
-                  y: layout.border.top
-                    + layout.padding.top
-                    + glyph_run.baseline()
-                    + setup.baseline_shift
-                    - setup.resolved_metrics.resolved_ascent,
-                  width: glyph_run.advance(),
-                  height: setup.resolved_metrics.resolved_line_height,
-                },
-                setup.state,
-                static_inline_prefix,
-              ));
-            }
-
-            let metrics = run.metrics();
-
-            if let Some(span_id) = brush.source_span_id
-              && let Some(ProcessedInlineSpan::Text {
-                decorations: Some(chain),
-                ..
-              }) = spans.get(span_id as usize)
-            {
-              // The run's leaded box, like Blink's inline box fragment
-              // (`InlineBoxState::ComputeTextMetrics` adds the line-height
-              // leading to the font height).
-              let (above, below) =
-                brush.line_box_contribution(metrics.line_height, metrics.ascent, metrics.descent);
-              let rect = scale_outline_rect(
-                InlineOutlineRect {
-                  span_id,
-                  line_index,
-                  x: layout.border.left + layout.padding.left + glyph_run.offset(),
-                  y: layout.border.top
-                    + layout.padding.top
-                    + glyph_run.baseline()
-                    + setup.baseline_shift
-                    - above,
-                  width: glyph_run.advance(),
-                  height: above + below,
-                },
-                setup.state,
-                static_inline_prefix,
-              );
-
-              decoration_coverage.cover(
-                Some(chain),
+          if need_outline && let Some(span_id) = brush.source_span_id {
+            outline_rects.push(scale_outline_rect(
+              InlineOutlineRect {
+                span_id,
                 line_index,
-                rect.x,
-                rect.x + rect.width,
-                &CoverExtent::Run {
-                  font_size: run.font_size(),
-                  top: rect.y,
-                  bottom: rect.y + rect.height,
-                  baseline: rect.y + above * setup.state.scale,
-                },
-              );
-            }
-            let glyphs: Vec<PositionedGlyph> = glyph_run
-              .positioned_glyphs()
-              .map(|g| PositionedGlyph {
-                id: g.id,
-                x: g.x,
-                y: g.y,
-              })
-              .collect();
-            let cluster_ranges = glyph_cluster_ranges(&glyph_run, &glyphs);
-            let synthesis = run_synthesis(&glyph_run);
-            let shaped = ShapedRun {
-              glyphs,
-              offset: glyph_run.offset(),
-              baseline: glyph_run.baseline(),
-              advance: glyph_run.advance(),
-              trailing_whitespace: run_trailing_whitespace[item_index],
-              brush,
-              metrics: RunMetrics {
-                ascent: metrics.ascent,
-                descent: metrics.descent,
-                underline_offset: metrics.underline_offset,
-                underline_size: metrics.underline_size,
-                strikethrough_offset: metrics.strikethrough_offset,
-                strikethrough_size: metrics.strikethrough_size,
+                x: layout.border.left + layout.padding.left + glyph_run.offset(),
+                y: layout.border.top
+                  + layout.padding.top
+                  + glyph_run.baseline()
+                  + setup.baseline_shift
+                  - setup.resolved_metrics.resolved_ascent,
+                width: glyph_run.advance(),
+                height: setup.resolved_metrics.resolved_line_height,
               },
-              font_size: run.font_size(),
-              font_index: run.font().index,
-              text_range: run.text_range(),
-              cluster_ranges,
-              variations: run_variations(&glyph_run),
-              synthetic_bold: synthesis.embolden,
-              synthetic_skew: synthesis.skew,
-              font_data: run.font().data.clone(),
-            };
-
-            runs.push(PositionedInlineRun {
-              glyph_run: shaped,
-              resolved_glyphs,
-              line_scale: setup.state,
+              setup.state,
               static_inline_prefix,
-              baseline_shift: setup.baseline_shift,
-            });
+            ));
           }
-          PositionedLayoutItem::InlineBox(inline_box) => {
-            if inline_box.kind != InlineBoxKind::InFlow {
-              continue;
-            }
-            let Some(inline_box) =
-              resolve_visual_inline_box(inline_box, Some(line_states[line_index]), spans)
-            else {
-              continue;
-            };
-            let inline_box = VisualInlineBox {
-              x: scale_text_fit_x(
-                inline_box.layout_x,
-                setup.line_scale_origin_x,
-                setup.state.scale,
-                static_inline_prefix,
-                setup.state.alignment_correction,
-              ),
-              ..inline_box
-            };
-            // A spacer or atomic box inside a decorated span stretches the
-            // span's fragment horizontally; runs set its height, like Blink's
-            // box metrics ignoring atomic descendants. The line extent is the
-            // last resort so padding-only coverage still paints.
-            let chain = match spans.get(inline_box.id as usize) {
-              Some(ProcessedInlineSpan::Box(item)) => item.decorations.as_ref(),
-              Some(ProcessedInlineSpan::Spacer { decorations, .. }) => decorations.as_ref(),
-              _ => None,
-            };
 
-            if chain.is_some() {
-              let x0 = layout.border.left + layout.padding.left + inline_box.x;
-              let origin_y = setup.state.layout_origin.y;
-              let content_top = layout.border.top + layout.padding.top;
-              let line_y =
-                |value: f32| origin_y + (content_top + value - origin_y) * setup.state.scale;
+          let metrics = run.metrics();
 
-              decoration_coverage.cover(
-                chain,
+          if let Some(span_id) = brush.source_span_id
+            && let Some(ProcessedInlineSpan::Text {
+              decorations: Some(chain),
+              ..
+            }) = spans.get(span_id as usize)
+          {
+            // The run's leaded box, like Blink's inline box fragment
+            // (`InlineBoxState::ComputeTextMetrics` adds the line-height
+            // leading to the font height).
+            let (above, below) =
+              brush.line_box_contribution(metrics.line_height, metrics.ascent, metrics.descent);
+            let rect = scale_outline_rect(
+              InlineOutlineRect {
+                span_id,
                 line_index,
-                x0,
-                x0 + inline_box.width,
-                &CoverExtent::Line {
-                  top: line_y(setup.resolved_metrics.resolved_line_top),
-                  bottom: line_y(setup.resolved_metrics.resolved_line_bottom),
-                  baseline: line_y(setup.resolved_metrics.resolved_baseline),
-                },
-              );
-            }
-            positioned_inline_boxes.insert(inline_box.id, inline_box);
-            static_inline_prefix += inline_box.layout_advance;
+                x: layout.border.left + layout.padding.left + glyph_run.offset(),
+                y: layout.border.top
+                  + layout.padding.top
+                  + glyph_run.baseline()
+                  + setup.baseline_shift
+                  - above,
+                width: glyph_run.advance(),
+                height: above + below,
+              },
+              setup.state,
+              static_inline_prefix,
+            );
+
+            decoration_coverage.cover(
+              Some(chain),
+              line_index,
+              rect.x,
+              rect.x + rect.width,
+              &CoverExtent::Run {
+                font_size: run.font_size(),
+                top: rect.y,
+                bottom: rect.y + rect.height,
+                baseline: rect.y + above * setup.state.scale,
+              },
+            );
           }
+          let glyphs: Vec<PositionedGlyph> = glyph_run
+            .positioned_glyphs()
+            .map(|g| PositionedGlyph {
+              id: g.id,
+              x: g.x,
+              y: g.y,
+            })
+            .collect();
+          let cluster_ranges = glyph_cluster_ranges(&glyph_run, &glyphs);
+          let synthesis = run_synthesis(&glyph_run);
+          let shaped = ShapedRun {
+            glyphs,
+            offset: glyph_run.offset(),
+            baseline: glyph_run.baseline(),
+            advance: glyph_run.advance(),
+            trailing_whitespace,
+            brush,
+            metrics: RunMetrics {
+              ascent: metrics.ascent,
+              descent: metrics.descent,
+              underline_offset: metrics.underline_offset,
+              underline_size: metrics.underline_size,
+              strikethrough_offset: metrics.strikethrough_offset,
+              strikethrough_size: metrics.strikethrough_size,
+            },
+            font_size: run.font_size(),
+            font_index: run.font().index,
+            text_range: run.text_range(),
+            cluster_ranges,
+            variations: run_variations(&glyph_run),
+            synthetic_bold: synthesis.embolden,
+            synthetic_skew: synthesis.skew,
+            font_data: run.font().data.clone(),
+          };
+
+          runs.push(PositionedInlineRun {
+            glyph_run: shaped,
+            resolved_glyphs,
+            line_scale: setup.state,
+            static_inline_prefix,
+            baseline_shift: setup.baseline_shift,
+          });
+        }
+        PlacedItem::Box(inline_box) => {
+          // A spacer or atomic box inside a decorated span stretches the
+          // span's fragment horizontally; runs set its height, like Blink's
+          // box metrics ignoring atomic descendants. The line extent is the
+          // last resort so padding-only coverage still paints.
+          let chain = match spans.get(inline_box.id as usize) {
+            Some(ProcessedInlineSpan::Box(item)) => item.decorations.as_ref(),
+            Some(ProcessedInlineSpan::Spacer { decorations, .. }) => decorations.as_ref(),
+            _ => None,
+          };
+
+          if chain.is_some() {
+            let x0 = layout.border.left + layout.padding.left + inline_box.x;
+            let origin_y = setup.state.layout_origin.y;
+            let content_top = layout.border.top + layout.padding.top;
+            let line_y =
+              |value: f32| origin_y + (content_top + value - origin_y) * setup.state.scale;
+
+            decoration_coverage.cover(
+              chain,
+              line_index,
+              x0,
+              x0 + inline_box.width,
+              &CoverExtent::Line {
+                top: line_y(setup.resolved_metrics.resolved_line_top),
+                bottom: line_y(setup.resolved_metrics.resolved_line_bottom),
+                baseline: line_y(setup.resolved_metrics.resolved_baseline),
+              },
+            );
+          }
+          positioned_inline_boxes.insert(inline_box.id, inline_box);
         }
       }
-    }
+      Ok(())
+    })?;
 
     for inline_box in positioned_floats {
       let Some(inline_box) = resolve_visual_inline_box(inline_box.clone(), None, spans) else {

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -2,9 +2,8 @@
 //! bounds. Raster and SVG backends consume this instead of each walking the node tree
 //! independently.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible};
 
-use parley::{InlineBoxKind, PositionedLayoutItem};
 use skrifa::FontRef;
 
 use crate::{
@@ -13,9 +12,8 @@ use crate::{
   geometry::{AvailableSpace, ComputedLayout, NodeId, Point, Size, transformed_rect_extents},
   layout::{
     inline::{
-      InlineContentKind, InlineLayoutMode, InlineLayoutRequest, ProcessedInlineSpan,
-      collect_inline_items, create_inline_layout, resolve_inline_max_height,
-      resolve_visual_inline_box, scale_text_fit_x, text_fit_line_alignment_correction,
+      InlineContentKind, InlineLayoutMode, InlineLayoutRequest, PlacedItem, ProcessedInlineSpan,
+      collect_inline_items, create_inline_layout, resolve_inline_max_height, scale_text_fit_x,
     },
     node::Node,
     tree::{LayoutResults, RenderNode},
@@ -428,137 +426,114 @@ fn compute_node_paint_bounds(
     layout.border.left + layout.padding.left,
     layout.border.top + layout.padding.top,
   ) * transform;
-  let line_vertical_metrics = built.line_metrics();
-  let line_states = built.line_states();
-  for (line_index, line) in built.layout.lines().enumerate() {
-    let baseline_shift = line_states[line_index].baseline_shift;
-    let resolved_metrics = line_vertical_metrics[line_index];
-    let line_scale = built.line_scales.get(line_index).copied().unwrap_or(1.0);
-    let (line_scale_origin_x, line_alignment_correction) =
-      text_fit_line_alignment_correction(&line, line_scale, layout.content_box_size().width);
-    let line_scale_origin = Point {
-      x: line_scale_origin_x,
-      y: resolved_metrics.resolved_baseline,
+  let Ok(()) = built.walk_items::<Infallible>(layout, |line, item| {
+    let setup = &line.setup;
+    let line_scale = setup.state.scale;
+    let scaled = |origin: Point<f32>, size: Size<f32>, static_inline_prefix: f32| {
+      if (line_scale - 1.0).abs() <= f32::EPSILON {
+        return (origin, size);
+      }
+      let baseline = setup.resolved_metrics.resolved_baseline;
+
+      (
+        Point {
+          x: scale_text_fit_x(
+            origin.x,
+            setup.line_scale_origin_x,
+            line_scale,
+            static_inline_prefix,
+            setup.state.alignment_correction,
+          ),
+          y: baseline + (origin.y - baseline) * line_scale,
+        },
+        Size {
+          width: size.width * line_scale,
+          height: size.height * line_scale,
+        },
+      )
     };
-    let mut static_inline_prefix = 0.0_f32;
-    for item in line.items() {
-      match item {
-        PositionedLayoutItem::GlyphRun(glyph_run) => {
-          let metrics = glyph_run.run().metrics();
-          let mut glyph_origin = Point {
+
+    match item {
+      PlacedItem::Run {
+        glyph_run,
+        static_inline_prefix,
+        ..
+      } => {
+        let metrics = glyph_run.run().metrics();
+        let (glyph_origin, glyph_size) = scaled(
+          Point {
             x: glyph_run.offset(),
-            y: glyph_run.baseline() + baseline_shift - metrics.ascent,
-          };
-          let mut glyph_size = Size {
+            y: glyph_run.baseline() + setup.baseline_shift - metrics.ascent,
+          },
+          Size {
             width: glyph_run.advance(),
             height: metrics.ascent + metrics.descent,
-          };
-          if (line_scale - 1.0).abs() > f32::EPSILON {
-            glyph_origin = Point {
-              x: scale_text_fit_x(
-                glyph_origin.x,
-                line_scale_origin.x,
-                line_scale,
-                static_inline_prefix,
-                line_alignment_correction,
-              ),
-              y: line_scale_origin.y + (glyph_origin.y - line_scale_origin.y) * line_scale,
-            };
-            glyph_size.width *= line_scale;
-            glyph_size.height *= line_scale;
-          }
-          let glyph_transform =
-            Affine::translation(glyph_origin.x, glyph_origin.y) * inline_transform;
-          bounds = merge_bounds(bounds, bounds_for_rect(glyph_size, glyph_transform));
+          },
+          static_inline_prefix,
+        );
+        let glyph_transform =
+          Affine::translation(glyph_origin.x, glyph_origin.y) * inline_transform;
+        bounds = merge_bounds(bounds, bounds_for_rect(glyph_size, glyph_transform));
 
-          // The metrics box above misses ink outside advance × (ascent+descent):
-          // synthetic-italic skew, faux-bold outset, negative bearings, and
-          // glyphs taller than the font's metrics. Merge per-glyph ink extents
-          // so isolation surfaces sized from these bounds never clip text.
-          let Ok(font) = FontRef::from_index(
-            glyph_run.run().font().data.as_ref(),
-            glyph_run.run().font().index,
-          ) else {
-            continue;
-          };
-          let glyph_ids = glyph_run.positioned_glyphs().map(|glyph| glyph.id);
-          let resolved_glyphs = node
-            .context
-            .fonts()
-            .with_context(|fonts| fonts.resolve_glyphs(&glyph_run, font, glyph_ids));
+        // The metrics box above misses ink outside advance × (ascent+descent):
+        // synthetic-italic skew, faux-bold outset, negative bearings, and
+        // glyphs taller than the font's metrics. Merge per-glyph ink extents
+        // so isolation surfaces sized from these bounds never clip text.
+        let Ok(font) = FontRef::from_index(
+          glyph_run.run().font().data.as_ref(),
+          glyph_run.run().font().index,
+        ) else {
+          return Ok(());
+        };
+        let glyph_ids = glyph_run.positioned_glyphs().map(|glyph| glyph.id);
+        let resolved_glyphs = node
+          .context
+          .fonts()
+          .with_context(|fonts| fonts.resolve_glyphs(&glyph_run, font, glyph_ids));
 
-          for glyph in glyph_run.positioned_glyphs() {
-            let Some((min_x, min_y, max_x, max_y)) = resolved_glyphs
-              .get(&glyph.id)
-              .and_then(|glyph| glyph.ink_extents())
-            else {
-              continue;
-            };
-
-            let mut ink_origin = Point {
-              x: glyph.x + min_x,
-              y: glyph.y + baseline_shift + min_y,
-            };
-            let mut ink_size = Size {
-              width: max_x - min_x,
-              height: max_y - min_y,
-            };
-            if (line_scale - 1.0).abs() > f32::EPSILON {
-              ink_origin = Point {
-                x: scale_text_fit_x(
-                  ink_origin.x,
-                  line_scale_origin.x,
-                  line_scale,
-                  static_inline_prefix,
-                  line_alignment_correction,
-                ),
-                y: line_scale_origin.y + (ink_origin.y - line_scale_origin.y) * line_scale,
-              };
-              ink_size.width *= line_scale;
-              ink_size.height *= line_scale;
-            }
-
-            bounds = merge_bounds(
-              bounds,
-              bounds_for_rect(
-                ink_size,
-                Affine::translation(ink_origin.x, ink_origin.y) * inline_transform,
-              ),
-            );
-          }
-        }
-        PositionedLayoutItem::InlineBox(inline_box) => {
-          if inline_box.kind != InlineBoxKind::InFlow {
-            continue;
-          }
-          let Some(inline_box) =
-            resolve_visual_inline_box(inline_box, Some(line_states[line_index]), &built.spans)
+        for glyph in glyph_run.positioned_glyphs() {
+          let Some((min_x, min_y, max_x, max_y)) = resolved_glyphs
+            .get(&glyph.id)
+            .and_then(|glyph| glyph.ink_extents())
           else {
             continue;
           };
-          let inline_box_x = scale_text_fit_x(
-            inline_box.x,
-            line_scale_origin_x,
-            line_scale,
+          let (ink_origin, ink_size) = scaled(
+            Point {
+              x: glyph.x + min_x,
+              y: glyph.y + setup.baseline_shift + min_y,
+            },
+            Size {
+              width: max_x - min_x,
+              height: max_y - min_y,
+            },
             static_inline_prefix,
-            line_alignment_correction,
           );
-          static_inline_prefix += inline_box.width;
 
           bounds = merge_bounds(
             bounds,
             bounds_for_rect(
-              Size {
-                width: inline_box.width,
-                height: inline_box.height,
-              },
-              Affine::translation(inline_box_x, inline_box.y) * inline_transform,
+              ink_size,
+              Affine::translation(ink_origin.x, ink_origin.y) * inline_transform,
             ),
           );
         }
       }
+      PlacedItem::Box(inline_box) => {
+        bounds = merge_bounds(
+          bounds,
+          bounds_for_rect(
+            Size {
+              width: inline_box.width,
+              height: inline_box.height,
+            },
+            Affine::translation(inline_box.x, inline_box.y) * inline_transform,
+          ),
+        );
+      }
     }
-  }
+    Ok(())
+  });
 
   for inline_box in built.positioned_floats {
     bounds = merge_bounds(


### PR DESCRIPTION
## Why
The per-line item walk, with its line setup, in-flow box resolution, and text-fit prefix accounting, was written out three times: once to paint, once to measure, and once to compute paint bounds.

## What
`BuiltInlineLayout::walk_items` visits every run and in-flow box with its line state and prefix resolved, and the three callers keep only what they do with each item. `VisualInlineBox` drops its duplicate `layout_x`/`layout_advance` and the line state its duplicate `baseline_shift`. Pure refactor, goldens byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in inline layout processing across text runs, inline boxes, and paint-bound calculations.
  * Updated text and inline-box positioning and measurement to use unified layout results.
  * Removed internal layout state no longer required for inline rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->