### PR TITLE
Helpers: recover from transient font and image requests

### DIFF
--- a/.tegami/font-fetch-retries.md
+++ b/.tegami/font-fetch-retries.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Retry transient font and image requests
+
+Retry temporary GET and HEAD failures within the existing timeout, including Google Fonts metadata and font file downloads.

--- a/takumi-helpers/src/utils.ts
+++ b/takumi-helpers/src/utils.ts
@@ -3,6 +3,9 @@ import type { Node } from "./types";
 
 const defaultFetchTimeout = 30_000;
 const maxRedirectHops = 5;
+const maxFetchAttempts = 3;
+const maxRetryDelay = 1000;
+const retryableStatuses = new Set([408, 429, 500, 502, 503, 504]);
 export const defaultMaxFetchBytes = 32 * 1024 * 1024;
 const cssUrlPattern = /url\(\s*(['"]?)(.*?)\1\s*\)/g;
 
@@ -11,7 +14,7 @@ export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>
 export type FetchOptions = {
   /** Custom fetch implementation. @default globalThis.fetch */
   fetch?: FetchLike;
-  /** Abort the request after this many milliseconds; `0` or negative disables it. @default 30000 */
+  /** Total request timeout, including retries; `0` or negative disables it. @default 30000 */
   timeout?: number;
   /** Caller abort signal, combined with the timeout. */
   signal?: AbortSignal;
@@ -31,17 +34,81 @@ export async function fetchOk(url: string, options: FetchOptions & { init?: Requ
   const timeout = options.timeout ?? defaultFetchTimeout;
   const timeoutSignal = timeout <= 0 ? undefined : AbortSignal.timeout(timeout);
   const signals = [options.signal, options.init?.signal, timeoutSignal].filter(
-    (s): s is AbortSignal => s !== undefined,
+    (s): s is AbortSignal => s != null,
   );
   const signal = signals.length ? AbortSignal.any(signals) : undefined;
   const init = { ...options.init, signal };
   const response = options.allowUrl
     ? await followRedirectsWithPolicy(url, options.allowUrl, fetchImpl, init)
-    : await fetchImpl(url, init);
+    : await fetchWithRetry(url, fetchImpl, init);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} ${response.statusText} fetching ${url}`);
   }
   return response;
+}
+
+async function fetchWithRetry(
+  url: string,
+  fetchImpl: FetchLike,
+  init: RequestInit,
+): Promise<Response> {
+  const method = init.method?.toUpperCase() ?? "GET";
+  const canRetry = method === "GET" || method === "HEAD";
+  for (let attempt = 0; ; attempt++) {
+    init.signal?.throwIfAborted();
+    let delay = 100 * 2 ** attempt;
+    try {
+      const response = await fetchImpl(url, init);
+      init.signal?.throwIfAborted();
+      if (
+        !canRetry ||
+        attempt === maxFetchAttempts - 1 ||
+        !retryableStatuses.has(response.status)
+      ) {
+        return response;
+      }
+      const retryAfter = response.headers.get("retry-after");
+      if (retryAfter !== null) {
+        const seconds = Number(retryAfter);
+        const milliseconds = Number.isFinite(seconds)
+          ? seconds * 1000
+          : Date.parse(retryAfter) - Date.now();
+        if (Number.isFinite(milliseconds)) {
+          delay = Math.max(delay, milliseconds);
+        }
+      }
+      if (delay > maxRetryDelay) {
+        return response;
+      }
+      void response.body?.cancel().catch(() => {});
+    } catch (error) {
+      init.signal?.throwIfAborted();
+      if (
+        !canRetry ||
+        attempt === maxFetchAttempts - 1 ||
+        !(error instanceof Error) ||
+        (error.name !== "TypeError" && error.name !== "TimeoutError")
+      ) {
+        throw error;
+      }
+    }
+    await waitForRetry(delay, init.signal);
+  }
+}
+
+function waitForRetry(delay: number, signal?: AbortSignal | null): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }, delay);
+    function abort() {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+  });
 }
 
 /** Follows redirects manually so `allowUrl` is enforced on every hop, not just the first URL. */
@@ -53,7 +120,7 @@ async function followRedirectsWithPolicy(
 ): Promise<Response> {
   let current = url;
   for (let hop = 0; hop < maxRedirectHops; hop++) {
-    const response = await fetchImpl(current, { ...init, redirect: "manual" });
+    const response = await fetchWithRetry(current, fetchImpl, { ...init, redirect: "manual" });
     const location = response.headers.get("location");
     if (response.status < 300 || response.status >= 400 || !location) {
       return response;

--- a/takumi-helpers/tests/fetch-retries.test.ts
+++ b/takumi-helpers/tests/fetch-retries.test.ts
@@ -1,0 +1,108 @@
+import { expect, mock, test } from "bun:test";
+import { fontFromUrl, googleFonts } from "../src/fonts";
+import { fetchOk } from "../src/utils";
+
+const fontCss =
+  "@font-face{font-family:'Inter';font-weight:400;src:url(https://fonts.gstatic.com/inter.woff2);unicode-range:U+0000-00FF}";
+
+test("recovers from a transient Google Fonts timeout", async () => {
+  const fetch = mock()
+    .mockRejectedValueOnce(new DOMException("The operation timed out", "TimeoutError"))
+    .mockResolvedValue(new Response(fontCss));
+  expect(await googleFonts({ families: ["Inter"], fetch })).toHaveLength(1);
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test("retries a font server error before sharing the CSS result", async () => {
+  const fetch = mock()
+    .mockResolvedValueOnce(new Response(null, { status: 503 }))
+    .mockResolvedValue(new Response(fontCss));
+  const [first, second] = await Promise.all([
+    googleFonts({ families: ["Inter"], fetch }),
+    googleFonts({ families: ["Inter"], fetch }),
+  ]);
+  expect(first).toHaveLength(1);
+  expect(second.map((font) => font.key)).toEqual(first.map((font) => font.key));
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test("retries a font file connection failure", async () => {
+  const fetch = mock()
+    .mockRejectedValueOnce(new TypeError("fetch failed"))
+    .mockResolvedValue(new Response(new Uint8Array([1, 2, 3])));
+  expect(
+    new Uint8Array(await fontFromUrl("https://example.com/font.woff2", { fetch }).data()),
+  ).toEqual(new Uint8Array([1, 2, 3]));
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test("stops after three attempts", async () => {
+  const fetch = mock(() => Promise.reject(new TypeError("fetch failed")));
+  await expect(fetchOk("https://example.com/font.woff2", { fetch })).rejects.toThrow(
+    "fetch failed",
+  );
+  expect(fetch).toHaveBeenCalledTimes(3);
+});
+
+test("does not retry permanent errors or non-idempotent requests", async () => {
+  for (const status of [400, 401, 403, 404]) {
+    const fetch = mock(() => Promise.resolve(new Response(null, { status })));
+    await expect(fetchOk("https://example.com/font.woff2", { fetch })).rejects.toThrow(
+      `HTTP ${status}`,
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+  }
+  const fetch = mock(() => Promise.resolve(new Response(null, { status: 503 })));
+  await expect(
+    fetchOk("https://example.com/submit", { fetch, init: { method: "POST" } }),
+  ).rejects.toThrow("HTTP 503");
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("the timeout bounds retry backoff as well as fetch", async () => {
+  const fetch = mock(() => Promise.resolve(new Response(null, { status: 503 })));
+  await expect(fetchOk("https://example.com/font.woff2", { fetch, timeout: 10 })).rejects.toThrow();
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("caller cancellation stops retry backoff", async () => {
+  const controller = new AbortController();
+  const fetch = mock(() => Promise.resolve(new Response(null, { status: 503 })));
+  const pending = fetchOk("https://example.com/font.woff2", { fetch, signal: controller.signal });
+  await Promise.resolve();
+  controller.abort(new Error("Stopped by caller"));
+  await expect(pending).rejects.toThrow("Stopped by caller");
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("does not shorten a server's long Retry-After instruction", async () => {
+  const fetch = mock(() =>
+    Promise.resolve(new Response(null, { status: 429, headers: { "retry-after": "120" } })),
+  );
+  await expect(fetchOk("https://example.com/font.woff2", { fetch })).rejects.toThrow("HTTP 429");
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("recovers from rate limiting with a short Retry-After", async () => {
+  const fetch = mock()
+    .mockResolvedValueOnce(new Response(null, { status: 429, headers: { "retry-after": "0" } }))
+    .mockResolvedValue(new Response(fontCss));
+  expect(await googleFonts({ families: ["Inter"], fetch })).toHaveLength(1);
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test("retries do not bypass redirect policy", async () => {
+  const fetch = mock()
+    .mockResolvedValueOnce(new Response(null, { status: 503 }))
+    .mockResolvedValue(
+      new Response(null, { status: 302, headers: { location: "https://blocked.test/font" } }),
+    );
+  await expect(
+    fetchOk("https://example.com/font", {
+      fetch,
+      allowUrl: (url) => new URL(url).hostname === "example.com",
+    }),
+  ).rejects.toThrow("URL blocked by allowUrl policy");
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(fetch.mock.calls.every(([url]) => url === "https://example.com/font")).toBeTrue();
+});

--- a/takumi-helpers/tsdown.config.ts
+++ b/takumi-helpers/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { defineConfig } from "tsdown";
+import { fetchOk } from "./src/utils.ts";
 
 const CATALOG_SOURCE = "https://fonts.google.com/metadata/fonts";
 const CATALOG_FILE = new URL("src/google-fonts-catalog.ts", import.meta.url);
@@ -11,15 +12,8 @@ interface FamilyMetadata {
 }
 
 async function generateCatalog() {
-  const data: { familyMetadataList: FamilyMetadata[] } = await fetch(CATALOG_SOURCE, {
-    signal: AbortSignal.timeout(30_000),
-  })
-    .then((r) => {
-      if (!r.ok) {
-        throw new Error(`${CATALOG_SOURCE} → ${r.status}`);
-      }
-      return r.json();
-    })
+  const data: { familyMetadataList: FamilyMetadata[] } = await fetchOk(CATALOG_SOURCE)
+    .then((r) => r.json())
     .catch((error) => {
       throw error.name === "TimeoutError"
         ? new Error(`${CATALOG_SOURCE} timed out after 30s`)


### PR DESCRIPTION
## Why

A temporary font-service failure rejects the render immediately. Retrying at the call site duplicates policy and can extend the request deadline.

## What

Retry transient GET and HEAD failures within the existing timeout, including font downloads and build-time Google Fonts metadata. Preserve cancellation, redirect checks, permanent errors, and server retry delays without adding options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Font and image requests now automatically retry transient network failures, timeouts, rate limits, and temporary server errors.
  * Google Fonts metadata and font downloads are more resilient to temporary service interruptions.
  * Redirected requests retain their existing security and policy checks.
  * Permanent errors and non-retryable request types are not retried.

* **Documentation**
  * Timeout behavior now reflects the total time allowed for the request, including retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->