### PR TITLE
CSS: share declarative keyword parsing

### DIFF
--- a/takumi-core/src/style/properties/box_alignment.rs
+++ b/takumi-core/src/style/properties/box_alignment.rs
@@ -78,7 +78,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::style::FromCssStr;
+  use crate::style::{FromCssStr, ToCss};
 
   #[test]
   fn test_parse_place_items() {
@@ -130,5 +130,19 @@ mod tests {
   fn test_parse_place_items_invalid() {
     assert!(PlaceItems::from_css_str("bogus").is_err());
     assert!(PlaceItems::from_css_str("123").is_err());
+  }
+
+  #[test]
+  fn alignment_overflow_prefixes_preserve_their_meaning() {
+    let safe = AlignItems::from_css_str("SAFE CENTER").unwrap();
+    let unsafe_value = AlignItems::from_css_str("unsafe center").unwrap();
+    let repeated_prefixes = AlignItems::from_css_str("safe unsafe center").unwrap();
+
+    assert_eq!(safe, AlignItems::SafeCenter);
+    assert_eq!(safe.to_css_string(), "safe center");
+    assert_eq!(unsafe_value, AlignItems::Center);
+    assert_eq!(unsafe_value.to_css_string(), "center");
+    assert_eq!(repeated_prefixes, AlignItems::Center);
+    assert!(AlignItems::from_css_str("safe stretch").is_err());
   }
 }

--- a/takumi-core/src/style/properties/font_kerning.rs
+++ b/takumi-core/src/style/properties/font_kerning.rs
@@ -1,11 +1,4 @@
-use std::fmt;
-
-use cssparser::{Parser, Token, match_ignore_ascii_case};
-
-use crate::style::{
-  Animatable, CssToken, FontFeature, FromCss, MakeComputed, ParseResult, Tag, ToCss,
-  unexpected_token,
-};
+use crate::style::{Animatable, FontFeature, Tag, declare_enum_from_css_impl};
 
 /// `font-kerning`. The shaper kerns by default, so only `normal`/`none` emit a `kern` tag.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -20,15 +13,6 @@ pub enum FontKerning {
 }
 
 impl FontKerning {
-  fn from_keyword(ident: &str) -> Option<Self> {
-    Some(match_ignore_ascii_case! { ident,
-      "auto" => Self::Auto,
-      "normal" => Self::Normal,
-      "none" => Self::None,
-      _ => return None,
-    })
-  }
-
   pub(crate) fn append_features(&self, out: &mut Vec<FontFeature>) {
     match self {
       Self::Auto => {}
@@ -36,36 +20,52 @@ impl FontKerning {
       Self::None => out.push(FontFeature::new(Tag::new(b"kern"), 0)),
     }
   }
-
-  fn keyword(&self) -> &'static str {
-    match self {
-      Self::Auto => "auto",
-      Self::Normal => "normal",
-      Self::None => "none",
-    }
-  }
 }
 
-impl MakeComputed for FontKerning {}
+declare_enum_from_css_impl!(
+  ident FontKerning,
+  "auto" => FontKerning::Auto,
+  "normal" => FontKerning::Normal,
+  "none" => FontKerning::None,
+);
+
 impl Animatable for FontKerning {}
 
-impl<'i> FromCss<'i> for FontKerning {
-  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    let location = input.current_source_location();
-    let ident = input.expect_ident()?;
-    Self::from_keyword(ident)
-      .ok_or_else(|| unexpected_token!(location, &Token::Ident(ident.to_owned())))
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::style::{FromCssStr, ToCss};
+
+  #[test]
+  fn keyword_parsing_is_case_insensitive_and_canonical() {
+    let parsed = FontKerning::from_css_str("NORMAL").unwrap();
+
+    assert_eq!(parsed, FontKerning::Normal);
+    assert_eq!(parsed.to_css_string(), "normal");
   }
 
-  const VALID_TOKENS: &'static [CssToken] = &[
-    CssToken::Keyword("auto"),
-    CssToken::Keyword("normal"),
-    CssToken::Keyword("none"),
-  ];
-}
+  #[test]
+  fn keyword_errors_preserve_ident_and_non_ident_forms() {
+    let keyword = FontKerning::from_css_str("kern").unwrap_err();
+    let number = FontKerning::from_css_str("1").unwrap_err();
+    let string = FontKerning::from_css_str("\"normal\"").unwrap_err();
+    let function = FontKerning::from_css_str("kern()").unwrap_err();
 
-impl ToCss for FontKerning {
-  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    dest.write_str(self.keyword())
+    assert_eq!(
+      keyword.to_string(),
+      "Unexpected token: kern, expected a value of 'auto', 'normal' or 'none'"
+    );
+    assert_eq!(
+      number.to_string(),
+      "Basic(UnexpectedToken(Number { has_sign: false, value: 1.0, int_value: Some(1) }))"
+    );
+    assert_eq!(
+      string.to_string(),
+      "Basic(UnexpectedToken(QuotedString(\"normal\")))"
+    );
+    assert_eq!(
+      function.to_string(),
+      "Basic(UnexpectedToken(Function(\"kern\")))"
+    );
   }
 }

--- a/takumi-core/src/style/properties/font_variant.rs
+++ b/takumi-core/src/style/properties/font_variant.rs
@@ -4,7 +4,7 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   Animatable, CssToken, FontFeature, FromCss, MakeComputed, ParseResult, Tag, ToCss,
-  unexpected_token,
+  declare_enum_from_css_impl, unexpected_token,
 };
 
 /// Tri-state for one `font-variant-ligatures` group.
@@ -434,19 +434,6 @@ pub enum FontVariantCaps {
 }
 
 impl FontVariantCaps {
-  fn from_keyword(ident: &str) -> Option<Self> {
-    Some(match_ignore_ascii_case! { ident,
-      "normal" => Self::Normal,
-      "small-caps" => Self::SmallCaps,
-      "all-small-caps" => Self::AllSmallCaps,
-      "petite-caps" => Self::PetiteCaps,
-      "all-petite-caps" => Self::AllPetiteCaps,
-      "unicase" => Self::Unicase,
-      "titling-caps" => Self::TitlingCaps,
-      _ => return None,
-    })
-  }
-
   fn append_features(&self, out: &mut Vec<FontFeature>) {
     match self {
       Self::Normal => {}
@@ -464,47 +451,20 @@ impl FontVariantCaps {
       Self::TitlingCaps => out.push(FontFeature::new(Tag::new(b"titl"), 1)),
     }
   }
-
-  fn keyword(&self) -> &'static str {
-    match self {
-      Self::Normal => "normal",
-      Self::SmallCaps => "small-caps",
-      Self::AllSmallCaps => "all-small-caps",
-      Self::PetiteCaps => "petite-caps",
-      Self::AllPetiteCaps => "all-petite-caps",
-      Self::Unicase => "unicase",
-      Self::TitlingCaps => "titling-caps",
-    }
-  }
 }
 
-impl MakeComputed for FontVariantCaps {}
+declare_enum_from_css_impl!(
+  ident keyword FontVariantCaps,
+  "normal" => FontVariantCaps::Normal,
+  "small-caps" => FontVariantCaps::SmallCaps,
+  "all-small-caps" => FontVariantCaps::AllSmallCaps,
+  "petite-caps" => FontVariantCaps::PetiteCaps,
+  "all-petite-caps" => FontVariantCaps::AllPetiteCaps,
+  "unicase" => FontVariantCaps::Unicase,
+  "titling-caps" => FontVariantCaps::TitlingCaps,
+);
+
 impl Animatable for FontVariantCaps {}
-
-impl<'i> FromCss<'i> for FontVariantCaps {
-  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    let location = input.current_source_location();
-    let ident = input.expect_ident()?;
-    Self::from_keyword(ident)
-      .ok_or_else(|| unexpected_token!(location, &Token::Ident(ident.to_owned())))
-  }
-
-  const VALID_TOKENS: &'static [CssToken] = &[
-    CssToken::Keyword("normal"),
-    CssToken::Keyword("small-caps"),
-    CssToken::Keyword("all-small-caps"),
-    CssToken::Keyword("petite-caps"),
-    CssToken::Keyword("all-petite-caps"),
-    CssToken::Keyword("unicase"),
-    CssToken::Keyword("titling-caps"),
-  ];
-}
-
-impl ToCss for FontVariantCaps {
-  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    dest.write_str(self.keyword())
-  }
-}
 
 /// `font-variant-position`.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -519,15 +479,6 @@ pub enum FontVariantPosition {
 }
 
 impl FontVariantPosition {
-  fn from_keyword(ident: &str) -> Option<Self> {
-    Some(match_ignore_ascii_case! { ident,
-      "normal" => Self::Normal,
-      "sub" => Self::Sub,
-      "super" => Self::Super,
-      _ => return None,
-    })
-  }
-
   fn append_features(&self, out: &mut Vec<FontFeature>) {
     match self {
       Self::Normal => {}
@@ -535,39 +486,16 @@ impl FontVariantPosition {
       Self::Super => out.push(FontFeature::new(Tag::new(b"sups"), 1)),
     }
   }
-
-  fn keyword(&self) -> &'static str {
-    match self {
-      Self::Normal => "normal",
-      Self::Sub => "sub",
-      Self::Super => "super",
-    }
-  }
 }
 
-impl MakeComputed for FontVariantPosition {}
+declare_enum_from_css_impl!(
+  ident keyword FontVariantPosition,
+  "normal" => FontVariantPosition::Normal,
+  "sub" => FontVariantPosition::Sub,
+  "super" => FontVariantPosition::Super,
+);
+
 impl Animatable for FontVariantPosition {}
-
-impl<'i> FromCss<'i> for FontVariantPosition {
-  fn from_css(input: &mut Parser<'i, '_>) -> ParseResult<'i, Self> {
-    let location = input.current_source_location();
-    let ident = input.expect_ident()?;
-    Self::from_keyword(ident)
-      .ok_or_else(|| unexpected_token!(location, &Token::Ident(ident.to_owned())))
-  }
-
-  const VALID_TOKENS: &'static [CssToken] = &[
-    CssToken::Keyword("normal"),
-    CssToken::Keyword("sub"),
-    CssToken::Keyword("super"),
-  ];
-}
-
-impl ToCss for FontVariantPosition {
-  fn to_css<W: fmt::Write>(&self, dest: &mut W) -> fmt::Result {
-    dest.write_str(self.keyword())
-  }
-}
 
 /// Appends every resolved `font-variant-*` feature to `out`, in property order. The caller
 /// appends `font-feature-settings` afterwards so explicit settings win on tag conflicts.

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -859,7 +859,7 @@ macro_rules! declare_enum_from_css_impl {
     $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?
   ) => {
     $crate::style::properties::declare_enum_from_css_impl!(@impl
-      crate::style::parse_enum_keyword,
+      $crate::style::properties::parse_enum_keyword,
       $enum_type,
       $($canonical $(| $alias)* => $variant),*
     );
@@ -867,7 +867,7 @@ macro_rules! declare_enum_from_css_impl {
 
   (ident $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
     $crate::style::properties::declare_enum_from_css_impl!(@impl
-      crate::style::parse_ident_enum_keyword,
+      $crate::style::properties::parse_ident_enum_keyword,
       $enum_type,
       $($canonical $(| $alias)* => $variant),*
     );
@@ -881,7 +881,10 @@ macro_rules! declare_enum_from_css_impl {
 
     impl $enum_type {
       fn from_keyword(ident: &str) -> Option<Self> {
-        crate::style::CssToken::keyword_index(ident, Self::VALID_TOKENS)
+        crate::style::CssToken::keyword_index(
+          ident,
+          <Self as $crate::style::properties::FromCss>::VALID_TOKENS,
+        )
           .map(|index| Self::KEYWORD_VALUES[index])
       }
     }

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, fmt, sync::Arc};
 
-use cssparser::{Parser, ParserInput};
+use cssparser::{Parser, ParserInput, Token};
 
-use crate::style::{Color, SizingContext, math::lcm};
+use crate::style::{Color, SizingContext, build_unexpected_token, math::lcm};
 
 /// Parser result type alias for CSS property parsers.
 pub(crate) type ParseResult<'i, T> = Result<T, cssparser::ParseError<'i, Cow<'i, str>>>;
@@ -289,6 +289,54 @@ impl CssToken {
     }
     merged
   }
+
+  #[inline(never)]
+  pub(crate) fn keyword_index(ident: &str, tokens: &[CssToken]) -> Option<usize> {
+    tokens.iter().position(
+      |token| matches!(token, Self::Keyword(keyword) if ident.eq_ignore_ascii_case(keyword)),
+    )
+  }
+}
+
+#[inline(never)]
+pub(crate) fn parse_enum_keyword<'i>(
+  input: &mut Parser<'i, '_>,
+  valid_tokens: &'static [CssToken],
+  expect: CssExpectedMessage,
+) -> ParseResult<'i, usize> {
+  let location = input.current_source_location();
+  let token = input.next()?;
+
+  let Token::Ident(ident) = token else {
+    return Err(build_unexpected_token(
+      location,
+      token,
+      expect,
+      valid_tokens,
+    ));
+  };
+
+  CssToken::keyword_index(ident, valid_tokens)
+    .ok_or_else(|| build_unexpected_token(location, token, expect, valid_tokens))
+}
+
+#[inline(never)]
+pub(crate) fn parse_ident_enum_keyword<'i>(
+  input: &mut Parser<'i, '_>,
+  valid_tokens: &'static [CssToken],
+  expect: CssExpectedMessage,
+) -> ParseResult<'i, usize> {
+  let location = input.current_source_location();
+  let ident = input.expect_ident()?;
+
+  CssToken::keyword_index(ident, valid_tokens).ok_or_else(|| {
+    build_unexpected_token(
+      location,
+      &Token::Ident(ident.to_owned()),
+      expect,
+      valid_tokens,
+    )
+  })
 }
 
 impl std::fmt::Display for CssToken {
@@ -810,6 +858,42 @@ macro_rules! declare_enum_from_css_impl {
     $enum_type:ty,
     $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?
   ) => {
+    $crate::style::properties::declare_enum_from_css_impl!(@impl
+      crate::style::parse_enum_keyword,
+      $enum_type,
+      $($canonical $(| $alias)* => $variant),*
+    );
+  };
+
+  (ident $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
+    $crate::style::properties::declare_enum_from_css_impl!(@impl
+      crate::style::parse_ident_enum_keyword,
+      $enum_type,
+      $($canonical $(| $alias)* => $variant),*
+    );
+  };
+
+  (ident keyword $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
+    $crate::style::properties::declare_enum_from_css_impl!(
+      ident $enum_type,
+      $($canonical $(| $alias)* => $variant),*
+    );
+
+    impl $enum_type {
+      fn from_keyword(ident: &str) -> Option<Self> {
+        crate::style::CssToken::keyword_index(ident, Self::VALID_TOKENS)
+          .map(|index| Self::KEYWORD_VALUES[index])
+      }
+    }
+  };
+
+  (@impl $parser:path, $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
+    impl $enum_type {
+      const KEYWORD_VALUES: &'static [Self] = &[
+        $($variant $(, $crate::style::properties::declare_enum_from_css_impl!(@value $variant, $alias))*),*
+      ];
+    }
+
     impl crate::style::MakeComputed for $enum_type {}
 
     impl<'i> crate::style::FromCss<'i> for $enum_type {
@@ -821,19 +905,13 @@ macro_rules! declare_enum_from_css_impl {
       ];
 
       fn from_css(input: &mut cssparser::Parser<'i, '_>) -> crate::style::ParseResult<'i, Self> {
-        let location = input.current_source_location();
-        let token = input.next()?;
+        let index = $parser(
+          input,
+          Self::VALID_TOKENS,
+          <Self as crate::style::FromCss>::EXPECT_MESSAGE,
+        )?;
 
-        let cssparser::Token::Ident(ident) = token else {
-          return Err($crate::style::unexpected_token!(location, token));
-        };
-
-        cssparser::match_ignore_ascii_case! {&ident,
-          $(
-            $canonical $(| $alias)* => Ok($variant),
-          )*
-          _ => Err($crate::style::unexpected_token!(location, token)),
-        }
+        Ok(Self::KEYWORD_VALUES[index])
       }
     }
 
@@ -847,6 +925,10 @@ macro_rules! declare_enum_from_css_impl {
       }
     }
 
+  };
+
+  (@value $variant:path, $alias:literal) => {
+    $variant
   };
 }
 

--- a/takumi-core/src/style/properties/transform.rs
+++ b/takumi-core/src/style/properties/transform.rs
@@ -513,62 +513,60 @@ impl<'i> FromCss<'i> for Transform {
       );
     };
 
-    match_ignore_ascii_case! {function,
-      "translate" => parser.parse_nested_block(|input| {
+    let parse: fn(&mut Parser<'i, '_>) -> ParseResult<'i, Self> = match_ignore_ascii_case! {function,
+      "translate" => |input| {
         let x = Length::from_css(input)?;
         input.expect_comma()?;
         let y = Length::from_css(input)?;
 
-        Ok(Transform::Translate(x, y))
-      }),
-      "translatex" => parser.parse_nested_block(|input| Ok(Transform::Translate(
+        Ok(Self::Translate(x, y))
+      },
+      "translatex" => |input| Ok(Self::Translate(
         Length::from_css(input)?,
         Length::zero(),
-      ))),
-      "translatey" => parser.parse_nested_block(|input| Ok(Transform::Translate(
+      )),
+      "translatey" => |input| Ok(Self::Translate(
         Length::zero(),
         Length::from_css(input)?,
-      ))),
-      "scale" => parser.parse_nested_block(|input| {
+      )),
+      "scale" => |input| {
         let PercentageNumber(x) = PercentageNumber::from_css(input)?;
         if input.try_parse(Parser::expect_comma).is_ok() {
           let PercentageNumber(y) = PercentageNumber::from_css(input)?;
-          Ok(Transform::Scale(x, y))
+          Ok(Self::Scale(x, y))
         } else {
-          Ok(Transform::Scale(x, x))
+          Ok(Self::Scale(x, x))
         }
-      }),
-      "scalex" => parser.parse_nested_block(|input| Ok(Transform::Scale(
+      },
+      "scalex" => |input| Ok(Self::Scale(
         PercentageNumber::from_css(input)?.0,
         DEFAULT_SCALE,
-      ))),
-      "scaley" => parser.parse_nested_block(|input| Ok(Transform::Scale(
+      )),
+      "scaley" => |input| Ok(Self::Scale(
         DEFAULT_SCALE,
         PercentageNumber::from_css(input)?.0,
-      ))),
-      "skew" => parser.parse_nested_block(|input| {
+      )),
+      "skew" => |input| {
         let x = Angle::from_css(input)?;
         input.expect_comma()?;
         let y = Angle::from_css(input)?;
 
-        Ok(Transform::Skew(x, y))
-      }),
-      "skewx" => parser.parse_nested_block(|input| Ok(Transform::Skew(
+        Ok(Self::Skew(x, y))
+      },
+      "skewx" => |input| Ok(Self::Skew(
         Angle::from_css(input)?,
         Angle::default(),
-      ))),
-      "skewy" => parser.parse_nested_block(|input| Ok(Transform::Skew(
+      )),
+      "skewy" => |input| Ok(Self::Skew(
         Angle::default(),
         Angle::from_css(input)?,
-      ))),
-      "rotate" => parser.parse_nested_block(|input| Ok(Transform::Rotate(
-        Angle::from_css(input)?,
-      ))),
-      "matrix" => parser.parse_nested_block(|input| Ok(Transform::Matrix(
-        Affine::from_css(input)?,
-      ))),
-      _ => Err(unexpected_token!(location, token)),
-    }
+      )),
+      "rotate" => |input| Ok(Self::Rotate(Angle::from_css(input)?)),
+      "matrix" => |input| Ok(Self::Matrix(Affine::from_css(input)?)),
+      _ => return Err(unexpected_token!(location, token)),
+    };
+
+    parser.parse_nested_block(parse)
   }
 
   const VALID_TOKENS: &'static [CssToken] = &[CssToken::Syntax(CssSyntaxKind::TransformFunction)];
@@ -593,6 +591,53 @@ mod tests {
       Transform::from_css_str("scale(10)"),
       Ok(Transform::Scale(10.0, 10.0))
     );
+  }
+
+  #[test]
+  fn transform_functions_keep_their_individual_grammars() {
+    for (css, expected) in [
+      (
+        "translate(1px, 2px)",
+        Transform::Translate(Length::Px(1.0), Length::Px(2.0)),
+      ),
+      (
+        "translateX(1px)",
+        Transform::Translate(Length::Px(1.0), Length::zero()),
+      ),
+      (
+        "translateY(2px)",
+        Transform::Translate(Length::zero(), Length::Px(2.0)),
+      ),
+      ("scale(2, 3)", Transform::Scale(2.0, 3.0)),
+      ("scaleX(2)", Transform::Scale(2.0, DEFAULT_SCALE)),
+      ("scaleY(3)", Transform::Scale(DEFAULT_SCALE, 3.0)),
+      (
+        "skew(1deg, 2deg)",
+        Transform::Skew(Angle::new(1.0), Angle::new(2.0)),
+      ),
+      (
+        "skewX(1deg)",
+        Transform::Skew(Angle::new(1.0), Angle::default()),
+      ),
+      (
+        "skewY(2deg)",
+        Transform::Skew(Angle::default(), Angle::new(2.0)),
+      ),
+      ("rotate(3deg)", Transform::Rotate(Angle::new(3.0))),
+      (
+        "matrix(1, 0, 0, 1, 2, 3)",
+        Transform::Matrix(Affine::translation(2.0, 3.0)),
+      ),
+    ] {
+      assert_eq!(Transform::from_css_str(css), Ok(expected), "{css}");
+    }
+  }
+
+  #[test]
+  fn transform_errors_reject_missing_trailing_and_unknown_tokens() {
+    assert!(Transform::from_css_str("translate(1px)").is_err());
+    assert!(Transforms::from_css_str("translateX(1px) trailing").is_err());
+    assert!(Transforms::from_css_str("spin(1deg)").is_err());
   }
 
   #[test]

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -343,18 +343,20 @@ macro_rules! define_style {
           }
 
           input.reset(&state);
-          match self {
+          let declaration = match self {
             $(
-              Self::[<$longhand:camel>] => Ok(smallvec![StyleDeclaration::[<$longhand:camel>](
+              Self::[<$longhand:camel>] => StyleDeclaration::[<$longhand:camel>](
                 <$longhand_ty as FromCss>::from_css(input)?,
-              )]),
+              ),
             )*
             $(
-              Self::[<$transient:camel>] => Ok(smallvec![StyleDeclaration::[<$transient:camel>](
+              Self::[<$transient:camel>] => StyleDeclaration::[<$transient:camel>](
                 <$transient_ty as FromCss>::from_css(input)?,
-              )]),
+              ),
             )*
-          }
+          };
+
+          Ok(smallvec![declaration])
         }
 
         const EXPECT_INFO: [(CssExpectedMessage, &'static [CssToken]); Self::COUNT] = [


### PR DESCRIPTION
## Why

Keyword parsers repeat token handling across enums, while font properties maintain separate parsing, serialization and diagnostic lists.

## What

Use one keyword declaration and shared token lookup, preserving aliases, canonical output and diagnostics. Share transform block parsing and assemble longhand results once after dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSS parsing and serialization for font kerning and font variant properties, including case-insensitive keywords and clearer invalid-value handling.
  - Corrected alignment overflow handling for `safe` and `unsafe` prefixes, including rejection of unsupported combinations.
  - Improved transform-function parsing and validation, including detection of missing arguments, trailing tokens, and unknown functions.

- **Tests**
  - Expanded coverage for supported CSS values, canonical serialization, and parsing error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->