### PR TITLE
Docs: write the project's working conventions into the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ Install these prerequisites:
 
 - Rust 1.91 or newer
 - Bun 1.4
+- The `wasm32-unknown-unknown` target, for the WebAssembly binding: `rustup target add wasm32-unknown-unknown`
+- [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/), for building that binding. CI installs the latest release, so no version is pinned.
 
 Install the workspace dependencies:
 
@@ -132,15 +134,15 @@ bun run lint:fix
 
 Run commands for the affected crate or package. A whole-workspace build is slow and is rarely useful twice.
 
-| Change                                | Command                                    |
-| ------------------------------------- | ------------------------------------------ |
-| Umbrella Rust crate or render goldens | `cargo test -p takumi`                     |
-| Rust engine crate                     | `cargo test -p takumi-core`                |
-| Helpers package                       | `(cd takumi-helpers && bun test --silent)` |
-| Native binding package                | `(cd takumi-napi && bun test --silent)`    |
-| WebAssembly binding package           | `(cd takumi-wasm && bun test --silent)`    |
-| JavaScript package                    | `(cd takumi-js && bun test --silent)`      |
-| Docs                                  | `(cd docs && bun run test)`                |
+| Change                                | Command                                               |
+| ------------------------------------- | ----------------------------------------------------- |
+| Umbrella Rust crate or render goldens | `cargo test -p takumi`                                |
+| Rust engine crate                     | `cargo test -p takumi-core`                           |
+| Helpers package                       | `(cd takumi-helpers && bun test --silent)`            |
+| Native binding package                | `(cd takumi-napi && bun test --silent)`               |
+| WebAssembly binding package           | `(cd takumi-wasm && bun test --silent)`               |
+| JavaScript package                    | `(cd takumi-js && bun test --silent)`                 |
+| Docs                                  | `(cd docs && bun test app/playground tests --silent)` |
 
 Run all package tests only when a change crosses package boundaries:
 
@@ -184,9 +186,9 @@ Build only the packages affected by the change:
 
 | Package             | Command                                          |
 | ------------------- | ------------------------------------------------ |
-| Helpers             | `bun --filter ./takumi-helpers run build`        |
-| WebAssembly binding | `bun --filter ./takumi-wasm run build:debug`     |
-| Image response      | `bun --filter ./takumi-image-response run build` |
+| Helpers             | `bun run --filter ./takumi-helpers build`        |
+| WebAssembly binding | `bun run --filter ./takumi-wasm build:debug`     |
+| Image response      | `bun run --filter ./takumi-image-response build` |
 
 The WebAssembly binding build requires `wasm-pack`.
 
@@ -196,8 +198,8 @@ The docs playground reads build output instead of package source.
 
 | Source change                                         | Build command                                |
 | ----------------------------------------------------- | -------------------------------------------- |
-| `takumi-helpers/src`                                  | `bun --filter ./takumi-helpers run build`    |
-| Rust rendering engine used by the WebAssembly binding | `bun --filter ./takumi-wasm run build:debug` |
+| `takumi-helpers/src`                                  | `bun run --filter ./takumi-helpers build`    |
+| Rust rendering engine used by the WebAssembly binding | `bun run --filter ./takumi-wasm build:debug` |
 
 ## Goldens and fixtures
 
@@ -257,7 +259,7 @@ CI fails when test execution changes a generated file that is not included in th
 The full JavaScript benchmark is the gate for a performance change:
 
 ```bash
-bun --filter ./takumi-napi run bench
+bun run --filter ./takumi-napi bench
 ```
 
 Do not use one native micro-benchmark as the gate. Measure a WebAssembly change in WebAssembly. Native results do not carry over.
@@ -271,7 +273,7 @@ Measure binary size through the shipped pipeline:
 For `takumi-wasm`, use:
 
 ```bash
-bun --filter ./takumi-wasm run build
+bun run --filter ./takumi-wasm build
 gzip -9 -c takumi-wasm/pkg/takumi_wasm_bg.wasm | wc -c
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,164 +1,360 @@
 # Contributing to Takumi
 
-First of all, thanks for contributing to Takumi.
+## Contents
 
-This guide covers local setup, development flow, testing/build commands, fixtures, and changelogs.
+- [Ways to contribute](#ways-to-contribute)
+- [Local setup](#local-setup)
+- [Code style](#code-style)
+- [Local validation](#local-validation)
+- [Goldens and fixtures](#goldens-and-fixtures)
+- [Performance changes](#performance-changes)
+- [Documentation and changelogs](#documentation-and-changelogs)
+- [Pull requests](#pull-requests)
+- [Release commands](#release-commands)
+- [Code of Conduct](#code-of-conduct)
 
-## Ways to Contribute
+## Ways to contribute
 
 - Report bugs with the [Bug Report template](https://github.com/kane50613/takumi/issues/new/choose).
 - Propose enhancements with the [Feature Request template](https://github.com/kane50613/takumi/issues/new/choose).
 - Ask usage questions via the [Question template](https://github.com/kane50613/takumi/issues/new/choose).
 - Improve docs, examples, tests, and fixture coverage.
 
-## Prerequisites
+## Local setup
 
-- Rust `1.91+`
-- Bun (latest)
+Install these prerequisites:
 
-## Local Setup
+- Rust 1.91 or newer
+- Bun 1.4
+
+Install the workspace dependencies:
 
 ```bash
 bun install
 ```
 
-This installs all workspace dependencies and sets up `lefthook`.
+The install also sets up `lefthook` through the root `postinstall` script.
 
-## Development Flow
+Create a feature branch before making changes. Keep the branch focused on one logical change.
 
-1. Create a feature branch.
-2. Make your changes.
-3. Run formatting and tests for affected packages.
-4. Update generated fixtures if rendering output changed.
-5. Add a changelog file for user-facing package/crate changes.
-6. Open a PR.
+## Code style
 
-## Formatting and Lint
+### Rust comments and documentation
+
+Code has no comment by default. Add a comment only for one of these reasons:
+
+- Link to an external reference.
+- Mark incomplete work with a TODO.
+- State an invariant that the code cannot show.
+
+Put the reason for a change in the commit message. Do not put it in a code comment.
+
+A doc comment is one line that says what the item is. Delete a doc comment that only repeats the name or signature. Use more than one line only to cite an external specification or another implementation.
+
+### Rust paths and expressions
+
+- Import a path with `use` at the top of the file. Do not use a fully qualified path in an expression, even for one call.
+- Give `format!` and related macros inline named arguments. Do not use positional `{}` placeholders followed by a trailing argument list.
+- Use `if` and `else` for a boolean condition. Do not `match` on a boolean.
+- Replace a repeatable value with a named constant. Do not hide it in a helper function or repeat the expression.
+
+### Rust functions and modules
+
+- Make a free function a method when its first parameter is a type the project owns.
+- Make a builder or parser an associated function on the type it creates.
+- Keep stateless recursive descent parser functions free.
+- Name a module file after a domain noun. Its contents should be clear from its name, such as `page.rs`.
+- Extract an inline helper closure into a named top-level function.
+- Reuse an existing helper. Do not add a second copy.
+
+### Cargo dependencies
+
+Put dependency versions in `[workspace.dependencies]` in the root `Cargo.toml`.
+
+A member inherits the dependency and adds features when needed:
+
+```toml
+[dependencies.serde]
+workspace = true
+features = ["rc"]
+```
+
+Do not repeat the version in a member. Use a `[dependencies.<name>]` block when an entry needs more than a bare version string. Do not use an inline table.
+
+### Rust public APIs
+
+- Lower an internal item to `pub(crate)` instead of hiding it with `#[doc(hidden)]`.
+- Put a cross-crate internal API in its own named module.
+- Add `#[non_exhaustive]` to public value types.
+
+### WebAssembly binding APIs
+
+A TypeScript-facing WebAssembly signature does not expose `JsValue` or `js_sys::Object`.
+
+Follow the pattern in `takumi-wasm`:
+
+- Put the TypeScript declarations in `takumi-wasm/src/dts-header.d.ts`.
+- Include that file from a `#[wasm_bindgen(typescript_custom_section)]` item.
+- Declare extern types with `#[wasm_bindgen(typescript_type = "...")]`.
+- Add `unchecked_return_type` to bindings that return bytes.
+
+Keep the `RwLock` used with `&self` in `takumi-wasm` and `takumi-pdf-wasm`. Keep the `Mutex` in `takumi-napi`. A shared-memory build would make `&mut self` unsound.
+
+### TypeScript type safety
+
+Fix the cause of every type error. Do not silence the checker with any of these changes:
+
+- A non-null assertion
+- An `as` assertion used to dodge an error
+- `as any`
+- `@ts-ignore`
+- `@ts-expect-error`
+- A looser `tsconfig`
+
+## Local validation
+
+### Formatting and linting
+
+Format Rust and check JavaScript and TypeScript:
 
 ```bash
 cargo fmt --all
 bun run lint
 ```
 
-Use auto-fix when needed:
+Apply JavaScript and TypeScript fixes when needed:
 
 ```bash
 bun run lint:fix
 ```
 
-## Test Commands
+### Focused test commands
 
-Run all Rust tests:
+Run commands for the affected crate or package. A whole-workspace build is slow and is rarely useful twice.
 
-```bash
-CARGO_PROFILE_TEST_STRIP=debuginfo cargo test -q
-```
+| Change                                | Command                                    |
+| ------------------------------------- | ------------------------------------------ |
+| Umbrella Rust crate or render goldens | `cargo test -p takumi`                     |
+| Rust engine crate                     | `cargo test -p takumi-core`                |
+| Helpers package                       | `(cd takumi-helpers && bun test --silent)` |
+| Native binding package                | `(cd takumi-napi && bun test --silent)`    |
+| WebAssembly binding package           | `(cd takumi-wasm && bun test --silent)`    |
+| JavaScript package                    | `(cd takumi-js && bun test --silent)`      |
+| Docs                                  | `(cd docs && bun run test)`                |
 
-Run workspace package tests (pick what you changed):
-
-```bash
-(cd takumi-helpers && bun test --silent)
-(cd takumi-napi && bun test --silent)
-(cd takumi-wasm && bun test --silent)
-(cd takumi-js && bun test --silent)
-(cd docs && bun test tests --silent)
-```
-
-Or run every package's suite at once:
+Run all package tests only when a change crosses package boundaries:
 
 ```bash
 bun run test
 ```
 
-To match CI quality gates for Rust changes, also run:
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings
-cargo machete
-```
-
-## Build Commands
-
-Run build only for packages you touched:
-
-```bash
-bun --filter ./takumi-helpers run build
-bun --filter ./takumi-napi run build:debug
-bun --filter ./takumi-wasm run build:debug
-bun --filter ./takumi-image-response run build
-```
-
-Notes:
-
-- `takumi-napi` release build needs target-specific setup; for local validation, `build:debug` is usually enough.
-- `takumi-wasm` build requires `wasm-pack`.
-
-## Fixture Workflow (Rust Rendering)
-
-Fixture sources are HTML files in `takumi/tests/fixtures-html`. The `html_fixtures` test parses each file and writes its goldens (`.webp`, `.svg`) to `takumi/tests/fixtures-generated`. The same file opens in a browser for a reference render.
-
-The harness reads the inline `<style>` block and the `<body>` size, nothing else. The linked `shared.css` is for the browser: it loads the test fonts and matches what the renderer already applies, such as `box-sizing: border-box` and no body margin.
-
-When you change rendering/layout behavior:
-
-1. Add or edit an HTML file in `takumi/tests/fixtures-html`. Put CSS in a `<style>` block. The `<body>` inline width/height set the viewport.
-2. Run:
+Run all Rust tests only when a change crosses crate boundaries:
 
 ```bash
 CARGO_PROFILE_TEST_STRIP=debuginfo cargo test -q
 ```
 
-3. Review updated files in `takumi/tests/fixtures-generated`. Compare against the HTML opened in a browser.
-4. Include intentional fixture updates in your PR.
+Do not accept a loose output pattern as proof that a test failed. The pattern `failed. [1-9]` misses output such as `test result: FAILED. 0 passed; 1 failed`. Match `FAILED|panicked`, or read the end of the output.
 
-CI will fail if generated files change unexpectedly.
+### Rust CI gates
 
-Do not format files in `fixtures-html`: whitespace is part of the fixture. `.oxfmtrc.json` ignores the directory.
+CI runs these Rust gates:
 
-A few fixtures stay as Rust tests in `takumi/tests/fixtures/*.rs`. They animate, or assert on rendered pixels and measured layout instead of a golden.
+```bash
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo clippy --locked --target wasm32-unknown-unknown -p takumi-wasm -p takumi-pdf-wasm -- -D warnings
+cargo test --locked
+cargo machete
+```
 
-## Changelogs
+A fresh cache can make Clippy skip an unchanged crate. Touch that crate's existing `src/lib.rs` before the Clippy command. The full flags cover feature-gated code and every target.
 
-For any user-facing change in published packages/crates, add a changelog file:
+### Binding checks
+
+Check changed bindings locally:
+
+```bash
+cargo check -p takumi-napi
+cargo check -p takumi-wasm --target wasm32-unknown-unknown
+```
+
+### Focused build commands
+
+Build only the packages affected by the change:
+
+| Package             | Command                                          |
+| ------------------- | ------------------------------------------------ |
+| Helpers             | `bun --filter ./takumi-helpers run build`        |
+| WebAssembly binding | `bun --filter ./takumi-wasm run build:debug`     |
+| Image response      | `bun --filter ./takumi-image-response run build` |
+
+The WebAssembly binding build requires `wasm-pack`.
+
+### Docs playground builds
+
+The docs playground reads build output instead of package source.
+
+| Source change                                         | Build command                                |
+| ----------------------------------------------------- | -------------------------------------------- |
+| `takumi-helpers/src`                                  | `bun --filter ./takumi-helpers run build`    |
+| Rust rendering engine used by the WebAssembly binding | `bun --filter ./takumi-wasm run build:debug` |
+
+## Goldens and fixtures
+
+### Golden change policy
+
+A change to rendered or serialized output includes its regenerated golden in the same pull request. Inspect every generated golden before committing it.
+
+A pure refactor keeps every golden byte for byte. Put a behavior change in its own pull request. Do not fold one into a refactor.
+
+Prove a behavior change with a differential run:
+
+- Simulate the old behavior.
+- Confirm that the old-behavior build compiled and ran.
+- Confirm that it regenerated the output.
+- Compare the old and new output.
+
+A result with no changed output counts only after all four checks.
+
+### Render fixture sources
+
+Render fixture sources are HTML files in `takumi/tests/fixtures-html`. The `html_fixtures` test writes `.webp` and `.svg` goldens to `takumi/tests/fixtures-generated`.
+
+The harness reads only these parts of each HTML file:
+
+- The inline `<style>` block
+- The contents of `<body>`
+- The inline `width` and `height` on `<body>`
+
+The linked `takumi/tests/shared.css` supports browser comparison. It loads the fixture fonts and matches renderer defaults such as `box-sizing: border-box` and a body margin of zero.
+
+Add or change a render fixture like this:
+
+- Add or edit an HTML file in `takumi/tests/fixtures-html`.
+- Put fixture CSS in the inline `<style>` block.
+- Set the viewport with inline `width` and `height` values on `<body>`.
+- Run `cargo test -p takumi`.
+- Review the changed files in `takumi/tests/fixtures-generated`.
+- Open the HTML in a browser and compare the reference render.
+- Include every intentional golden change in the pull request.
+
+The render goldens belong to the umbrella `takumi` crate. Tests for lower crates do not regenerate them.
+
+Do not make unrelated formatting changes in `takumi/tests/fixtures-html`. Whitespace is fixture input. `.oxfmtrc.json` applies strict HTML whitespace handling to this directory.
+
+Fixtures that animate or assert on pixels or measured layout stay as Rust tests in `takumi/tests/fixtures`.
+
+CI fails when test execution changes a generated file that is not included in the pull request.
+
+### Platform-specific goldens
+
+- WebP goldens are canonical on Linux.
+- Some WebP fixtures differ on macOS because the platform math library produces different floating-point results. Let CI regenerate those fixtures.
+- PDF fixtures in `takumi-pdf/tests/fixtures-generated` are byte identical on Linux and macOS.
+
+## Performance changes
+
+The full JavaScript benchmark is the gate for a performance change:
+
+```bash
+bun --filter ./takumi-napi run bench
+```
+
+Do not use one native micro-benchmark as the gate. Measure a WebAssembly change in WebAssembly. Native results do not carry over.
+
+Measure binary size through the shipped pipeline:
+
+- Build the release WebAssembly package. Its `wasm-pack` profile runs `wasm-opt`.
+- Compress the resulting `.wasm` file with `gzip -9`.
+- Report the size difference. Do not report only the absolute size.
+
+For `takumi-wasm`, use:
+
+```bash
+bun --filter ./takumi-wasm run build
+gzip -9 -c takumi-wasm/pkg/takumi_wasm_bg.wasm | wc -c
+```
+
+## Documentation and changelogs
+
+### External behavior and public APIs
+
+A change to external behavior or a public API includes both of these updates:
+
+- The relevant file in `docs/content/docs/*.mdx`
+- A changelog file in `.tegami/*.md`
+
+Create the changelog file with:
 
 ```bash
 bun run tegami
 ```
 
-Select affected packages and choose `patch` / `minor` / `major`.
+Select the affected packages and the `patch`, `minor`, or `major` release type.
 
-Changelog files are stored in `.tegami/*.md`. See the [changelog format docs](https://tegami.fuma-nama.dev/changelog) for the frontmatter and headings.
+Write the changelog entry as one imperative sentence. Do not add a second sentence or a rationale. Put reasoning in the commit body or pull request.
 
-## README Sync for Rust Crate
+See the [changelog format docs](https://tegami.fuma-nama.dev/changelog) for the frontmatter and headings.
 
-`takumi/README.md` is checked in CI with `cargo rdme --check`.
+### Rust crate READMEs
 
-If Rust doc comments or crate-facing examples changed, regenerate:
+CI checks published Rust crate READMEs with `cargo rdme --check`.
+
+Regenerate a changed crate README from that crate's directory. For the umbrella crate:
 
 ```bash
 cd takumi
 cargo rdme
 ```
 
-Then commit the updated `takumi/README.md`.
+Include the regenerated `takumi/README.md` when Rust doc comments or crate-facing examples change.
 
-## Release Notes
+## Pull requests
 
-Release/version commands are handled by maintainers/CI via Tegami:
+### Pull request scope
 
-- `bun tegami ci`
+- Name the user-visible outcome in the title. Prefer `Support display: table` to `Lay out tables on the grid algorithm`.
+- Keep one logical change in each pull request.
+- Split multi-part work into a stack. Give reviewers one layer per pull request.
+- Keep behavior changes separate from refactors.
 
-You usually do not need to run these in feature PRs.
+### Push safety
 
-## PR Checklist
+Check the current branch before pushing:
 
-- Code is formatted (`cargo fmt --all`, oxlint passes)
-- Relevant tests pass locally
-- Scope is focused (one logical change per PR when possible)
-- Fixture updates are intentional and reviewed
-- Changelog file added (if user-facing)
-- Generated files that CI checks are committed
-- Docs updated where needed
+```bash
+git branch --show-current
+```
+
+Push with an explicit remote and branch:
+
+```bash
+git push origin "$(git branch --show-current)"
+```
+
+Do not push another commit to a pull request after auto-merge is armed. The squash can land first and leave the new commit behind on the branch.
+
+### Pull request checklist
+
+- Rust code is formatted with `cargo fmt --all`.
+- `bun run lint` passes.
+- Tests for affected crates and packages pass.
+- Clippy covers all targets and all features.
+- Fixture changes are intentional and reviewed.
+- Pure refactors leave goldens unchanged.
+- User-visible changes include docs and a changelog entry.
+- Generated files checked by CI are included.
+- The pull request contains one logical change or one layer of a stack.
+
+## Release commands
+
+Maintainers and CI handle release and version commands through Tegami:
+
+```bash
+bun tegami ci
+```
+
+Feature pull requests do not need this command.
 
 ## Code of Conduct
 


### PR DESCRIPTION
The guide covered setup, commands and fixtures. The conventions a reviewer actually enforces were never written down, so a contributor could only learn them by getting a pull request sent back.

## What is new

- **Rust style.** Comments default to none. Doc comments are one line. `use` at the top instead of a fully qualified path. Inline named arguments in `format!`. No `match` on a boolean. A free function whose first parameter is a type we own belongs on that type.
- **Cargo.** Versions live in `[workspace.dependencies]` and members inherit them.
- **Public API.** `pub(crate)` instead of `#[doc(hidden)]`, `#[non_exhaustive]` on public value types, and no `JsValue` in a wasm binding signature. The `RwLock` with `&self` in the wasm crates is deliberate and documented as such.
- **TypeScript.** Never silence the checker.
- **Goldens.** A rendering change lands with its regenerated golden. A pure refactor leaves every golden byte identical. A behavior change is proven with a differential run. Render goldens belong to the umbrella crate, so lower-crate tests do not regenerate them. WebP goldens are canonical on Linux, PDF goldens are identical on both.
- **Local validation.** Which command to run for which change, and the fact that Clippy skips a cache-fresh crate and reports a clean tree it never checked.
- **Performance.** The full JavaScript benchmark is the gate. Measure a wasm change in wasm. Report a size difference through the shipped pipeline rather than an absolute number.
- **Pull requests.** Title names the outcome. Multi-part work is a stack. Do not push to a pull request with auto-merge armed.

## Corrections to what was already there

- `.oxfmtrc.json` does not ignore `fixtures-html`. It sets `htmlWhitespaceSensitivity: strict` for that directory.
- `bun --filter ./takumi-napi run build:debug` does not exist. `takumi-napi` has only `build`.
- The Rust CI gates now match the workflow, including the wasm target Clippy run and `--locked`.
- Bun is pinned to 1.4 in the setup action, so the prerequisite says so instead of "latest".

The whole file was rewritten for the house style: short sentences, tables instead of stacks of conditional prose, sentence-case headings, no em dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the contribution guide with instructions for the `wasm32-unknown-unknown` target and the latest `wasm-pack` prerequisite.
  - Expanded documentation test instructions to cover both the playground and test projects.
  - Updated workspace commands for builds, benchmarks, and WebAssembly size measurements to use the current Bun filtering syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->