### PR TITLE
Core: share resolved gradient geometry

### DIFF
--- a/takumi-core/src/lib.rs
+++ b/takumi-core/src/lib.rs
@@ -63,8 +63,8 @@ pub mod paint {
     conic_gradient::ConicGradientTile,
     filter::compose_transfer_table,
     gradient_utils::{ColorLut, GradientOverlayTile},
-    linear_gradient::{LinearGradientFastPathKind, LinearGradientTile},
-    radial_gradient::RadialGradientTile,
+    linear_gradient::{LinearGradientFastPathKind, LinearGradientGeometry, LinearGradientTile},
+    radial_gradient::{RadialGradientGeometry, RadialGradientTile},
   };
 }
 

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
+use smallvec::SmallVec;
 use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 
@@ -38,6 +39,93 @@ pub struct LinearGradient {
 impl MakeComputed for LinearGradient {
   fn make_computed(&mut self, sizing: &SizingContext) {
     self.stops.make_computed(sizing);
+  }
+}
+
+/// Resolved geometry and stops shared by gradient renderers.
+#[derive(Debug, Clone)]
+pub struct LinearGradientGeometry {
+  /// Direction vector X component.
+  pub dir_x: f32,
+  /// Direction vector Y component.
+  pub dir_y: f32,
+  /// Full axis length in pixels.
+  pub axis_length: f32,
+  /// Projection offset for the gradient axis.
+  pub projection_bias: f32,
+  stops: SmallVec<[ResolvedGradientStop; 4]>,
+}
+
+impl LinearGradient {
+  fn direction_components(&self, width: u32, height: u32) -> (f32, f32) {
+    match self.direction {
+      LinearGradientDirection::Angle(angle) => {
+        let rad = angle.0.to_radians();
+        (rad.sin(), -rad.cos())
+      }
+      LinearGradientDirection::Keyword(keyword_direction) => {
+        if let (Some(horizontal), Some(vertical)) =
+          (keyword_direction.horizontal, keyword_direction.vertical)
+        {
+          let dir_x = match horizontal {
+            HorizontalKeyword::Left => -(height as f32),
+            HorizontalKeyword::Right => height as f32,
+          };
+          let dir_y = match vertical {
+            VerticalKeyword::Top => -(width as f32),
+            VerticalKeyword::Bottom => width as f32,
+          };
+          let magnitude = dir_x.hypot(dir_y);
+          if magnitude > f32::EPSILON {
+            return (dir_x / magnitude, dir_y / magnitude);
+          }
+        }
+
+        let angle = keyword_direction.to_angle();
+        let rad = angle.0.to_radians();
+        (rad.sin(), -rad.cos())
+      }
+    }
+  }
+
+  /// Resolves the geometry and stops for a target viewport.
+  pub fn resolve_geometry(
+    &self,
+    width: u32,
+    height: u32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) -> LinearGradientGeometry {
+    let (dir_x, dir_y) = self.direction_components(width, height);
+    let cx = width as f32 / 2.0;
+    let cy = height as f32 / 2.0;
+    let max_extent = ((width as f32 * dir_x.abs()) + (height as f32 * dir_y.abs())) / 2.0;
+    let axis_length = 2.0 * max_extent;
+
+    LinearGradientGeometry {
+      dir_x,
+      dir_y,
+      axis_length,
+      projection_bias: max_extent - cx * dir_x - cy * dir_y,
+      stops: ResolvedGradientStop::resolve(
+        &self.stops,
+        axis_length.max(1e-6),
+        sizing,
+        current_color,
+      ),
+    }
+  }
+}
+
+impl LinearGradientGeometry {
+  /// Resolved stops in axis pixels.
+  pub fn stops(&self) -> &[ResolvedGradientStop] {
+    &self.stops
+  }
+
+  /// Mutable resolved stops for backend color filtering.
+  pub fn stops_mut(&mut self) -> &mut [ResolvedGradientStop] {
+    &mut self.stops
   }
 }
 
@@ -115,37 +203,6 @@ pub struct LinearGradientFastPath<'a> {
 
 impl LinearGradientTile {
   const AXIS_ALIGNMENT_EPSILON: f32 = 1e-4;
-
-  fn direction_components(gradient: &LinearGradient, width: u32, height: u32) -> (f32, f32) {
-    match gradient.direction {
-      LinearGradientDirection::Angle(angle) => {
-        let rad = angle.0.to_radians();
-        (rad.sin(), -rad.cos())
-      }
-      LinearGradientDirection::Keyword(keyword_direction) => {
-        if let (Some(horizontal), Some(vertical)) =
-          (keyword_direction.horizontal, keyword_direction.vertical)
-        {
-          let dir_x = match horizontal {
-            HorizontalKeyword::Left => -(height as f32),
-            HorizontalKeyword::Right => height as f32,
-          };
-          let dir_y = match vertical {
-            VerticalKeyword::Top => -(width as f32),
-            VerticalKeyword::Bottom => width as f32,
-          };
-          let magnitude = dir_x.hypot(dir_y);
-          if magnitude > f32::EPSILON {
-            return (dir_x / magnitude, dir_y / magnitude);
-          }
-        }
-
-        let angle = keyword_direction.to_angle();
-        let rad = angle.0.to_radians();
-        (rad.sin(), -rad.cos())
-      }
-    }
-  }
 
   /// Projects a pixel onto the gradient axis, in pixels.
   #[inline(always)]
@@ -232,22 +289,10 @@ impl LinearGradientTile {
     current_color: Color,
     dither: bool,
   ) -> Self {
-    let (dir_x, dir_y) = Self::direction_components(gradient, width, height);
+    let geometry = gradient.resolve_geometry(width, height, sizing, current_color);
+    let (dir_x, dir_y) = (geometry.dir_x, geometry.dir_y);
     let axis_aligned_kind = Self::classify_axis_aligned(dir_x, dir_y);
-
-    let cx = width as f32 / 2.0;
-    let cy = height as f32 / 2.0;
-    let max_extent = ((width as f32 * dir_x.abs()) + (height as f32 * dir_y.abs())) / 2.0;
-    let axis_length = 2.0 * max_extent;
-    let projection_bias = max_extent - cx * dir_x - cy * dir_y;
-
-    let resolved_stops = ResolvedGradientStop::resolve(
-      &gradient.stops,
-      axis_length.max(1e-6),
-      sizing,
-      current_color,
-    );
-    let axis = LutAxis::new(gradient.repeating, resolved_stops, axis_length);
+    let axis = LutAxis::new(gradient.repeating, geometry.stops, geometry.axis_length);
     let lut_size = match axis_aligned_kind {
       Some(LinearGradientFastPathKind::Horizontal) => axis.lut_size_covering(width as usize + 1),
       Some(LinearGradientFastPathKind::Vertical) => axis.lut_size_covering(height as usize + 1),
@@ -267,11 +312,11 @@ impl LinearGradientTile {
       height,
       dir_x,
       dir_y,
-      axis_length,
+      axis_length: geometry.axis_length,
       repeating: axis.repeating,
       repeat_start: axis.repeat_start,
       repeat_period: axis.repeat_period,
-      projection_bias,
+      projection_bias: geometry.projection_bias,
       position_to_lut_scale,
       fully_opaque,
       lut,

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -43,7 +43,6 @@ impl MakeComputed for LinearGradient {
 }
 
 /// Resolved geometry and stops shared by gradient renderers.
-#[derive(Debug, Clone)]
 pub struct LinearGradientGeometry {
   /// Direction vector X component.
   pub dir_x: f32,
@@ -52,7 +51,7 @@ pub struct LinearGradientGeometry {
   /// Full axis length in pixels.
   pub axis_length: f32,
   /// Projection offset for the gradient axis.
-  pub projection_bias: f32,
+  projection_bias: f32,
   stops: SmallVec<[ResolvedGradientStop; 4]>,
 }
 

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -116,7 +116,8 @@ pub use line_clamp::*;
 pub use line_height::*;
 pub use linear_gradient::{
   Angle, GradientKeywordDirection, GradientStop, HorizontalKeyword, LinearGradient,
-  LinearGradientDirection, ResolvedGradientStop, StopPosition, VerticalKeyword,
+  LinearGradientDirection, LinearGradientGeometry, ResolvedGradientStop, StopPosition,
+  VerticalKeyword,
 };
 pub use list_style::*;
 pub use max_size::*;
@@ -126,7 +127,7 @@ pub use overflow::*;
 pub use overflow_wrap::*;
 use parley::Alignment;
 pub use percentage_number::*;
-pub use radial_gradient::{RadialGradient, RadialShape, RadialSize};
+pub use radial_gradient::{RadialGradient, RadialGradientGeometry, RadialShape, RadialSize};
 use serde::Deserialize;
 pub use sides::*;
 pub use space_pair::*;

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -116,8 +116,7 @@ pub use line_clamp::*;
 pub use line_height::*;
 pub use linear_gradient::{
   Angle, GradientKeywordDirection, GradientStop, HorizontalKeyword, LinearGradient,
-  LinearGradientDirection, LinearGradientGeometry, ResolvedGradientStop, StopPosition,
-  VerticalKeyword,
+  LinearGradientDirection, ResolvedGradientStop, StopPosition, VerticalKeyword,
 };
 pub use list_style::*;
 pub use max_size::*;
@@ -127,7 +126,7 @@ pub use overflow::*;
 pub use overflow_wrap::*;
 use parley::Alignment;
 pub use percentage_number::*;
-pub use radial_gradient::{RadialGradient, RadialGradientGeometry, RadialShape, RadialSize};
+pub use radial_gradient::{RadialGradient, RadialShape, RadialSize};
 use serde::Deserialize;
 pub use sides::*;
 pub use space_pair::*;

--- a/takumi-core/src/style/properties/radial_gradient.rs
+++ b/takumi-core/src/style/properties/radial_gradient.rs
@@ -1,6 +1,7 @@
 use std::{f32::consts::SQRT_2, fmt};
 
 use cssparser::{Parser, Token, match_ignore_ascii_case};
+use smallvec::SmallVec;
 use tiny_skia::PremultipliedColorU8;
 use typed_builder::TypedBuilder;
 
@@ -118,6 +119,116 @@ impl<'i> FromCss<'i> for RadialSize {
 
 impl MakeComputed for RadialSize {}
 
+/// Resolved geometry and stops shared by gradient renderers.
+#[derive(Debug, Clone)]
+pub struct RadialGradientGeometry {
+  /// Center X coordinate in pixels.
+  pub cx: f32,
+  /// Center Y coordinate in pixels.
+  pub cy: f32,
+  /// Reciprocal horizontal radius for sampling.
+  pub inv_radius_x: f32,
+  /// Reciprocal vertical radius for sampling.
+  pub inv_radius_y: f32,
+  /// Axis length in pixels.
+  pub radius_scale: f32,
+  stops: SmallVec<[ResolvedGradientStop; 4]>,
+}
+
+impl RadialGradient {
+  /// Resolves the geometry and stops for a target viewport.
+  pub fn resolve_geometry(
+    &self,
+    width: u32,
+    height: u32,
+    sizing: &SizingContext,
+    current_color: Color,
+  ) -> RadialGradientGeometry {
+    let cx = Length::from(self.center.0.x).to_px(sizing, width as f32);
+    let cy = Length::from(self.center.0.y).to_px(sizing, height as f32);
+    let dx_left = cx.abs();
+    let dx_right = (width as f32 - cx).abs();
+    let dy_top = cy.abs();
+    let dy_bottom = (height as f32 - cy).abs();
+    let corner_distances = [
+      (dx_left, dy_top),
+      (dx_left, dy_bottom),
+      (dx_right, dy_top),
+      (dx_right, dy_bottom),
+    ]
+    .map(|(dx, dy)| (dx * dx + dy * dy).sqrt());
+    let (radius_x, radius_y) = match (self.shape, self.size) {
+      (shape, RadialSize::Explicit { radius_x, radius_y }) => {
+        let radius_x = radius_x.to_px(sizing, width as f32).max(0.0);
+        let radius_y = radius_y.to_px(sizing, height as f32).max(0.0);
+
+        match shape {
+          RadialShape::Circle => {
+            let radius = radius_x.max(radius_y);
+            (radius, radius)
+          }
+          RadialShape::Ellipse => (radius_x, radius_y),
+        }
+      }
+      (RadialShape::Ellipse, RadialSize::FarthestCorner) => {
+        ellipse_radii_through((dx_left.max(dx_right), dy_top.max(dy_bottom)))
+      }
+      (RadialShape::Circle, RadialSize::FarthestCorner) => {
+        let radius = corner_distances.into_iter().fold(0.0_f32, f32::max);
+        (radius, radius)
+      }
+      (RadialShape::Ellipse, RadialSize::FarthestSide) => {
+        (dx_left.max(dx_right), dy_top.max(dy_bottom))
+      }
+      (RadialShape::Ellipse, RadialSize::ClosestSide) => {
+        (dx_left.min(dx_right), dy_top.min(dy_bottom))
+      }
+      (RadialShape::Circle, RadialSize::FarthestSide) => {
+        let radius = dx_left.max(dx_right).max(dy_top.max(dy_bottom));
+        (radius, radius)
+      }
+      (RadialShape::Circle, RadialSize::ClosestSide) => {
+        let radius = dx_left.min(dx_right).min(dy_top.min(dy_bottom));
+        (radius, radius)
+      }
+      (RadialShape::Ellipse, RadialSize::ClosestCorner) => {
+        ellipse_radii_through((dx_left.min(dx_right), dy_top.min(dy_bottom)))
+      }
+      (RadialShape::Circle, RadialSize::ClosestCorner) => {
+        let radius = corner_distances.into_iter().fold(f32::INFINITY, f32::min);
+        (radius, radius)
+      }
+    };
+    let radius_scale = radius_x.max(radius_y);
+
+    RadialGradientGeometry {
+      cx,
+      cy,
+      inv_radius_x: radius_x.max(1e-6).recip(),
+      inv_radius_y: radius_y.max(1e-6).recip(),
+      radius_scale,
+      stops: ResolvedGradientStop::resolve(
+        &self.stops,
+        radius_scale.max(1e-6),
+        sizing,
+        current_color,
+      ),
+    }
+  }
+}
+
+impl RadialGradientGeometry {
+  /// Resolved stops in radius pixels.
+  pub fn stops(&self) -> &[ResolvedGradientStop] {
+    &self.stops
+  }
+
+  /// Mutable resolved stops for backend color filtering.
+  pub fn stops_mut(&mut self) -> &mut [ResolvedGradientStop] {
+    &mut self.stops
+  }
+}
+
 /// Precomputed drawing context for repeated sampling of a `RadialGradient`.
 #[derive(Debug, Clone)]
 pub struct RadialGradientTile {
@@ -221,81 +332,14 @@ impl RadialGradientTile {
     current_color: Color,
     dither: bool,
   ) -> Self {
-    let cx = Length::from(gradient.center.0.x).to_px(sizing, width as f32);
-    let cy = Length::from(gradient.center.0.y).to_px(sizing, height as f32);
-
-    // Absolute distances to the sides, so an out-of-box center still measures
-    // non-negative radii (Blink RadiusToSide).
-    let dx_left = cx.abs();
-    let dx_right = (width as f32 - cx).abs();
-    let dy_top = cy.abs();
-    let dy_bottom = (height as f32 - cy).abs();
-
-    let corner_distances = [
-      (dx_left, dy_top),
-      (dx_left, dy_bottom),
-      (dx_right, dy_top),
-      (dx_right, dy_bottom),
-    ]
-    .map(|(dx, dy)| (dx * dx + dy * dy).sqrt());
-
-    let (radius_x, radius_y) = match (gradient.shape, gradient.size) {
-      (shape, RadialSize::Explicit { radius_x, radius_y }) => {
-        let resolved_radius_x = radius_x.to_px(sizing, width as f32).max(0.0);
-        let resolved_radius_y = radius_y.to_px(sizing, height as f32).max(0.0);
-
-        match shape {
-          RadialShape::Circle => {
-            let r = resolved_radius_x.max(resolved_radius_y);
-            (r, r)
-          }
-          RadialShape::Ellipse => (resolved_radius_x, resolved_radius_y),
-        }
-      }
-      (RadialShape::Ellipse, RadialSize::FarthestCorner) => {
-        ellipse_radii_through((dx_left.max(dx_right), dy_top.max(dy_bottom)))
-      }
-      (RadialShape::Circle, RadialSize::FarthestCorner) => {
-        let r = corner_distances.into_iter().fold(0.0_f32, f32::max);
-        (r, r)
-      }
-      // Fallbacks for other size keywords: approximate using sides
-      (RadialShape::Ellipse, RadialSize::FarthestSide) => {
-        (dx_left.max(dx_right), dy_top.max(dy_bottom))
-      }
-      (RadialShape::Ellipse, RadialSize::ClosestSide) => {
-        (dx_left.min(dx_right), dy_top.min(dy_bottom))
-      }
-      (RadialShape::Circle, RadialSize::FarthestSide) => {
-        let r = dx_left.max(dx_right).max(dy_top.max(dy_bottom));
-        (r, r)
-      }
-      (RadialShape::Circle, RadialSize::ClosestSide) => {
-        let r = dx_left.min(dx_right).min(dy_top.min(dy_bottom));
-        (r, r)
-      }
-      (RadialShape::Ellipse, RadialSize::ClosestCorner) => {
-        ellipse_radii_through((dx_left.min(dx_right), dy_top.min(dy_bottom)))
-      }
-      (RadialShape::Circle, RadialSize::ClosestCorner) => {
-        let r = corner_distances.into_iter().fold(f32::INFINITY, f32::min);
-        (r, r)
-      }
-    };
-
-    let radius_scale = radius_x.max(radius_y);
-    let resolved_stops = ResolvedGradientStop::resolve(
-      &gradient.stops,
-      radius_scale.max(1e-6),
-      sizing,
-      current_color,
-    );
-    let axis = LutAxis::new(gradient.repeating, resolved_stops, radius_scale);
-    let lut_size = axis.lut_size_covering((radius_scale.ceil() as usize).saturating_add(1));
+    let geometry = gradient.resolve_geometry(width, height, sizing, current_color);
+    let axis = LutAxis::new(gradient.repeating, geometry.stops, geometry.radius_scale);
+    let lut_size =
+      axis.lut_size_covering((geometry.radius_scale.ceil() as usize).saturating_add(1));
     let lut = axis.lut(lut_size, gradient.interpolation, dither);
     let lut_len = lut.len();
-    let inv_radius_x = radius_x.max(1e-6).recip();
-    let inv_radius_y = radius_y.max(1e-6).recip();
+    let inv_radius_x = geometry.inv_radius_x;
+    let inv_radius_y = geometry.inv_radius_y;
     let position_to_lut_scale = if axis.length.abs() <= f32::EPSILON || lut_len <= 1 {
       0.0
     } else {
@@ -306,11 +350,11 @@ impl RadialGradientTile {
     RadialGradientTile {
       width,
       height,
-      cx,
-      cy,
+      cx: geometry.cx,
+      cy: geometry.cy,
       inv_radius_x,
       inv_radius_y,
-      radius_scale,
+      radius_scale: geometry.radius_scale,
       repeating: axis.repeating,
       repeat_start: axis.repeat_start,
       repeat_period: axis.repeat_period,

--- a/takumi-core/src/style/properties/radial_gradient.rs
+++ b/takumi-core/src/style/properties/radial_gradient.rs
@@ -120,7 +120,6 @@ impl<'i> FromCss<'i> for RadialSize {
 impl MakeComputed for RadialSize {}
 
 /// Resolved geometry and stops shared by gradient renderers.
-#[derive(Debug, Clone)]
 pub struct RadialGradientGeometry {
   /// Center X coordinate in pixels.
   pub cx: f32,

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -25,7 +25,7 @@ use takumi_core::{
     node::NodeKind,
     tree::{LayoutResults, NodeOrigin, RenderNode},
   },
-  paint::{ConicGradientTile, LinearGradientTile, RadialGradientTile},
+  paint::ConicGradientTile,
   painter::{
     BoxPainter, BoxShadows, FillShape, PaintDevice, StrokeStyle, paint_border,
     paint_run_decorations,
@@ -728,31 +728,23 @@ impl Emitter<'_> {
 
     let paint: Paint = match image {
       BackgroundImage::Linear(gradient) => {
-        let tile =
-          LinearGradientTile::new(gradient, w as u32, h as u32, sizing, current_color, false);
-        let resolved = self.filtered_stops(ResolvedGradientStop::resolve(
-          &gradient.stops,
-          tile.axis_length.max(1e-6),
-          sizing,
-          current_color,
-        ));
+        let mut geometry = gradient.resolve_geometry(w as u32, h as u32, sizing, current_color);
+        let axis_length = geometry.axis_length;
+        let (dir_x, dir_y) = (geometry.dir_x, geometry.dir_y);
+        self.filter_stops(geometry.stops_mut());
+        let resolved = geometry.stops();
         if resolved.is_empty() {
           return None;
         }
-        let max_extent = tile.axis_length / 2.0;
+        let max_extent = axis_length / 2.0;
         let (cx, cy) = (x + w / 2.0, y + h / 2.0);
-        let point_at = |t: f32| {
-          (
-            cx + (t - max_extent) * tile.dir_x,
-            cy + (t - max_extent) * tile.dir_y,
-          )
-        };
+        let point_at = |t: f32| (cx + (t - max_extent) * dir_x, cy + (t - max_extent) * dir_y);
         let (t0, t1, base, span) = if gradient.repeating {
           let first = resolved.first().map_or(0.0, |s| s.position);
-          let last = resolved.last().map_or(tile.axis_length, |s| s.position);
+          let last = resolved.last().map_or(axis_length, |s| s.position);
           (first, last, first, (last - first).max(1e-6))
         } else {
-          (0.0, tile.axis_length, 0.0, tile.axis_length.max(1e-6))
+          (0.0, axis_length, 0.0, axis_length.max(1e-6))
         };
         let (x1, y1) = point_at(t0);
         let (x2, y2) = point_at(t1);
@@ -764,32 +756,28 @@ impl Emitter<'_> {
           y2,
           transform: Transform::identity(),
           spread_method: spread(gradient.repeating),
-          stops: krilla_stops(&resolved, base, span),
+          stops: krilla_stops(resolved, base, span),
           anti_alias: false,
         }
         .into()
       }
       BackgroundImage::Radial(gradient) => {
-        let tile =
-          RadialGradientTile::new(gradient, w as u32, h as u32, sizing, current_color, false);
-        let resolved = self.filtered_stops(ResolvedGradientStop::resolve(
-          &gradient.stops,
-          tile.radius_scale.max(1e-6),
-          sizing,
-          current_color,
-        ));
+        let mut geometry = gradient.resolve_geometry(w as u32, h as u32, sizing, current_color);
+        let (cx, cy) = (geometry.cx, geometry.cy);
+        let radius_x = geometry.inv_radius_x.max(1e-6).recip();
+        let radius_y = geometry.inv_radius_y.max(1e-6).recip();
+        let extent = geometry.radius_scale.max(1e-6);
+        self.filter_stops(geometry.stops_mut());
+        let resolved = geometry.stops();
         if resolved.is_empty() {
           return None;
         }
-        let radius_x = tile.inv_radius_x.max(1e-6).recip();
-        let radius_y = tile.inv_radius_y.max(1e-6).recip();
-        let extent = tile.radius_scale.max(1e-6);
         // PDF radial shadings cannot repeat, so a repeating gradient expands
         // its period across the full radius instead of relying on the spread.
         let stops = if gradient.repeating {
-          expanded_radial_stops(&resolved, extent)
+          expanded_radial_stops(resolved, extent)
         } else {
-          krilla_stops(&resolved, 0.0, extent)
+          krilla_stops(resolved, 0.0, extent)
         };
         let scale_x = (radius_x / extent).max(1e-6);
         let scale_y = (radius_y / extent).max(1e-6);
@@ -801,7 +789,7 @@ impl Emitter<'_> {
           cx: 0.0,
           cy: 0.0,
           cr: extent,
-          transform: Transform::from_row(scale_x, 0.0, 0.0, scale_y, x + tile.cx, y + tile.cy),
+          transform: Transform::from_row(scale_x, 0.0, 0.0, scale_y, x + cx, y + cy),
           spread_method: SpreadMethod::Pad,
           stops,
           anti_alias: false,
@@ -951,16 +939,12 @@ impl Emitter<'_> {
   }
 
   /// Gradient stops as this subtree's `filter` leaves them.
-  fn filtered_stops<S>(&self, mut resolved: S) -> S
-  where
-    S: AsMut<[ResolvedGradientStop]>,
-  {
+  fn filter_stops(&self, resolved: &mut [ResolvedGradientStop]) {
     if let Some(filter) = &self.color_filter {
-      for stop in resolved.as_mut() {
+      for stop in resolved {
         stop.color = filter.apply_color(stop.color);
       }
     }
-    resolved
   }
 
   /// Opens an artifact sequence around a decoration when tagging is on, so it stays out of the

--- a/takumi-svg/src/gradient.rs
+++ b/takumi-svg/src/gradient.rs
@@ -6,7 +6,7 @@ use takumi_core::{
   context::RenderContext,
   geometry::{Point, Size},
   layout::background::{BackgroundLayerInput, LayerTileStyle},
-  paint::{ColorLut, ConicGradientTile, LinearGradientTile, RadialGradientTile},
+  paint::{ColorLut, ConicGradientTile},
   style::{
     BackgroundImage, BackgroundRepeat, BackgroundSize, BlendMode, ColorInterpolationMethod,
     ConicGradient, LinearGradient, PositionValue, RadialGradient, ResolvedGradientStop,
@@ -212,45 +212,38 @@ impl<'a, 'd> LayerEmitter<'a, 'd> {
 
   fn linear(&mut self, gradient: &LinearGradient, rect: Frame) -> io::Result<()> {
     let Frame { x, y, w, h } = rect;
-    let tile = LinearGradientTile::new(
-      gradient,
+    let geometry = gradient.resolve_geometry(
       w as u32,
       h as u32,
       &self.context.sizing,
       self.context.current_color,
-      false,
     );
-    let resolved = ResolvedGradientStop::resolve(
-      &gradient.stops,
-      tile.axis_length.max(1e-6),
-      &self.context.sizing,
-      self.context.current_color,
-    );
+    let resolved = geometry.stops();
     if resolved.is_empty() {
       return Ok(());
     }
 
-    let max_extent = tile.axis_length / 2.0;
+    let max_extent = geometry.axis_length / 2.0;
     let (cx, cy) = (x + w / 2.0, y + h / 2.0);
     let point_at = |t: f32| {
       (
-        cx + (t - max_extent) * tile.dir_x,
-        cy + (t - max_extent) * tile.dir_y,
+        cx + (t - max_extent) * geometry.dir_x,
+        cy + (t - max_extent) * geometry.dir_y,
       )
     };
 
     let (t0, t1, base, span) = if gradient.repeating {
       let first = resolved.first().map_or(0.0, |s| s.position);
-      let last = resolved.last().map_or(tile.axis_length, |s| s.position);
+      let last = resolved.last().map_or(geometry.axis_length, |s| s.position);
       (first, last, first, last - first)
     } else {
-      (0.0, tile.axis_length, 0.0, tile.axis_length)
+      (0.0, geometry.axis_length, 0.0, geometry.axis_length)
     };
 
     let stops = if gradient.repeating {
-      svg_stops(&resolved, base, span)
+      svg_stops(resolved, base, span)
     } else {
-      lut_svg_stops(&resolved, tile.axis_length, gradient.interpolation)
+      lut_svg_stops(resolved, geometry.axis_length, gradient.interpolation)
     };
     let paint = self
       .doc
@@ -260,45 +253,40 @@ impl<'a, 'd> LayerEmitter<'a, 'd> {
 
   fn radial(&mut self, gradient: &RadialGradient, rect: Frame) -> io::Result<()> {
     let Frame { x, y, w, h } = rect;
-    let tile = RadialGradientTile::new(
-      gradient,
+    let geometry = gradient.resolve_geometry(
       w as u32,
       h as u32,
       &self.context.sizing,
       self.context.current_color,
-      false,
     );
-    let resolved = ResolvedGradientStop::resolve(
-      &gradient.stops,
-      tile.radius_scale.max(1e-6),
-      &self.context.sizing,
-      self.context.current_color,
-    );
+    let resolved = geometry.stops();
     if resolved.is_empty() {
       return Ok(());
     }
 
-    let radius_x = tile.inv_radius_x.recip();
-    let radius_y = tile.inv_radius_y.recip();
+    let radius_x = geometry.inv_radius_x.recip();
+    let radius_y = geometry.inv_radius_y.recip();
     let (r, base, span) = if gradient.repeating {
       let first = resolved.first().map_or(0.0, |s| s.position);
-      let last = resolved.last().map_or(tile.radius_scale, |s| s.position);
+      let last = resolved
+        .last()
+        .map_or(geometry.radius_scale, |s| s.position);
       ((last - first).max(1e-6), first, last - first)
     } else {
-      (tile.radius_scale, 0.0, tile.radius_scale)
+      (geometry.radius_scale, 0.0, geometry.radius_scale)
     };
     let scale = (
-      (radius_x / tile.radius_scale.max(1e-6)).max(1e-6),
-      (radius_y / tile.radius_scale.max(1e-6)).max(1e-6),
+      (radius_x / geometry.radius_scale.max(1e-6)).max(1e-6),
+      (radius_y / geometry.radius_scale.max(1e-6)).max(1e-6),
     );
 
     let stops = if gradient.repeating {
-      svg_stops(&resolved, base, span)
+      svg_stops(resolved, base, span)
     } else {
-      lut_svg_stops(&resolved, tile.radius_scale, gradient.interpolation)
+      lut_svg_stops(resolved, geometry.radius_scale, gradient.interpolation)
     };
     let paint = self.doc.radial_gradient(
-      (x + tile.cx, y + tile.cy),
+      (x + geometry.cx, y + geometry.cy),
       r,
       scale,
       gradient.repeating,


### PR DESCRIPTION
## Why

SVG and PDF built raster gradient lookup tables just to obtain geometry, then resolved the same stops again.

## What

Share resolved geometry and stops through the gradient types. Raster tiles build their lookup tables from that result, while vector backends consume it directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added publicly accessible geometry information for linear and radial gradients, including resolved directions, dimensions, and color stops.
  - Added APIs for inspecting and updating resolved linear-gradient stops.

- **Bug Fixes**
  - Improved consistency of linear and radial gradient rendering in PDF output.
  - Improved SVG gradient generation, including positioning, repetition, scaling, and color-stop handling.
  - Ensured color filters are applied consistently to gradient stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->