### PR TITLE
CSS: reject repeated alignment overflow prefixes

### DIFF
--- a/.tegami/alignment-overflow-prefixes.md
+++ b/.tegami/alignment-overflow-prefixes.md
@@ -1,0 +1,7 @@
+---
+"takumi": patch
+---
+
+# Reject repeated alignment overflow prefixes
+
+Reject repeated `safe` and `unsafe` prefixes in CSS alignment values.

--- a/takumi-core/src/style/properties/box_alignment.rs
+++ b/takumi-core/src/style/properties/box_alignment.rs
@@ -136,13 +136,20 @@ mod tests {
   fn alignment_overflow_prefixes_preserve_their_meaning() {
     let safe = AlignItems::from_css_str("SAFE CENTER").unwrap();
     let unsafe_value = AlignItems::from_css_str("unsafe center").unwrap();
-    let repeated_prefixes = AlignItems::from_css_str("safe unsafe center").unwrap();
+    let repeated_prefixes = [
+      "safe safe center",
+      "unsafe unsafe center",
+      "safe unsafe center",
+      "UNSAFE safe center",
+    ];
 
     assert_eq!(safe, AlignItems::SafeCenter);
     assert_eq!(safe.to_css_string(), "safe center");
     assert_eq!(unsafe_value, AlignItems::Center);
     assert_eq!(unsafe_value.to_css_string(), "center");
-    assert_eq!(repeated_prefixes, AlignItems::Center);
+    for css in repeated_prefixes {
+      assert!(AlignItems::from_css_str(css).is_err(), "{css}");
+    }
     assert!(AlignItems::from_css_str("safe stretch").is_err());
   }
 }

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -956,7 +956,7 @@ macro_rules! declare_box_alignment_enum_impl {
       ];
 
       fn from_css(input: &mut cssparser::Parser<'i, '_>) -> crate::style::ParseResult<'i, Self> {
-        let mut safe = false;
+        let mut overflow_position = None;
 
         loop {
           let location = input.current_source_location();
@@ -967,10 +967,13 @@ macro_rules! declare_box_alignment_enum_impl {
           };
 
           cssparser::match_ignore_ascii_case! {&ident,
-            "safe" => safe = true,
-            "unsafe" => safe = false,
-            $($safe_css => return Ok(if safe { Self::$safe_variant } else { Self::$base_variant }),)*
-            $($plain_css => return if safe {
+            "safe" | "unsafe" => {
+              if overflow_position.replace(ident.eq_ignore_ascii_case("safe")).is_some() {
+                return Err($crate::style::unexpected_token!(location, token));
+              }
+            },
+            $($safe_css => return Ok(if overflow_position.unwrap_or(false) { Self::$safe_variant } else { Self::$base_variant }),)*
+            $($plain_css => return if overflow_position.unwrap_or(false) {
               Err($crate::style::unexpected_token!(location, token))
             } else {
               Ok(Self::$plain_variant)


### PR DESCRIPTION
## Why

CSS alignment parsing accepted repeated `safe` and `unsafe` prefixes and silently used the last one.

## What

Reject a second overflow-position keyword while preserving single-prefix parsing. Keep the repeated-prefix regression assertion and cover matching, mixed, and case-insensitive prefixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CSS alignment values now reject repeated or conflicting `safe` and `unsafe` overflow-position prefixes.
  - Explicit `safe` and `unsafe` prefixes retain their distinct meanings during parsing.
  - Plain alignment keywords are rejected when an invalid `safe` prefix is present.

- **Documentation**
  - Added documentation describing the handling of repeated overflow-position prefixes in alignment values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->