### PR TITLE
Docs: rewrite PDF and chart guides

### DIFF
--- a/docs/content/docs/charts.mdx
+++ b/docs/content/docs/charts.mdx
@@ -1,17 +1,26 @@
 ---
 title: Charts
-description: Render charts from any library that outputs SVG
+description: Generate SVG charts and render them as images or PDF.
 icon: ChartColumn
 ---
 
-Takumi renders SVG natively: any chart library that outputs an SVG string works, with no browser, DOM, or canvas. The same chart renders to a PNG for an OG image or stays vector in a PDF.
+Generate a chart as an SVG string, then pass it to an `<img>` in your document. Takumi renders the SVG without running the chart library in a browser. The library must support generating SVG in your runtime.
 
-## ECharts
+## Render an ECharts chart
 
-[Apache ECharts](https://echarts.apache.org) has zero-dependency server-side rendering: pass `null` as the container and read the SVG back as a string.
+Install ECharts alongside `takumi-js`:
 
-```tsx
+```npm
+npm i echarts takumi-js @takumi-rs/helpers react
+```
+
+This example generates a bar chart and saves it as a PNG. ECharts uses its SVG server renderer, so it needs no DOM or canvas.
+
+```tsx twoslash
 import * as echarts from "echarts";
+import { render } from "takumi-js";
+import { googleFonts } from "@takumi-rs/helpers";
+import { writeFile } from "node:fs/promises";
 
 const chart = echarts.init(null, null, {
   renderer: "svg",
@@ -22,6 +31,7 @@ const chart = echarts.init(null, null, {
 
 chart.setOption({
   animation: false,
+  textStyle: { fontFamily: "Inter" },
   xAxis: { type: "category", data: ["Q1", "Q2", "Q3", "Q4"] },
   yAxis: { type: "value" },
   series: [{ type: "bar", data: [320, 730, 550, 910] }],
@@ -29,53 +39,55 @@ chart.setOption({
 
 const svg = chart.renderToSVGString();
 chart.dispose();
-```
 
-Set `animation: false`. An animated chart's SVG carries its first keyframe, which renders as an empty or partly drawn chart.
-
-An `<img>` takes the SVG string directly as its `src`. A chart is one-off content, so nothing needs registering under `images`:
-
-```tsx
-import { render } from "takumi-js";
-
+const fonts = (await googleFonts(["Inter"])).map((font) => ({ ...font, ranges: [] }));
 const png = await render(
-  <div style={{ display: "flex" }}>
-    <img src={svg} alt="Quarterly revenue" style={{ width: 560, height: 360 }} />
-  </div>,
-  { width: 1200, height: 630 },
+  <img
+    src={svg}
+    alt="Quarterly revenue: 320, 730, 550, and 910"
+    style={{ width: 560, height: 360 }}
+  />,
+  { width: 560, height: 360, fonts },
 );
+
+await writeFile("revenue.png", png);
 ```
 
-An HTML string works too, with the SVG inlined into the markup: ``render(`<div style="display:flex">${svg}</div>`, …)``.
+Keep `animation: false` for static output. Animated SVG can capture an empty or partially drawn chart. Dispose of the ECharts instance after extracting the SVG.
 
-The same SVG stays vector in a PDF. See [Charts in PDF](/docs/pdf/charts).
+The SVG string goes directly in `src`. It does not need an `images` entry. To include it in an HTML string, insert the SVG markup inside the document.
+
+For PDF output, see [Charts in PDF](/docs/pdf/charts).
 
 ## Fonts for chart labels
 
-SVG text renders through the same font registry as everything else. Missing glyphs render as tofu, so CJK labels need a registered CJK font.
+Register fonts that cover every label, tick, and legend entry. Set the chart's font family to the same name.
 
-One catch with [`googleFonts`](/docs/typography-and-fonts): the renderer subsets fonts against the text in your element tree, and it cannot see text inside an SVG string. Filter the subsets against the label text yourself, then clear `ranges` so the renderer keeps the result:
+`googleFonts()` returns font subsets with Unicode ranges. Takumi filters those subsets against text in the document tree, which excludes text inside an SVG image. Clearing `ranges`, as above, keeps every returned subset.
 
-```tsx
+For a large font family, select the subsets against the chart text first. Include generated numeric ticks and punctuation as well as your data labels:
+
+```tsx twoslash
 import { googleFonts, subsetFonts } from "@takumi-rs/helpers";
 
-const labels = ["一月", "二月", "三月", "四月"];
-const all = await googleFonts(["Noto Sans TC"]);
-const fonts = subsetFonts({ fonts: all, source: labels.join("") }).map((font) => ({
-  ...font,
-  ranges: [],
-}));
+const chartText = "一月二月三月四月營收0123456789.,−-%";
+const fonts = subsetFonts({
+  fonts: await googleFonts(["Noto Sans TC"]),
+  source: chartText,
+}).map((font) => ({ ...font, ranges: [] }));
 ```
 
-## Picking a library
+Pass `fonts` to `render()` and set ECharts `textStyle.fontFamily` to `"Noto Sans TC"`. For offline output, load bundled font bytes instead. See [Fonts in CI and offline renders](/docs/typography-and-fonts#fonts-in-ci-and-offline-renders).
 
-Choose a library that produces SVG without a DOM:
+## Use another chart library
 
-| Library            | Server-side SVG                                                |
-| ------------------ | -------------------------------------------------------------- |
-| ECharts            | `ssr: true` + `renderToSVGString()`                            |
-| Vega / Vega-Lite   | `new View(parse(spec), { renderer: "none" })` + `view.toSVG()` |
-| d3-shape, d3-scale | Pure math; build the `<svg>` in JSX from the path strings      |
-| visx               | React SVG primitives through `renderToStaticMarkup`            |
+Takumi accepts the SVG output, not the library's interactive component. Generate the final chart before calling `render()`.
 
-Observable Plot and Recharts need a DOM implementation on the server. Chart.js, uPlot, and lightweight-charts render to canvas only. Prefer a library from the table above.
+| Approach              | SVG generation                                            |
+| --------------------- | --------------------------------------------------------- |
+| ECharts               | `ssr: true`, then `renderToSVGString()`                   |
+| Vega or Vega-Lite     | Create a Vega view and call `toSVG()`                     |
+| d3-shape and d3-scale | Build SVG elements from computed paths and coordinates    |
+| React SVG components  | Render supported components with `renderToStaticMarkup()` |
+
+A library that requires a DOM or canvas needs its own server rendering setup. If it produces a PNG, pass that image to Takumi instead. A raster chart remains raster in PDF.

--- a/docs/content/docs/pdf/attachments.mdx
+++ b/docs/content/docs/pdf/attachments.mdx
@@ -4,7 +4,7 @@ description: Embed files in the PDF, including PDF/A-3 e-invoice data
 icon: Paperclip
 ---
 
-Attach files with `attachments`. They appear in the viewer's attachment panel:
+Pass files through `attachments` to include source data, supporting documents, or invoice XML. Readers can access them in PDF viewers that expose an attachment panel:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -29,7 +29,7 @@ const pdf = await render(invoice, {
 
 `data` takes raw bytes as a `Uint8Array`, or a string encoded as UTF-8.
 
-`relationship` states how the file relates to the document. It becomes the PDF/A-3 `AFRelationship`:
+`relationship` describes the attachment's role and is written as `AFRelationship`:
 
 | Value           | Meaning                                          |
 | --------------- | ------------------------------------------------ |
@@ -41,7 +41,7 @@ const pdf = await render(invoice, {
 
 ## Electronic invoices
 
-ZUGFeRD and Factur-X invoices are PDF/A-3 documents with the invoice XML attached. Combine `attachments` with `pdfa`:
+For a Factur-X or ZUGFeRD document, use PDF/A-3 and attach the invoice XML. This example shows the attachment configuration:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -72,8 +72,8 @@ The PDF/A-3 levels require three fields on each attachment:
 - `description`
 - a modification date: `modificationDate`, or the `metadata.creationDate` fallback
 
-A missing field fails the render with the violated rule.
+The render fails if required attachment metadata is missing.
 
 Invalid combinations are **TypeScript type errors**. The PDF/A-2 levels and `"4"` forbid attachments. Use `"4f"` to attach files to a PDF 2.0 archival document. The PDF/A-3 levels require `mimeType` and `description` on each one.
 
-Full Factur-X conformance also expects its `fx:` XMP extension schema. `metadata.xmp` writes it. See [Invoices](/docs/pdf/invoices).
+This configuration alone does not validate the invoice XML or its profile. Add the profile's XMP metadata and validate the result as described in [Invoices](/docs/pdf/invoices).

--- a/docs/content/docs/pdf/charts.mdx
+++ b/docs/content/docs/pdf/charts.mdx
@@ -1,26 +1,47 @@
 ---
 title: Charts
-description: Vector charts from SVG-producing libraries
+description: Place SVG charts in a PDF and provide accessible descriptions.
 icon: ChartColumn
 ---
 
-A chart embedded as SVG stays vector in the PDF. It is drawn as paths, gradients become PDF shadings, and dashed lines keep their dash pattern. A page with two full charts is around 20 KB.
+Use an SVG chart to preserve vector lines and shapes in PDF. Generate the SVG before rendering the document. See [Charts](/docs/charts#render-an-echarts-chart) for a complete ECharts example.
 
-Generate the SVG with any library that renders without a DOM, like [ECharts in SSR mode](/docs/charts), and hand the string to an `<img>` as its `src`:
+## Add a chart
 
-```tsx
+Pass the SVG string directly to `src`. Set its dimensions in CSS pixels and register the fonts used by its labels.
+
+```tsx twoslash
+declare const svg: string;
+// ---cut---
 import { render } from "takumi-pdf";
+import { googleFonts } from "@takumi-rs/helpers";
 
+const fonts = (await googleFonts(["Inter"])).map((font) => ({ ...font, ranges: [] }));
 const pdf = await render(
-  <div style={{ display: "flex" }}>
-    <img src={svg} alt="Quarterly revenue" style={{ width: 560, height: 360 }} />
-  </div>,
-  { page: "a4" },
+  <figure style={{ margin: 0, breakInside: "avoid" }}>
+    <img
+      src={svg}
+      alt="Quarterly revenue: 320, 730, 550, and 910"
+      style={{ width: 560, height: 360 }}
+    />
+    <figcaption>Revenue by quarter</figcaption>
+  </figure>,
+  { size: "a4", fonts },
 );
 ```
 
-## Text inside the chart
+Replace `svg` with your generated chart. `breakInside: "avoid"` keeps the chart and caption together when they fit on one page. Choose dimensions that fit within the page margins.
 
-Axis labels and values are drawn as outlines. They are visible but not selectable or extractable. In tagged output, give the `<img>` an `alt` so the chart becomes a `Figure` with a description.
+The empty `ranges` array prevents the renderer from discarding font subsets used only inside the SVG. See [Fonts for chart labels](/docs/charts#fonts-for-chart-labels) to load fewer subsets for large font families.
 
-Labels need a registered font that covers them. See [fonts for chart labels](/docs/charts#fonts-for-chart-labels) for the CJK subsetting catch.
+## Vector output and text
+
+SVG paths, supported gradients, and dashed lines remain vector. Embedded bitmaps and SVG effects that require rasterization still use pixels. A PNG chart stays raster even when placed in a PDF.
+
+SVG labels are drawn as outlines. They remain visible but cannot be selected, searched, or extracted as text. Put searchable titles, captions, and data tables in the surrounding JSX.
+
+## Describe the data
+
+Give the chart a meaningful `alt`. Tagged output uses it as the figure description. A label such as “Bar chart” identifies the image but does not explain its data.
+
+For detailed charts, include a table with the underlying values. See [Reports and statements](/docs/pdf/reports#long-tables) for a table that continues across pages.

--- a/docs/content/docs/pdf/comparison.mdx
+++ b/docs/content/docs/pdf/comparison.mdx
@@ -1,10 +1,10 @@
 ---
 title: Comparison
-description: takumi-pdf against Puppeteer and react-pdf, measured.
+description: Compare renderer behavior and recorded invoice benchmarks.
 icon: Scale
 ---
 
-This comparison benchmarks three JavaScript PDF renderers. The benchmark uses an 80-line invoice. The invoice spans two pages and has a page-number footer.
+This page records a benchmark of an 80-line invoice across three PDF renderers. The numbers apply to the package versions and environment below, not necessarily the current releases.
 
 Each harness uses its engine's native template language. Geometry, columns, and the embedded font (Inter 400/700) are the same in each harness. react-pdf's pt values mirror the other renderers' px values. takumi and Chrome produce the same two-page layout.
 
@@ -38,14 +38,12 @@ These measurements use npm-registry packages and esbuild (`--bundle --minify`, g
 
 pdf-lib, pdfkit, and jspdf are drawing primitives. You position each text line yourself. They are not in the benchmark above.
 
-takumi-pdf's wasm binary is the largest single JS download. It is also the whole engine. `node_modules` has 45 files.
+Measure the complete bundle for your deployment target. These figures exclude application code and should not be used as a current platform size limit.
 
-Cloudflare Workers caps a free-plan bundle at 3 MB after compression. The 1.52 MB wasm and the 10 KB JS wrapper leave half of that for application code.
-
-Reading the numbers honestly:
+## Interpret the results
 
 - Chrome's cold start includes launching a browser process. It varies with machine state. Its memory spans several processes. A single-process measurement misses this. Chrome performs well after warming. It has the most complete CSS support of the three.
 - react-pdf embeds the same Inter subsets as the other two. Subsetting on every render is most of its warm cost; the standard 14 PDF fonts avoid it. Documents use react-pdf's component set. Existing HTML, JSX, and Tailwind markup cannot be reused. It shapes Arabic, but paragraph direction is manual, and our Arabic sample dropped its first letter.
 - takumi-pdf reuses OG-image components unchanged. Its CSS coverage is narrower than Chromium's. PDF output does not support `filter: blur()`, `drop-shadow()`, or `backdrop-filter`. A blurred `box-shadow` is approximated with bands, and a blurred `text-shadow` draws sharp. Tagged output is on by default and adds about 4 KB to this invoice, down from 10 KB before the structure tree moved into an object stream. `tagged: false` removes it.
 
-Rule of thumb: use Puppeteer to reproduce a complex web page pixel-perfectly. Any renderer suits documents written from scratch for PDF work. Use takumi-pdf to reuse Takumi image components. It suits edge runtimes. It also offers lower per-document latency.
+Choose based on your template and runtime. Puppeteer uses browser layout and executes page scripts. react-pdf uses document components. Takumi accepts HTML, JSX, and node trees with its supported CSS subset. Run your own documents through the benchmark before using these timings to estimate workload capacity.

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -1,8 +1,10 @@
 ---
 title: Fonts & images
-description: Embed subset fonts and pre-fetched images.
+description: Register document fonts and supply image data before rendering.
 icon: Type
 ---
+
+Supply fonts through `fonts` and image bytes through `images`. Remote document images must be fetched before rendering. Font URL loaders and `googleFonts()` perform their own requests.
 
 ## Fonts
 
@@ -26,11 +28,11 @@ Text stays selectable and searchable. Pass font URLs, raw bytes, or [`googleFont
 
 For offline renders, [bundle font files](/docs/typography-and-fonts#fonts-in-ci-and-offline-renders). Google Fonts requests use the shared [fetch limits and retries](/docs/load-images#fetch-limits).
 
-There is no system font to fall back on. A character that none of the registered fonts covers would draw nothing and leave nothing in the text layer, so `render` rejects it and names the character and its codepoint. Register a font covering every script the document uses. Watch the Google Fonts subsets in particular: `latin` and `latin-ext` split their coverage, so one file on its own can leave common accented characters out.
+The renderer does not use installed system fonts. If no registered font covers a body-text character, the render fails with the character and its codepoint. Register coverage for every script you use. Google Fonts may split accented characters between `latin` and `latin-ext` subsets.
 
 ## Images
 
-The renderer never fetches over the network. Pass pre-fetched bytes for each image URL in the document:
+Pass fetched bytes for each image URL in the document. The PDF renderer does not fetch those URLs:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -39,7 +41,9 @@ declare const logoUrl: string;
 // ---cut---
 import { render } from "takumi-pdf";
 
-const logoBytes = new Uint8Array(await (await fetch(logoUrl)).arrayBuffer());
+const response = await fetch(logoUrl);
+if (!response.ok) throw new Error(`Logo request failed: ${response.status}`);
+const logoBytes = new Uint8Array(await response.arrayBuffer());
 
 const pdf = await render(doc, {
   // [!code highlight]
@@ -51,4 +55,4 @@ SVG image sources embed as vector paths and gradients, so logos stay sharp at an
 
 PNG, JPEG and WebP bytes all embed. A JPEG goes in as the JPEG you passed, so the PDF carries the compression the file already had. GIF bytes are rejected: no decoder for them ships in this build.
 
-A CSS `filter` needs pixels to work on, and this build decodes only PNG. An image under a filter that arrived as JPEG or WebP has none, so `render` rejects the document and names the image rather than leaving a hole in the page. The same goes for `filter: blur()` and `drop-shadow()`, which a PDF cannot express at all.
+CSS color filters on images require decoded pixels. The PDF build decodes PNG for this path, so filtered JPEG and WebP images are rejected. PDF output also rejects CSS `filter: blur()` and `drop-shadow()`. Prepare those effects in a raster image before rendering.

--- a/docs/content/docs/pdf/from-puppeteer.mdx
+++ b/docs/content/docs/pdf/from-puppeteer.mdx
@@ -1,12 +1,12 @@
 ---
 title: From Puppeteer
-description: Replace headless Chrome with a 1.5 MB wasm module.
+description: Move a Puppeteer PDF template to takumi-pdf.
 icon: Globe
 ---
 
-`takumi-pdf` was designed against Puppeteer's `page.pdf()`. Most options have a direct counterpart, header and footer bands use the same class hooks, and pagination follows Chromium's fragmentation rules. Names and input types differ in places, so read the map below.
+Start with the HTML you pass to `page.setContent()`. Pass that string to `render()` and translate the page options using the table below. Headers and footers use the same `pageNumber` and `totalPages` class hooks.
 
-What changes is the deploy. No browser process, no Chrome install, no page to navigate. The renderer takes a tree and returns bytes, so it runs on Cloudflare Workers.
+Takumi does not navigate a page or execute its scripts. Generate dynamic content and fetch document images before rendering. Check your template against the supported CSS features.
 
 ## Before and after
 
@@ -34,18 +34,12 @@ declare const html: string;
 // ---cut---
 // takumi-pdf
 import { googleFonts } from "@takumi-rs/helpers";
-import { fromHtml } from "@takumi-rs/helpers/html";
 import { render } from "takumi-pdf";
 import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 
-// [!code highlight]
-const { node, css } = fromHtml(html);
-
-const pdf = await render(node, {
+const pdf = await render(html, {
   size: "a4",
   margin: { top: 48, bottom: 64, left: 48, right: 48 },
-  // [!code highlight]
-  css,
   footer: (
     <div tw="flex w-full justify-center text-[10px]">
       Page <PageNumber /> of <TotalPages />
@@ -55,7 +49,7 @@ const pdf = await render(node, {
 });
 ```
 
-`fromHtml` converts the markup already being fed to `setContent`. JSX and node trees skip that step. Bands take the same input, so a header can be a component instead of a template string.
+`render()` parses HTML strings, including embedded `<style>` tags. It also accepts JSX and node trees. Headers and footers accept the same inputs.
 
 ## Option map
 
@@ -75,7 +69,7 @@ const pdf = await render(node, {
 | `path`                                   | write the returned `Uint8Array`        |
 | `timeout`, `waitForFonts`                | not needed: no page to load            |
 | `scale`                                  | not supported: scale the CSS instead   |
-| `pageRanges`                             | not supported                          |
+| `pageRanges`                             | `pageRanges: [1, { from: 4, to: 8 }]`  |
 | `preferCSSPageSize`, `@page`             | not supported: set `size` and `margin` |
 | `omitBackground`                         | not supported                          |
 
@@ -83,7 +77,7 @@ Margins take numbers in CSS px. Chromium's `"0.5in"` strings have no equivalent;
 
 ## Fetching moves to your code
 
-Nothing is fetched implicitly. A browser resolved image URLs and web fonts while it loaded the page. Now the fetch is a call you make:
+Use `prepareImages()` to fetch document images before rendering. Parse the HTML first so the helper can inspect its image references:
 
 ```tsx twoslash
 declare const html: string;
@@ -103,9 +97,9 @@ const pdf = await render(node, { images, css }); // [!code highlight]
 
 Fonts come from the `fonts` option rather than a CSS `@font-face` rule. See [Fonts & images](/docs/pdf/fonts-and-images).
 
-A render never reaches for a URL on its own. Timeouts and allow-lists sit in the fetch, where they can be enforced.
+Apply timeouts and URL policies to image fetching. Font URL loaders and `googleFonts()` also perform requests, so configure their fetch policies separately.
 
-## What Chrome still does better
+## Check browser-dependent features
 
 Chrome is a browser. Takumi is a layout engine with a document-shaped CSS subset.
 

--- a/docs/content/docs/pdf/from-react-pdf.mdx
+++ b/docs/content/docs/pdf/from-react-pdf.mdx
@@ -1,16 +1,18 @@
 ---
 title: From react-pdf
-description: Trade a private component set for HTML, CSS, and Tailwind.
+description: Convert react-pdf components and point-based layouts to HTML and CSS.
 icon: Atom
 ---
 
-`@react-pdf/renderer` gives React a private set of document primitives: `<Document>`, `<Page>`, `<View>`, `<Text>`, and a `StyleSheet` that accepts part of CSS. `takumi-pdf` renders ordinary markup instead. A component built for an OG image renders to PDF unchanged.
+Replace react-pdf document primitives with HTML elements, move page settings into `render()` options, and convert lengths from points to CSS pixels. Takumi uses the same JSX and styles for image and PDF output.
 
 ## Before and after
 
 ```tsx
 // @react-pdf/renderer
-import { Document, Page, View, Text, StyleSheet, renderToBuffer } from "@react-pdf/renderer";
+import { Document, Page, View, Text, StyleSheet, renderToBuffer, Font } from "@react-pdf/renderer";
+
+Font.register({ family: "Inter", src: "./Inter-Regular.ttf" });
 
 const styles = StyleSheet.create({
   page: { padding: 48, fontFamily: "Inter" },
@@ -36,41 +38,41 @@ import { googleFonts } from "@takumi-rs/helpers";
 import { render } from "takumi-pdf";
 
 const pdf = await render(
-  <div tw="flex justify-between text-[10px] text-gray-500">
+  <div tw="flex justify-between text-gray-500" style={{ fontSize: (10 * 96) / 72 }}>
     <span>Invoice</span>
     <span>INV-0042</span>
   </div>,
   // [!code highlight]
-  { size: "a4", margin: 48, fonts: await googleFonts(["Inter"]) },
+  { size: "a4", margin: 64, fonts: await googleFonts(["Inter"]) },
 );
 ```
 
 ## Component map
 
-| `@react-pdf/renderer`                   | `takumi-pdf`                          |
-| --------------------------------------- | ------------------------------------- |
-| `<Document>`                            | none: `render()` takes the tree       |
-| `<Page size="A4">`                      | the `size` option                     |
-| `<View>`                                | `<div>`                               |
-| `<Text>`                                | `<span>`, `<p>`, or bare text         |
-| `<Image src>`                           | `<img src>` plus the `images` option  |
-| `<Link src>`                            | `<a href>`                            |
-| `<Svg>` primitives                      | `<svg>`, or an SVG through `images`   |
-| `StyleSheet.create`                     | `style` objects or `tw` classes       |
-| `Font.register`                         | the `fonts` option                    |
-| `renderToBuffer`                        | `render()` returns a `Uint8Array`     |
-| `renderToStream`, `renderToFile`        | write the returned bytes yourself     |
-| a `fixed` header or footer `<View>`     | the `header` and `footer` options     |
-| `render={({ pageNumber, totalPages })}` | `<PageNumber />` and `<TotalPages />` |
-| the `break` prop                        | `break-before: page`                  |
-| `wrap={false}`                          | `break-inside: avoid`                 |
-| `orphans`, `widows`                     | the same CSS properties               |
-| `minPresenceAhead`                      | not supported                         |
-| `Font.registerHyphenationCallback`      | not supported                         |
-| `Font.registerEmojiSource`              | `extractEmojis`, then `prepareImages` |
-| `<PDFViewer>`, `<PDFDownloadLink>`      | not supported: render on the server   |
+| `@react-pdf/renderer`                   | `takumi-pdf`                                     |
+| --------------------------------------- | ------------------------------------------------ |
+| `<Document>`                            | none: `render()` takes the tree                  |
+| `<Page size="A4">`                      | the `size` option                                |
+| `<View>`                                | `<div>`                                          |
+| `<Text>`                                | `<span>`, `<p>`, or bare text                    |
+| `<Image src>`                           | `<img src>` plus the `images` option             |
+| `<Link src>`                            | `<a href>`                                       |
+| `<Svg>` primitives                      | `<svg>`, or an SVG through `images`              |
+| `StyleSheet.create`                     | `style` objects or `tw` classes                  |
+| `Font.register`                         | the `fonts` option                               |
+| `renderToBuffer`                        | `render()` returns a `Uint8Array`                |
+| `renderToStream`, `renderToFile`        | write the returned bytes yourself                |
+| a `fixed` header or footer `<View>`     | the `header` and `footer` options                |
+| `render={({ pageNumber, totalPages })}` | `<PageNumber />` and `<TotalPages />`            |
+| the `break` prop                        | `break-before: page`                             |
+| `wrap={false}`                          | `break-inside: avoid`                            |
+| `orphans`, `widows`                     | the same CSS properties                          |
+| `minPresenceAhead`                      | not supported                                    |
+| `Font.registerHyphenationCallback`      | not supported                                    |
+| `Font.registerEmojiSource`              | `extractEmojis`, then `prepareImages`            |
+| `<PDFViewer>`, `<PDFDownloadLink>`      | render bytes, then provide a preview or download |
 
-## Three differences that bite
+## Preserve the layout
 
 **Units are CSS px.** react-pdf measures lengths in pt. Takumi measures them in CSS px at 96 dpi. Multiply every length by `96 / 72`, or about `1.333`. A4 is `595 × 842` pt and `794 × 1123` px. Unitless values carry over as they are: `flexGrow`, `opacity`, `fontWeight`.
 
@@ -102,17 +104,10 @@ const pdf = await render(report, {
 
 The counter is a class on an element, not a `render` callback. See [Headers & footers](/docs/pdf/headers-and-footers) for counter styles and for sizing the margin to the band.
 
-## What each side is better at
+## Features to adapt
 
-`@react-pdf/renderer` keeps:
+Takumi has no equivalents for `minPresenceAhead`, custom hyphenation callbacks, or react-pdf's preview and download components. Render a `Uint8Array` and handle its delivery in your application. Browser bundles can use the [manual initialization entry](/docs/pdf#in-the-browser).
 
-- **A browser build.** `<PDFViewer>` and `<PDFDownloadLink>` render in the tab. Takumi renders on a server or a worker.
-- **Text refinements.** `orphans`, `widows`, and a hyphenation callback have no equivalent.
-- **The standard 14 fonts.** Skipping font embedding produces a smaller file.
+`widows` and `orphans` are supported CSS properties. See [Pagination](/docs/pdf/pagination#widows-and-orphans). Fonts are embedded, so register the fonts your template uses instead of relying on the standard PDF fonts.
 
-`takumi-pdf` brings:
-
-- **Real CSS and Tailwind**, on the same components an image render uses.
-- **Archival output.** PDF/A, PDF/UA, and attachments, validated during the render.
-- **Edge runtimes.** One wasm module, no Node built-ins.
-- **Lower latency.** See [Comparison](/docs/pdf/comparison) for the benchmark.
+For archival output and accessibility validation, see [PDF/A and PDF/UA](/docs/pdf/pdf-a).

--- a/docs/content/docs/pdf/headers-and-footers.mdx
+++ b/docs/content/docs/pdf/headers-and-footers.mdx
@@ -1,10 +1,10 @@
 ---
 title: Headers & footers
-description: Repeat bands on every page with page counters.
+description: Add repeating headers, footers, and page numbers.
 icon: PanelTop
 ---
 
-`header` and `footer` accept any node input. They repeat on every page. Bands lay out at full page width and draw in the page margin areas, like Chromium's print templates. Pick a margin at least as tall as the band, or the band overlaps content, exactly as in Chromium.
+Pass JSX, HTML, or a node tree to `header` or `footer`. Each repeats in the page margin. Automatic margins make room for their content.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -25,39 +25,17 @@ const pdf = await render(report, {
 
 ## Sizing the margin
 
-A band draws in the page margin, so the margin has to be tall enough to hold it.
-`margin` defaults to `"auto"`, which measures the band and takes the space it needs.
+`margin` defaults to `"auto"`. It measures the header and footer at full page width and reserves space above and below the document.
 
-```tsx twoslash
-import type { ReactNode } from "react";
-declare const report: ReactNode;
-// ---cut---
-import { render } from "takumi-pdf";
-import { PageNumber, TotalPages } from "takumi-pdf/primitives";
-
-const pdf = await render(report, {
-  footer: (
-    <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <PageNumber /> of <TotalPages />
-    </div>
-  ),
-});
-```
-
-An `"auto"` side comes out at the band height plus the 20px bands are inset from
-the paper edge, and never below the 37.8px a page starts with. A short band
-leaves the page looking as it did before. Set a side to a number to size it yourself,
-and leave out the sides you are happy with:
+For ordinary page sizes, each automatic top or bottom margin is the larger of 37.8px and the header or footer height plus a 20px inset. Set a numeric margin to override it. Omitted sides remain automatic:
 
 ```ts
 const margin = { top: 96 };
 ```
 
-Left and right hold no band. `"auto"` there is that same 37.8px.
+Automatic left and right margins are 37.8px on ordinary page sizes. A numeric margin that is too small can let the header or footer overlap the body.
 
-To size a margin yourself, `measure` lays out a tree the way `render` measures a
-band: full page width, counter hooks filled with three-digit numbers. Leave the
-20px inset on top of the height it returns.
+To calculate a numeric margin, call `measure()` with the same page size and fonts as the render. It measures at full page width with three-digit page counters. Add the 20px inset to the returned height.
 
 ```tsx twoslash
 declare const footer: import("react").ReactNode;
@@ -83,7 +61,7 @@ A node carrying both classes gets the page number.
 
 ## Counters outside a band
 
-A hook fills wherever it sits. A `fixed` box repeats on every page, so it lays out again for each one and its counters count with it. A component can carry its own footer that way, instead of passing one to `render`.
+Counters also work in document content. Inside a `position: fixed` box, they update on every page:
 
 ```tsx
 <div style={{ position: "fixed", bottom: 24, left: 24, right: 24 }}>
@@ -93,7 +71,7 @@ A hook fills wherever it sits. A `fixed` box repeats on every page, so it lays o
 
 A fixed box draws over the content rather than in the margin, so leave it room. `margin` sizes itself to the header and footer alone.
 
-A hook in the page content names the page it lands on, which is what a cover page counting the report's length needs. One laid out inline has no box of its own, so it reads the box that holds it and the flow that closed before it, and takes whichever page is later. Content that paints nowhere, such as a box scaled to zero, closes no flow to read. Content counters lay the document out a second time, since the page a hook sits on is only known once the content is cut into pages, and a document without one pays nothing.
+In ordinary flow, `<PageNumber />` shows the page containing the counter and `<TotalPages />` shows the document length. These counters require another layout pass because their values depend on pagination. Inline counters use the enclosing box and preceding rendered flow to determine their page.
 
 ## Counter styles
 
@@ -110,7 +88,7 @@ const pdf = await render(report, {
   footer: (
     <div style={{ fontSize: 12 }}>
       {/* [!code highlight:2] */}
-      第 <PageNumber format="trad-chinese-informal" /> 頁,共{" "}
+      第 <PageNumber format="trad-chinese-informal" /> 頁，共{" "}
       <TotalPages format="trad-chinese-informal" /> 頁
     </div>
   ),
@@ -166,4 +144,4 @@ A registered font has to cover the digits of the style you pick. Latin fonts rar
 
 ## Band height
 
-Band height is measured with the real page count, and the document re-paginates until the height settles, up to three passes. A counter that wraps the band at page 100 grows the margin for the whole document, so the layout never shifts between pages.
+The renderer recalculates header and footer height with the actual page count, up to three passes. Automatic margins use that height across the document. Leave enough width for counters to avoid wrapping when the page count grows.

--- a/docs/content/docs/pdf/index.mdx
+++ b/docs/content/docs/pdf/index.mdx
@@ -1,54 +1,45 @@
 ---
-title: Introduction to takumi-pdf
-description: Render JSX to paged, selectable-text PDF with takumi-pdf.
+title: Generate PDFs
+description: Render JSX, HTML, or node trees to PDF with takumi-pdf.
 index: true
 icon: BookOpen
 ---
 
-`takumi-pdf` renders the same JSX, Tailwind classes, and node trees as image output. It writes a paged vector PDF instead. It ships as a WebAssembly module. It runs on Node.js, Bun, and Cloudflare Workers without Chromium.
-
-- **Page breaks** honor `break-before: page`, `break-after: page`, and `break-inside: avoid`.
-- **[Headers and footers](/docs/pdf/headers-and-footers)** repeat on every page, with page counters.
-- **Text** stays selectable and searchable. Fonts embed as subsets.
-- **[Links](/docs/pdf/links-and-outline)** and metadata carry into the output. `outline: true` builds bookmarks from headings.
-- **[Attachments](/docs/pdf/attachments)** embed files, including Factur-X e-invoice XML.
-- **Tagged PDF** is on by default. [PDF/A-2, A-3, A-4, and PDF/UA-1](/docs/pdf/pdf-a) pass veraPDF.
-- **Arabic**, bidi text, CJK, Devanagari, and emoji shape correctly.
-- **Gradients**, `box-shadow`, transforms, and color filters stay vector, conic gradients included.
-- **1.5 MB** of gzip wasm fits the Cloudflare Workers free plan.
+`takumi-pdf` renders JSX, HTML, and node trees to PDF. Use CSS and Tailwind to lay out the document, then save the returned bytes or send them in an HTTP response. The WebAssembly renderer runs without a browser process.
 
 ```npm
-npm i takumi-pdf
+npm i takumi-pdf @takumi-rs/helpers react
 ```
 
 ## Render a document
 
 ```tsx twoslash
-import type { ReactNode } from "react";
-declare const data: { total: number };
-declare function Invoice(props: { data: typeof data }): ReactNode;
-// ---cut---
 import { render } from "takumi-pdf";
 import { PageNumber, TotalPages } from "takumi-pdf/primitives";
 import { googleFonts } from "@takumi-rs/helpers";
 import { writeFile } from "node:fs/promises";
 
-const pdf = await render(<Invoice data={data} />, {
-  // A4 portrait with a 37.8px margin is the default
-  size: "a4",
-  // [!code highlight]
-  fonts: await googleFonts(["Inter"]),
-  footer: (
-    <div tw="flex w-full justify-center text-[10px] text-gray-500">
-      Page <PageNumber /> of <TotalPages />
-    </div>
-  ),
-});
+const pdf = await render(
+  <main>
+    <h1>Invoice 1042</h1>
+    <p>Total: $1,290</p>
+  </main>,
+  {
+    size: "a4",
+    // [!code highlight]
+    fonts: await googleFonts(["Inter"]),
+    footer: (
+      <div tw="flex w-full justify-center text-[10px] text-gray-500">
+        Page <PageNumber /> of <TotalPages />
+      </div>
+    ),
+  },
+);
 
 await writeFile("invoice.pdf", pdf);
 ```
 
-`render()` accepts JSX, HTML strings, or JSON node trees. It returns `Uint8Array` PDF bytes. Content lays out at the page's content width. It flows onto as many pages as needed.
+`render()` returns a `Uint8Array`. By default, it flows content across A4 pages with automatic margins. Body text stays selectable, and registered fonts are embedded as subsets. SVG labels are drawn as outlines.
 
 HTML strings use the same parser as `takumi-js`. A `<style>` tag in the string applies only to that render:
 
@@ -87,7 +78,7 @@ const pdf = await render(report, {
 | `margin`          | `number`, `"auto"`, or `{ top?, right?, bottom?, left? }` | `"auto"` | `"auto"` fits the band on that side, and a side left out of the object is `"auto"` too. |
 | `backgroundColor` | CSS color                                                 | unset    | Fills the page box, margins included, under everything.                                 |
 
-`size` takes the page keywords CSS Paged Media defines, portrait as that module writes them:
+`size` accepts these paper sizes. Each keyword uses portrait orientation:
 
 | Keyword | Size         | Keyword    | Size         |
 | ------- | ------------ | ---------- | ------------ |
@@ -99,20 +90,16 @@ const pdf = await render(report, {
 
 Set `landscape` to turn any of them, or pass `{ width, height }` for a size with no keyword.
 
-These options are the structured form of `@page`, which takumi does not parse as CSS.
-`size` and `margin` map to the descriptors of the same name, `header` and `footer` to its margin boxes.
+Set page geometry through these options. CSS `@page` rules are not parsed.
 
-A margin left at `"auto"` takes the space its band needs: the band's measured
-height plus the 20px it is inset from the paper edge, and never less than the
-37.8px a page starts with. Without a band on that side it stays at 37.8px, the
-1cm Chromium prints at.
+Automatic top and bottom margins fit the header or footer, including its 20px inset from the paper edge. They are at least 37.8px on ordinary page sizes. Without a header or footer, the default is 37.8px (1cm). See [Headers and footers](/docs/pdf/headers-and-footers#sizing-the-margin).
 
 Leave `backgroundColor` unset for white paper.
 A viewer draws white by default, and the file stays free of a full-page rectangle.
 
 ## Reuse a renderer
 
-`render()` keeps one shared renderer alive. Construct `PdfRenderer` directly for applications that manage several font sets:
+`render()` reuses a shared renderer. Create a `PdfRenderer` when you need a separate font registry:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -122,24 +109,20 @@ import { PdfRenderer } from "takumi-pdf";
 
 // [!code highlight:2]
 const renderer = new PdfRenderer();
-await renderer.registerFont("https://example.com/Inter-Regular.woff2");
+await renderer.registerFont("https://example.com/fonts/Inter-Regular.woff2");
 
 const pdf = await renderer.render(doc);
 ```
 
-Registered fonts deduplicate across calls. Rendering many documents pays the font cost once.
+Registered fonts are deduplicated across calls. Replace the example URL with your font file.
 
 ## Runtimes
 
-`takumi-pdf` ships as WebAssembly. It runs on Node.js, Bun, and Cloudflare Workers.
-The module fits the Workers free-tier size limit.
-Import `takumi-pdf/no-init` to instantiate the wasm yourself.
+Use the default import on Node.js, Bun, and Cloudflare Workers. For manual initialization, import `takumi-pdf/no-init`.
 
 ### Next.js
 
-Import `takumi-pdf/next` from a route handler. It hands the binary to Turbopack in the form
-Turbopack emits, on the Node runtime and the Edge runtime alike, so the package needs no
-`serverExternalPackages` entry.
+Import `takumi-pdf/next` in a Next.js route handler. This entry supports the Node and Edge runtimes without a `serverExternalPackages` entry.
 
 ```ts
 import { render } from "takumi-pdf/next";
@@ -147,11 +130,7 @@ import { render } from "takumi-pdf/next";
 
 ### In the browser
 
-The default entry picks its loader from the export conditions the bundler sets.
-Vite, webpack, and Turbopack set the same conditions for a browser build.
-All three land on the Vite entry, and its `?url` import only works in Vite.
-
-Load the binary yourself instead:
+For browser bundles, initialize the renderer with `takumi-pdf/no-init` and `takumi-pdf/wasm-url`:
 
 ```ts
 import init, { render } from "takumi-pdf/no-init";
@@ -170,3 +149,16 @@ server chunk, where the asset never lands.
 On Turbopack, drop any `turbopack.rules` entry mapping `*.wasm` to `type: "wasm"`.
 That rule makes Turbopack instantiate the binary and look for wasm-bindgen glue the
 package does not ship.
+
+## Choose the next guide
+
+| Task                                           | Guide                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| Control page breaks and repeated table headers | [Pagination](/docs/pdf/pagination)                          |
+| Add page numbers                               | [Headers and footers](/docs/pdf/headers-and-footers)        |
+| Load fonts, logos, and photos                  | [Fonts and images](/docs/pdf/fonts-and-images)              |
+| Add links or a table of contents               | [Links, outline, and metadata](/docs/pdf/links-and-outline) |
+| Create a receipt or label                      | [Single-page viewport](/docs/pdf/single-page)               |
+| Generate archival or accessible output         | [PDF/A and PDF/UA](/docs/pdf/pdf-a)                         |
+
+For complete document patterns, see [Invoices](/docs/pdf/invoices), [Reports](/docs/pdf/reports), and [Charts](/docs/pdf/charts).

--- a/docs/content/docs/pdf/invoices.mdx
+++ b/docs/content/docs/pdf/invoices.mdx
@@ -1,10 +1,10 @@
 ---
 title: Invoices
-description: Paged invoices, and the PDF/A-3 container an EU e-invoice needs.
+description: Render invoice line items and attach structured invoice data.
 icon: Receipt
 ---
 
-An invoice PDF serves two readers. A person reads the layout. A tax authority's software reads structured data attached inside the same file. `takumi-pdf` writes both halves.
+Render line items and totals as a paged document. If your invoice format requires embedded XML, add it as an attachment with the required PDF/A and XMP settings.
 
 ## A plain invoice
 
@@ -41,7 +41,7 @@ const pdf = await render(<InvoiceDocument data={invoice} />, {
 });
 ```
 
-Mark each line row `break-inside: avoid` so a row never straddles a page. The Tailwind class is `break-inside-avoid`:
+Use `break-inside: avoid` to keep a line item together when it fits on a page. In Tailwind, use `break-inside-avoid`:
 
 ```tsx twoslash
 declare const item: { description: string; amount: string };
@@ -55,11 +55,11 @@ import "takumi-pdf";
 </div>;
 ```
 
-Wrap the totals block the same way. It is the part a reader most expects to see whole.
+Apply the same style to the totals block.
 
 ## Electronic invoices
 
-Factur-X and ZUGFeRD are the same file twice: a readable invoice, plus the invoice as XML attached inside it. The standards pin how that file is packaged.
+Factur-X and ZUGFeRD combine a readable PDF invoice with structured XML. Configure the container for the profile you are implementing:
 
 | The standard requires        | The option         |
 | ---------------------------- | ------------------ |
@@ -103,7 +103,7 @@ const pdf = await render(invoice, {
 });
 ```
 
-The renderer validates while it writes. A document that cannot conform fails with the violated rule, instead of producing a file a tax portal rejects.
+The renderer checks PDF conformance while writing. It does not validate invoice XML, tax rules, or acceptance by a receiving system.
 
 Takumi does not build the invoice XML. Use a library for the profile, or emit the elements the profile lists. The [e-invoice example](https://github.com/kane50613/takumi/tree/master/example/e-invoice) writes a MINIMUM profile by hand.
 
@@ -128,8 +128,8 @@ Mustang finds the profile through the `fx:` XMP block. Takumi writes the values 
 
 ## Accessible invoices
 
-Public-sector buyers often require an accessible invoice. `tagged: "ua1"` validates the structure tree against PDF/UA-1 during the render. See [PDF/A](/docs/pdf/pdf-a) for what it needs.
+For PDF/UA-1 output, set `tagged: "ua1"` and supply the required metadata. Review the reading order and table semantics as well. See [PDF/A and PDF/UA](/docs/pdf/pdf-a).
 
 ## Reproducible bytes
 
-A fixed `metadata.creationDate` makes the output byte-identical across runs. The same invoice hashes to the same value, which suits archival storage and golden tests.
+Use a fixed `metadata.creationDate` with the same content, resources, and renderer version when you need reproducible bytes. A new date changes the file even if the invoice looks the same.

--- a/docs/content/docs/pdf/links-and-outline.mdx
+++ b/docs/content/docs/pdf/links-and-outline.mdx
@@ -4,6 +4,8 @@ description: Clickable hyperlinks, a table of contents, bookmarks, and document 
 icon: Link
 ---
 
+Add links with `<a href>`, bookmarks with `outline`, and document properties with `metadata`.
+
 ## Hyperlinks
 
 Anchors with an `href` become clickable link annotations. They appear on every page that their box touches:
@@ -35,11 +37,11 @@ const pdf = await render(
 );
 ```
 
-Clicking it moves to the page holding that element. A fragment matching no element is dropped, so the reader never gets a link that goes nowhere. Other schemes are dropped too: they have no meaning inside a standalone document.
+Internal links jump to the target element. Unresolved fragments and unsupported URL schemes are omitted.
 
 ## Table of contents
 
-`<TargetPageNumber />` prints the page its link points at. The link is the nearest enclosing element carrying an `href`, usually the `<a>` around the entry, so one piece of markup gives an entry that is both clickable and numbered. Pass `href` instead to have it render its own link. Underneath it is the `targetPageNumber` class hook, which HTML input uses directly.
+`<TargetPageNumber />` prints the page number of an internal link target. Put it inside an `<a href="#id">`, or pass `href` to the primitive to create its own link. HTML input can use the `targetPageNumber` class on an element inside the link.
 
 ```tsx twoslash
 import { render } from "takumi-pdf";
@@ -64,17 +66,17 @@ The stretched span draws the dot leader. Counter styles work here too, so `forma
 
 A fragment naming no element prints nothing. This follows the rule links already use.
 
-### Why the fixed width
+### Reserve space for page numbers
 
 A page number exists only after pagination. Takumi paginates, fills the numbers in, and lays the document out again. A number that widens its line can move a page break, and the moved break can renumber the entry. The render repeats this up to three times, then keeps what it has.
 
-A number that cannot widen its line settles on the second pass. That is what `w-8 shrink-0 text-right` does above. Reserve enough width for the highest page number the document reaches.
+The example reserves width with `w-8 shrink-0 text-right`. Increase it if your document needs more digits. This prevents page numbers from changing the entry width during layout.
 
 Headers and footers are laid out per page, outside this loop. A `<TargetPageNumber />` in a band renders nothing.
 
 ## Outline
 
-Set `outline: true` to build PDF bookmarks from `h1`–`h6` headings. Deeper headings nest under the previous shallower heading. This matches an HTML document outline:
+Set `outline: true` to build PDF bookmarks from `h1`–`h6`. Deeper headings nest under the previous shallower heading:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -111,4 +113,4 @@ const pdf = await render(report, {
 });
 ```
 
-All fields are optional. Omitting `metadata` writes no document properties. This keeps output byte-identical across runs for golden testing.
+Metadata fields are optional for ordinary PDF output. [PDF/A and PDF/UA](/docs/pdf/pdf-a) require some fields. Use a fixed `creationDate` when you need reproducible output.

--- a/docs/content/docs/pdf/pagination.mdx
+++ b/docs/content/docs/pdf/pagination.mdx
@@ -4,7 +4,7 @@ description: Control where pages break with CSS.
 icon: Scissors
 ---
 
-Content lays out once at unbounded height. It then splits into pages. Unsplittable atoms never straddle a cut. These atoms include text lines, images, and transformed subtrees. A cut inside an atom moves to its top. This matches browser print fragmentation.
+Content flows across pages at the width available inside the margins. Use CSS break properties to start chapters, keep related content together, and control how paragraphs split. Percentage heights do not resolve in this mode because the content has no fixed height.
 
 ## Break properties
 
@@ -27,7 +27,7 @@ const pdf = await render(
 | `break-inside: avoid`         | Keeps the element on one page when it fits.             |
 | `box-decoration-break: clone` | Repeats borders and backgrounds on every page fragment. |
 
-A `break-inside: avoid` box taller than the page window cannot fit on a page. It stops participating in cut avoidance. Browsers apply the same rule.
+`break-inside: avoid` applies only when the box fits on a page. An oversized box can still split. Text lines, images, and transformed subtrees are kept together where possible.
 
 ## Widows and orphans
 
@@ -44,7 +44,7 @@ const pdf = await render(
 );
 ```
 
-Both properties inherit. When a paragraph is too short to satisfy both minimums, the orphans win, as in Chromium. A break that cannot keep the orphans moves the whole paragraph to the next page. A minimum that cannot fit the current page at all is dropped for that page, like `break-inside: avoid` on an oversized box.
+Both properties inherit. If a paragraph is too short to satisfy both values, `orphans` takes priority. A paragraph moves to the next page when the current page cannot hold the required lines. A requirement larger than a full page is relaxed.
 
 ## Split decorations
 
@@ -69,7 +69,7 @@ const pdf = await render(
 
 ## Repeated table headers
 
-A `<thead>` paints again at the top of every page its table continues onto, following css-tables-3 repeated headers. The band is monolithic: a page break never lands inside it, and the spacing to the first body row repeats with it.
+Use `<thead>` for column headings that repeat on continuation pages. The header stays together, including its spacing before the first body row.
 
 ```tsx twoslash
 declare const rows: import("react").ReactNode;
@@ -121,7 +121,6 @@ import { render } from "takumi-pdf";
 
 const pdf = await render(
   <main>
-    {/* Centers the watermark inside each page area. */}
     <div
       style={{
         position: "fixed",
@@ -138,9 +137,6 @@ const pdf = await render(
 );
 ```
 
-A transformed or filtered ancestor captures a fixed descendant.
-That descendant stays in flow and paginates with its ancestor.
+Place the fixed box outside transformed or filtered ancestors. Those ancestors contain the box, so it paginates with them instead of repeating independently.
 
-A negative `z-index` paints the box under the content.
-A background on the root covers it, exactly as it does in a browser.
-Set the paper with `backgroundColor` instead, which paints under the box.
+Use a negative `z-index` to place the watermark behind content. Set the page color through `backgroundColor` if the root background would otherwise cover the watermark.

--- a/docs/content/docs/pdf/pdf-a.mdx
+++ b/docs/content/docs/pdf/pdf-a.mdx
@@ -1,10 +1,10 @@
 ---
-title: PDF/A
-description: Archival output that validators accept
+title: PDF/A and PDF/UA
+description: Configure archival output, document tags, and accessibility validation.
 icon: Archive
 ---
 
-Render a PDF/A document with `pdfa`.
+Use `pdfa` for archival output and `tagged` for document structure and PDF/UA validation. The selected standard determines which metadata and attachments are allowed.
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -41,11 +41,11 @@ PDF/A-1 is not offered. It prohibits transparency.
 
 Validation runs during rendering. When a document cannot conform, the render fails with the violated rule instead of writing a broken file.
 
-Every level, and PDF/UA-1, passes [veraPDF](https://verapdf.org), the reference validator.
+Validate your generated document with [veraPDF](https://verapdf.org). Internal checks do not replace reviewing reading order, alternative text, or the meaning of your content.
 
 ## Tagged output
 
-`tagged` defaults to `true`. Tagged output mirrors Chromium's print-to-PDF.
+`tagged` defaults to `true`, which writes a structure tree from the document's HTML semantics. This alone does not request PDF/UA validation.
 
 Set `tagged: "ua1"` to also validate against PDF/UA-1:
 
@@ -84,13 +84,13 @@ The structure tree comes from the HTML semantics:
 | `tr`, `th`, `td`          | `TR`, `TH` with `Scope`, `TD`       |
 | page headers and footers  | artifacts                           |
 
-Heading levels come from nesting, not the tag name. A document that starts with `h2` gets an `H1`. A jump from `h1` to `h4` becomes `H1` then `H2`. PDF/UA rejects a sequence that skips a level or starts below `H1`. HTML written for visual styling does this all the time.
+Heading levels are normalized in the structure tree. A document starting with `h2` gets `H1`, and a jump from `h1` to `h4` becomes `H1` followed by `H2`. Use meaningful heading levels in your source even when their visual sizes differ.
 
 Header cells carry a `Scope` attribute: `Column` inside `thead`, `Row` elsewhere. A `scope` attribute on the cell overrides it. `rowspan` and `colspan` become `RowSpan` and `ColSpan` attributes. A table that spans pages stays one `Table` element. The repeated header band is marked as an artifact.
 
 Table elements follow the rendered layout, like the rest of the tree. A `<table>` whose `display` is overridden gets none, and neither does a table built from flex rows. Screen readers cannot navigate those by row or column, and the file still passes PDF/UA, because the validator only checks the tags that are there.
 
-Set `tagged: false` to skip the tree when file size matters more than accessibility.
+Set `tagged: false` only when you do not need a structure tree and the selected standard permits it.
 
 ### PDF/UA-2
 
@@ -116,7 +116,7 @@ const pdf = await render(report, {
 
 Links and outline entries target structure elements, not page positions. Reading order survives when a viewer follows one.
 
-### What combines with what
+### Compatible options
 
 Invalid combinations are TypeScript type errors. PDF/UA-1 uses PDF 1.7. PDF/A-4 and PDF/UA-2 use PDF 2.0. The two generations never mix.
 

--- a/docs/content/docs/pdf/reports.mdx
+++ b/docs/content/docs/pdf/reports.mdx
@@ -4,13 +4,15 @@ description: Long documents with chapters, bookmarks, and running bands.
 icon: FileSpreadsheet
 ---
 
-Reports and account statements are long. They break into chapters, repeat a band on every page, and get navigated rather than read straight through.
+Use page breaks for chapters, repeating headers for context, and bookmarks or a table of contents for navigation. The examples below combine these features for reports and account statements.
 
 ## Chapters
 
 `break-before: page` starts a section on a fresh page. `break-inside: avoid` keeps a figure with its caption:
 
 ```tsx twoslash
+declare const chartSvg: string;
+// ---cut---
 import { render } from "takumi-pdf";
 
 const pdf = await render(
@@ -20,7 +22,7 @@ const pdf = await render(
       <h1>Results</h1>
       {/* [!code highlight] */}
       <figure style={{ breakInside: "avoid" }}>
-        <img src="chart.svg" alt="Revenue by quarter" />
+        <img src={chartSvg} alt="Revenue by quarter" style={{ width: 560, height: 360 }} />
         <figcaption>Revenue by quarter</figcaption>
       </figure>
     </section>
@@ -155,8 +157,8 @@ for (const account of accounts) {
 }
 ```
 
-Set `tagged: false` when nobody reads these with assistive technology. It drops the structure tree and the file gets smaller.
+The renderer reuses registered fonts between documents. Keep `tagged` enabled when the output needs a structure tree.
 
 ## Accessibility
 
-Public bodies often have to publish accessible documents. `tagged: "ua1"` validates the structure tree against PDF/UA-1 during the render. It builds on the heading outline above. See [PDF/A](/docs/pdf/pdf-a) for the rest of its inputs.
+Set `tagged: "ua1"` to request PDF/UA-1 validation. Supply the document language and title, then review heading order, tables, and chart descriptions. See [PDF/A and PDF/UA](/docs/pdf/pdf-a).

--- a/docs/content/docs/pdf/single-page.mdx
+++ b/docs/content/docs/pdf/single-page.mdx
@@ -4,7 +4,7 @@ description: Fixed one-page PDFs for certificates, cards, and receipts.
 icon: File
 ---
 
-`viewport` renders one fixed page instead of paged output. It behaves like an image render. Percentage heights resolve against the viewport. It clips overflow.
+Set `viewport` to create a single page for a certificate, card, or receipt. With both dimensions set, percentage heights resolve against the viewport and content outside it is clipped.
 
 ```tsx twoslash
 import { render } from "takumi-pdf";
@@ -17,7 +17,7 @@ const pdf = await render(<div style={{ width: "100%", height: "100%" }}>Certific
 
 ## Content-sized pages
 
-Omit `height` to size the single page to its laid-out content. This works like a thermal receipt. Percentage heights do not resolve in this mode:
+Omit `height` for a page that grows to fit its content, such as a thermal receipt. Use content or explicit lengths to determine element heights. Percentage heights do not resolve in this mode:
 
 ```tsx twoslash
 import type { ReactNode } from "react";
@@ -29,4 +29,4 @@ import { render } from "takumi-pdf";
 const pdf = await render(receipt, { viewport: { width: 302 } }); // 80mm at 96 dpi
 ```
 
-`viewport` cannot be combined with `size`, `landscape`, `margin`, `header`, or `footer`. Those options work only with paged output. Hyperlinks, `outline`, and `metadata` work in both modes.
+`viewport` cannot be combined with `size`, `landscape`, `margin`, `header`, `footer`, or `pageRanges`. Use padding inside the document for whitespace around a single page. Hyperlinks, `outline`, and `metadata` work in both modes.

--- a/docs/content/docs/pdf/tickets.mdx
+++ b/docs/content/docs/pdf/tickets.mdx
@@ -4,7 +4,7 @@ description: One-page output at an exact paper size, or sized to its content.
 icon: Ticket
 ---
 
-Some documents are one page by definition. A ticket, a shipping label, a certificate, a till receipt. `viewport` renders exactly one page and skips pagination entirely. See [Single-page viewport](/docs/pdf/single-page) for how the mode behaves.
+Use `viewport` for a ticket, shipping label, certificate, or receipt. Set both dimensions for fixed paper, or omit the height for a receipt that grows with its content.
 
 ## Labels and tickets
 
@@ -27,7 +27,7 @@ const pdf = await render(
 );
 ```
 
-Generate the QR or barcode as SVG and pass its bytes through `images`. SVG sources embed as vector paths, so the code stays crisp at any zoom and any print resolution.
+Generate the QR code or barcode as SVG and pass its bytes through `images`. Vector paths scale with the page. Check that the printed code has enough physical size and clear space for scanning.
 
 Common sizes in CSS px:
 
@@ -79,8 +79,8 @@ const pdf = await render(
 
 Overflowing content is clipped, exactly like an image render. Size the text to the box, or measure it first.
 
-## What the mode gives up
+## Options and overflow
 
 `viewport` rejects the paged options as type errors. Everything else carries over, including `pdfa` and `attachments`. See [Single-page viewport](/docs/pdf/single-page).
 
-Rendering the same component as a PNG for email or as a PDF for print is a matter of swapping the renderer. The tree, the CSS, and the Tailwind classes stay as they are.
+The same component can also render as a PNG with `takumi-js`. Pass image dimensions to the image renderer instead of PDF page options.


### PR DESCRIPTION
## Why

The PDF guides contain outdated migration advice and incomplete chart examples. Some pages also imply broader browser compatibility or validation guarantees than the renderer provides.

## What

Rewrite the PDF category and chart guides around concrete tasks, with runnable starting examples and current option mappings. Clarify font loading, SVG text, pagination, and the limits of PDF conformance checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked PDF guides with clearer guidance for pagination, single-page output, headers and footers, charts, invoices, attachments, links, accessibility, PDF/A, and PDF/UA.
  - Updated migration guides for Puppeteer and react-pdf, including current rendering workflows and supported options.
  - Clarified font and image handling, fetching requirements, filtering limitations, reproducible output, and validation responsibilities.
  - Added and refreshed examples for charts, reports, receipts, tickets, and invoice rendering.
  - Improved comparison guidance and added navigation to related PDF documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->