### PR TITLE
Helpers: keep credentials off HTTP requests

### DIFF
--- a/.tegami/http-request-credentials.md
+++ b/.tegami/http-request-credentials.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/helpers":
+    type: patch
+---
+
+### Keep credentials off HTTP requests
+
+Remove Authorization and Cookie headers before HTTP requests, including same-origin redirects. Keep credentials on same-origin HTTPS requests.

--- a/takumi-helpers/src/fetch.ts
+++ b/takumi-helpers/src/fetch.ts
@@ -47,9 +47,13 @@ class FetchRequest {
   }
 
   async send() {
-    const response = this.allowUrl
-      ? await this.followRedirects(this.allowUrl)
-      : await this.attempt(this.url, this.init);
+    const headers = new Headers(this.init.headers);
+    const hasCredentials = headers.has("authorization") || headers.has("cookie");
+    const follow = this.init.redirect === undefined || this.init.redirect === "follow";
+    const response =
+      this.allowUrl || (hasCredentials && follow)
+        ? await this.followRedirects(this.allowUrl)
+        : await this.attempt(this.url, this.init);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status} ${response.statusText} fetching ${this.url}`);
     }
@@ -57,6 +61,14 @@ class FetchRequest {
   }
 
   private async attempt(url: string, init: RequestInit): Promise<Response> {
+    if (new URL(url).protocol === "http:") {
+      const headers = new Headers(init.headers);
+
+      headers.delete("authorization");
+      headers.delete("cookie");
+      init = { ...init, headers };
+    }
+
     const method = init.method?.toUpperCase() ?? "GET";
     const canRetry = method === "GET" || method === "HEAD";
     for (let attempt = 0; ; attempt++) {
@@ -117,7 +129,7 @@ class FetchRequest {
     });
   }
 
-  private async followRedirects(allowUrl: (url: string) => boolean): Promise<Response> {
+  private async followRedirects(allowUrl: FetchOptions["allowUrl"]): Promise<Response> {
     let current = this.url;
     let init: RequestInit = {
       ...this.init,
@@ -136,7 +148,7 @@ class FetchRequest {
       await response.body?.cancel().catch(() => {});
       const next = new URL(location, current);
 
-      if (!allowUrl(next.href)) {
+      if (allowUrl && !allowUrl(next.href)) {
         throw new Error(`URL blocked by allowUrl policy: ${next.href}`);
       }
       if (

--- a/takumi-helpers/tests/fetch-redirects.test.ts
+++ b/takumi-helpers/tests/fetch-redirects.test.ts
@@ -1,6 +1,64 @@
 import { expect, mock, test } from "bun:test";
 import { fetchOk } from "../src/fetch";
 
+test.each([true, false])("protects HTTP credentials with allowUrl=%s", async (usePolicy) => {
+  for (const protocol of ["http:", "https:"]) {
+    for (const name of ["Authorization", "Cookie"]) {
+      const headers = new Headers({ [name]: "secret", "x-request-id": "kept" });
+      const requests: { url: string; credential: string | null }[] = [];
+      const fetch = mock(async (url: string, init?: RequestInit) => {
+        expect(init?.redirect).toBe("manual");
+        const sent = new Headers(init?.headers);
+
+        expect(sent.get("x-request-id")).toBe("kept");
+        requests.push({ url, credential: sent.get(name) });
+        return requests.length < 3
+          ? new Response(null, {
+              status: 307,
+              headers: { location: requests.length === 1 ? "/same" : "http://example.com/end" },
+            })
+          : new Response("ok");
+      });
+
+      await fetchOk(`${protocol}//example.com/start`, {
+        fetch,
+        allowUrl: usePolicy ? () => true : undefined,
+        init: { headers },
+      });
+      expect(requests).toEqual([
+        {
+          url: `${protocol}//example.com/start`,
+          credential: protocol === "https:" ? "secret" : null,
+        },
+        {
+          url: `${protocol}//example.com/same`,
+          credential: protocol === "https:" ? "secret" : null,
+        },
+        { url: "http://example.com/end", credential: null },
+      ]);
+      expect(headers.get(name)).toBe("secret");
+    }
+  }
+});
+
+test.each(["manual", "error"] satisfies RequestRedirect[])(
+  "preserves explicit redirect mode %s",
+  async (redirect) => {
+    const fetch = mock(async (_url: string, init?: RequestInit) => {
+      expect(init?.redirect).toBe(redirect);
+      expect(new Headers(init?.headers).get("authorization")).toBeNull();
+      expect(new Headers(init?.headers).get("cookie")).toBeNull();
+      return new Response("ok");
+    });
+
+    await fetchOk("http://example.com/start", {
+      fetch,
+      init: { redirect, headers: { Authorization: "secret", Cookie: "secret" } },
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  },
+);
+
 test.each([
   [301, "POST", "GET"],
   [302, "POST", "GET"],


### PR DESCRIPTION
## Why

HTTP requests could send Authorization and Cookie headers, including on same-origin redirects.

## What

Strip both headers before HTTP requests and handle redirects explicitly when credentials are present. Preserve same-origin HTTPS credentials and cover HTTP redirects with regression tests.
