### PR TITLE
Helpers: keep font caching within caller limits

### DIFF
--- a/.tegami/font-css-cache.md
+++ b/.tegami/font-css-cache.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Keep Google Fonts cache entries within caller limits
+
+Bound the default `googleFonts` CSS cache, isolate custom fetch implementations, and honor request policies on repeated calls.

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -128,8 +128,10 @@ Pass an object instead of a list for request-level options:
 | ---------- | ---------------------- | --------------------------------------------------------- |
 | `families` | the list above         | The families to load, in fallback priority order.         |
 | `display`  | a `font-display` value | Maps to CSS `font-display`.                               |
-| `cache`    | a `Map`                | Reuses the metadata CSS across renders.                   |
+| `cache`    | a `Map`                | Overrides the bounded metadata CSS cache.                 |
 | `baseUrl`  | a css2 endpoint        | Point at a mirror such as `https://fonts.bunny.net/css2`. |
+
+The default CSS cache shares concurrent requests within each fetch implementation and evicts old entries automatically. Requests with `signal` or `allowUrl` bypass caching so cancellation and redirect checks stay local to the caller. `maxBytes` also applies to cache hits.
 
 Each subset registers under its own internal name; `font-family: Inter` expands across all of them, so each script finds the file that covers it.
 

--- a/takumi-helpers/src/fonts.ts
+++ b/takumi-helpers/src/fonts.ts
@@ -1,6 +1,12 @@
 import type { GoogleFontShapeFamilies, GoogleFontShapes } from "./google-fonts-catalog";
 import type { Node } from "./types";
-import { defaultMaxFetchBytes, fetchOk, type FetchOptions, readBodyLimited } from "./utils";
+import {
+  defaultMaxFetchBytes,
+  fetchOk,
+  type FetchLike,
+  type FetchOptions,
+  readBodyLimited,
+} from "./utils";
 
 const chromeUserAgent =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -68,12 +74,7 @@ export type GoogleFontsOptions = FetchOptions & {
   families: GoogleFontFamily[];
   /** `font-display` strategy passed through to the CSS request. */
   display?: "auto" | "block" | "swap" | "fallback" | "optional";
-  /**
-   * Cache for the Google Fonts CSS, keyed by request URL, so the metadata is fetched once across
-   * renders (e.g. a playground re-rendering on each edit). Holds the in-flight promise, so
-   * concurrent calls share one request; failures evict themselves. Defaults to a process-wide
-   * cache; pass your own `Map` to scope it, or a fresh one per call to opt out.
-   */
+  /** CSS promise cache; defaults to a bounded cache per fetch implementation. Signals and URL policies bypass caching. */
   cache?: Pick<Map<string, Promise<string>>, "get" | "set" | "delete">;
   /**
    * css2 base URL. Defaults to Google Fonts; point it at an API-compatible mirror like
@@ -84,9 +85,75 @@ export type GoogleFontsOptions = FetchOptions & {
 
 const GOOGLE_FONTS_CSS = "https://fonts.googleapis.com/css2";
 
-// ponytail: shared default so callers who forget `cache` still fetch each URL once. Entries are
-// small (CSS metadata) and self-evict on failure; pass an explicit `cache` for isolation.
-const defaultCssCache = new Map<string, Promise<string>>();
+const maxCachedCssBytes = 1024 * 1024;
+const maxCachedCssEntries = 64;
+
+class FontCssCache {
+  private static readonly byFetch = new WeakMap<FetchLike, FontCssCache>();
+  private readonly entries = new Map<string, { pending: Promise<string>; bytes: number }>();
+  private bytes = 0;
+
+  static forFetch(fetch: FetchLike) {
+    let cache = this.byFetch.get(fetch);
+    if (!cache) {
+      cache = new FontCssCache();
+      this.byFetch.set(fetch, cache);
+    }
+    return cache;
+  }
+
+  get(url: string) {
+    const entry = this.entries.get(url);
+    if (entry) {
+      this.entries.delete(url);
+      this.entries.set(url, entry);
+    }
+    return entry?.pending;
+  }
+
+  set(url: string, pending: Promise<string>) {
+    this.delete(url);
+    const entry = { pending, bytes: url.length * 2 };
+    this.entries.set(url, entry);
+    this.bytes += entry.bytes;
+    this.trim();
+    pending.then(
+      (css) => {
+        if (this.entries.get(url) !== entry) {
+          return;
+        }
+        entry.bytes += css.length * 2;
+        this.bytes += css.length * 2;
+        if (entry.bytes > maxCachedCssBytes) {
+          this.delete(url);
+        }
+        this.trim();
+      },
+      () => {
+        if (this.entries.get(url) === entry) {
+          this.delete(url);
+        }
+      },
+    );
+  }
+
+  delete(url: string) {
+    const entry = this.entries.get(url);
+    if (entry) {
+      this.bytes -= entry.bytes;
+      this.entries.delete(url);
+    }
+  }
+
+  private trim() {
+    for (const url of this.entries.keys()) {
+      if (this.entries.size <= maxCachedCssEntries && this.bytes <= maxCachedCssBytes) {
+        break;
+      }
+      this.delete(url);
+    }
+  }
+}
 
 // Builds a css2 `family=` value, e.g. `Inter:ital,opsz,wght@0,14..32,400`. Takes plain values
 // rather than a GoogleFontFamily so it never relates that ~2000-member union to a parameter, which
@@ -159,16 +226,32 @@ function fetchCss(url: string, options: FetchOptions) {
 }
 
 function fetchCssCached(url: string, options: GoogleFontsOptions) {
-  const cache = options.cache ?? defaultCssCache;
+  options.signal?.throwIfAborted();
+  if (options.signal || options.allowUrl) {
+    return fetchCss(url, options);
+  }
+  const cache = options.cache ?? FontCssCache.forFetch(options.fetch ?? globalThis.fetch);
 
   const cached = cache.get(url);
   if (cached) {
-    return cached;
+    return cached.then((css) => {
+      const maxBytes = options.maxBytes ?? maxCssBytes;
+      if (new TextEncoder().encode(css).byteLength > maxBytes) {
+        throw new Error(`Response exceeds ${maxBytes} bytes`);
+      }
+      return css;
+    });
   }
 
   const pending = fetchCss(url, options);
   cache.set(url, pending);
-  pending.catch(() => cache.delete(url));
+  if (options.cache) {
+    pending.catch(() => {
+      if (cache.get(url) === pending) {
+        cache.delete(url);
+      }
+    });
+  }
 
   return pending;
 }

--- a/takumi-helpers/tests/fonts.test.ts
+++ b/takumi-helpers/tests/fonts.test.ts
@@ -325,6 +325,101 @@ describe("googleFonts", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test("isolates default CSS caches by fetch implementation", async () => {
+    const first = mockInter();
+    const second = mock(() => Promise.resolve(new Response(twoWeightCss)));
+
+    expect(await googleFonts({ families: ["Inter"], fetch: first })).toHaveLength(3);
+    expect(await googleFonts({ families: ["Inter"], fetch: second })).toHaveLength(2);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("evicts old default CSS entries while keeping recent hits", async () => {
+    const fetchMock = mockInter();
+    const load = (weight: number) =>
+      googleFonts({ families: [{ name: "Inter", weight }], fetch: fetchMock });
+
+    for (let weight = 100; weight < 164; weight++) {
+      await load(weight);
+    }
+    await load(100);
+    expect(fetchMock).toHaveBeenCalledTimes(64);
+    await load(164);
+    await load(100);
+    expect(fetchMock).toHaveBeenCalledTimes(65);
+    await load(101);
+    expect(fetchMock).toHaveBeenCalledTimes(66);
+  });
+
+  test("does not retain CSS larger than the default cache budget", async () => {
+    const css = `/*${"x".repeat(600_000)}*/${interCss}`;
+    const fetchMock = mock(() => Promise.resolve(new Response(css)));
+
+    await googleFonts({ families: ["Inter"], fetch: fetchMock });
+    await googleFonts({ families: ["Inter"], fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("bounds the combined size of retained CSS", async () => {
+    const css = `/*${"x".repeat(200_000)}*/${interCss}`;
+    const fetchMock = mock(() => Promise.resolve(new Response(css)));
+    for (const weight of [100, 101, 102, 100]) {
+      await googleFonts({ families: [{ name: "Inter", weight }], fetch: fetchMock });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  test("shares concurrent default requests and retries failures", async () => {
+    const response = Promise.withResolvers<Response>();
+    const fetchMock = mock(() => response.promise);
+    const first = googleFonts({ families: ["Inter"], fetch: fetchMock });
+    const second = googleFonts({ families: ["Inter"], fetch: fetchMock });
+    const settled = Promise.allSettled([first, second]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    response.reject(new Error("Request failed"));
+    expect((await settled).map((result) => result.status)).toEqual(["rejected", "rejected"]);
+
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(interCss)));
+    expect(await googleFonts({ families: ["Inter"], fetch: fetchMock })).toHaveLength(3);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("applies each caller's policies after warming the CSS cache", async () => {
+    const fetchMock = mockInter();
+    await googleFonts({ families: ["Inter"], fetch: fetchMock });
+
+    await expect(
+      googleFonts({ families: ["Inter"], fetch: fetchMock, maxBytes: 1 }),
+    ).rejects.toThrow("exceeds 1 bytes");
+    await expect(
+      googleFonts({ families: ["Inter"], fetch: fetchMock, allowUrl: () => false }),
+    ).rejects.toThrow("blocked by allowUrl");
+    await expect(
+      googleFonts({ families: ["Inter"], fetch: fetchMock, signal: AbortSignal.abort() }),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps a replacement cache entry when an older request fails", async () => {
+    const response = Promise.withResolvers<Response>();
+    const cache = new Map<string, Promise<string>>();
+    const pending = googleFonts({
+      families: ["Inter"],
+      fetch: () => response.promise,
+      cache,
+    });
+    const [url] = cache.keys();
+    if (!url) {
+      throw new Error("Expected an in-flight cache entry");
+    }
+    const replacement = Promise.resolve(interCss);
+    cache.set(url, replacement);
+    response.reject(new Error("Request failed"));
+
+    await expect(pending).rejects.toThrow("Request failed");
+    expect(cache.get(url)).toBe(replacement);
+  });
+
   test("returns nothing for an empty families list without a request", async () => {
     const fetchMock = mockInter();
 


### PR DESCRIPTION
## Why

Google Fonts retained CSS indefinitely and reused it across custom fetch implementations. Cache hits could ignore a later caller's request limits.

## What

Bound the default cache by retained text size and entry count, scoped to each fetch implementation. Preserve concurrent sharing, validate cached response sizes, and bypass caching for cancellation or URL policies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `googleFonts` CSS caching with automatic size and entry limits.
  - Prevented cached font responses from being incorrectly shared between different fetch configurations.
  - Ensured request-specific limits, redirects, and cancellation settings are honored even when cached data is available.
  - Improved recovery after failed font requests and retained recently used cache entries more reliably.

- **Documentation**
  - Clarified default cache behavior and request-level cache controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->