### PR TITLE
Core: build inline spans from their own helpers

### DIFF
--- a/takumi-core/src/layout/inline/mod.rs
+++ b/takumi-core/src/layout/inline/mod.rs
@@ -2,6 +2,7 @@ use crate::{
   context::RenderContext,
   font_style::{SizedFontStyle, contains_variation_selector, presentation_segments},
   geometry::{AvailableSpace, ComputedLayout, LAYOUT_UNIT_EPSILON, Point, Rect, Size},
+  layout::tree::RenderNode,
   resources::font::FontClasses,
   style::{
     Color, Direction, FontSynthesis, Lang, Length, SizedTextDecorationThickness,
@@ -607,33 +608,9 @@ fn build_inline_layout_tree<'c>(
   let mut previous_collapsible_space = false;
   let mut previous_was_line_break = false;
 
-  let text_item_context = items.iter().find_map(|item| match item {
-    InlineItem::Text { context, .. } => Some(*context),
-    _ => None,
-  });
-
-  // Parley has no base-direction API and infers the paragraph level from the
-  // first strong character, so every block leads with its direction's mark. A
-  // text-less LTR paragraph already has that base level, and the mark's line
-  // metrics would inflate its line box.
-  if !items.is_empty() && (text_item_context.is_some() || context.style.direction == Direction::Rtl)
-  {
-    let direction = context.style.direction;
-
-    // The mark borrows the first text span's style so it resolves to the same
-    // font and cannot skew the line's metrics, and it must not advance the
-    // line: spacing applies per cluster, so a zero-width glyph would still
-    // widen the paragraph by one letter-spacing.
-    let mark_context = text_item_context.unwrap_or(context);
-    let mut mark_style = SizedFontStyle::from_style(&mark_context.style, mark_context);
-    mark_style.letter_spacing = 0.0;
-    mark_style.word_spacing = 0.0;
-
-    spans.push(ProcessedInlineSpan::DirectionMark {
-      direction,
-      style: Box::new(mark_style),
-    });
-    index_pos = direction.bidi_mark().len();
+  if let Some(mark) = direction_mark_span(items, context) {
+    index_pos = context.style.direction.bidi_mark().len();
+    spans.push(mark);
   }
 
   for item in items {
@@ -669,91 +646,13 @@ fn build_inline_layout_tree<'c>(
         render_node,
         decorations,
       } => {
-        let context = &render_node.context;
-        let vertical_align = context.style.vertical_align.resolve(
-          &context.sizing,
-          context.sizing.font_size,
-          context.style.line_height,
-        );
-        let margin = Rect {
-          top: context.style.margin_top,
-          right: context.style.margin_right,
-          bottom: context.style.margin_bottom,
-          left: context.style.margin_left,
-        }
-        .map(|length| length.to_px(&context.sizing, 0.0));
-        let padding = Rect {
-          top: context.style.padding_top,
-          right: context.style.padding_right,
-          bottom: context.style.padding_bottom,
-          left: context.style.padding_left,
-        }
-        .map(|length| length.to_px(&context.sizing, 0.0));
-        let border = Rect {
-          top: (
-            context.style.border_top_style,
-            context.style.border_top_width,
-          ),
-          right: (
-            context.style.border_right_style,
-            context.style.border_right_width,
-          ),
-          bottom: (
-            context.style.border_bottom_style,
-            context.style.border_bottom_width,
-          ),
-          left: (
-            context.style.border_left_style,
-            context.style.border_left_width,
-          ),
-        }
-        .map(|(border_style, width)| {
-          if border_style.is_rendered() {
-            Length::from(width).to_px(&context.sizing, 0.0)
-          } else {
-            0.0
-          }
-        });
-
-        let atomic_metrics = render_node
-          .node
-          .as_ref()
-          .map(|_| render_node.measure_inline_box(available_space));
-        let content_size = atomic_metrics.map_or(Size::ZERO, |metrics| metrics.size);
-        let raw_baseline_offset = atomic_metrics.and_then(|metrics| metrics.baseline_offset);
-
-        let paint_width = if render_node.participates_as_inline_box() {
-          content_size.width + margin.horizontal()
-        } else {
-          content_size.width + margin.horizontal() + padding.horizontal() + border.horizontal()
-        };
-        let paint_height = if render_node.participates_as_inline_box() {
-          content_size.height + margin.vertical()
-        } else {
-          content_size.height + margin.vertical() + padding.vertical() + border.vertical()
-        };
-        let inline_box = InlineBox {
-          index: index_pos,
-          id: spans.len() as u64,
-          kind: inline_box_kind(render_node),
-          width: paint_width,
-          height: paint_height,
-        };
-        let baseline_offset =
-          raw_baseline_offset.map(|baseline| baseline.clamp(0.0, inline_box.height));
-
-        spans.push(ProcessedInlineSpan::Box(InlineBoxItem {
+        spans.push(inline_box_span(
           render_node,
-          decorations: decorations.clone(),
-          inline_box,
-          paint_width,
-          paint_height,
-          margin,
-          padding,
-          border,
-          baseline_offset,
-          vertical_align,
-        }));
+          decorations.clone(),
+          available_space,
+          index_pos,
+          spans.len() as u64,
+        ));
         previous_collapsible_space = false;
         previous_was_line_break = false;
       }
@@ -774,14 +673,160 @@ fn build_inline_layout_tree<'c>(
     }
   }
 
-  // Inline boxes bake constraint-dependent measured sizes into the layout, so
-  // only pure-text content is safe to cache across calls.
+  let (layout, text) = shape_spans(context, &spans, style, shape_cacheable);
+
+  BuiltInlineLayout {
+    layout,
+    text,
+    spans,
+    positioned_floats: Vec::new(),
+    line_scales: Vec::new(),
+  }
+}
+
+/// The direction mark a paragraph leads with. Parley has no base-direction
+/// API and infers the paragraph level from the first strong character, so
+/// every block leads with its direction's mark; a text-less LTR paragraph
+/// already has that base level, and the mark's line metrics would inflate its
+/// line box.
+fn direction_mark_span<'c>(
+  items: &[InlineItem<'c>],
+  context: &'c RenderContext,
+) -> Option<ProcessedInlineSpan<'c>> {
+  let text_item_context = items.iter().find_map(|item| match item {
+    InlineItem::Text { context, .. } => Some(*context),
+    _ => None,
+  });
+
+  if items.is_empty() || (text_item_context.is_none() && context.style.direction != Direction::Rtl)
+  {
+    return None;
+  }
+
+  // The mark borrows the first text span's style so it resolves to the same
+  // font and cannot skew the line's metrics, and it must not advance the
+  // line: spacing applies per cluster, so a zero-width glyph would still
+  // widen the paragraph by one letter-spacing.
+  let mark_context = text_item_context.unwrap_or(context);
+  let mut mark_style = SizedFontStyle::from_style(&mark_context.style, mark_context);
+  mark_style.letter_spacing = 0.0;
+  mark_style.word_spacing = 0.0;
+
+  Some(ProcessedInlineSpan::DirectionMark {
+    direction: context.style.direction,
+    style: Box::new(mark_style),
+  })
+}
+
+/// Measures an inline-level node and sizes the box that stands in for it.
+fn inline_box_span<'c>(
+  render_node: &'c RenderNode,
+  decorations: Option<Rc<DecorationLink>>,
+  available_space: Size<AvailableSpace>,
+  index: usize,
+  id: u64,
+) -> ProcessedInlineSpan<'c> {
+  let context = &render_node.context;
+  let vertical_align = context.style.vertical_align.resolve(
+    &context.sizing,
+    context.sizing.font_size,
+    context.style.line_height,
+  );
+  let margin = Rect {
+    top: context.style.margin_top,
+    right: context.style.margin_right,
+    bottom: context.style.margin_bottom,
+    left: context.style.margin_left,
+  }
+  .map(|length| length.to_px(&context.sizing, 0.0));
+  let padding = Rect {
+    top: context.style.padding_top,
+    right: context.style.padding_right,
+    bottom: context.style.padding_bottom,
+    left: context.style.padding_left,
+  }
+  .map(|length| length.to_px(&context.sizing, 0.0));
+  let border = Rect {
+    top: (
+      context.style.border_top_style,
+      context.style.border_top_width,
+    ),
+    right: (
+      context.style.border_right_style,
+      context.style.border_right_width,
+    ),
+    bottom: (
+      context.style.border_bottom_style,
+      context.style.border_bottom_width,
+    ),
+    left: (
+      context.style.border_left_style,
+      context.style.border_left_width,
+    ),
+  }
+  .map(|(border_style, width)| {
+    if border_style.is_rendered() {
+      Length::from(width).to_px(&context.sizing, 0.0)
+    } else {
+      0.0
+    }
+  });
+
+  let atomic_metrics = render_node
+    .node
+    .as_ref()
+    .map(|_| render_node.measure_inline_box(available_space));
+  let content_size = atomic_metrics.map_or(Size::ZERO, |metrics| metrics.size);
+  let raw_baseline_offset = atomic_metrics.and_then(|metrics| metrics.baseline_offset);
+
+  let paint_width = if render_node.participates_as_inline_box() {
+    content_size.width + margin.horizontal()
+  } else {
+    content_size.width + margin.horizontal() + padding.horizontal() + border.horizontal()
+  };
+  let paint_height = if render_node.participates_as_inline_box() {
+    content_size.height + margin.vertical()
+  } else {
+    content_size.height + margin.vertical() + padding.vertical() + border.vertical()
+  };
+  let inline_box = InlineBox {
+    index,
+    id,
+    kind: inline_box_kind(render_node),
+    width: paint_width,
+    height: paint_height,
+  };
+  let baseline_offset = raw_baseline_offset.map(|baseline| baseline.clamp(0.0, inline_box.height));
+
+  ProcessedInlineSpan::Box(InlineBoxItem {
+    render_node,
+    decorations,
+    inline_box,
+    paint_width,
+    paint_height,
+    margin,
+    padding,
+    border,
+    baseline_offset,
+    vertical_align,
+  })
+}
+
+/// Shapes `spans` into a layout, through the render's shape cache when the
+/// content is pure text. Inline boxes bake constraint-dependent measured sizes
+/// into the layout, so only pure-text content is safe to cache across calls.
+fn shape_spans(
+  context: &RenderContext,
+  spans: &[ProcessedInlineSpan<'_>],
+  style: &SizedFontStyle,
+  shape_cacheable: bool,
+) -> (InlineLayout, String) {
   let cacheable = shape_cacheable
     && spans
       .iter()
       .all(|span| matches!(span, ProcessedInlineSpan::Text { .. }));
   let cache_key = cacheable
-    .then(|| shape_fingerprint(&spans, style, context.style.lang.as_ref().map(Lang::as_str)));
+    .then(|| shape_fingerprint(spans, style, context.style.lang.as_ref().map(Lang::as_str)));
   // The stored text double-checks the fingerprint against hash collisions.
   let expected_text = cacheable.then(|| {
     spans.iter().fold(String::new(), |mut joined, span| {
@@ -801,30 +846,20 @@ fn build_inline_layout_tree<'c>(
     },
     _ => (None, false),
   };
-  let (layout, text) = match cached {
-    Some(cached) => cached,
-    None => {
-      let (layout, text) =
-        context.tree_builder(style.into(), chromium_line_breaks(&spans), |builder| {
-          push_spans_into_builder(builder, &spans, &context.fonts().classes)
-        });
-
-      if let Some(key) = cache_key {
-        let stored = seen.then(|| (layout.clone(), text.clone()));
-
-        context.shape_cache().borrow_mut().insert(key, stored);
-      }
-      (layout, text)
-    }
-  };
-
-  BuiltInlineLayout {
-    layout,
-    text,
-    spans,
-    positioned_floats: Vec::new(),
-    line_scales: Vec::new(),
+  if let Some(cached) = cached {
+    return cached;
   }
+
+  let (layout, text) = context.tree_builder(style.into(), chromium_line_breaks(spans), |builder| {
+    push_spans_into_builder(builder, spans, &context.fonts().classes)
+  });
+
+  if let Some(key) = cache_key {
+    let stored = seen.then(|| (layout.clone(), text.clone()));
+
+    context.shape_cache().borrow_mut().insert(key, stored);
+  }
+  (layout, text)
 }
 
 fn prepare_inline_layout(

--- a/takumi-core/src/layout/node/mod.rs
+++ b/takumi-core/src/layout/node/mod.rs
@@ -1166,9 +1166,6 @@ mod matching_tests {
     let root = Node::container([]).with_class_name("test");
     let matched = match_stylesheets_view(&root, &stylesheet, Viewport::default());
 
-    // Matched normal: should have width: 10px.
-    // Matched important: should have height: 20px.
-
     assert_eq!(matched[0].element().unlayered_normal()[0].len(), 1);
     assert!(
       matched[0].element().unlayered_normal()[0]

--- a/takumi-core/src/style/properties/conic_gradient.rs
+++ b/takumi-core/src/style/properties/conic_gradient.rs
@@ -315,15 +315,12 @@ impl<'i> FromCss<'i> for ConicGradient {
       let mut center: Option<PositionValue> = None;
       let mut interpolation = None;
 
-      // Parse optional "from <angle>" and/or "at <position>" before the comma
       loop {
-        // Try "from <angle>"
         if input.try_parse(|i| i.expect_ident_matching("from")).is_ok() {
           from_angle = Some(Angle::from_css(input)?);
           continue;
         }
 
-        // Try "at <position>"
         if input.try_parse(|i| i.expect_ident_matching("at")).is_ok() {
           center = Some(PositionValue::from_css(input)?);
           continue;
@@ -334,7 +331,6 @@ impl<'i> FromCss<'i> for ConicGradient {
           continue;
         }
 
-        // Consume the comma separator if present
         input.try_parse(Parser::expect_comma).ok();
         break;
       }
@@ -520,14 +516,12 @@ mod tests {
       .build();
     let tile = ConicGradientTile::new(&gradient, 100, 100, &sizing, Color::black(), false);
 
-    // Top center (50, 0) should be red (start of gradient)
     let color_top = tile.sample_pixel(50, 0).demultiply();
     assert_eq!(color_top, ColorU8::from_rgba(255, 0, 0, 255));
   }
 
   #[test]
   fn test_conic_gradient_hard_stops() {
-    // Simulate the card cost gradient: 3 colors with hard stops
     let gradient = ConicGradient::builder()
       .stops([
         GradientStop::ColorHint {

--- a/takumi-core/src/style/properties/gradient_utils.rs
+++ b/takumi-core/src/style/properties/gradient_utils.rs
@@ -816,12 +816,10 @@ impl ResolvedGradientStop {
       }
     }
 
-    // If there are no color stops, return an empty vector
     if resolved.is_empty() {
       return resolved;
     }
 
-    // if there is only one stop, treat it as pure color image
     if resolved.len() == 1 {
       if let Some(first_stop) = resolved.first_mut() {
         first_stop.position = axis_size_px;
@@ -845,7 +843,6 @@ impl ResolvedGradientStop {
     // Distribute unspecified or non-increasing positions in pixel domain
     let mut i = 1usize;
     while i < resolved.len() - 1 {
-      // if the position is defined and valid, skip it
       if resolved[i].position != UNDEFINED_POSITION {
         i += 1;
         continue;
@@ -853,7 +850,6 @@ impl ResolvedGradientStop {
 
       let last_defined_position = resolved.get(i - 1).map(|s| s.position).unwrap_or(0.0);
 
-      // try to find next defined position
       let next_index = resolved
         .iter()
         .skip(i + 1)
@@ -863,11 +859,9 @@ impl ResolvedGradientStop {
 
       let next_position = resolved[next_index].position;
 
-      // number of segments between last defined and next position
       let segments_count = (next_index - i + 1) as f32;
       let step_for_each_segment = (next_position - last_defined_position) / segments_count;
 
-      // distribute the step evenly between the stops
       for j in i..next_index {
         let offset = (j - i + 1) as f32;
         resolved[j].position = last_defined_position + step_for_each_segment * offset;
@@ -1027,7 +1021,6 @@ mod tests {
       },
     );
 
-    // the mid color between red and blue should be at 10%
     assert_eq!(
       resolved[1],
       ResolvedGradientStop {

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -1187,10 +1187,8 @@ mod tests {
 
   #[test]
   fn test_angle_degrees_from_keywords() {
-    // None, None
     assert_eq!(Angle::degrees_from_keywords(None, None), Angle::new(180.0));
 
-    // Some horizontal, None
     assert_eq!(
       Angle::degrees_from_keywords(Some(HorizontalKeyword::Left), None),
       Angle::new(270.0) // "to left" = 270deg
@@ -1200,7 +1198,6 @@ mod tests {
       Angle::new(90.0) // "to right" = 90deg
     );
 
-    // None, Some vertical
     assert_eq!(
       Angle::degrees_from_keywords(None, Some(VerticalKeyword::Top)),
       Angle::new(0.0)
@@ -1210,7 +1207,6 @@ mod tests {
       Angle::new(180.0)
     );
 
-    // Some horizontal, Some vertical
     assert_eq!(
       Angle::degrees_from_keywords(Some(HorizontalKeyword::Left), Some(VerticalKeyword::Top)),
       Angle::new(315.0)
@@ -1274,7 +1270,6 @@ mod tests {
       .into(),
     };
 
-    // Test at the top (should be red)
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((100, 100)))
       .build();
@@ -1283,11 +1278,9 @@ mod tests {
     let color_top = tile.sample_pixel(50, 0).demultiply();
     assert_eq!(color_top, ColorU8::from_rgba(255, 0, 0, 255));
 
-    // Test at the bottom (should be blue)
     let color_bottom = tile.sample_pixel(50, 100).demultiply();
     assert_eq!(color_bottom, ColorU8::from_rgba(0, 0, 255, 255));
 
-    // Test in the middle (should be purple)
     let color_middle = tile.sample_pixel(50, 50).demultiply();
     assert_eq!(color_middle, ColorU8::from_rgba(127, 0, 128, 255));
   }
@@ -1305,7 +1298,6 @@ mod tests {
       .into(),
     };
 
-    // Test at the left (should be red)
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((100, 100)))
       .build();
@@ -1314,7 +1306,6 @@ mod tests {
     let color_left = tile.sample_pixel(0, 50).demultiply();
     assert_eq!(color_left, ColorU8::from_rgba(255, 0, 0, 255));
 
-    // Test at the right (should be blue)
     let color_right = tile.sample_pixel(100, 50).demultiply();
     assert_eq!(color_right, ColorU8::from_rgba(0, 0, 255, 255));
   }
@@ -1357,7 +1348,6 @@ mod tests {
       .into(),
     };
 
-    // Should always return the same color
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((100, 100)))
       .build();
@@ -1375,7 +1365,6 @@ mod tests {
       stops: [].into(),
     };
 
-    // Should return transparent
     let sizing = SizingContext::builder()
       .viewport(Viewport::new((100, 100)))
       .build();
@@ -1440,15 +1429,12 @@ mod tests {
       .build();
     let tile = LinearGradientTile::new(&gradient, 40, 40, &sizing, Color::black(), false);
 
-    // grey at 0,0
     let c0 = tile.sample_pixel(0, 0).demultiply();
     assert_eq!(c0, ColorU8::from_rgba(128, 128, 128, 255));
 
-    // transparent at 1,0
     let c1 = tile.sample_pixel(1, 0).demultiply();
     assert_eq!(c1, ColorU8::from_rgba(0, 0, 0, 0));
 
-    // transparent till the end
     let c2 = tile.sample_pixel(40, 0).demultiply();
     assert_eq!(c2, ColorU8::from_rgba(0, 0, 0, 0));
   }

--- a/takumi-raster/src/components/border.rs
+++ b/takumi-raster/src/components/border.rs
@@ -594,8 +594,6 @@ mod tests {
       .into_inner()
       .unwrap_or_else(|error| unreachable!("test canvas should be readable: {error}"));
 
-    // Check top border line (y=2)
-    // It should have some transparent pixels (gaps) and some opaque pixels (dashes)
     let row: Vec<u8> = (0..48).map(|x| image.get_pixel(x, 2).0[3]).collect();
     let has_opaque = row.iter().any(|&a| a > 0);
     let has_transparent = row.iter().skip(8).take(32).any(|&a| a == 0);


### PR DESCRIPTION
## Why
`build_inline_layout_tree` injected the direction mark, measured inline boxes, and consulted the shape cache in one 226-line body.

## What
`direction_mark_span`, `inline_box_span`, and `shape_spans` each do one of those, and the tree builder loops over items. Pure refactor, goldens byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized inline layout processing without changing its behavior.

* **Documentation**
  * Removed outdated or redundant internal comments across layout, gradient, and border-rendering code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->