### PR TITLE
Core: share run line decoration metrics

### DIFF
--- a/takumi-core/src/layout/inline/decorations.rs
+++ b/takumi-core/src/layout/inline/decorations.rs
@@ -28,22 +28,13 @@ pub struct DecorationRect {
   pub line: TextDecorationLines,
 }
 
-/// Raw position and thickness for one decoration line.
-#[derive(Clone, Copy)]
-pub struct DecorationLine {
-  /// Top edge relative to the line origin.
-  pub offset: f32,
-  /// Raw CSS or font thickness before backend rounding.
-  pub thickness: f32,
-}
-
 impl ShapedRun {
   /// Raw metrics for an enabled decoration line.
   pub fn decoration_line(
     &self,
     line: TextDecorationLines,
     baseline_shift: f32,
-  ) -> Option<DecorationLine> {
+  ) -> Option<(f32, f32)> {
     if !self.brush.decoration_line.contains(line) {
       return None;
     }
@@ -70,7 +61,7 @@ impl ShapedRun {
       SizedTextDecorationThickness::FromFont => font_thickness,
     };
 
-    Some(DecorationLine { offset, thickness })
+    Some((offset, thickness))
   }
 
   /// The active decoration lines for a glyph run, in border-box space.
@@ -125,7 +116,7 @@ impl ShapedRun {
     }
     let top = layout.border.top + layout.padding.top;
     // Blink floors every decoration at 1px (`TextDecorationInfo::ResolvedThickness`).
-    let thickness = |line: DecorationLine| line.thickness.max(1.0);
+    let thickness = |value: f32| value.max(1.0);
     let mut emit = |x: f32,
                     span_width: f32,
                     y_offset: f32,
@@ -146,9 +137,10 @@ impl ShapedRun {
       });
     };
 
-    if let Some(line) = self.decoration_line(TextDecorationLines::UNDERLINE, baseline_shift) {
-      let y_offset = line.offset;
-      let height = thickness(line);
+    if let Some((y_offset, raw_thickness)) =
+      self.decoration_line(TextDecorationLines::UNDERLINE, baseline_shift)
+    {
+      let height = thickness(raw_thickness);
       // `skip-ink` cuts the line where the glyphs cross it. The pieces carry the
       // same transform, so a backend paints them exactly as it paints one line.
       let spans = if brush.decoration_skip_ink == TextDecorationSkipInk::None {
@@ -190,12 +182,12 @@ impl ShapedRun {
       (TextDecorationLines::OVERLINE, false),
       (TextDecorationLines::LINE_THROUGH, true),
     ] {
-      if let Some(line) = self.decoration_line(line_kind, baseline_shift) {
+      if let Some((offset, raw_thickness)) = self.decoration_line(line_kind, baseline_shift) {
         emit(
           snapped_start_x,
           width,
-          line.offset,
-          thickness(line),
+          offset,
+          thickness(raw_thickness),
           over,
           line_kind,
         );

--- a/takumi-core/src/layout/inline/decorations.rs
+++ b/takumi-core/src/layout/inline/decorations.rs
@@ -49,23 +49,20 @@ impl ShapedRun {
     }
 
     let metrics = self.metrics;
-    let (offset, font_thickness) = if line == TextDecorationLines::UNDERLINE {
-      (
+    let (offset, font_thickness) = match line {
+      TextDecorationLines::UNDERLINE => (
         self.baseline + baseline_shift + self.underline_offset_from_baseline(),
         metrics.underline_size,
-      )
-    } else if line == TextDecorationLines::OVERLINE {
-      (
+      ),
+      TextDecorationLines::OVERLINE => (
         self.baseline + baseline_shift - metrics.ascent - metrics.underline_offset,
         metrics.underline_size,
-      )
-    } else if line == TextDecorationLines::LINE_THROUGH {
-      (
+      ),
+      TextDecorationLines::LINE_THROUGH => (
         self.baseline + baseline_shift - metrics.strikethrough_offset,
         metrics.strikethrough_size,
-      )
-    } else {
-      return None;
+      ),
+      _ => return None,
     };
 
     let thickness = match self.brush.decoration_thickness {

--- a/takumi-core/src/layout/inline/decorations.rs
+++ b/takumi-core/src/layout/inline/decorations.rs
@@ -28,7 +28,54 @@ pub struct DecorationRect {
   pub line: TextDecorationLines,
 }
 
+/// Raw position and thickness for one decoration line.
+#[derive(Clone, Copy)]
+pub struct DecorationLine {
+  /// Top edge relative to the line origin.
+  pub offset: f32,
+  /// Raw CSS or font thickness before backend rounding.
+  pub thickness: f32,
+}
+
 impl ShapedRun {
+  /// Raw metrics for an enabled decoration line.
+  pub fn decoration_line(
+    &self,
+    line: TextDecorationLines,
+    baseline_shift: f32,
+  ) -> Option<DecorationLine> {
+    if !self.brush.decoration_line.contains(line) {
+      return None;
+    }
+
+    let metrics = self.metrics;
+    let (offset, font_thickness) = if line == TextDecorationLines::UNDERLINE {
+      (
+        self.baseline + baseline_shift + self.underline_offset_from_baseline(),
+        metrics.underline_size,
+      )
+    } else if line == TextDecorationLines::OVERLINE {
+      (
+        self.baseline + baseline_shift - metrics.ascent - metrics.underline_offset,
+        metrics.underline_size,
+      )
+    } else if line == TextDecorationLines::LINE_THROUGH {
+      (
+        self.baseline + baseline_shift - metrics.strikethrough_offset,
+        metrics.strikethrough_size,
+      )
+    } else {
+      return None;
+    };
+
+    let thickness = match self.brush.decoration_thickness {
+      SizedTextDecorationThickness::Value(value) => value,
+      SizedTextDecorationThickness::FromFont => font_thickness,
+    };
+
+    Some(DecorationLine { offset, thickness })
+  }
+
   /// The active decoration lines for a glyph run, in border-box space.
   pub fn glyph_outlines<'g>(
     &self,
@@ -69,7 +116,6 @@ impl ShapedRun {
     if lines.is_empty() {
       return out;
     }
-    let metrics = &self.metrics;
     // A fully trimmed run must not snap up to a 1px decoration.
     if self.decorated_advance() <= 0.0 {
       return out;
@@ -80,16 +126,9 @@ impl ShapedRun {
     if width <= 0.0 {
       return out;
     }
-    let baseline = self.baseline + baseline_shift;
     let top = layout.border.top + layout.padding.top;
     // Blink floors every decoration at 1px (`TextDecorationInfo::ResolvedThickness`).
-    let thickness = |from_font: f32| {
-      match brush.decoration_thickness {
-        SizedTextDecorationThickness::Value(value) => value,
-        SizedTextDecorationThickness::FromFont => from_font,
-      }
-      .max(1.0)
-    };
+    let thickness = |line: DecorationLine| line.thickness.max(1.0);
     let mut emit = |x: f32,
                     span_width: f32,
                     y_offset: f32,
@@ -110,9 +149,9 @@ impl ShapedRun {
       });
     };
 
-    if lines.contains(TextDecorationLines::UNDERLINE) {
-      let y_offset = baseline + self.underline_offset_from_baseline();
-      let height = thickness(metrics.underline_size);
+    if let Some(line) = self.decoration_line(TextDecorationLines::UNDERLINE, baseline_shift) {
+      let y_offset = line.offset;
+      let height = thickness(line);
       // `skip-ink` cuts the line where the glyphs cross it. The pieces carry the
       // same transform, so a backend paints them exactly as it paints one line.
       let spans = if brush.decoration_skip_ink == TextDecorationSkipInk::None {
@@ -150,25 +189,20 @@ impl ShapedRun {
         );
       }
     }
-    if lines.contains(TextDecorationLines::OVERLINE) {
-      emit(
-        snapped_start_x,
-        width,
-        baseline - metrics.ascent - metrics.underline_offset,
-        thickness(metrics.underline_size),
-        false,
-        TextDecorationLines::OVERLINE,
-      );
-    }
-    if lines.contains(TextDecorationLines::LINE_THROUGH) {
-      emit(
-        snapped_start_x,
-        width,
-        baseline - metrics.strikethrough_offset,
-        thickness(metrics.strikethrough_size),
-        true,
-        TextDecorationLines::LINE_THROUGH,
-      );
+    for (line_kind, over) in [
+      (TextDecorationLines::OVERLINE, false),
+      (TextDecorationLines::LINE_THROUGH, true),
+    ] {
+      if let Some(line) = self.decoration_line(line_kind, baseline_shift) {
+        emit(
+          snapped_start_x,
+          width,
+          line.offset,
+          thickness(line),
+          over,
+          line_kind,
+        );
+      }
     }
     out
   }

--- a/takumi-core/src/layout/inline/mod.rs
+++ b/takumi-core/src/layout/inline/mod.rs
@@ -35,7 +35,7 @@ mod truncation;
 
 pub use self::{
   background::InlineBackgroundFragment,
-  decorations::DecorationRect,
+  decorations::{DecorationLine, DecorationRect},
   items::{DecorationLink, InlineBoxItem, InlineItem, ProcessedInlineSpan, collect_inline_items},
   metrics::VisualInlineBox,
   outline::{InlineOutlineRect, outline_island_contour, outline_islands},

--- a/takumi-core/src/layout/inline/mod.rs
+++ b/takumi-core/src/layout/inline/mod.rs
@@ -35,7 +35,7 @@ mod truncation;
 
 pub use self::{
   background::InlineBackgroundFragment,
-  decorations::{DecorationLine, DecorationRect},
+  decorations::DecorationRect,
   items::{DecorationLink, InlineBoxItem, InlineItem, ProcessedInlineSpan, collect_inline_items},
   metrics::VisualInlineBox,
   outline::{InlineOutlineRect, outline_island_contour, outline_islands},

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -129,7 +129,8 @@ fn draw_glyph_run_decorations(
       continue;
     }
 
-    let Some(line) = glyph_run.decoration_line(line_kind, options.baseline_shift) else {
+    let Some((offset, thickness)) = glyph_run.decoration_line(line_kind, options.baseline_shift)
+    else {
       continue;
     };
 
@@ -143,8 +144,8 @@ fn draw_glyph_run_decorations(
         resolved_glyphs,
         UnderlineDrawOptions {
           color: brush.decoration_color,
-          offset: line.offset,
-          size: line.thickness,
+          offset,
+          size: thickness,
           layout: options.layout,
           transform: options.transform,
           baseline_shift: options.baseline_shift,
@@ -155,8 +156,8 @@ fn draw_glyph_run_decorations(
         canvas,
         glyph_run,
         brush.decoration_color,
-        line.offset,
-        line.thickness,
+        offset,
+        thickness,
         options.layout,
         options.transform,
       );

--- a/takumi-raster/src/inline_drawing.rs
+++ b/takumi-raster/src/inline_drawing.rs
@@ -24,10 +24,7 @@ use crate::{
   render::render_node,
   render_mask, resolve_outline,
   resources::{font::FontError, glyph::ResolvedGlyph},
-  style::{
-    Affine, BackgroundClip, BlendMode, Color, SizedTextDecorationThickness, TextDecorationLines,
-    TextDecorationSkipInk,
-  },
+  style::{Affine, BackgroundClip, BlendMode, Color, TextDecorationLines, TextDecorationSkipInk},
 };
 
 fn draw_with_inline_opacity(
@@ -114,27 +111,30 @@ fn draw_underline_with_skip_ink(
   }
 }
 
-fn draw_glyph_run_under_overline(
+fn draw_glyph_run_decorations(
   glyph_run: &ShapedRun,
   resolved_glyphs: &HashMap<u32, Arc<ResolvedGlyph>>,
   canvas: &mut Canvas,
   options: GlyphRunLineOptions,
+  lines: TextDecorationLines,
 ) -> Result<()> {
   let brush = glyph_run.brush;
-  let metrics = glyph_run.metrics;
 
-  if brush
-    .decoration_line
-    .contains(TextDecorationLines::UNDERLINE)
-  {
-    let offset =
-      glyph_run.baseline + options.baseline_shift + glyph_run.underline_offset_from_baseline();
-    let size = match brush.decoration_thickness {
-      SizedTextDecorationThickness::Value(v) => v,
-      SizedTextDecorationThickness::FromFont => metrics.underline_size,
+  for line_kind in [
+    TextDecorationLines::UNDERLINE,
+    TextDecorationLines::OVERLINE,
+    TextDecorationLines::LINE_THROUGH,
+  ] {
+    if !lines.contains(line_kind) {
+      continue;
+    }
+
+    let Some(line) = glyph_run.decoration_line(line_kind, options.baseline_shift) else {
+      continue;
     };
 
-    if options.transform.only_translation()
+    if line_kind == TextDecorationLines::UNDERLINE
+      && options.transform.only_translation()
       && brush.decoration_skip_ink != TextDecorationSkipInk::None
     {
       draw_underline_with_skip_ink(
@@ -143,8 +143,8 @@ fn draw_glyph_run_under_overline(
         resolved_glyphs,
         UnderlineDrawOptions {
           color: brush.decoration_color,
-          offset,
-          size,
+          offset: line.offset,
+          size: line.thickness,
           layout: options.layout,
           transform: options.transform,
           baseline_shift: options.baseline_shift,
@@ -155,63 +155,13 @@ fn draw_glyph_run_under_overline(
         canvas,
         glyph_run,
         brush.decoration_color,
-        offset,
-        size,
+        line.offset,
+        line.thickness,
         options.layout,
         options.transform,
       );
     }
   }
-
-  if brush
-    .decoration_line
-    .contains(TextDecorationLines::OVERLINE)
-  {
-    draw_decoration(
-      canvas,
-      glyph_run,
-      glyph_run.brush.decoration_color,
-      glyph_run.baseline + options.baseline_shift - metrics.ascent - metrics.underline_offset,
-      match brush.decoration_thickness {
-        SizedTextDecorationThickness::Value(v) => v,
-        SizedTextDecorationThickness::FromFont => metrics.underline_size,
-      },
-      options.layout,
-      options.transform,
-    );
-  }
-
-  Ok(())
-}
-
-fn draw_glyph_run_line_through(
-  glyph_run: &ShapedRun,
-  canvas: &mut Canvas,
-  options: GlyphRunLineOptions,
-) -> Result<()> {
-  let brush = glyph_run.brush;
-  let decoration_line = brush.decoration_line;
-
-  if !decoration_line.contains(TextDecorationLines::LINE_THROUGH) {
-    return Ok(());
-  }
-
-  let metrics = glyph_run.metrics;
-  let size = match brush.decoration_thickness {
-    SizedTextDecorationThickness::Value(v) => v,
-    SizedTextDecorationThickness::FromFont => metrics.strikethrough_size,
-  };
-  let offset = glyph_run.baseline + options.baseline_shift - metrics.strikethrough_offset;
-
-  draw_decoration(
-    canvas,
-    glyph_run,
-    glyph_run.brush.decoration_color,
-    offset,
-    size,
-    options.layout,
-    options.transform,
-  );
 
   Ok(())
 }
@@ -503,7 +453,13 @@ pub(crate) fn draw_inline_layout(
     for run in &runs {
       let opts = line_options(run);
       draw_with_inline_opacity(canvas, run.glyph_run.brush.opacity, |canvas| {
-        draw_glyph_run_under_overline(&run.glyph_run, &run.resolved_glyphs, canvas, opts)
+        draw_glyph_run_decorations(
+          &run.glyph_run,
+          &run.resolved_glyphs,
+          canvas,
+          opts,
+          TextDecorationLines::UNDERLINE | TextDecorationLines::OVERLINE,
+        )
       })?;
     }
   }
@@ -533,7 +489,13 @@ pub(crate) fn draw_inline_layout(
     for run in &runs {
       let opts = line_options(run);
       draw_with_inline_opacity(canvas, run.glyph_run.brush.opacity, |canvas| {
-        draw_glyph_run_line_through(&run.glyph_run, canvas, opts)
+        draw_glyph_run_decorations(
+          &run.glyph_run,
+          &run.resolved_glyphs,
+          canvas,
+          opts,
+          TextDecorationLines::LINE_THROUGH,
+        )
       })?;
     }
   }


### PR DESCRIPTION
## Why

Core and raster rendering repeated text-decoration metrics, thickness selection, and line-specific drawing setup.

## What

Resolve decoration metrics through `ShapedRun` and share raster line drawing. Preserve backend rounding, skip-ink rules, and decoration order around glyphs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering of underline, overline, and strikethrough text decorations.
  - Ensured decoration positioning and thickness remain consistent across inline text and glyph rendering.
  - Improved support for decorated text with baseline shifts, resulting in more accurate visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->