### PR TITLE
Docs: explain automatic caching and reliable resource loading

### DIFF
--- a/docs/content/docs/helpers.mdx
+++ b/docs/content/docs/helpers.mdx
@@ -4,7 +4,16 @@ description: Build inputs and load images without the renderer.
 icon: Wrench
 ---
 
-`takumi-js/helpers` re-exports `@takumi-rs/helpers`: functions for building the node tree and loading fonts, images, and emoji. `render` and `ImageResponse` call them for you. Reach for these only when you build inputs by hand.
+```ts twoslash
+import { container, text } from "takumi-js/helpers";
+
+const node = container({
+  style: { padding: 32, backgroundColor: "white" },
+  children: [text("Hello Takumi", { fontSize: 48 })],
+});
+```
+
+`takumi-js/helpers` re-exports `@takumi-rs/helpers`. Use these functions to build nodes or prepare resources yourself. With JSX or HTML, `render` and `ImageResponse` handle conversion and resource loading.
 
 ## Fonts
 
@@ -14,7 +23,7 @@ icon: Wrench
 | `fontFromUrl(url, options?)`     | Turn a font URL into a lazy `fonts` entry. `options` takes the [fetch limits](/docs/load-images#fetch-limits).                                |
 | `subsetFonts({ fonts, source })` | Trim font subsets to the codepoints `source` renders (what `render` does internally).                                                         |
 
-`googleFonts` and `prepareImages` accept the same [fetch limits](/docs/load-images#fetch-limits): `timeout` (default 5 s on every fetch), `maxBytes`, `allowUrl`, and a custom `fetch`.
+`googleFonts`, `fontFromUrl`, and `prepareImages` share [fetch limits and retry behavior](/docs/load-images#fetch-limits).
 
 ## Building nodes
 

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -20,7 +20,7 @@ const image = await render(element, {
 });
 ```
 
-Takumi fetches remote images referenced by `src`, `background-image`, `mask-image`, and `list-style-image`. An optional `fetchCache` shares downloaded bytes and pending requests across renders. It accepts a `Map` or an object with `get`, `set`, and `delete` methods.
+Takumi fetches remote images referenced by `src`, `background-image`, `mask-image`, and `list-style-image`. An optional `fetchCache` shares downloaded bytes and pending requests across renders. Use `Map<string, Promise<ArrayBuffer>>` or an object with the same `get`, `set`, and `delete` contract. Values are promises, not raw buffers.
 
 A plain `Map` never evicts. If each render uses a different URL, pass a bounded cache such as an LRU, or omit `fetchCache`.
 
@@ -54,7 +54,7 @@ GET and HEAD requests make up to three attempts for connection errors, transient
 
 Caller cancellation and an expired deadline stop retries. Other HTTP errors and failures while reading a response body are not retried. A custom `fetch` must honor the supplied abort signal.
 
-`render()` and `ImageResponse` fetch these URLs from your server. Set `allowUrl` whenever user input can influence the markup. It checks each redirect destination, with at most five hops. DNS is not inspected; use a custom `fetch` for resolved-address filtering.
+`render()` and `ImageResponse` fetch these URLs from your server. Set `allowUrl` whenever user input can influence the markup. On a cache miss, it checks each redirect destination, with at most five hops. An image byte-cache hit checks only the entry URL: cached values do not retain redirect history. Do not share `images.fetchCache` across different URL policies or trust boundaries. DNS is not inspected; use a custom `fetch` for resolved-address filtering.
 
 ## Pre-fetched images
 

--- a/docs/content/docs/load-images.mdx
+++ b/docs/content/docs/load-images.mdx
@@ -4,11 +4,7 @@ description: Load and cache images, and render emoji.
 icon: Image
 ---
 
-## External Images
-
-Takumi fetches external images in `src` attributes and CSS `background-image` / `mask-image`.
-
-To reuse fetched bytes across renders, pass a `fetchCache`: a `Map<string, Promise<ArrayBuffer>>`, or anything with `Map`-like `get`/`set`/`delete`. It stores the in-flight promise, so concurrent renders needing the same URL share one fetch:
+## External images
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -24,18 +20,11 @@ const image = await render(element, {
 });
 ```
 
-A plain `Map` never evicts. If your URLs are high-cardinality (a different image per render), pass a bounded cache such as an LRU, or omit `fetchCache`.
+Takumi fetches remote images referenced by `src`, `background-image`, `mask-image`, and `list-style-image`. An optional `fetchCache` shares downloaded bytes and pending requests across renders. It accepts a `Map` or an object with `get`, `set`, and `delete` methods.
+
+A plain `Map` never evicts. If each render uses a different URL, pass a bounded cache such as an LRU, or omit `fetchCache`.
 
 ## Fetch limits
-
-Every remote fetch (images, fonts, Google Fonts CSS) is bounded. The group form of `images` takes the same options:
-
-| Option     | Default            | Use                                                                                  |
-| :--------- | :----------------- | :----------------------------------------------------------------------------------- |
-| `timeout`  | `5000` (ms)        | Abort a hanging host. `0` or negative disables it.                                   |
-| `maxBytes` | 32 MiB             | Reject a body past this size, by `content-length` or streamed.                       |
-| `allowUrl` | allow all          | Return `false` to block a URL, e.g. an SSRF (server-side request forgery) allowlist. |
-| `fetch`    | `globalThis.fetch` | Custom fetch implementation.                                                         |
 
 ```tsx twoslash
 import { render } from "takumi-js";
@@ -51,9 +40,23 @@ const image = await render(element, {
 });
 ```
 
-`render()` and `ImageResponse` fetch these URLs from your server, so set an `allowUrl` allowlist whenever user input can influence the markup. The policy is checked on every redirect hop (capped at 5), so an allowed URL can't 3xx its way to an internal address. DNS is not inspected; keep a custom `fetch` for a stricter policy such as resolved-address filtering.
+These options apply to Takumi's image fetches, `googleFonts`, and `fontFromUrl`. A custom `data` loader manages its own requests.
 
-## Pre-fetched Images
+| Option     | Default            | Effect                                                                          |
+| :--------- | :----------------- | :------------------------------------------------------------------------------ |
+| `timeout`  | `30000` ms         | Deadline for each request, including retry delays. `0` or negative disables it. |
+| `signal`   | none               | Cancel a request and any pending retry.                                         |
+| `maxBytes` | 32 MiB             | Reject oversized bodies, using `content-length` and streamed bytes.             |
+| `allowUrl` | allow all          | Reject a URL before fetching it, including redirect destinations.               |
+| `fetch`    | `globalThis.fetch` | Supply a custom fetch implementation.                                           |
+
+GET and HEAD requests make up to three attempts for connection errors, transient timeouts, or HTTP `408`, `429`, `500`, `502`, `503`, and `504`. Retries wait 100 ms, then 200 ms. A `Retry-After` header can extend that delay up to one second; a longer value returns the error without retrying. Redirects use the same deadline, with a separate attempt limit per destination.
+
+Caller cancellation and an expired deadline stop retries. Other HTTP errors and failures while reading a response body are not retried. A custom `fetch` must honor the supplied abort signal.
+
+`render()` and `ImageResponse` fetch these URLs from your server. Set `allowUrl` whenever user input can influence the markup. It checks each redirect destination, with at most five hops. DNS is not inspected; use a custom `fetch` for resolved-address filtering.
+
+## Pre-fetched images
 
 Provide images by key so the renderer doesn't have to fetch them itself. Each key can be used in any `src` field or in the `background-image` / `mask-image` CSS properties.
 
@@ -213,7 +216,7 @@ const image = await renderer.render(node, {
 });
 ```
 
-`prepareImages` walks the node tree for remote `<img>`, `backgroundImage`, and `maskImage` URLs, fetches the ones missing from `sources`, and returns `images` entries. Pass a `fetchCache` (a `Map<string, Promise<ArrayBuffer>>`, or anything with `Map`-like `get`/`set`/`delete`) to deduplicate concurrent fetches and reuse bytes across renders.
+`prepareImages` returns image entries for remote URLs missing from `sources`. It accepts the same [fetch cache](#external-images) and [limits](#fetch-limits).
 
 ### COLR / bitmap fonts
 

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -6,8 +6,6 @@ icon: Type
 
 ## Fonts
 
-Text embeds as real glyph runs with subset fonts. It stays selectable, searchable, and copyable. Pass a URL or raw bytes. You can also use the [`googleFonts`](/docs/typography-and-fonts#from-google-fonts) helper:
-
 ```tsx twoslash
 import type { ReactNode } from "react";
 declare const doc: ReactNode;
@@ -24,7 +22,9 @@ const pdf = await render(doc, {
 });
 ```
 
-`fontFamilies` sets the fallback chain for each render. Registered fonts deduplicate across calls that use the same renderer.
+Text stays selectable and searchable. Pass font URLs, raw bytes, or [`googleFonts`](/docs/typography-and-fonts#from-google-fonts) entries. `fontFamilies` sets the fallback chain, and a reused renderer deduplicates registered fonts.
+
+For offline renders, [bundle font files](/docs/typography-and-fonts#fonts-in-ci-and-offline-renders). Google Fonts requests use the shared [fetch limits and retries](/docs/load-images#fetch-limits).
 
 There is no system font to fall back on. A character that none of the registered fonts covers would draw nothing and leave nothing in the text layer, so `render` rejects it and names the character and its codepoint. Register a font covering every script the document uses. Watch the Google Fonts subsets in particular: `latin` and `latin-ext` split their coverage, so one file on its own can leave common accented characters out.
 

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -1,66 +1,69 @@
 ---
 title: Performance & Optimization
-description: Best practices for building high-performance rendering pipelines with Takumi.
+description: Reuse rendering work and measure before tuning caches.
 icon: Zap
 ---
 
-These practices keep Takumi fast as your node trees grow.
+## Reuse the renderer
 
-## The Renderer
+```tsx twoslash
+import { render } from "takumi-js";
 
-### Reuse the Renderer Instance
+const image = await render(<div tw="p-8 text-4xl">Hello Takumi</div>, {
+  width: 1200,
+  height: 630,
+});
+```
 
-The `Renderer` holds Takumi's caches. Reuse one instance across renders instead of constructing a new one each time.
+`render` and `ImageResponse` reuse a managed renderer. No cache setup is needed. When using `Renderer` directly, create it outside the request handler so registered fonts and decoded resources survive between renders.
 
-[`ImageResponse`](/docs/image-response) manages an internal renderer, or pass your own through the `renderer` option. See [Typography & Fonts](/docs/typography-and-fonts) and [Load Images](/docs/load-images).
+## Know what is cached
 
-### Size the Resource Cache
+| Work                                            | Lifetime              | Configuration                                                      |
+| :---------------------------------------------- | :-------------------- | :----------------------------------------------------------------- |
+| Decoded images, SVG rasters, parsed stylesheets | Renderer              | `cacheMaxBytes`, 16 MiB by default                                 |
+| Glyph outlines and rasterized masks             | Loaded backend module | `setGlyphCacheMaxBytes`, 8 MiB by default                          |
+| Parsed Tailwind classes                         | Loaded backend module | Automatic, bounded internally                                      |
+| Resolved Tailwind declarations                  | Render                | Automatic, separated by viewport width, font size, and pixel ratio |
+| Google Fonts CSS                                | Fetch implementation  | Automatic, bounded internally                                      |
+| Downloaded image bytes                          | Caller-provided cache | Optional `images.fetchCache`                                       |
 
-Decoded images, SVG rasters, and parsed stylesheets share one byte budget, 16 MiB by default. The default suits a single-template server; raise it when many large images stay hot across renders:
+Cache budgets account for retained entries, not total process memory. Fonts, active renders, output buffers, and allocator overhead use memory too. See [image caching](/docs/load-images#decode-caching) and [Google Fonts](/docs/typography-and-fonts#from-google-fonts) for resource-specific behavior.
 
-```ts
+## Measure cold and repeated renders
+
+Measure the first render separately from repeated renders. Font downloads and decoding affect startup; layout, painting, and encoding still happen on a warm renderer.
+
+Use representative text, images, output formats, and concurrent requests. Compare latency and memory before changing a budget. Increasing a cache helps only when it keeps work that later renders reuse.
+
+### Resource cache
+
+```ts twoslash
+import { Renderer } from "takumi-js/node";
+
 const renderer = new Renderer({ cacheMaxBytes: 64 * 1024 * 1024 });
 ```
 
-### Size the Glyph Cache
+Raise the budget when frequently reused images or stylesheets are being evicted. For images used only once, [`cache: "none"`](/docs/load-images#decode-caching) avoids displacing reusable entries. An unbounded `images.fetchCache` is separate from this budget.
 
-Resolved glyph outlines and their rasterized masks share a separate 8 MiB budget. These caches belong to the module rather than to a `Renderer`, so `setGlyphCacheMaxBytes` covers every renderer in the process and has to run before the first render — the budget is read when a cache is first used.
+### Glyph cache
 
-The default suits Latin text. A CJK outline runs a few kilobytes, so 8 MiB holds on the order of a thousand of them, and a page of Chinese re-rasterizes glyphs it just evicted:
-
-```ts
-import { setGlyphCacheMaxBytes } from "@takumi-rs/core";
-
-setGlyphCacheMaxBytes(64 * 1024 * 1024);
-```
-
-`takumi-js` exports it as well. That one records the budget and applies it when the backend loads:
-
-```ts
+```ts twoslash
 import { setGlyphCacheMaxBytes } from "takumi-js";
 
 setGlyphCacheMaxBytes(64 * 1024 * 1024);
 ```
 
-### Preload Frequently Used Images
+Call this before the first render. Outlines and masks share the budget across renderers in the same backend module. Large glyph sets or text sizes can benefit from more space, but benchmark your content first.
 
-Loading images from URLs or bytes during the rendering pass is a bottleneck. Register [Load Images](/docs/load-images) to avoid re-decoding.
+## Keep network requests out of repeated work
 
-### Parallel Rendering
+Bundle fonts for predictable startup without a font service. WOFF2 saves transfer and storage space but needs decompression; TTF avoids that step. A reused renderer decodes a registered file once. See [local fonts and CI](/docs/typography-and-fonts#fonts-in-ci-and-offline-renders).
 
-On the server, prefer `@takumi-rs/core`: it renders across multiple threads, where `@takumi-rs/wasm` is single-threaded.
+For repeated remote images, use a bounded [fetch cache](/docs/load-images#external-images). The renderer's decode cache does not replace a download cache.
 
-## Component Design
+## Reduce painting work
 
-### Stack Filters in a Single Node
+Each filtered node needs an offscreen layer. Put filters on one node when they should apply to the same composed content. Moving filters from children to a parent can change the output, so compare the result.
 
-Each filtered node allocates its own offscreen composition layer, sized to the element (viewport-sized only as a worst case). Stacking filters on one node reuses a single layer.
-
-## Fonts
-
-### Prefer TTF over WOFF2
-
-| Format | Decode cost             | When to use                              |
-| ------ | ----------------------- | ---------------------------------------- |
-| TTF    | Used directly           | Default                                  |
-| WOFF2  | Decompressed before use | File size matters more than decode speed |
+On servers, the native backend supports multithreaded rendering. The Wasm backend is single-threaded. `takumi-js` selects the backend for the environment; use explicit backend imports only when you need to control that choice.

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -4,12 +4,7 @@ description: Load fonts, route scripts across them, and style text.
 icon: Type
 ---
 
-Takumi never reads system fonts. Load every font a render needs, or its glyphs fall back to tofu.
-
-One **last-resort** font ships built in: Geist, Latin glyphs, weights 300 to 800. It only serves text no registered font covers:
-
-- Fonts you load always win.
-- Generic families like `sans-serif` resolve to your fonts, not to it.
+Takumi never reads system fonts. Load fonts covering your text. The built-in Geist covers Latin at weights 300–800 as a last resort. Registered fonts take priority, and generic families such as `sans-serif` resolve to them.
 
 ## Loading fonts
 
@@ -75,8 +70,6 @@ export function GET() {
 
 ### From Google Fonts
 
-`googleFonts` fetches families from Google Fonts in one request and returns `fonts` entries: one lazy loader per coverage subset, downloaded when the renderer first needs it. Reference each family by name in `font-family`. [Subsetting](#subsetting) trims them to the content, so unused weights and scripts download nothing.
-
 ```tsx twoslash
 import { render } from "takumi-js";
 import { googleFonts } from "takumi-js/helpers";
@@ -88,6 +81,8 @@ const image = await render(<div style={{ fontFamily: "Inter" }}>Hello 你好 こ
   fonts: googleFonts(["Inter", "Noto Sans JP", "Noto Sans TC"]),
 });
 ```
+
+`googleFonts` fetches one CSS response for the requested families. Font files load when the renderer needs their coverage subsets. Use the family name in `fontFamily`; [subsetting](#subsetting) selects the files needed for the text.
 
 Pass an object instead of a name to set a family's weight, style, or variable axes:
 
@@ -122,7 +117,16 @@ Each family accepts:
 | `axes`    | `{ tag: value \| "min..max" }`              | Variable axes to load, e.g. `{ opsz: "9..144" }`. A range keeps them live. |
 | `generic` | a CSS generic family keyword                | Every loaded subset claims it, so e.g. `font-mono` resolves to the family. |
 
-Pass an object instead of a list for request-level options:
+Pass an object for request-level options:
+
+```ts twoslash
+import { googleFonts } from "takumi-js/helpers";
+
+const fonts = await googleFonts({
+  families: ["Inter"],
+  timeout: 3000,
+});
+```
 
 | Option     | Accepts                | Effect                                                    |
 | ---------- | ---------------------- | --------------------------------------------------------- |
@@ -133,7 +137,24 @@ Pass an object instead of a list for request-level options:
 
 The default CSS cache shares concurrent requests within each fetch implementation and evicts old entries automatically. Requests with `signal` or `allowUrl` bypass caching so cancellation and redirect checks stay local to the caller. `maxBytes` also applies to cache hits.
 
-Each subset registers under its own internal name; `font-family: Inter` expands across all of them, so each script finds the file that covers it.
+Temporary network failures are retried within the request's timeout. See [fetch limits](/docs/load-images#fetch-limits) for defaults, cancellation, and retry conditions. The timeout applies separately to the CSS request and each font file, not to the whole render.
+
+### Fonts in CI and offline renders
+
+```tsx twoslash
+import { readFile } from "node:fs/promises";
+import { render } from "takumi-js";
+
+const inter = await readFile(new URL("./fonts/Inter.woff2", import.meta.url));
+
+const image = await render(<div style={{ fontFamily: "Inter" }}>Hello</div>, {
+  fonts: [{ name: "Inter", data: inter }],
+});
+```
+
+Bundle font files when a render must work without Google Fonts. Retries can recover a brief outage, but not an unavailable host or a blocked CI network. Keep unit tests on local files or an injected `fetch`, and test the live service separately.
+
+An outer test or route timeout can end the render before the helper's deadline. Set `timeout` below that outer limit, leaving time for layout and encoding.
 
 ### Subsetting
 

--- a/docs/content/docs/typography-and-fonts.mdx
+++ b/docs/content/docs/typography-and-fonts.mdx
@@ -156,6 +156,8 @@ Bundle font files when a render must work without Google Fonts. Retries can reco
 
 An outer test or route timeout can end the render before the helper's deadline. Set `timeout` below that outer limit, leaving time for layout and encoding.
 
+CJK families can expose many coverage subsets. Takumi filters them by the text's codepoints before downloading, but matching subsets from multiple families or weights may still load together. Request only the families and weights your template needs. A timeout in `await googleFonts(...)` occurs during the CSS request, before these font downloads start.
+
 ### Subsetting
 
 `render` registers only the subsets the content draws, so the same `fonts` work for any text and unused ranges never download. The pass runs automatically.

--- a/takumi-helpers/tests/fetch-limits.test.ts
+++ b/takumi-helpers/tests/fetch-limits.test.ts
@@ -154,6 +154,37 @@ describe("allowUrl policy", () => {
 });
 
 describe("shared fetchCache policy enforcement", () => {
+  test("cached images recheck the entry URL, not the original redirect chain", async () => {
+    const entry = "https://allowed.example.com/image.png";
+    const destination = "https://other.example.com/image.png";
+    const payload = new Uint8Array([1, 2, 3]);
+    const fetchMock = mock((url: string) =>
+      Promise.resolve(
+        url === entry
+          ? new Response(null, { status: 302, headers: { location: destination } })
+          : new Response(payload),
+      ),
+    );
+    const node = tree(entry);
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl: () => true });
+    const checked: string[] = [];
+    const allowUrl = (url: string) => {
+      checked.push(url);
+      return url === entry;
+    };
+
+    const images = await prepareImages({ node, fetchCache, fetch: fetchMock, allowUrl });
+    expect(images.map((image) => new Uint8Array(image.data))).toEqual([payload]);
+    expect(checked).toEqual([entry]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await expect(
+      prepareImages({ node, fetchCache: new Map(), fetch: fetchMock, allowUrl }),
+    ).rejects.toThrow("URL blocked by allowUrl policy");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   test("a cache hit re-runs a stricter maxBytes and keeps the entry reusable", async () => {
     const fetchMock = mock(() => Promise.resolve(new Response(streamOf(new Uint8Array(60)))));
     const fetchCache = new Map<string, Promise<ArrayBuffer>>();


### PR DESCRIPTION
## Why

The guides duplicate resource-loading advice and document the wrong fetch timeout. Performance guidance introduces tuning before explaining automatic reuse.

## What

Lead with working examples, distinguish cache lifetimes, and centralize fetch limits and retry behavior. Add local-font guidance for offline CI and replace blanket tuning advice with workload-based checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added helper examples for `container` and `text` usage.
  * Clarified shared fetch limits, retries, redirects, caching, cancellation, and timeout settings for images, fonts, and emoji.
  * Expanded font guidance covering Google Fonts, fallback behavior, offline rendering, subsetting, and local font files.
  * Reworked performance guidance for renderer reuse, caching, repeated renders, network requests, and painting efficiency.
  * Clarified PDF font embedding and deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->