### PR TITLE
Helpers: honor request policies across redirects and cache hits

### DIFF
--- a/.tegami/resource-request-policies.md
+++ b/.tegami/resource-request-policies.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Honor request policies across redirects and cache hits
+
+Strip sensitive headers on cross-origin redirects, apply redirect method and body rules, and honor image cache readers' cancellation and timeout without aborting shared downloads.

--- a/takumi-helpers/package.json
+++ b/takumi-helpers/package.json
@@ -91,7 +91,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown --config-loader unrun",
     "publish-lint": "attw --pack . && publint --strict ."
   },
   "devDependencies": {

--- a/takumi-helpers/src/fetch.ts
+++ b/takumi-helpers/src/fetch.ts
@@ -1,5 +1,7 @@
-const defaultFetchTimeout = 30_000;
+import { FetchDeadline } from "./fetch/deadline";
+
 const maxRedirectHops = 5;
+const redirectStatuses = new Set([301, 302, 303, 307, 308]);
 const maxFetchAttempts = 3;
 const maxRetryDelay = 1000;
 const retryableStatuses = new Set([408, 429, 500, 502, 503, 504]);
@@ -38,14 +40,9 @@ class FetchRequest {
     this.url = url;
     this.allowUrl = options.allowUrl;
     this.fetchImpl = options.fetch ?? globalThis.fetch;
-    const timeout = options.timeout ?? defaultFetchTimeout;
-    const timeoutSignal = timeout <= 0 ? undefined : AbortSignal.timeout(timeout);
-    const signals = [options.signal, options.init?.signal, timeoutSignal].filter(
-      (signal): signal is AbortSignal => signal != null,
-    );
     this.init = {
       ...options.init,
-      signal: signals.length ? AbortSignal.any(signals) : undefined,
+      signal: new FetchDeadline(options, options.init?.signal).signal,
     };
   }
 
@@ -122,18 +119,61 @@ class FetchRequest {
 
   private async followRedirects(allowUrl: (url: string) => boolean): Promise<Response> {
     let current = this.url;
+    const init = {
+      ...this.init,
+      headers: new Headers(this.init.headers),
+      redirect: "manual" as const,
+    };
+
     for (let hop = 0; hop < maxRedirectHops; hop++) {
-      const response = await this.attempt(current, { ...this.init, redirect: "manual" });
+      const response = await this.attempt(current, init);
       const location = response.headers.get("location");
-      if (response.status < 300 || response.status >= 400 || !location) {
+
+      if (!redirectStatuses.has(response.status) || location === null) {
         return response;
       }
 
       await response.body?.cancel().catch(() => {});
-      current = new URL(location, current).toString();
-      if (!allowUrl(current)) {
-        throw new Error(`URL blocked by allowUrl policy: ${current}`);
+      const next = new URL(location, current);
+
+      if (!allowUrl(next.href)) {
+        throw new Error(`URL blocked by allowUrl policy: ${next.href}`);
       }
+      if (
+        (next.protocol !== "https:" && next.protocol !== "http:") ||
+        next.username ||
+        next.password
+      ) {
+        throw new Error(`Invalid redirect URL: ${next.href}`);
+      }
+      // https://fetch.spec.whatwg.org/#http-redirect-fetch
+      if (response.status !== 303 && init.body instanceof ReadableStream) {
+        throw new Error("Cannot replay a streamed request body after a redirect");
+      }
+      const method = init.method?.toUpperCase() ?? "GET";
+
+      if (
+        ((response.status === 301 || response.status === 302) && method === "POST") ||
+        (response.status === 303 && method !== "GET" && method !== "HEAD")
+      ) {
+        init.method = "GET";
+        init.body = undefined;
+        for (const header of [
+          "content-encoding",
+          "content-language",
+          "content-location",
+          "content-type",
+          "content-length",
+        ]) {
+          init.headers.delete(header);
+        }
+      }
+      if (new URL(current).origin !== next.origin) {
+        for (const header of ["authorization", "proxy-authorization", "cookie", "cookie2"]) {
+          init.headers.delete(header);
+        }
+      }
+      current = next.href;
     }
     throw new Error(`Too many redirects fetching ${this.url}`);
   }

--- a/takumi-helpers/src/fetch.ts
+++ b/takumi-helpers/src/fetch.ts
@@ -119,10 +119,10 @@ class FetchRequest {
 
   private async followRedirects(allowUrl: (url: string) => boolean): Promise<Response> {
     let current = this.url;
-    const init = {
+    let init: RequestInit = {
       ...this.init,
       headers: new Headers(this.init.headers),
-      redirect: "manual" as const,
+      redirect: "manual",
     };
 
     for (let hop = 0; hop < maxRedirectHops; hop++) {
@@ -146,36 +146,52 @@ class FetchRequest {
       ) {
         throw new Error(`Invalid redirect URL: ${next.href}`);
       }
-      // https://fetch.spec.whatwg.org/#http-redirect-fetch
-      if (response.status !== 303 && init.body instanceof ReadableStream) {
-        throw new Error("Cannot replay a streamed request body after a redirect");
-      }
-      const method = init.method?.toUpperCase() ?? "GET";
-
-      if (
-        ((response.status === 301 || response.status === 302) && method === "POST") ||
-        (response.status === 303 && method !== "GET" && method !== "HEAD")
-      ) {
-        init.method = "GET";
-        init.body = undefined;
-        for (const header of [
-          "content-encoding",
-          "content-language",
-          "content-location",
-          "content-type",
-          "content-length",
-        ]) {
-          init.headers.delete(header);
-        }
-      }
-      if (new URL(current).origin !== next.origin) {
-        for (const header of ["authorization", "proxy-authorization", "cookie", "cookie2"]) {
-          init.headers.delete(header);
-        }
-      }
+      init = FetchRequest.redirectInit(init, response.status, current, next);
       current = next.href;
     }
     throw new Error(`Too many redirects fetching ${this.url}`);
+  }
+
+  // https://fetch.spec.whatwg.org/#http-redirect-fetch
+  private static redirectInit(
+    init: RequestInit,
+    status: number,
+    current: string,
+    next: URL,
+  ): RequestInit {
+    if (status !== 303 && init.body instanceof ReadableStream) {
+      throw new Error("Cannot replay a streamed request body after a redirect");
+    }
+
+    const headers = new Headers(init.headers);
+    const method = init.method?.toUpperCase() ?? "GET";
+    const changeToGet =
+      ((status === 301 || status === 302) && method === "POST") ||
+      (status === 303 && method !== "GET" && method !== "HEAD");
+
+    if (changeToGet) {
+      for (const header of [
+        "content-encoding",
+        "content-language",
+        "content-location",
+        "content-type",
+        "content-length",
+      ]) {
+        headers.delete(header);
+      }
+    }
+    if (new URL(current).origin !== next.origin) {
+      for (const header of ["authorization", "proxy-authorization", "cookie", "cookie2"]) {
+        headers.delete(header);
+      }
+    }
+
+    return {
+      ...init,
+      headers,
+      method: changeToGet ? "GET" : init.method,
+      body: changeToGet ? undefined : init.body,
+    };
   }
 }
 

--- a/takumi-helpers/src/fetch/deadline.ts
+++ b/takumi-helpers/src/fetch/deadline.ts
@@ -1,0 +1,47 @@
+import type { FetchOptions } from "../fetch";
+
+const defaultFetchTimeout = 30_000;
+
+export class FetchDeadline {
+  readonly signal: AbortSignal | undefined;
+
+  constructor(options: FetchOptions, initSignal?: AbortSignal | null) {
+    const timeout = options.timeout ?? defaultFetchTimeout;
+    const signals = [
+      options.signal,
+      initSignal,
+      timeout <= 0 ? undefined : AbortSignal.timeout(timeout),
+    ].filter((signal): signal is AbortSignal => signal != null);
+
+    this.signal = signals.length ? AbortSignal.any(signals) : undefined;
+  }
+
+  waitFor<T>(promise: Promise<T>): Promise<T> {
+    const signal = this.signal;
+
+    if (!signal) {
+      return promise;
+    }
+
+    return new Promise((resolve, reject) => {
+      function abort() {
+        signal?.removeEventListener("abort", abort);
+        reject(signal?.reason);
+      }
+      signal.addEventListener("abort", abort, { once: true });
+      promise.then(
+        (value) => {
+          signal.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        (error) => {
+          signal.removeEventListener("abort", abort);
+          reject(error);
+        },
+      );
+      if (signal.aborted) {
+        abort();
+      }
+    });
+  }
+}

--- a/takumi-helpers/src/images.ts
+++ b/takumi-helpers/src/images.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import type { Node } from "./types";
 import { defaultMaxFetchBytes, fetchOk, type FetchOptions, readBodyLimited } from "./fetch";
+import { FetchDeadline } from "./fetch/deadline";
 
 const cssUrlPattern = /url\(\s*(['"]?)(.*?)\1\s*\)/g;
 
@@ -74,9 +75,6 @@ export interface ImageFetchCache {
   delete(url: string): unknown;
 }
 
-/** Fetches a URL's bytes, coalescing concurrent requests for the same URL through `cache`. A
- * rejected fetch is evicted so a later call can retry instead of replaying the failure. A cache
- * hit rechecks the caller's `allowUrl` (entry URL only, not redirect hops) and `maxBytes`. */
 function fetchImageData(
   url: string,
   options: FetchOptions,
@@ -87,7 +85,7 @@ function fetchImageData(
 
   const cached = fetchCache?.get(url);
   if (cached) {
-    return cached.then((data) => {
+    return new FetchDeadline(options).waitFor(cached).then((data) => {
       if (allowUrl && !allowUrl(url)) {
         throw new Error(`URL blocked by allowUrl policy: ${url}`);
       }

--- a/takumi-helpers/tests/fetch-redirects.test.ts
+++ b/takumi-helpers/tests/fetch-redirects.test.ts
@@ -1,0 +1,95 @@
+import { expect, mock, test } from "bun:test";
+import { fetchOk } from "../src/fetch";
+
+test.each([
+  [301, "POST", "GET"],
+  [302, "POST", "GET"],
+  [303, "POST", "GET"],
+  [303, "PUT", "GET"],
+  [303, "HEAD", "HEAD"],
+  [303, "GET", "GET"],
+  [301, "PUT", "PUT"],
+  [302, "PUT", "PUT"],
+  [307, "POST", "POST"],
+  [308, "POST", "POST"],
+])("%i redirects %s as %s", async (status, method, expectedMethod) => {
+  const headers = new Headers({
+    "content-type": "text/plain",
+    "content-language": "en",
+    "content-encoding": "identity",
+    "content-location": "/body",
+    "content-length": "7",
+    "x-request-id": "kept",
+  });
+  const body = method === "HEAD" || method === "GET" ? undefined : "payload";
+  const fetch = mock(async (_url: string, init?: RequestInit) => {
+    if (fetch.mock.calls.length === 1) {
+      return new Response(null, { status, headers: { location: "/next" } });
+    }
+    expect(init?.method).toBe(expectedMethod);
+    expect(init?.body ?? undefined).toBe(method === expectedMethod ? body : undefined);
+    for (const [name, value] of headers) {
+      expect(new Headers(init?.headers).get(name)).toBe(
+        method !== expectedMethod && name.startsWith("content-") ? null : value,
+      );
+    }
+    return new Response("ok");
+  });
+  await fetchOk("https://example.com/start", {
+    fetch,
+    allowUrl: () => true,
+    init: { method, body, headers },
+  });
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(headers.get("content-type")).toBe("text/plain");
+});
+
+test("keeps same-origin credentials and removes them permanently after an origin change", async () => {
+  const headers = new Headers({
+    authorization: "Bearer secret",
+    cookie: "session=secret",
+    "proxy-authorization": "Basic secret",
+    "x-request-id": "kept",
+  });
+  const destinations = [
+    "https://first.test/same",
+    "https://second.test/cross",
+    "https://first.test/return",
+  ];
+  const fetch = mock(async (_url: string, init?: RequestInit) => {
+    for (const [name, value] of headers) {
+      expect(new Headers(init?.headers).get(name)).toBe(
+        fetch.mock.calls.length <= 2 || name === "x-request-id" ? value : null,
+      );
+    }
+    const location = destinations[fetch.mock.calls.length - 1];
+    return location
+      ? new Response(null, { status: 307, headers: { location } })
+      : new Response("ok");
+  });
+  await fetchOk("https://first.test/start", { fetch, allowUrl: () => true, init: { headers } });
+  expect(fetch).toHaveBeenCalledTimes(4);
+  expect(headers.get("authorization")).toBe("Bearer secret");
+});
+
+test.each([300, 304, 305, 306])("does not follow status %i", async (status) => {
+  const fetch = mock(async () => new Response(null, { status, headers: { location: "/next" } }));
+  await expect(
+    fetchOk("https://example.com/start", { fetch, allowUrl: () => true }),
+  ).rejects.toThrow(`HTTP ${status}`);
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("rejects a streamed body that cannot be replayed", async () => {
+  const fetch = mock(
+    async () => new Response(null, { status: 307, headers: { location: "/next" } }),
+  );
+  await expect(
+    fetchOk("https://example.com/start", {
+      fetch,
+      allowUrl: () => true,
+      init: { method: "POST", body: new ReadableStream() },
+    }),
+  ).rejects.toThrow("Cannot replay a streamed request body");
+  expect(fetch).toHaveBeenCalledTimes(1);
+});

--- a/takumi-helpers/tests/image-cache-cancellation.test.ts
+++ b/takumi-helpers/tests/image-cache-cancellation.test.ts
@@ -1,0 +1,39 @@
+import { expect, mock, test } from "bun:test";
+import { prepareImages } from "../src/images";
+
+const node = { type: "image", src: "https://example.com/image.png" } as const;
+
+test("rejects an already-cancelled cache reader", async () => {
+  const signal = AbortSignal.abort(new Error("cancelled"));
+  const fetchCache = new Map([[node.src, Promise.resolve(new ArrayBuffer(1))]]);
+  await expect(prepareImages({ node, fetchCache, signal })).rejects.toThrow("cancelled");
+});
+
+test.each(["abort", "timeout"])(
+  "%s stops one cache reader without cancelling the shared download",
+  async (mode) => {
+    const download = Promise.withResolvers<Response>();
+    const fetch = mock(() => download.promise);
+    const fetchCache = new Map<string, Promise<ArrayBuffer>>();
+    const first = prepareImages({ node, fetchCache, fetch, timeout: 0 });
+    const controller = new AbortController();
+    const second = prepareImages({
+      node,
+      fetchCache,
+      signal: controller.signal,
+      timeout: mode === "timeout" ? 10 : 0,
+    });
+    if (mode === "abort") controller.abort(new Error("cancelled"));
+    try {
+      await expect(
+        Promise.race([second, Bun.sleep(200).then(() => "still waiting")]),
+      ).rejects.toThrow(mode === "timeout" ? "timed out" : "cancelled");
+    } finally {
+      download.resolve(new Response(new Uint8Array([1, 2, 3])));
+      expect(await first).toHaveLength(1);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetchCache.has(node.src)).toBe(true);
+    expect(await prepareImages({ node, fetchCache })).toHaveLength(1);
+  },
+);

--- a/takumi-helpers/tsdown.config.ts
+++ b/takumi-helpers/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { defineConfig } from "tsdown";
-import { fetchOk } from "./src/fetch.ts";
+import { fetchOk } from "./src/fetch";
 
 const CATALOG_SOURCE = "https://fonts.google.com/metadata/fonts";
 const CATALOG_FILE = new URL("src/google-fonts-catalog.ts", import.meta.url);


### PR DESCRIPTION
## Why

Manual redirects could forward credentials across origins or replay POST bodies incorrectly. Image cache readers ignored their own cancellation and timeout.

## What

Apply redirect status, method, body, and credential rules while preserving URL policy checks. Let each cache reader stop waiting without aborting the shared download.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request policies are now enforced consistently across redirects, including URL validation and protection of sensitive headers during cross-origin redirects.
  * Redirect handling now follows standard method and request-body rules.
  * Image cache reads now honor cancellation and timeout settings without interrupting shared downloads.
  * Unsupported redirect responses and non-replayable streamed request bodies now fail with clear errors.

* **Documentation**
  * Added release notes documenting request-policy behavior across redirects and image cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->