### PR TITLE
Playground: add fillable form templates

### DIFF
--- a/docs/app/playground/templates.ts
+++ b/docs/app/playground/templates.ts
@@ -2,6 +2,8 @@ import animatedShowcase from "./templates/animated-showcase?raw";
 import accessible from "./templates/accessible?raw";
 import analyticsChart from "./templates/analytics-chart?raw";
 import articleCover from "./templates/article-cover?raw";
+import formControls from "./templates/form-controls?raw";
+import formLease from "./templates/form-lease?raw";
 import gradientPoster from "./templates/gradient-poster?raw";
 import invoice from "./templates/invoice?raw";
 import multilingual from "./templates/multilingual?raw";
@@ -120,6 +122,20 @@ export const templates: Template[] = [
     description: "One page sized to its content, like a receipt roll",
     kind: "pdf",
     code: receipt,
+  },
+  {
+    id: "form-lease",
+    name: "Fillable lease",
+    description: "A rental agreement whose blanks stay editable in a PDF reader",
+    kind: "pdf",
+    code: formLease,
+  },
+  {
+    id: "form-controls",
+    name: "Form controls",
+    description: "Every control that becomes a PDF field, with its flags and names",
+    kind: "pdf",
+    code: formControls,
   },
 ];
 

--- a/docs/app/playground/templates/form-controls.tsx
+++ b/docs/app/playground/templates/form-controls.tsx
@@ -1,0 +1,171 @@
+function Row({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div tw="mt-7 flex items-start">
+      <div tw="flex w-[165px] flex-col pr-6">
+        <span tw="text-[11px] font-semibold">{label}</span>
+        <span tw="mt-1 text-[10px] leading-relaxed text-[#8a9099]">{hint}</span>
+      </div>
+      <div tw="flex flex-1 items-start">{children}</div>
+    </div>
+  );
+}
+
+const field = "h-8 rounded border border-[#ccd2da] bg-white px-3 text-xs";
+const box = "mr-2.5 h-4 w-4 border border-[#8d95a0] bg-white";
+
+export default function FormControls() {
+  return (
+    <div tw="flex w-full flex-col text-[#1f2328]">
+      <h1 tw="m-0 text-lg font-semibold">Every fillable control</h1>
+      <span tw="mt-1 text-[11px] text-[#8a9099]">
+        Open the output in a PDF reader and type into it. Each row names the PDF field it becomes.
+      </span>
+
+      <div tw="mt-6 flex flex-col">
+        <h2 tw="m-0 mb-1 text-sm font-semibold">Text fields</h2>
+        <Row label="Text" hint='name="plain", starts with a value'>
+          <input name="plain" defaultValue="Editable" tw={`w-[220px] ${field}`} />
+        </Row>
+
+        <Row label="Dotted name" hint="contact.email nests email under contact">
+          <input
+            name="contact.email"
+            defaultValue="hi@example.com"
+            aria-label="Email"
+            tw={`w-[220px] ${field}`}
+          />
+        </Row>
+
+        <Row label="maxlength" hint="The reader stops at 5 characters">
+          <input name="code" maxLength={5} defaultValue="AB12" tw={`w-[90px] ${field}`} />
+        </Row>
+
+        <Row label="Password" hint="Masked in the reader, plain in the bytes">
+          <input name="secret" type="password" defaultValue="hunter2" tw={`w-[140px] ${field}`} />
+        </Row>
+
+        <Row label="Required" hint="Sets the required field flag">
+          <input name="fullName" required aria-label="Full name" tw={`w-[220px] ${field}`} />
+        </Row>
+
+        <Row label="Read-only" hint="Visible, not editable">
+          <input name="issued" readOnly defaultValue="2026-03-01" tw={`w-[140px] ${field}`} />
+        </Row>
+
+        <Row label="Disabled" hint="Read-only and left out of the export">
+          <input
+            name="reference"
+            disabled
+            defaultValue="AGR-2026-0413"
+            tw={`w-[180px] ${field} bg-[#f3f4f6] text-[#8a9099]`}
+          />
+        </Row>
+
+        <Row label="Right aligned" hint="text-align reaches the widget text">
+          <input name="amount" defaultValue="1450.00" tw={`w-[110px] ${field} text-right`} />
+        </Row>
+
+        <Row label="Textarea" hint="Multiline; the text content is the value">
+          <textarea name="summary" aria-label="Summary" tw={`h-[54px] w-[300px] ${field} p-2`}>
+            Two lines fit here comfortably.
+          </textarea>
+        </Row>
+      </div>
+
+      <div style={{ breakBefore: "page" }} tw="flex flex-col">
+        <h2 tw="m-0 mb-1 text-sm font-semibold">Selection controls</h2>
+
+        <Row label="Checkbox" hint="value is the export state, default on">
+          <div tw="flex items-center">
+            <input
+              type="checkbox"
+              name="subscribe"
+              value="yes"
+              defaultChecked
+              aria-label="Subscribe"
+              tw={`${box} rounded-[2px]`}
+            />
+            <span tw="text-xs">Subscribe</span>
+          </div>
+        </Row>
+
+        <Row label="Radio group" hint="One field; same name, different values">
+          <div tw="flex">
+            {["monthly", "annual"].map((plan) => (
+              <div key={plan} tw="mr-5 flex items-center">
+                <input
+                  type="radio"
+                  name="billing"
+                  value={plan}
+                  defaultChecked={plan === "annual"}
+                  aria-label={plan}
+                  tw={`${box} rounded-full`}
+                />
+                <span tw="text-xs capitalize">{plan}</span>
+              </div>
+            ))}
+          </div>
+        </Row>
+
+        <Row label="Drop-down" hint="Closed select; label shows, value exports">
+          <select name="region" defaultValue="apac" aria-label="Region" tw={`w-[180px] ${field}`}>
+            <option value="emea">Europe</option>
+            <option value="apac">Asia Pacific</option>
+            <option value="amer">Americas</option>
+          </select>
+        </Row>
+
+        <Row label="List box" hint="size&gt;1; selected row is highlighted">
+          <select
+            name="tier"
+            size={3}
+            defaultValue="pro"
+            aria-label="Tier"
+            tw={`w-[180px] ${field} h-[56px] px-0`}
+          >
+            <option value="free">Free</option>
+            <option value="pro">Pro</option>
+            <option value="scale">Scale</option>
+          </select>
+        </Row>
+
+        <Row label="Multi-select" hint="multiple allows several values">
+          <select
+            name="addons"
+            multiple
+            size={3}
+            defaultValue={["sso", "audit"]}
+            aria-label="Add-ons"
+            tw={`w-[180px] ${field} h-[56px] px-0`}
+          >
+            <option value="sso">SSO</option>
+            <option value="audit">Audit log</option>
+            <option value="sla">SLA</option>
+          </select>
+        </Row>
+
+        <Row label="Not fillable" hint="Buttons stay static; no field is made">
+          <input type="submit" value="Send" tw="text-xs" />
+        </Row>
+      </div>
+    </div>
+  );
+}
+
+export const options: PlaygroundOptions = {
+  pdf: {
+    size: "a4",
+    margin: 44,
+    form: true,
+    metadata: { title: "Fillable form controls", creationDate: "2026-03-01" },
+    lang: "en",
+  },
+};

--- a/docs/app/playground/templates/form-lease.tsx
+++ b/docs/app/playground/templates/form-lease.tsx
@@ -1,0 +1,172 @@
+const occupants = ["", "", ""];
+
+const blank = "h-[26px] border-0 border-b border-[#9aa1ab] bg-transparent px-1.5 text-xs";
+const boxed = "h-8 w-full rounded border border-[#ccd2da] bg-white px-3 text-xs";
+const tick = "mr-2.5 h-4 w-4 border border-[#8d95a0] bg-white";
+const heading = "text-[11px] font-semibold uppercase tracking-wider text-[#6b7280]";
+
+export default function Lease() {
+  return (
+    <div tw="flex w-full flex-col text-[#1f2328]">
+      <div tw="flex flex-col">
+        <h1 tw="m-0 text-xl font-semibold">Simple Rental Agreement</h1>
+        <span tw="mt-1 text-[11px] text-[#6b7280]">
+          Fill this in your PDF reader. Nothing here needs printing.
+        </span>
+      </div>
+
+      <div tw="mt-7 flex flex-col text-xs">
+        <div tw="flex items-center">
+          <span tw="mr-2">This agreement is between</span>
+          <input
+            name="party.landlord"
+            defaultValue="Elisa Beckett"
+            aria-label="Landlord"
+            tw={`w-[180px] ${blank}`}
+          />
+          <span tw="mx-2">(landlord) and</span>
+          <input
+            name="party.tenant"
+            defaultValue="John Smith"
+            aria-label="Tenant"
+            tw={`w-[180px] ${blank}`}
+          />
+          <span tw="ml-2">(tenant).</span>
+        </div>
+
+        <div tw="mt-5 flex items-center">
+          <span tw="mr-2">Takes effect on</span>
+          <input
+            name="term.start"
+            defaultValue="2026-10-01"
+            aria-label="Start date"
+            tw={`w-[110px] ${blank}`}
+          />
+          <span tw="mx-2">and runs for</span>
+          <select
+            name="term.length"
+            defaultValue="12"
+            aria-label="Term length"
+            tw={`w-[110px] ${blank}`}
+          >
+            <option value="6">6 months</option>
+            <option value="12">12 months</option>
+            <option value="24">24 months</option>
+          </select>
+        </div>
+
+        <div tw="mt-5 flex items-center">
+          <span tw="mr-2">Rent of $</span>
+          <input
+            name="rent.amount"
+            defaultValue="1450"
+            maxLength={7}
+            aria-label="Monthly rent"
+            tw={`w-[80px] ${blank} text-right`}
+          />
+          <span tw="mx-2">is due on day</span>
+          <input
+            name="rent.dueDay"
+            defaultValue="1"
+            maxLength={2}
+            aria-label="Due day"
+            tw={`w-[40px] ${blank} text-center`}
+          />
+          <span tw="ml-2">of each month.</span>
+        </div>
+      </div>
+
+      <span tw={`mt-9 ${heading}`}>Additional occupants</span>
+      <div tw="mt-2 flex flex-col">
+        {occupants.map((_, index) => (
+          <input
+            key={index}
+            name={`occupant.${index + 1}`}
+            aria-label={`Occupant ${index + 1}`}
+            tw={`mt-2.5 ${boxed}`}
+          />
+        ))}
+      </div>
+
+      <span tw={`mt-9 ${heading}`}>Utilities included in the rent</span>
+      <div tw="mt-2 flex">
+        {["water", "power", "gas", "internet"].map((utility) => (
+          <div key={utility} tw="mr-6 flex items-center">
+            <input
+              type="checkbox"
+              name={`utility.${utility}`}
+              defaultChecked={utility === "water"}
+              aria-label={utility}
+              tw={`${tick} rounded-[2px]`}
+            />
+            <span tw="text-xs capitalize">{utility}</span>
+          </div>
+        ))}
+      </div>
+
+      <span tw={`mt-9 ${heading}`}>Deposit returned after the lease expires</span>
+      <div tw="mt-2 flex">
+        {["yes", "no"].map((answer) => (
+          <div key={answer} tw="mr-6 flex items-center">
+            <input
+              type="radio"
+              name="deposit"
+              value={answer}
+              defaultChecked={answer === "yes"}
+              aria-label={answer}
+              tw={`${tick} rounded-full`}
+            />
+            <span tw="text-xs capitalize">{answer}</span>
+          </div>
+        ))}
+      </div>
+
+      <span tw={`mt-9 ${heading}`}>Notes</span>
+      <textarea
+        name="notes"
+        aria-label="Notes"
+        tw="mt-3 h-[84px] w-full rounded border border-[#ccd2da] bg-white p-3 text-xs"
+      >
+        The tenant may repaint with written consent.
+      </textarea>
+
+      <div tw="mt-12 flex items-end justify-between">
+        <div tw="flex flex-col">
+          <input
+            name="signature.tenant"
+            required
+            aria-label="Signature of tenant"
+            tw={`w-[230px] ${blank} h-10 text-base`}
+          />
+          <span tw="mt-1 text-[10px] text-[#6b7280]">Signature of tenant</span>
+        </div>
+        <div tw="flex flex-col">
+          <input
+            name="signature.date"
+            aria-label="Date signed"
+            tw={`w-[120px] ${blank} h-10 text-base`}
+          />
+          <span tw="mt-1 text-[10px] text-[#6b7280]">Date</span>
+        </div>
+      </div>
+
+      <span tw="mt-6 text-[10px] text-[#9ca3af]">
+        Reference AGR-2026-0413 · generated by takumi
+      </span>
+    </div>
+  );
+}
+
+export const options: PlaygroundOptions = {
+  pdf: {
+    size: "a4",
+    margin: 56,
+    form: true,
+    metadata: {
+      title: "Simple Rental Agreement",
+      authors: ["Kiln Werkstatt"],
+      creationDate: "2026-03-01",
+    },
+    lang: "en",
+  },
+};


### PR DESCRIPTION
## Why

The playground has no template that turns `form: true` on, so there is nothing runnable to try the fillable-form work against.

## What

A rental agreement whose blanks, checkboxes, radios and signature line stay editable in a PDF reader. A reference sheet that pairs every supported control with the PDF field it becomes, including the flags and names it carries.

The reference sheet splits across two pages on purpose: `breakBefore: page` separates text fields from selection controls, which also covers fields laid out after a page break.

![Rental agreement](https://github.com/user-attachments/assets/859dd92e-f274-4d48-86eb-ddd86fc33b46)

![Reference sheet, page one](https://github.com/user-attachments/assets/024cb736-3732-436a-b628-fbcf8aa1d86f)

![Reference sheet, page two](https://github.com/user-attachments/assets/819f0a41-51fc-4ab5-8b45-d5db296251db)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fillable lease agreement template to the PDF playground, including rental terms, payment details, utilities, deposit options, notes, and signature fields.
  - Added a form controls template demonstrating text fields, checkboxes, radio buttons, drop-downs, list boxes, multi-select fields, and text areas.
  - Both templates support generating A4 PDFs with interactive form fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->