### PR TITLE
Core: encapsulate render-local text caches

### DIFF
--- a/takumi-core/src/context.rs
+++ b/takumi-core/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, rc::Rc, sync::Arc};
 use typed_builder::TypedBuilder;
 
 use crate::{
-  layout::inline::{MeasureCache, ShapeCache},
+  layout::inline::{InlineLayoutCache, MeasureCache, ShapeCache},
   resources::{font::FontsSnapshot, image::ImageSource},
   style::{Affine, Color, ComputedStyle, SizingContext, StyleSheet, TwCache},
 };
@@ -13,8 +13,7 @@ struct RenderShared {
   fonts: FontsSnapshot,
   images: Rc<HashMap<Arc<str>, ImageSource>>,
   stylesheet: Arc<StyleSheet>,
-  shape_cache: ShapeCache,
-  measure_cache: MeasureCache,
+  inline_cache: InlineLayoutCache,
   tw_cache: TwCache,
   time_ms: u64,
   draw_debug_border: bool,
@@ -63,8 +62,7 @@ impl From<RenderContextInit> for RenderContext {
         fonts: init.fonts,
         images: init.images,
         stylesheet: init.stylesheet,
-        shape_cache: init.shape_cache,
-        measure_cache: init.measure_cache,
+        inline_cache: InlineLayoutCache::new(init.shape_cache, init.measure_cache),
         tw_cache: TwCache::default(),
         time_ms: init.time_ms,
         draw_debug_border: init.draw_debug_border,
@@ -140,14 +138,8 @@ impl RenderContext {
     &self.shared.stylesheet
   }
 
-  /// Per-render cache of shaped text-only inline layouts.
-  pub(crate) fn shape_cache(&self) -> &ShapeCache {
-    &self.shared.shape_cache
-  }
-
-  /// Per-render cache of measured text-node sizes.
-  pub(crate) fn measure_cache(&self) -> &MeasureCache {
-    &self.shared.measure_cache
+  pub(crate) fn inline_cache(&self) -> &InlineLayoutCache {
+    &self.shared.inline_cache
   }
 
   /// Per-render cache of expanded Tailwind class lists.

--- a/takumi-core/src/layout/inline/cache.rs
+++ b/takumi-core/src/layout/inline/cache.rs
@@ -1,0 +1,123 @@
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+use crate::geometry::Size;
+
+use super::InlineLayout;
+
+type ShapedText = (InlineLayout, String);
+// None records first sight without retaining a layout clone.
+pub(crate) type ShapeCache = Rc<RefCell<HashMap<u64, Option<ShapedText>>>>;
+pub(crate) type MeasureCache = Rc<RefCell<HashMap<(u64, u32), Size<f32>>>>;
+
+/// Render-local text shaping and measurement reuse.
+#[derive(Clone, Default)]
+pub(crate) struct InlineLayoutCache {
+  shapes: ShapeCache,
+  measurements: MeasureCache,
+}
+
+impl InlineLayoutCache {
+  pub(crate) fn new(shapes: ShapeCache, measurements: MeasureCache) -> Self {
+    Self {
+      shapes,
+      measurements,
+    }
+  }
+
+  pub(crate) fn get_or_shape(
+    &self,
+    key: Option<(u64, &str)>,
+    shape: impl FnOnce() -> ShapedText,
+  ) -> ShapedText {
+    let seen = if let Some((fingerprint, expected_text)) = key {
+      match self.shapes.borrow().get(&fingerprint) {
+        Some(Some((layout, text))) if text == expected_text => {
+          return (layout.clone(), text.clone());
+        }
+        Some(_) => true,
+        None => false,
+      }
+    } else {
+      false
+    };
+
+    let shaped = shape();
+    if let Some((fingerprint, _)) = key {
+      self
+        .shapes
+        .borrow_mut()
+        .insert(fingerprint, seen.then(|| shaped.clone()));
+    }
+    shaped
+  }
+
+  pub(crate) fn get_or_measure(
+    &self,
+    key: (u64, u32),
+    measure: impl FnOnce() -> Size<f32>,
+  ) -> Size<f32> {
+    if let Some(size) = self.measurements.borrow().get(&key) {
+      return *size;
+    }
+    let size = measure();
+    self.measurements.borrow_mut().insert(key, size);
+    size
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::cell::Cell;
+
+  use super::*;
+
+  #[test]
+  fn shaping_retains_repeated_inputs_and_checks_text() {
+    let cache = InlineLayoutCache::default();
+    let calls = Cell::new(0);
+    let shape = || {
+      calls.set(calls.get() + 1);
+      (InlineLayout::new(), "hello".to_owned())
+    };
+    for _ in 0..3 {
+      cache.get_or_shape(Some((1, "hello")), shape);
+    }
+    assert_eq!(calls.get(), 2);
+    cache.clone().get_or_shape(Some((1, "hello")), shape);
+    assert_eq!(calls.get(), 2);
+
+    let (_, text) = cache.get_or_shape(Some((1, "other")), || {
+      (InlineLayout::new(), "other".to_owned())
+    });
+    assert_eq!(text, "other");
+    InlineLayoutCache::default().get_or_shape(Some((1, "hello")), shape);
+    assert_eq!(calls.get(), 3);
+  }
+
+  #[test]
+  fn uncacheable_shapes_do_not_create_entries() {
+    let cache = InlineLayoutCache::default();
+    cache.get_or_shape(None, || (InlineLayout::new(), "hello".to_owned()));
+    assert!(cache.shapes.borrow().is_empty());
+  }
+
+  #[test]
+  fn measurements_share_only_with_clones_and_matching_inputs() {
+    let cache = InlineLayoutCache::default();
+    let first = Size {
+      width: 10.0,
+      height: 20.0,
+    };
+    let second = Size {
+      width: 30.0,
+      height: 40.0,
+    };
+    assert_eq!(cache.get_or_measure((1, 5), || first), first);
+    assert_eq!(cache.clone().get_or_measure((1, 5), || second), first);
+    assert_eq!(cache.get_or_measure((1, 6), || second), second);
+    assert_eq!(
+      InlineLayoutCache::default().get_or_measure((1, 5), || second),
+      second
+    );
+  }
+}

--- a/takumi-core/src/layout/inline/mod.rs
+++ b/takumi-core/src/layout/inline/mod.rs
@@ -18,11 +18,12 @@ use parley::{
   GlyphRun, IndentOptions, InlineBox, InlineBoxKind, Line, PositionedInlineBox,
   PositionedLayoutItem, TextStyle, TreeBuilder,
 };
-use std::{cell::RefCell, collections::HashMap, convert::Infallible, rc::Rc};
+use std::{convert::Infallible, rc::Rc};
 use xxhash_rust::xxh3::Xxh3;
 
 mod background;
 mod breaking;
+mod cache;
 mod decorations;
 mod floats;
 mod items;
@@ -60,6 +61,7 @@ pub(crate) use self::{
   },
   text_fit::{LineScaleState, scale_text_fit_x, text_fit_line_alignment_correction},
 };
+pub(crate) use cache::{InlineLayoutCache, MeasureCache, ShapeCache};
 
 /// Inputs for building an inline layout.
 pub struct InlineLayoutRequest<'c> {
@@ -132,18 +134,6 @@ impl<'c> InlineLayoutRequest<'c> {
     }
   }
 }
-
-/// A per-render cache of shaped text-only parley layouts, keyed by a hash of
-/// the span texts and styles. Shaping is width-independent for pure text
-/// (inline boxes bake in measured sizes, so they bypass the cache); line
-/// breaking and alignment run on a clone per call. A layout is stored only
-/// once its fingerprint repeats (`None` marks first sight), so single-use
-/// text costs one map entry, not a retained layout clone.
-pub(crate) type ShapeCache = Rc<RefCell<HashMap<u64, Option<(InlineLayout, String)>>>>;
-
-/// Per-render map from a text node's measure inputs to its measured size.
-/// Keyed by content hash plus text length as a cheap collision guard.
-pub(crate) type MeasureCache = Rc<RefCell<HashMap<(u64, u32), Size<f32>>>>;
 
 /// Hashes everything shaping depends on: each span's processed text and
 /// style, plus the root style and language.
@@ -836,30 +826,13 @@ fn shape_spans(
       joined
     })
   });
-  let (cached, seen) = match (cache_key, &expected_text) {
-    (Some(key), Some(expected)) => match context.shape_cache().borrow().get(&key) {
-      Some(Some((layout, text))) if text == expected => {
-        ((Some((layout.clone(), text.clone()))), true)
-      }
-      Some(_) => (None, true),
-      None => (None, false),
-    },
-    _ => (None, false),
-  };
-  if let Some(cached) = cached {
-    return cached;
-  }
-
-  let (layout, text) = context.tree_builder(style.into(), chromium_line_breaks(spans), |builder| {
-    push_spans_into_builder(builder, spans, &context.fonts().classes)
-  });
-
-  if let Some(key) = cache_key {
-    let stored = seen.then(|| (layout.clone(), text.clone()));
-
-    context.shape_cache().borrow_mut().insert(key, stored);
-  }
-  (layout, text)
+  context
+    .inline_cache()
+    .get_or_shape(cache_key.zip(expected_text.as_deref()), || {
+      context.tree_builder(style.into(), chromium_line_breaks(spans), |builder| {
+        push_spans_into_builder(builder, spans, &context.fonts().classes)
+      })
+    })
 }
 
 fn prepare_inline_layout(
@@ -1135,7 +1108,7 @@ impl BuiltInlineLayout<'_> {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
-  use std::{fs::File, io::Read, path::Path, sync::Arc};
+  use std::{collections::HashMap, fs::File, io::Read, path::Path, sync::Arc};
 
   use super::{outline::x_ranges_touch, runs::slice_text_at_char_boundaries, *};
   use crate::{

--- a/takumi-core/src/layout/node/text.rs
+++ b/takumi-core/src/layout/node/text.rs
@@ -93,39 +93,35 @@ pub(crate) fn measure_text_node(
     clamp_to_max_width,
   );
 
-  if let Some(size) = context.measure_cache().borrow().get(&key) {
-    return *size;
-  }
-  let inline_content: InlineItem<'_> = InlineItem::Text {
-    text: text.text.as_str().into(),
-    context,
-    link: None,
-    decorations: None,
-  };
-  let mut built = create_inline_layout(InlineLayoutRequest {
-    items: vec![inline_content],
-    available_space,
-    max_width,
-    max_height,
-    style: &font_style,
-    context,
-    mode: InlineLayoutMode::Measure,
-    shape_cacheable: true,
-  });
-  let parent_font_metrics = built.parent_font_metrics();
-  let size = measure_inline_layout(
-    &mut built.layout,
-    &built.spans,
-    &built.positioned_floats,
-    &built.line_scales,
-    InlineMeasureOptions {
+  context.inline_cache().get_or_measure(key, || {
+    let inline_content: InlineItem<'_> = InlineItem::Text {
+      text: text.text.as_str().into(),
+      context,
+      link: None,
+      decorations: None,
+    };
+    let mut built = create_inline_layout(InlineLayoutRequest {
+      items: vec![inline_content],
+      available_space,
       max_width,
-      ceil_width: true,
-      parent_font_metrics,
-      clamp_to_max_width,
-    },
-  );
-
-  context.measure_cache().borrow_mut().insert(key, size);
-  size
+      max_height,
+      style: &font_style,
+      context,
+      mode: InlineLayoutMode::Measure,
+      shape_cacheable: true,
+    });
+    let parent_font_metrics = built.parent_font_metrics();
+    measure_inline_layout(
+      &mut built.layout,
+      &built.spans,
+      &built.positioned_floats,
+      &built.line_scales,
+      InlineMeasureOptions {
+        max_width,
+        ceil_width: true,
+        parent_font_metrics,
+        clamp_to_max_width,
+      },
+    )
+  })
 }


### PR DESCRIPTION
## Why

Text layout callers directly manipulated shaping and measurement maps. Shaping admission and collision checks were mixed into layout construction.

## What

Keep render-local text reuse in InlineLayoutCache, with private storage and domain operations. Preserve builder inputs, cache keys, second-use admission, and rendered output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved reuse of text shaping and measurement results during rendering.
  * Added handling for text content changes to prevent reuse of mismatched cached layouts.
* **Reliability**
  * Improved caching behavior for repeated and uncacheable text shaping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->