### PR TITLE
Core: share placement overlap regions

### DIFF
--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -461,17 +461,6 @@ pub struct Placement {
   pub height: u32,
 }
 
-/// The shared pixels and source offsets of two overlapping placements.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PlacementOverlap {
-  /// Shared placement in the original coordinate space.
-  pub placement: Placement,
-  /// Origin within the left-hand placement.
-  pub lhs_offset: Point<u32>,
-  /// Origin within the right-hand placement.
-  pub rhs_offset: Point<u32>,
-}
-
 impl Placement {
   /// Right edge, exclusive.
   pub fn right(self) -> i32 {
@@ -525,77 +514,11 @@ impl Placement {
       self.bottom().clamp(0, size.height as i32),
     )
   }
-
-  /// Finds the shared pixels and their offsets in both placements.
-  pub fn overlap(self, other: Self) -> Option<PlacementOverlap> {
-    let placement = Self::from_bounds(
-      self.left.max(other.left),
-      self.top.max(other.top),
-      self.right().min(other.right()),
-      self.bottom().min(other.bottom()),
-    )?;
-
-    Some(PlacementOverlap {
-      lhs_offset: Point::new(
-        (placement.left - self.left) as u32,
-        (placement.top - self.top) as u32,
-      ),
-      rhs_offset: Point::new(
-        (placement.left - other.left) as u32,
-        (placement.top - other.top) as u32,
-      ),
-      placement,
-    })
-  }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::{Placement, Point, Size};
-
-  #[test]
-  fn placement_overlap_tracks_both_source_offsets() {
-    let overlap = Placement {
-      left: 0,
-      top: 0,
-      width: 4,
-      height: 3,
-    }
-    .overlap(Placement {
-      left: -1,
-      top: 1,
-      width: 4,
-      height: 3,
-    })
-    .unwrap();
-
-    assert_eq!(
-      overlap.placement,
-      Placement {
-        left: 0,
-        top: 1,
-        width: 3,
-        height: 2,
-      }
-    );
-    assert_eq!(overlap.lhs_offset, Point::new(0, 1));
-    assert_eq!(overlap.rhs_offset, Point::new(1, 0));
-    assert!(
-      Placement {
-        left: 0,
-        top: 0,
-        width: 1,
-        height: 1,
-      }
-      .overlap(Placement {
-        left: 1,
-        top: 0,
-        width: 1,
-        height: 1,
-      })
-      .is_none()
-    );
-  }
+  use super::Size;
 
   #[test]
   fn aspect_ratio_fills_height_from_width() {

--- a/takumi-core/src/geometry.rs
+++ b/takumi-core/src/geometry.rs
@@ -461,6 +461,17 @@ pub struct Placement {
   pub height: u32,
 }
 
+/// The shared pixels and source offsets of two overlapping placements.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PlacementOverlap {
+  /// Shared placement in the original coordinate space.
+  pub placement: Placement,
+  /// Origin within the left-hand placement.
+  pub lhs_offset: Point<u32>,
+  /// Origin within the right-hand placement.
+  pub rhs_offset: Point<u32>,
+}
+
 impl Placement {
   /// Right edge, exclusive.
   pub fn right(self) -> i32 {
@@ -514,11 +525,77 @@ impl Placement {
       self.bottom().clamp(0, size.height as i32),
     )
   }
+
+  /// Finds the shared pixels and their offsets in both placements.
+  pub fn overlap(self, other: Self) -> Option<PlacementOverlap> {
+    let placement = Self::from_bounds(
+      self.left.max(other.left),
+      self.top.max(other.top),
+      self.right().min(other.right()),
+      self.bottom().min(other.bottom()),
+    )?;
+
+    Some(PlacementOverlap {
+      lhs_offset: Point::new(
+        (placement.left - self.left) as u32,
+        (placement.top - self.top) as u32,
+      ),
+      rhs_offset: Point::new(
+        (placement.left - other.left) as u32,
+        (placement.top - other.top) as u32,
+      ),
+      placement,
+    })
+  }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::Size;
+  use super::{Placement, Point, Size};
+
+  #[test]
+  fn placement_overlap_tracks_both_source_offsets() {
+    let overlap = Placement {
+      left: 0,
+      top: 0,
+      width: 4,
+      height: 3,
+    }
+    .overlap(Placement {
+      left: -1,
+      top: 1,
+      width: 4,
+      height: 3,
+    })
+    .unwrap();
+
+    assert_eq!(
+      overlap.placement,
+      Placement {
+        left: 0,
+        top: 1,
+        width: 3,
+        height: 2,
+      }
+    );
+    assert_eq!(overlap.lhs_offset, Point::new(0, 1));
+    assert_eq!(overlap.rhs_offset, Point::new(1, 0));
+    assert!(
+      Placement {
+        left: 0,
+        top: 0,
+        width: 1,
+        height: 1,
+      }
+      .overlap(Placement {
+        left: 1,
+        top: 0,
+        width: 1,
+        height: 1,
+      })
+      .is_none()
+    );
+  }
 
   #[test]
   fn aspect_ratio_fills_height_from_width() {

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -14,7 +14,7 @@ use std::{borrow::Cow, mem::replace, sync::Arc};
 
 use blit::blit_paint_source_translation;
 pub(crate) use blit::{
-  composite_mask_source_to_pixmap, overlay_image, overlay_sampled_paint_source,
+  composite_mask_source_to_pixmap, overlay_image, overlay_sampled_paint_source, placement_overlap,
 };
 pub(crate) use gradient::try_overlay_gradient_tile;
 use image::{

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -36,6 +36,34 @@ pub(crate) struct OverlayBounds {
   pub y_max: i32,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct PlacementOverlap {
+  pub(crate) placement: Placement,
+  pub(crate) lhs_offset: Point<u32>,
+  pub(crate) rhs_offset: Point<u32>,
+}
+
+pub(crate) fn placement_overlap(lhs: Placement, rhs: Placement) -> Option<PlacementOverlap> {
+  let placement = Placement::from_bounds(
+    lhs.left.max(rhs.left),
+    lhs.top.max(rhs.top),
+    lhs.right().min(rhs.right()),
+    lhs.bottom().min(rhs.bottom()),
+  )?;
+
+  Some(PlacementOverlap {
+    lhs_offset: Point::new(
+      (placement.left - lhs.left) as u32,
+      (placement.top - lhs.top) as u32,
+    ),
+    rhs_offset: Point::new(
+      (placement.left - rhs.left) as u32,
+      (placement.top - rhs.top) as u32,
+    ),
+    placement,
+  })
+}
+
 #[inline(always)]
 pub(crate) fn compute_overlay_bounds_for_canvas(
   canvas_width: u32,
@@ -585,6 +613,54 @@ mod tests {
     BorderProperties, Canvas, PaintSource, Result, pixmap_from_buffer,
     resources::image_buffer::ImageBuffer, style::ImageScalingAlgorithm,
   };
+
+  #[test]
+  fn placement_overlap_tracks_both_source_offsets() {
+    let overlap = placement_overlap(
+      Placement {
+        left: 0,
+        top: 0,
+        width: 4,
+        height: 3,
+      },
+      Placement {
+        left: -1,
+        top: 1,
+        width: 4,
+        height: 3,
+      },
+    )
+    .unwrap();
+
+    assert_eq!(
+      overlap.placement,
+      Placement {
+        left: 0,
+        top: 1,
+        width: 3,
+        height: 2,
+      }
+    );
+    assert_eq!(overlap.lhs_offset, Point::new(0, 1));
+    assert_eq!(overlap.rhs_offset, Point::new(1, 0));
+    assert!(
+      placement_overlap(
+        Placement {
+          left: 0,
+          top: 0,
+          width: 1,
+          height: 1,
+        },
+        Placement {
+          left: 1,
+          top: 0,
+          width: 1,
+          height: 1,
+        },
+      )
+      .is_none()
+    );
+  }
 
   #[test]
   fn test_subcanvas_overlay_sampled_image_matches_direct_render() -> Result<()> {

--- a/takumi-raster/src/canvas/blit.rs
+++ b/takumi-raster/src/canvas/blit.rs
@@ -50,27 +50,21 @@ pub(crate) fn compute_overlay_bounds_for_canvas(
 
   let offset_x = offset.x.trunc() as i32;
   let offset_y = offset.y.trunc() as i32;
-  let bottom_width = canvas_width as i32;
-  let bottom_height = canvas_height as i32;
-  let y_min = offset_y.max(0);
-  let y_max = (offset_y + height as i32).min(bottom_height);
-  if y_min >= y_max {
-    return None;
+  let clipped = Placement {
+    left: offset_x,
+    top: offset_y,
+    width,
+    height,
   }
-
-  let x_min = offset_x.max(0);
-  let x_max = (offset_x + width as i32).min(bottom_width);
-  if x_min >= x_max {
-    return None;
-  }
+  .clamp_to(Size::new(canvas_width, canvas_height))?;
 
   Some(OverlayBounds {
     offset_x,
     offset_y,
-    x_min,
-    x_max,
-    y_min,
-    y_max,
+    x_min: clipped.left,
+    x_max: clipped.right(),
+    y_min: clipped.top,
+    y_max: clipped.bottom(),
   })
 }
 

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -366,22 +366,15 @@ struct AlphaOverlap {
 
 impl AlphaOverlap {
   fn new(lhs: Placement, rhs: Placement) -> Option<Self> {
-    let placement = Placement::from_bounds(
-      lhs.left.max(rhs.left),
-      lhs.top.max(rhs.top),
-      lhs.right().min(rhs.right()),
-      lhs.bottom().min(rhs.bottom()),
-    )?;
+    let overlap = lhs.overlap(rhs)?;
     let lhs_stride = lhs.width as usize;
     let rhs_stride = rhs.width as usize;
     Some(Self {
-      lhs_origin: (placement.top - lhs.top) as usize * lhs_stride
-        + (placement.left - lhs.left) as usize,
-      rhs_origin: (placement.top - rhs.top) as usize * rhs_stride
-        + (placement.left - rhs.left) as usize,
+      lhs_origin: overlap.lhs_offset.y as usize * lhs_stride + overlap.lhs_offset.x as usize,
+      rhs_origin: overlap.rhs_offset.y as usize * rhs_stride + overlap.rhs_offset.x as usize,
       lhs_stride,
       rhs_stride,
-      placement,
+      placement: overlap.placement,
     })
   }
 }

--- a/takumi-raster/src/canvas/mask.rs
+++ b/takumi-raster/src/canvas/mask.rs
@@ -10,6 +10,7 @@ use crate::{
   BorderProperties, Command, Fill, Placement, RenderContext, Result, Style, build_path,
   checked_area, create_mask, fast_div_255,
   layout::clip::clip_shape_commands,
+  placement_overlap,
   style::{Affine, BasicShape, ComputedStyle, FillRule, Overflow},
 };
 
@@ -366,7 +367,7 @@ struct AlphaOverlap {
 
 impl AlphaOverlap {
   fn new(lhs: Placement, rhs: Placement) -> Option<Self> {
-    let overlap = lhs.overlap(rhs)?;
+    let overlap = placement_overlap(lhs, rhs)?;
     let lhs_stride = lhs.width as usize;
     let rhs_stride = rhs.width as usize;
     Some(Self {

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -48,18 +48,30 @@ pub(crate) fn blend_pixmap_software(
   if opacity <= 0.0 {
     return;
   }
+  if offset.x >= dst.width() as i32 || offset.y >= dst.height() as i32 {
+    return;
+  }
 
-  let Some(OverlapRegion {
-    dst_left,
-    dst_top,
-    src_left,
-    src_top,
-    width,
-    height,
-  }) = overlapping_region(dst, src, offset)
-  else {
+  let Some(overlap) = (Placement {
+    left: 0,
+    top: 0,
+    width: dst.width(),
+    height: dst.height(),
+  })
+  .overlap(Placement {
+    left: offset.x,
+    top: offset.y,
+    width: src.width(),
+    height: src.height(),
+  }) else {
     return;
   };
+  let dst_left = overlap.lhs_offset.x as usize;
+  let dst_top = overlap.lhs_offset.y as usize;
+  let src_left = overlap.rhs_offset.x as usize;
+  let src_top = overlap.rhs_offset.y as usize;
+  let width = overlap.placement.width as usize;
+  let height = overlap.placement.height as usize;
 
   let dst_width = dst.width() as usize;
   let src_width = src.width() as usize;
@@ -86,40 +98,6 @@ pub(crate) fn blend_pixmap_software(
   }
 }
 
-fn overlapping_region(dst: &Pixmap, src: &Pixmap, offset: Point<i32>) -> Option<OverlapRegion> {
-  let dst_left = offset.x.max(0) as usize;
-  let dst_top = offset.y.max(0) as usize;
-  let src_left = (-offset.x).max(0) as usize;
-  let src_top = (-offset.y).max(0) as usize;
-  let width = (dst.width() as i32 - offset.x.max(0))
-    .min(src.width() as i32 - src_left as i32)
-    .max(0) as usize;
-  let height = (dst.height() as i32 - offset.y.max(0))
-    .min(src.height() as i32 - src_top as i32)
-    .max(0) as usize;
-
-  if width == 0 || height == 0 {
-    return None;
-  }
-
-  Some(OverlapRegion {
-    dst_left,
-    dst_top,
-    src_left,
-    src_top,
-    width,
-    height,
-  })
-}
-
-struct OverlapRegion {
-  dst_left: usize,
-  dst_top: usize,
-  src_left: usize,
-  src_top: usize,
-  width: usize,
-  height: usize,
-}
 enum DeferredNodeRender {
   Deferred {
     path: Vec<usize>,
@@ -740,6 +718,9 @@ fn draw_render_node_inline(
 mod tests {
   use std::error::Error;
 
+  use tiny_skia::Pixmap;
+
+  use super::{BlendMode, Point, blend_pixmap_software};
   use crate::{Fonts, RenderOptions, layout::node::Node, render, viewport::Viewport};
 
   type TestResult = Result<(), Box<dyn Error>>;
@@ -790,5 +771,23 @@ mod tests {
       "overflowing child of zero-sized opacity parent must still paint, got {pixel:?}"
     );
     Ok(())
+  }
+
+  #[test]
+  fn blending_outside_the_destination_leaves_pixels_unchanged() {
+    let mut dst = Pixmap::new(1, 1).unwrap();
+    dst.data_mut().copy_from_slice(&[1, 2, 3, 4]);
+    let mut src = Pixmap::new(1, 1).unwrap();
+    src.data_mut().copy_from_slice(&[5, 6, 7, 8]);
+
+    blend_pixmap_software(
+      &mut dst,
+      &src,
+      BlendMode::Normal,
+      Point::new(i32::MAX, i32::MAX),
+      1.0,
+    );
+
+    assert_eq!(dst.data(), &[1, 2, 3, 4]);
   }
 }

--- a/takumi-raster/src/stacking_context.rs
+++ b/takumi-raster/src/stacking_context.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     tree::{LayoutResults, RenderNode},
   },
-  prepare_node_mask, resolve_outline,
+  placement_overlap, prepare_node_mask, resolve_outline,
   style::{Affine, BackgroundImage, BlendMode, Filter, SizingContext},
 };
 
@@ -52,18 +52,20 @@ pub(crate) fn blend_pixmap_software(
     return;
   }
 
-  let Some(overlap) = (Placement {
-    left: 0,
-    top: 0,
-    width: dst.width(),
-    height: dst.height(),
-  })
-  .overlap(Placement {
-    left: offset.x,
-    top: offset.y,
-    width: src.width(),
-    height: src.height(),
-  }) else {
+  let Some(overlap) = placement_overlap(
+    Placement {
+      left: 0,
+      top: 0,
+      width: dst.width(),
+      height: dst.height(),
+    },
+    Placement {
+      left: offset.x,
+      top: offset.y,
+      width: src.width(),
+      height: src.height(),
+    },
+  ) else {
     return;
   };
   let dst_left = overlap.lhs_offset.x as usize;


### PR DESCRIPTION
## Why

Mask composition, overlays, and software blending maintained separate placement intersection calculations.

## What

Use shared placement operations for clipping and source offsets. Keep stride adapters, fractional-offset truncation, and early returns for empty or offscreen surfaces.
