### PR TITLE
PDF: accept object stylesheet rules in binding types

### DIFF
--- a/.tegami/pdf-css-types.md
+++ b/.tegami/pdf-css-types.md
@@ -1,0 +1,7 @@
+---
+"takumi-pdf": patch
+---
+
+# Accept object stylesheet rules in PDF bindings
+
+Match the PDF binding's `css` type to the object rules already accepted at runtime.

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { expect, spyOn, test } from "bun:test";
 import { container, text } from "@takumi-rs/helpers";
-import { PageNumber, PdfRenderer, TotalPages } from "../bundlers/node.mjs";
+import { PageNumber, PdfRenderer, TotalPages } from "takumi-pdf";
 
 const renderer = new PdfRenderer();
 
@@ -41,6 +41,19 @@ test("renders an HTML string with its own stylesheet", async () => {
 
   expect(decoder.decode(pdf.subarray(0, 5))).toBe("%PDF-");
   expect(pageCount(pdf)).toBe(1);
+});
+
+test("object stylesheet rules match CSS strings in render and measure", async () => {
+  const node = container({ className: "card", children: [text("Hello PDF")] });
+  const viewport = { width: 600, height: 300 };
+  const css = [{ selector: ".card", style: { width: 200, height: 100, "--accent": "red" } }];
+  const stylesheet = ".card { width: 200px; height: 100px; --accent: red }";
+  expect(await renderer.measure(node, { viewport, css })).toEqual(
+    await renderer.measure(node, { viewport, css: stylesheet }),
+  );
+  expect(await renderer.render(node, { viewport, css })).toEqual(
+    await renderer.render(node, { viewport, css: stylesheet }),
+  );
 });
 
 test("stylesheets warns once", async () => {

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -48,6 +48,7 @@ test("object stylesheet rules match CSS strings in render and measure", async ()
   const viewport = { width: 600, height: 300 };
   const css = [{ selector: ".card", style: { width: 200, height: 100, "--accent": "red" } }];
   const stylesheet = ".card { width: 200px; height: 100px; --accent: red }";
+  expect(await renderer.measure(node, { viewport, css })).toEqual({ width: 200, height: 100 });
   expect(await renderer.measure(node, { viewport, css })).toEqual(
     await renderer.measure(node, { viewport, css: stylesheet }),
   );

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -1,4 +1,4 @@
-import type { Node } from "@takumi-rs/helpers";
+import type { CssInput, Node } from "@takumi-rs/helpers";
 
 export type ByteBuf = Uint8Array | ArrayBuffer | Buffer;
 
@@ -157,7 +157,7 @@ export type PdfRenderOptions = {
   /** Pre-fetched images keyed by URL. */
   images?: ImageSource[];
   /** CSS to apply before layout. */
-  css?: string[];
+  css?: CssInput[];
   /**
    * CSS custom properties for `:root`, which utilities and `var()` both read.
    * A name without the `--` prefix gains it.


### PR DESCRIPTION
## Why

PDF binding declarations reject object stylesheet rules that the runtime already accepts.

## What

Use the shared CSS input type and check object rules against equivalent CSS strings for layout and PDF output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PDF rendering options now support stylesheet rules provided as objects, in addition to CSS strings.
  - Object-form styles are supported consistently during both layout measurement and PDF rendering.
  - Updated type definitions provide accurate editor and type-checking support for the expanded `css` option.
  - Object-based styles produce the same results as equivalent CSS string styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->