### PR TITLE
Helpers: accept custom properties consistently

### DIFF
--- a/.tegami/style-declarations.md
+++ b/.tegami/style-declarations.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Accept custom properties in node styles
+
+Use `Declarations` consistently for node styles, presets, and style helpers so custom properties typecheck without casts.

--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -27,6 +27,8 @@ icon: Wrench
 
 The `props` argument holds the node's own fields. [Node types](/docs/reference#node-types) lists them.
 
+Styles, presets, and stylesheet rules share the `Declarations` type. Custom properties such as `"--accent": "red"` accept strings or numbers, including in React's `style` prop.
+
 Length and color shorthands return CSS strings. `vw`/`vh` are viewport width/height, `em`/`rem` are font-relative sizes, `fr` is a grid fraction. See the [MDN CSS values reference](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units).
 
 `rem` resolves against the viewport, not the outermost node. [Units](/docs/reference#units) covers what each font-relative unit follows.

--- a/takumi-helpers/src/helpers.ts
+++ b/takumi-helpers/src/helpers.ts
@@ -1,13 +1,12 @@
-import type { CSSProperties } from "react";
-import type { ContainerNode, ImageNode, Node, NodeMetadata, TextNode } from "./types";
+import type { ContainerNode, Declarations, ImageNode, Node, NodeMetadata, TextNode } from "./types";
 
-function applyStyle(node: Node, style?: CSSProperties) {
+function applyStyle(node: Node, style?: Declarations) {
   if (style && Object.keys(style).length > 0) {
     node.style = style;
   }
 }
 
-function applyPreset(node: Node, preset?: CSSProperties) {
+function applyPreset(node: Node, preset?: Declarations) {
   if (preset && Object.keys(preset).length > 0) {
     node.preset = preset;
   }
@@ -56,10 +55,10 @@ export function container(props: Omit<ContainerNode, "type">): ContainerNode {
   return node;
 }
 
-export function text(text: string, style?: CSSProperties): TextNode;
+export function text(text: string, style?: Declarations): TextNode;
 export function text(props: Omit<TextNode, "type">): TextNode;
 
-export function text(props: Omit<TextNode, "type"> | string, style?: CSSProperties): TextNode {
+export function text(props: Omit<TextNode, "type"> | string, style?: Declarations): TextNode {
   if (typeof props === "string") {
     const node: TextNode = {
       type: "text",
@@ -106,7 +105,7 @@ export function image(props: Omit<ImageNode, "type">): ImageNode {
   return node;
 }
 
-export function style(style: CSSProperties) {
+export function style(style: Declarations) {
   return style;
 }
 

--- a/takumi-helpers/src/html/entities.ts
+++ b/takumi-helpers/src/html/entities.ts
@@ -276,7 +276,7 @@ export function decodeHtmlEntities(value: string): string {
         return decodeCodePoint(Number.parseInt(hex, 16)) ?? match;
       }
 
-      return Object.hasOwn(namedHtmlEntities, named) ? namedHtmlEntities[named] : match;
+      return Object.hasOwn(namedHtmlEntities, named) ? (namedHtmlEntities[named] ?? match) : match;
     },
   );
 }

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -4,9 +4,8 @@ import type {
   ElementNode as UltraHtmlElementNode,
   Node as UltraHtmlNode,
 } from "ultrahtml";
-import type { CSSProperties } from "react";
 import { container, image, text } from "../helpers";
-import type { Node, NodeMetadata } from "../types";
+import type { Declarations, Node, NodeMetadata } from "../types";
 import { extractAttributes, getPresets } from "../jsx/metadata";
 import type { FromJsxOptions } from "../jsx";
 import type { defaultStylePresets } from "../jsx/style-presets";
@@ -229,7 +228,7 @@ function decodeAttributeMap(attributes: Record<string, string>): Record<string, 
   return decodedAttributes;
 }
 
-function parseInlineStyle(styleText: string): CSSProperties | undefined {
+function parseInlineStyle(styleText: string): Declarations | undefined {
   const style: Record<string, string> = {};
   let start = 0;
   let colon = -1;
@@ -274,7 +273,7 @@ function parseInlineStyle(styleText: string): CSSProperties | undefined {
 
   commit(styleText.length);
 
-  return Object.keys(style).length > 0 ? (style as CSSProperties) : undefined;
+  return Object.keys(style).length > 0 ? style : undefined;
 }
 
 function skipQuoted(styleText: string, start: number): number {

--- a/takumi-helpers/src/jsx/index.ts
+++ b/takumi-helpers/src/jsx/index.ts
@@ -1,6 +1,6 @@
-import type { ComponentProps, CSSProperties, ReactElement, ReactNode } from "react";
+import type { ComponentProps, ReactElement, ReactNode } from "react";
 import { container, image, percentage, text } from "../helpers";
-import type { Node, NodeMetadata, RgbaImage, ReactElementLike } from "../types";
+import type { Declarations, Node, NodeMetadata, RgbaImage, ReactElementLike } from "../types";
 import { extractAttributes, getPresets, type HtmlProps } from "./metadata";
 export type { HtmlProps } from "./metadata";
 import { callWithDispatcher, getProperty, readContext, type RenderEnv } from "./dispatcher";
@@ -485,25 +485,17 @@ function createSvgElement(
 }
 
 function extractStyle(
-  element: ReactElementLike,
+  tagName: string | undefined,
+  inlineStyle: HtmlProps["style"],
   options: ResolvedFromJsxOptions,
-): { preset?: CSSProperties; style?: CSSProperties } {
+): { preset?: Declarations; style?: Declarations } {
   const presets = options.presets;
   const preset =
-    presets && typeof element.type === "string" && element.type in presets
-      ? presets[element.type as keyof typeof presets]
+    presets && tagName !== undefined && tagName in presets
+      ? presets[tagName as keyof typeof presets]
       : undefined;
 
-  const inlineStyle =
-    typeof element.props === "object" &&
-    element.props !== null &&
-    "style" in element.props &&
-    typeof element.props.style === "object" &&
-    element.props.style !== null
-      ? element.props.style
-      : undefined;
-
-  if (!inlineStyle) {
+  if (typeof inlineStyle !== "object" || inlineStyle === null) {
     return { preset };
   }
 
@@ -533,12 +525,13 @@ function extractNodeMetadata(
   options: ResolvedFromJsxOptions,
 ): NodeMetadata {
   const htmlProps = element.props as HtmlProps;
-  const { preset, style } = extractStyle(element, options);
+  const tagName = typeof element.type === "string" ? element.type : undefined;
+  const { preset, style } = extractStyle(tagName, htmlProps.style, options);
   const tw = extractTw(element, options);
   const attributes = extractAttributes(htmlProps, options.tailwindClassesProperty);
 
   return {
-    tagName: typeof element.type === "string" ? element.type : undefined,
+    tagName,
     className: htmlProps.className ?? htmlProps.class,
     id: htmlProps.id,
     dir: htmlProps.dir as NodeMetadata["dir"],

--- a/takumi-helpers/src/jsx/metadata.ts
+++ b/takumi-helpers/src/jsx/metadata.ts
@@ -1,11 +1,11 @@
-import type { CSSProperties } from "react";
+import type { Declarations } from "../types";
 import { defaultStylePresets } from "./style-presets";
 
 export type HtmlProps = {
   className?: string;
   class?: string;
   id?: string;
-  style?: string | CSSProperties;
+  style?: string | Declarations;
   dir?: string;
   lang?: string;
   [key: string]: unknown;

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -16,9 +16,8 @@ export type TextFit =
   | (string & {});
 
 declare module "react" {
-  interface CSSProperties {
+  interface CSSProperties extends Record<`--${string}`, string | number | undefined> {
     textFit?: TextFit;
-    [key: `--${string}`]: string | number | undefined;
   }
 }
 

--- a/takumi-helpers/src/types.ts
+++ b/takumi-helpers/src/types.ts
@@ -18,15 +18,14 @@ export type TextFit =
 declare module "react" {
   interface CSSProperties {
     textFit?: TextFit;
+    [key: `--${string}`]: string | number | undefined;
   }
 }
 
 export type NodeAttributes = Record<string, string>;
 
 /** A declaration block, with custom properties allowed. */
-export type Declarations = CSSProperties & {
-  [key: `--${string}`]: string | number;
-};
+export type Declarations = CSSProperties;
 
 /** A style rule written as an object. */
 export type StyleRule = {
@@ -85,8 +84,8 @@ export type NodeMetadata = {
   lang?: string;
   attributes?: NodeAttributes;
   tw?: string;
-  style?: CSSProperties;
-  preset?: CSSProperties;
+  style?: Declarations;
+  preset?: Declarations;
 };
 
 export type Node = ContainerNode | TextNode | ImageNode;

--- a/takumi-helpers/tests/declarations.test.ts
+++ b/takumi-helpers/tests/declarations.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { createElement, type CSSProperties } from "react";
+import { container, image, style, text } from "../src/helpers";
+import { fromHtml } from "../src/html";
+import { fromJsx } from "../src/jsx";
+import type { Declarations, NodeMetadata, StyleRule } from "../src/types";
+
+test("custom properties pass through every declaration entry point", async () => {
+  const declarations: Declarations = style({
+    "--accent": "red",
+    "--step": 2,
+    color: "var(--accent)",
+  });
+  const metadata: NodeMetadata = { style: declarations, preset: declarations };
+  const rule: StyleRule = { selector: ".card", style: declarations };
+  const nodes = [
+    container({ children: [], ...metadata }),
+    text({ text: "hello", ...metadata }),
+    image({ src: "image.png", ...metadata }),
+  ];
+
+  for (const node of nodes) {
+    expect(node.style).toEqual(rule.style);
+    expect(node.preset).toEqual(declarations);
+  }
+  expect(text("hello", { "--accent": "red" }).style).toEqual({ "--accent": "red" });
+  expect(fromHtml('<div style="--accent:red;color:var(--accent)"></div>').node.style).toEqual({
+    "--accent": "red",
+    color: "var(--accent)",
+  });
+  const reactStyle: CSSProperties = declarations;
+  const jsx = await fromJsx(createElement("div", { style: reactStyle }));
+  expect(jsx.node.style).toEqual(declarations);
+});


### PR DESCRIPTION
## Why

Custom CSS properties worked at runtime but failed typechecking in node styles and helper arguments. Stylesheet rules accepted the same declarations.

## What

Use the existing declaration type across styles, presets, and helpers, including React style props. Reuse parsed JSX metadata and handle absent entity lookups explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom CSS properties, such as `--accent`, are now supported across styles, presets, HTML, JSX, and helper APIs.
  * Custom properties accept string and numeric values.

* **Bug Fixes**
  * Improved fallback handling when decoding named HTML entities.

* **Documentation**
  * Added guidance on shared style declarations and custom CSS property support.

* **Tests**
  * Added coverage for custom properties across supported declaration entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->