### PR TITLE
Core: resolve hoisted children through ContainingBlocks

### DIFF
--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -27,10 +27,10 @@ use crate::{
   },
   matching::{MatchedDeclarationsView, NodeMatchedDeclarations, match_stylesheets_view},
   style::{
-    BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle, ContentItem,
-    ContentValue, Display, Filters, Float, Isolation, Length, LineHeight, ListStylePosition,
-    PercentageNumber, Position, SizingContext, Style as NodeStyle, StyleDeclaration,
-    StyleDeclarationBlock, StyleSheet, TextWrapMode, WhiteSpaceCollapse,
+    Affine, BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle,
+    ContentItem, ContentValue, Display, Filters, Float, Isolation, Length, LineHeight,
+    ListStylePosition, PercentageNumber, Position, SizingContext, Style as NodeStyle,
+    StyleDeclaration, StyleDeclarationBlock, StyleSheet, TextWrapMode, WhiteSpaceCollapse,
     apply_stylesheet_animations,
   },
   viewport::Viewport,
@@ -45,6 +45,52 @@ pub struct OrderedChild {
   pub node_id: NodeId,
   /// Containing block the child was hoisted to, if out-of-flow.
   pub hoisted_cb: Option<NodeId>,
+}
+
+/// Each visited node's device transform and content box, kept so a hoisted
+/// out-of-flow child resolves against its containing block instead of its
+/// box-tree parent.
+#[derive(Default)]
+pub struct ContainingBlocks {
+  transforms: HashMap<NodeId, Affine>,
+  content_boxes: HashMap<NodeId, Size<Option<f32>>>,
+}
+
+impl ContainingBlocks {
+  /// Records the device transform a node was placed with.
+  pub fn record_transform(&mut self, node_id: NodeId, transform: Affine) {
+    self.transforms.insert(node_id, transform);
+  }
+
+  /// Records the content box a node lays its children out in.
+  pub fn record_content_box(&mut self, node_id: NodeId, content_box: Size<Option<f32>>) {
+    self.content_boxes.insert(node_id, content_box);
+  }
+
+  /// The transform and container size `child` resolves against: its containing
+  /// block's when hoisted, otherwise the parent's.
+  pub fn base_for(
+    &self,
+    child: &OrderedChild,
+    parent_transform: Affine,
+    parent_content_box: Size<Option<f32>>,
+  ) -> (Affine, Size<Option<f32>>) {
+    match child.hoisted_cb {
+      Some(cb) => (
+        self
+          .transforms
+          .get(&cb)
+          .copied()
+          .unwrap_or(parent_transform),
+        self
+          .content_boxes
+          .get(&cb)
+          .copied()
+          .unwrap_or(parent_content_box),
+      ),
+      None => (parent_transform, parent_content_box),
+    }
+  }
 }
 
 /// Immutable per-node layout output after computing a tree.

--- a/takumi-core/src/scene.rs
+++ b/takumi-core/src/scene.rs
@@ -2,7 +2,7 @@
 //! bounds. Raster and SVG backends consume this instead of each walking the node tree
 //! independently.
 
-use std::{collections::HashMap, convert::Infallible};
+use std::convert::Infallible;
 
 use skrifa::FontRef;
 
@@ -16,7 +16,7 @@ use crate::{
       collect_inline_items, create_inline_layout, resolve_inline_max_height, scale_text_fit_x,
     },
     node::Node,
-    tree::{LayoutResults, RenderNode},
+    tree::{ContainingBlocks, LayoutResults, RenderNode},
   },
   style::{Affine, ComputedStyle, Display, SizingContext},
 };
@@ -30,8 +30,8 @@ pub struct NodePaint {
   pub node_id: NodeId,
   /// Accumulated transform applied when painting.
   pub transform: Affine,
-  /// Containing-block size as `(width, height)`; `None` on an axis is indefinite.
-  pub container_size: (Option<f32>, Option<f32>),
+  /// Containing-block size; `None` on an axis is indefinite.
+  pub container_size: Size<Option<f32>>,
   /// Device-space bounds of the paint output, if any.
   pub paint_bounds: Option<SceneBounds>,
 }
@@ -171,7 +171,7 @@ struct StackingContextBuildVisit {
   path: Vec<usize>,
   node_id: NodeId,
   transform: Affine,
-  container_size: (Option<f32>, Option<f32>),
+  container_size: Size<Option<f32>>,
   context_id: usize,
   parent_display: Option<Display>,
   is_root: bool,
@@ -204,15 +204,11 @@ pub fn build_stacking_contexts(
   layout_results: &LayoutResults,
   node_id: NodeId,
   transform: Affine,
-  container_size: (Option<f32>, Option<f32>),
+  container_size: Size<Option<f32>>,
 ) -> Result<Vec<StackingContextNode>> {
   let mut contexts = vec![StackingContextNode::with_root(None)];
   let mut source_order = 0usize;
-  // Hoisted out-of-flow nodes resolve geometry against their containing block,
-  // not their box-tree parent. Memoize each node's transform and content box so
-  // a hoisted child can use its CB's values as its base.
-  let mut node_transforms: HashMap<NodeId, Affine> = HashMap::new();
-  let mut node_content_box: HashMap<NodeId, (Option<f32>, Option<f32>)> = HashMap::new();
+  let mut containing_blocks = ContainingBlocks::default();
   let mut visits = vec![StackingContextBuildVisit {
     path: Vec::new(),
     node_id,
@@ -242,7 +238,7 @@ pub fn build_stacking_contexts(
     if !current_transform.is_invertible() {
       continue;
     }
-    node_transforms.insert(visit.node_id, current_transform);
+    containing_blocks.record_transform(visit.node_id, current_transform);
 
     let node_paint = NodePaint {
       path: visit.path.clone(),
@@ -309,22 +305,17 @@ pub fn build_stacking_contexts(
     }
 
     let layout_children = layout_results.box_children(visit.node_id)?;
-    let child_container_size = (
-      Some(layout.content_box_width()),
-      Some(layout.content_box_height()),
-    );
-    node_content_box.insert(visit.node_id, child_container_size);
+    let child_container_size = Size {
+      width: Some(layout.content_box_width()),
+      height: Some(layout.content_box_height()),
+    };
+    containing_blocks.record_content_box(visit.node_id, child_container_size);
 
     for child in layout_children.iter().rev() {
       let mut child_path = visit.path.clone();
       child_path.push(child.render_index);
-      let (base_transform, base_container) = match child.hoisted_cb {
-        Some(cb) => (
-          *node_transforms.get(&cb).unwrap_or(&current_transform),
-          *node_content_box.get(&cb).unwrap_or(&child_container_size),
-        ),
-        None => (current_transform, child_container_size),
-      };
+      let (base_transform, base_container) =
+        containing_blocks.base_for(child, current_transform, child_container_size);
       visits.push(StackingContextBuildVisit {
         path: child_path,
         node_id: child.node_id,

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -1549,7 +1549,7 @@ impl Emitter<'_> {
       &subtree.results,
       NodeId::ROOT,
       Affine::IDENTITY,
-      (Some(subtree.size.width), Some(subtree.size.height)),
+      subtree.size.map(Some),
     ) else {
       return;
     };

--- a/takumi-pdf/src/tree.rs
+++ b/takumi-pdf/src/tree.rs
@@ -154,7 +154,10 @@ impl PreparedTree {
       &results,
       NodeId::ROOT,
       Affine::IDENTITY,
-      (Some(width), Some(height)),
+      Size {
+        width: Some(width),
+        height: Some(height),
+      },
     )?;
 
     Ok(Self {

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -17,7 +17,7 @@ use crate::{
       InlineItem, InlineLayoutMode, InlineLayoutRequest, collect_inline_items, create_inline_layout,
     },
     node::Node,
-    tree::{LayoutResults, LayoutTree, RenderNode},
+    tree::{ContainingBlocks, LayoutResults, LayoutTree, RenderNode},
   },
   resources::{font::FontsSnapshot, image::ImageSource},
   stacking_context::paint_context,
@@ -210,10 +210,7 @@ fn collect_measure_result(
     container_size,
   })];
   let mut measured_by_node_id: HashMap<usize, MeasuredNode> = HashMap::new();
-  // Hoisted out-of-flow nodes resolve geometry against their containing block.
-  // Memoize each node's transform and content box for hoisted children to base on.
-  let mut node_transforms: HashMap<NodeId, Affine> = HashMap::new();
-  let mut node_content_box: HashMap<NodeId, Size<Option<f32>>> = HashMap::new();
+  let mut containing_blocks = ContainingBlocks::default();
 
   while let Some(visit) = visits.pop() {
     match visit {
@@ -239,7 +236,7 @@ fn collect_measure_result(
           layout.size.height,
           &current.context.sizing,
         );
-        node_transforms.insert(node_id, local_transform);
+        containing_blocks.record_transform(node_id, local_transform);
 
         let mut children = Vec::new();
         let mut runs = Vec::new();
@@ -341,7 +338,7 @@ fn collect_measure_result(
           width: Some(layout.content_box_width()),
           height: Some(layout.content_box_height()),
         };
-        node_content_box.insert(node_id, child_container_size);
+        containing_blocks.record_content_box(node_id, child_container_size);
 
         visits.push(TraversalVisit::Exit(MeasureExit {
           node_id,
@@ -355,13 +352,8 @@ fn collect_measure_result(
         for child in layout_children.iter().rev() {
           let mut child_path = path.clone();
           child_path.push(child.render_index);
-          let (base_transform, base_container) = match child.hoisted_cb {
-            Some(cb) => (
-              *node_transforms.get(&cb).unwrap_or(&local_transform),
-              *node_content_box.get(&cb).unwrap_or(&child_container_size),
-            ),
-            None => (local_transform, child_container_size),
-          };
+          let (base_transform, base_container) =
+            containing_blocks.base_for(child, local_transform, child_container_size);
           visits.push(TraversalVisit::Enter(TraversalEnter {
             path: child_path,
             node_id: child.node_id,
@@ -692,13 +684,7 @@ pub(crate) fn render_node(
   transform: Affine,
   container_size: Size<Option<f32>>,
 ) -> Result<()> {
-  let contexts = build_stacking_contexts(
-    node,
-    layout_results,
-    node_id,
-    transform,
-    (container_size.width, container_size.height),
-  )?;
+  let contexts = build_stacking_contexts(node, layout_results, node_id, transform, container_size)?;
   paint_context(node, &contexts, layout_results, canvas, 0)
 }
 

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -319,10 +319,10 @@ fn begin_node_render(
     return Ok(Some(DeferredNodeRender::SkipRendering));
   }
 
-  current
-    .context
-    .sizing
-    .set_container_size(node_paint.container_size.0, node_paint.container_size.1);
+  current.context.sizing.set_container_size(
+    node_paint.container_size.width,
+    node_paint.container_size.height,
+  );
   current.context.transform = node_paint.transform;
 
   if !current.context.style.backdrop_filter.is_empty() {

--- a/takumi-svg/src/render.rs
+++ b/takumi-svg/src/render.rs
@@ -109,7 +109,10 @@ pub fn render(options: SvgOptions<'_>) -> Result<String> {
     &results,
     root_id,
     IDENTITY,
-    (Some(width), Some(height)),
+    Size {
+      width: Some(width),
+      height: Some(height),
+    },
   )?;
   emit_scene(&root, &contexts, &results, &mut doc)?;
 
@@ -707,7 +710,7 @@ pub(crate) fn emit_inline_box(
         &subtree.results,
         NodeId::ROOT,
         origin,
-        (Some(subtree.size.width), Some(subtree.size.height)),
+        subtree.size.map(Some),
       )
       .map_err(io::Error::other)?;
 


### PR DESCRIPTION
## Why
The stacking-context builder and the raster measure walk each kept two hash maps of node transforms and content boxes to resolve hoisted out-of-flow children, and each re-derived the fallback logic by hand.

## What
`ContainingBlocks` records both and answers `base_for(child, parent_transform, parent_content_box)`. `NodePaint::container_size` is a `Size<Option<f32>>` like the raster side already used. Pure refactor, goldens byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved positioning and sizing for out-of-flow and hoisted elements during rendering.
  - Corrected how containing-block transforms and dimensions are resolved, helping nested content appear in the intended location and size.
  - Improved consistency of layout sizing across raster, PDF, and SVG output.
- **Refactor**
  - Standardized container-size handling across rendering paths without changing the available output formats or user-facing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->