### PR TITLE
PDF: reduce wasm size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,8 @@ opt-level = "s"
 # takumi-pdf includes the vendored krilla fork.
 [profile.release.package.takumi-pdf]
 opt-level = "s"
+[profile.release.package.takumi-pdf-wasm]
+opt-level = "s"
 [profile.release.package.write-fonts]
 opt-level = "z"
 [profile.release.package.pdf-writer]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ opt-level = "s"
 [profile.release.package.takumi-pdf]
 opt-level = "s"
 [profile.release.package.takumi-pdf-wasm]
-opt-level = "s"
+opt-level = "z"
 [profile.release.package.write-fonts]
 opt-level = "z"
 [profile.release.package.pdf-writer]

--- a/takumi-pdf/src/krilla/chunk_container.rs
+++ b/takumi-pdf/src/krilla/chunk_container.rs
@@ -349,7 +349,7 @@ impl ChunkContainer {
           let mut sorted = named_destinations.into_iter().collect::<Vec<_>>();
           // Note that named destinations are guaranteed to be unique,
           // hence just comparing by the name is enough.
-          sorted.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+          sorted.sort_unstable_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
 
           for (name, (dest_ref, _)) in sorted {
             dest_name_entries.insert(Str(name.as_bytes()), remapper[&dest_ref]);

--- a/takumi-pdf/src/subsetter/mod.rs
+++ b/takumi-pdf/src/subsetter/mod.rs
@@ -276,7 +276,7 @@ fn parse(data: &[u8], index: u32) -> Result<Face<'_>> {
 
 /// Construct a brand-new font.
 fn construct(mut ctx: Context) -> Vec<u8> {
-  ctx.tables.sort_by_key(|&(tag, _)| tag);
+  ctx.tables.sort_unstable_by_key(|&(tag, _)| tag);
 
   let mut w = Writer::new();
   w.write(ctx.flavor);

--- a/takumi-pdf/src/subsetter/remapper.rs
+++ b/takumi-pdf/src/subsetter/remapper.rs
@@ -152,11 +152,11 @@ impl GlyphRemapper {
   /// Create a remapper from an existing set of glyphs. The method
   /// will ensure that the mapping is monotonically increasing.
   pub fn new_from_glyphs_sorted(glyphs: &[u16]) -> Self {
-    let mut sorted = BTreeSet::from_iter(glyphs)
+    let sorted = BTreeSet::from_iter(glyphs)
       .iter()
       .map(|g| **g)
       .collect::<Vec<_>>();
-    sorted.sort();
+
     GlyphRemapper::new_from_glyphs(&sorted)
   }
 


### PR DESCRIPTION
## Why

PDF wasm bindings use the default optimization level, while collections with unique keys retain stable-sort code.

## What

Use `opt-level = "z"` for the PDF wasm bindings, sort unique table tags and destination names with unstable sorting, and remove redundant glyph sorting. Golden PDFs remain byte-identical.

The local release build shrinks by 140,830 bytes raw, 42,526 bytes gzip, and 29,596 bytes Brotli. Node and Bun benchmarks cover Latin, CJK, Arabic, and Devanagari documents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Optimized the WebAssembly release build to reduce its size.
  - Improved efficiency when processing PDF destinations and embedded font data.
  - Maintained consistent ordering of generated PDF and font information for reliable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->