### PR TITLE
Core: export the CssInput type from binding declarations

### DIFF
--- a/.tegami/core-css-input-type.md
+++ b/.tegami/core-css-input-type.md
@@ -1,0 +1,9 @@
+---
+packages:
+  "@takumi-rs/core":
+    type: patch
+---
+
+### Export the CssInput type from @takumi-rs/core
+
+The `css` option referenced `CssInput` without importing it, so type checking failed on the declaration file when `skipLibCheck` was off.

--- a/takumi-napi/src/dts-header.d.ts
+++ b/takumi-napi/src/dts-header.d.ts
@@ -1,4 +1,4 @@
-import type { Node } from "@takumi-rs/helpers";
+import type { CssInput, Node } from "@takumi-rs/helpers";
 import type { Properties } from "csstype";
 
 export type {
@@ -9,7 +9,7 @@ export type {
   TextNode,
 } from "@takumi-rs/helpers";
 
-export type { Node };
+export type { CssInput, Node };
 
 export type ByteBuf = Uint8Array | ArrayBuffer | Buffer;
 


### PR DESCRIPTION
Fixes #1562

## Why

`@takumi-rs/core` types the `css` option as `CssInput[]`, but its declaration file never imported that type. Anyone compiling with `skipLibCheck` disabled got `TS2304: Cannot find name 'CssInput'`.

## What

The N-API declaration header now imports `CssInput` from `@takumi-rs/helpers` and re-exports it, matching `@takumi-rs/wasm`. The wasm and PDF bindings already declared every type their generated signatures reference, so they need no change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported the `CssInput` type so TypeScript declaration checks work correctly when `skipLibCheck` is disabled.

* **Chores**
  * Added release metadata for the patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->