### PR TITLE
CSS: share enum animation traits

### DIFF
--- a/takumi-core/src/style/animation.rs
+++ b/takumi-core/src/style/animation.rs
@@ -550,66 +550,33 @@ macro_rules! impl_passthrough_animatable {
 }
 
 impl_passthrough_animatable!(
-  BoxSizing,
   AnimationNames,
   AnimationDurations,
   AnimationTimingFunctions,
   AnimationIterationCounts,
-  AnimationDirections,
-  AnimationFillModes,
-  AnimationPlayStates,
-  Clear,
-  Display,
-  Direction,
-  Float,
-  FlexDirection,
   AlignItems,
   JustifyContent,
-  FlexWrap,
-  Position,
-  BorderStyle,
   Border,
-  ObjectFit,
-  Overflow,
-  BackgroundClip,
-  BackgroundOrigin,
   GridAutoFlow,
   GridLine,
   GridTemplateAreas,
   TextOverflow,
-  TextTransform,
   FontStyle,
   FontFamily,
   LineHeight,
   FontSynthesis,
-  FontSynthesic,
   LineClamp,
-  TextAlign,
   TextStroke,
-  LineJoin,
   TextDecoration,
   TextDecorationLines,
-  TextDecorationStyle,
-  TextDecorationSkipInk,
-  TextUnderlinePosition,
   BreakBetween,
-  BreakInside,
-  BoxDecorationBreak,
-  ImageScalingAlgorithm,
   OverflowWrap,
-  WordBreak,
   BasicShape,
   OffsetPath,
   OffsetAnchor,
   OffsetPosition,
-  FillRule,
   WhiteSpace,
-  WhiteSpaceCollapse,
-  TextWrapMode,
-  TextWrapStyle,
   TextWrap,
-  Isolation,
-  Visibility,
   VerticalAlign,
   Flex,
   Background,
@@ -750,6 +717,78 @@ mod tests {
 
     target.interpolate(&Dummy(3), &Dummy(7), 0.5, &sizing(), current_color());
     assert_eq!(target, Dummy(7));
+  }
+
+  #[test]
+  fn animation_keyword_lists_remain_discrete() {
+    fn interpolate<T: Animatable>(from: T, to: T, progress: f32) -> T {
+      let mut value = from.clone();
+
+      value.interpolate(&from, &to, progress, &sizing(), current_color());
+      value
+    }
+
+    macro_rules! assert_discrete_list {
+      ($type:ty; [$($from:expr),*]; [$($to:expr),*]) => {
+        let from: $type = Box::from([$($from),*]);
+        let to: $type = Box::from([$($to),*]);
+
+        assert_eq!(interpolate(from.clone(), to.clone(), 0.49), from);
+        assert_eq!(interpolate(from.clone(), to.clone(), 0.5), to);
+      };
+    }
+
+    assert_discrete_list!(
+      AnimationDirections;
+      [AnimationDirection::Normal, AnimationDirection::Reverse];
+      [AnimationDirection::Alternate, AnimationDirection::AlternateReverse]
+    );
+    assert_discrete_list!(
+      AnimationDirections;
+      [AnimationDirection::Normal];
+      [AnimationDirection::Reverse, AnimationDirection::Alternate]
+    );
+    assert_discrete_list!(
+      AnimationFillModes;
+      [AnimationFillMode::None, AnimationFillMode::Forwards];
+      [AnimationFillMode::Backwards, AnimationFillMode::Both]
+    );
+    assert_discrete_list!(
+      AnimationFillModes;
+      [AnimationFillMode::None];
+      [AnimationFillMode::Forwards, AnimationFillMode::Both]
+    );
+    assert_discrete_list!(
+      AnimationPlayStates;
+      [AnimationPlayState::Running, AnimationPlayState::Paused];
+      [AnimationPlayState::Paused, AnimationPlayState::Running]
+    );
+    assert_discrete_list!(
+      AnimationPlayStates;
+      [AnimationPlayState::Running];
+      [AnimationPlayState::Paused, AnimationPlayState::Running]
+    );
+  }
+
+  #[test]
+  fn blend_modes_repeat_to_lcm() {
+    let from: BlendModes = Box::from([BlendMode::Normal, BlendMode::Multiply]);
+    let to: BlendModes = Box::from([BlendMode::Screen, BlendMode::Overlay, BlendMode::Darken]);
+    let mut value = from.clone();
+
+    value.interpolate(&from, &to, 0.5, &sizing(), current_color());
+
+    assert_eq!(
+      value.as_ref(),
+      [
+        BlendMode::Screen,
+        BlendMode::Overlay,
+        BlendMode::Darken,
+        BlendMode::Screen,
+        BlendMode::Overlay,
+        BlendMode::Darken,
+      ]
+    );
   }
 
   #[test]

--- a/takumi-core/src/style/properties/animation.rs
+++ b/takumi-core/src/style/properties/animation.rs
@@ -5,7 +5,7 @@ use typed_builder::TypedBuilder;
 
 use crate::style::{
   CssDescriptorKind, CssSyntaxKind, CssToken, FromCss, FromCssStr, MakeComputed, ParseResult,
-  ToCss, declare_enum_from_css_impl, next_is_comma, tw::TailwindPropertyParser, unexpected_token,
+  ToCss, impl_css_enum, next_is_comma, tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Implements `FromCss` for a `Box<[T]>` animation list type as a comma-separated list of `$elem`.
@@ -232,7 +232,7 @@ pub enum AnimationDirection {
   AlternateReverse,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   AnimationDirection,
   "normal" => AnimationDirection::Normal,
   "reverse" => AnimationDirection::Reverse,
@@ -260,7 +260,7 @@ pub enum AnimationFillMode {
   Both,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   AnimationFillMode,
   "none" => AnimationFillMode::None,
   "forwards" => AnimationFillMode::Forwards,
@@ -284,7 +284,7 @@ pub enum AnimationPlayState {
   Paused,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   AnimationPlayState,
   "running" => AnimationPlayState::Running,
   "paused" => AnimationPlayState::Paused,

--- a/takumi-core/src/style/properties/background_repeat.rs
+++ b/takumi-core/src/style/properties/background_repeat.rs
@@ -6,7 +6,7 @@ use smallvec::{SmallVec, smallvec};
 use super::background_image::parse_comma_list;
 use crate::style::{
   Animatable, CssToken, FromCss, ListInterpolationStrategy, MakeComputed, ParseResult, ToCss,
-  declare_enum_from_css_impl,
+  impl_css_enum,
 };
 
 /// Tile origins along one axis for `background-repeat: repeat`: the first origin
@@ -91,7 +91,7 @@ pub enum BackgroundRepeatStyle {
   Round,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BackgroundRepeatStyle,
   "repeat" => BackgroundRepeatStyle::Repeat,
   "no-repeat" => BackgroundRepeatStyle::NoRepeat,

--- a/takumi-core/src/style/properties/blend_mode.rs
+++ b/takumi-core/src/style/properties/blend_mode.rs
@@ -2,8 +2,8 @@ use cssparser::Parser;
 
 use super::background_image::parse_comma_list;
 use crate::style::{
-  Animatable, CssToken, FromCss, FromCssStr, ListInterpolationStrategy, ParseResult,
-  declare_enum_from_css_impl, tw::TailwindPropertyParser,
+  Animatable, CssToken, FromCss, FromCssStr, ListInterpolationStrategy, ParseResult, impl_css_enum,
+  tw::TailwindPropertyParser,
 };
 
 /// A list of blend modes.
@@ -60,8 +60,8 @@ pub enum BlendMode {
   PlusDarker,
 }
 
-declare_enum_from_css_impl!(
-  BlendMode,
+impl_css_enum!(
+  custom_animatable BlendMode,
   "normal" => BlendMode::Normal,
   "multiply" => BlendMode::Multiply,
   "screen" => BlendMode::Screen,

--- a/takumi-core/src/style/properties/border.rs
+++ b/takumi-core/src/style/properties/border.rs
@@ -4,8 +4,8 @@ use cssparser::Parser;
 
 use crate::style::{
   Animatable, BorderStyle, Color, ColorInput, CssSyntaxKind, CssToken, FromCss, MakeComputed,
-  ParseResult, SizingContext, ToCss, declare_enum_from_css_impl, properties::Length,
-  tw::TailwindPropertyParser, unexpected_token,
+  ParseResult, SizingContext, ToCss, impl_css_enum, properties::Length, tw::TailwindPropertyParser,
+  unexpected_token,
 };
 
 /// CSSWG `<line-width>` keyword (`thin | medium | thick`).
@@ -20,7 +20,7 @@ pub enum LineWidthKeyword {
   Thick,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   LineWidthKeyword,
   "thin" => LineWidthKeyword::Thin,
   "medium" => LineWidthKeyword::Medium,

--- a/takumi-core/src/style/properties/breaks.rs
+++ b/takumi-core/src/style/properties/breaks.rs
@@ -8,7 +8,7 @@ use cssparser::{BasicParseErrorKind, Parser};
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, SizingContext,
-  ToCss, declare_enum_from_css_impl, lerp,
+  ToCss, impl_css_enum, lerp,
 };
 
 /// A forced-break value for `break-before` / `break-after`. Pagination has no
@@ -71,7 +71,7 @@ pub enum BreakInside {
   Avoid,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BreakInside,
   "auto" => BreakInside::Auto,
   "avoid" => BreakInside::Avoid
@@ -149,7 +149,7 @@ pub enum BoxDecorationBreak {
   Clone,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BoxDecorationBreak,
   "slice" => BoxDecorationBreak::Slice,
   "clone" => BoxDecorationBreak::Clone

--- a/takumi-core/src/style/properties/clip_path.rs
+++ b/takumi-core/src/style/properties/clip_path.rs
@@ -161,7 +161,7 @@ impl BasicShape {
   }
 }
 
-crate::style::properties::declare_enum_from_css_impl!(
+crate::style::properties::impl_css_enum!(
   FillRule,
   "nonzero" => FillRule::NonZero,
   "evenodd" => FillRule::EvenOdd,

--- a/takumi-core/src/style/properties/font_kerning.rs
+++ b/takumi-core/src/style/properties/font_kerning.rs
@@ -1,4 +1,4 @@
-use crate::style::{Animatable, FontFeature, Tag, declare_enum_from_css_impl};
+use crate::style::{FontFeature, Tag, impl_css_enum};
 
 /// `font-kerning`. The shaper kerns by default, so only `normal`/`none` emit a `kern` tag.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -22,14 +22,12 @@ impl FontKerning {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   ident FontKerning,
   "auto" => FontKerning::Auto,
   "normal" => FontKerning::Normal,
   "none" => FontKerning::None,
 );
-
-impl Animatable for FontKerning {}
 
 #[cfg(test)]
 mod tests {

--- a/takumi-core/src/style/properties/font_size.rs
+++ b/takumi-core/src/style/properties/font_size.rs
@@ -4,7 +4,7 @@ use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
-  SizingContext, ToCss, declare_enum_from_css_impl, unexpected_token,
+  SizingContext, ToCss, impl_css_enum, unexpected_token,
 };
 
 /// Absolute `font-size` keywords.
@@ -46,7 +46,7 @@ impl FontSizeKeyword {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   FontSizeKeyword,
   "xx-small" => FontSizeKeyword::XXSmall,
   "x-small" => FontSizeKeyword::XSmall,

--- a/takumi-core/src/style/properties/font_synthesis.rs
+++ b/takumi-core/src/style/properties/font_synthesis.rs
@@ -1,9 +1,7 @@
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
-use crate::style::{
-  CssToken, FromCss, MakeComputed, ParseResult, declare_enum_from_css_impl, unexpected_token,
-};
+use crate::style::{CssToken, FromCss, MakeComputed, ParseResult, impl_css_enum, unexpected_token};
 
 /// Controls synthetic font behaviors.
 #[derive(Debug, Clone, Copy, PartialEq, Default, TypedBuilder)]
@@ -69,7 +67,7 @@ impl FontSynthesic {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   FontSynthesic,
   "auto" => FontSynthesic::Auto,
   "none" => FontSynthesic::None,

--- a/takumi-core/src/style/properties/font_variant.rs
+++ b/takumi-core/src/style/properties/font_variant.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use cssparser::{Parser, Token, match_ignore_ascii_case};
 
 use crate::style::{
-  Animatable, CssToken, FontFeature, FromCss, MakeComputed, ParseResult, Tag, ToCss,
-  declare_enum_from_css_impl, unexpected_token,
+  Animatable, CssToken, FontFeature, FromCss, MakeComputed, ParseResult, Tag, ToCss, impl_css_enum,
+  unexpected_token,
 };
 
 /// Tri-state for one `font-variant-ligatures` group.
@@ -453,7 +453,7 @@ impl FontVariantCaps {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   ident keyword FontVariantCaps,
   "normal" => FontVariantCaps::Normal,
   "small-caps" => FontVariantCaps::SmallCaps,
@@ -463,8 +463,6 @@ declare_enum_from_css_impl!(
   "unicase" => FontVariantCaps::Unicase,
   "titling-caps" => FontVariantCaps::TitlingCaps,
 );
-
-impl Animatable for FontVariantCaps {}
 
 /// `font-variant-position`.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -488,14 +486,12 @@ impl FontVariantPosition {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   ident keyword FontVariantPosition,
   "normal" => FontVariantPosition::Normal,
   "sub" => FontVariantPosition::Sub,
   "super" => FontVariantPosition::Super,
 );
-
-impl Animatable for FontVariantPosition {}
 
 /// Appends every resolved `font-variant-*` feature to `out`, in property order. The caller
 /// appends `font-feature-settings` afterwards so explicit settings win on tag conflicts.

--- a/takumi-core/src/style/properties/line_clamp.rs
+++ b/takumi-core/src/style/properties/line_clamp.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use cssparser::{Parser, serialize_string};
 
 use crate::style::{
-  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
-  declare_enum_from_css_impl, tw::TailwindPropertyParser,
+  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, impl_css_enum,
+  tw::TailwindPropertyParser,
 };
 
 /// `block-ellipsis`: `none | auto | <string>`. Inherited.
@@ -65,13 +65,11 @@ pub enum Continue {
   Collapse,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Continue,
   "normal" => Continue::Normal,
   "collapse" => Continue::Collapse,
 );
-
-impl Animatable for Continue {}
 
 /// Parsed `line-clamp` shorthand: `none | <integer> || <'block-ellipsis'>`.
 ///

--- a/takumi-core/src/style/properties/linear_gradient.rs
+++ b/takumi-core/src/style/properties/linear_gradient.rs
@@ -13,8 +13,8 @@ use super::gradient_utils::{
 };
 use crate::style::{
   Animatable, Color, ColorInterpolationMethod, CssDescriptorKind, CssSyntaxKind, CssToken, FromCss,
-  Length, MakeComputed, ParseResult, SizingContext, ToCss, declare_enum_from_css_impl,
-  properties::ColorInput, tw::TailwindPropertyParser, unexpected_token,
+  Length, MakeComputed, ParseResult, SizingContext, ToCss, impl_css_enum, properties::ColorInput,
+  tw::TailwindPropertyParser, unexpected_token,
 };
 
 /// Represents a linear gradient.
@@ -528,13 +528,13 @@ pub enum VerticalKeyword {
   Bottom,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   HorizontalKeyword,
   "left" => HorizontalKeyword::Left,
   "right" => HorizontalKeyword::Right,
 );
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   VerticalKeyword,
   "top" => VerticalKeyword::Top,
   "bottom" => VerticalKeyword::Bottom,

--- a/takumi-core/src/style/properties/list_style.rs
+++ b/takumi-core/src/style/properties/list_style.rs
@@ -4,7 +4,7 @@ use cssparser::{Parser, Token, match_ignore_ascii_case, serialize_string};
 
 use crate::style::{
   Animatable, BackgroundImage, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
-  declare_enum_from_css_impl, unexpected_token,
+  impl_css_enum, unexpected_token,
 };
 
 /// The counter style a list item's marker is generated from.
@@ -92,13 +92,11 @@ pub enum ListStylePosition {
   Inside,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   ListStylePosition,
   "outside" => ListStylePosition::Outside,
   "inside" => ListStylePosition::Inside,
 );
-
-impl Animatable for ListStylePosition {}
 
 /// The `list-style` shorthand.
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/takumi-core/src/style/properties/mod.rs
+++ b/takumi-core/src/style/properties/mod.rs
@@ -139,9 +139,7 @@ pub use text_shadow::*;
 pub use text_stroke::*;
 pub use text_wrap::*;
 pub use traits::*;
-pub(crate) use traits::{
-  declare_box_alignment_enum_impl, declare_enum_from_css_impl, impl_from_taffy_enum,
-};
+pub(crate) use traits::{declare_box_alignment_enum_impl, impl_css_enum, impl_from_taffy_enum};
 pub use transform::*;
 pub use vertical_align::*;
 pub use white_space::*;
@@ -278,7 +276,7 @@ pub enum ObjectFit {
   None,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   ObjectFit,
   "fill" => ObjectFit::Fill,
   "contain" => ObjectFit::Contain,
@@ -304,7 +302,7 @@ pub enum BackgroundClip {
   BorderArea,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BackgroundClip,
   "border-box" => BackgroundClip::BorderBox,
   "padding-box" => BackgroundClip::PaddingBox,
@@ -339,7 +337,7 @@ pub enum BackgroundOrigin {
   ContentBox,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BackgroundOrigin,
   "border-box" => BackgroundOrigin::BorderBox,
   "padding-box" => BackgroundOrigin::PaddingBox,
@@ -439,7 +437,7 @@ pub enum BoxSizing {
   BorderBox,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BoxSizing,
   "content-box" => BoxSizing::ContentBox,
   "border-box" => BoxSizing::BorderBox
@@ -468,7 +466,7 @@ pub enum TextAlign {
   End,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextAlign,
   "left" => TextAlign::Left,
   "right" => TextAlign::Right,
@@ -493,7 +491,7 @@ pub enum Isolation {
   Auto,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Isolation,
   "isolate" => Isolation::Isolate,
   "auto" => Isolation::Auto
@@ -513,7 +511,7 @@ pub enum Visibility {
   Hidden,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Visibility,
   "visible" => Visibility::Visible,
   "hidden" => Visibility::Hidden
@@ -530,13 +528,11 @@ pub enum CaptionSide {
   Bottom,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   CaptionSide,
   "top" => CaptionSide::Top,
   "bottom" => CaptionSide::Bottom
 );
-
-impl Animatable for CaptionSide {}
 
 /// Defines whether adjacent table cell borders collapse onto one grid line.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -549,13 +545,11 @@ pub enum BorderCollapse {
   Collapse,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BorderCollapse,
   "separate" => BorderCollapse::Separate,
   "collapse" => BorderCollapse::Collapse
 );
-
-impl Animatable for BorderCollapse {}
 
 /// Defines how a table distributes its column widths.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -568,13 +562,11 @@ pub enum TableLayout {
   Fixed,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TableLayout,
   "auto" => TableLayout::Auto,
   "fixed" => TableLayout::Fixed
 );
-
-impl Animatable for TableLayout {}
 
 /// A `border-spacing` value: one or two non-negative lengths. A declaration
 /// carrying a percentage, `auto`, or a negative length is discarded, so the
@@ -646,7 +638,7 @@ pub enum LineJoin {
   Bevel,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   LineJoin,
   "miter" => LineJoin::Miter,
   "round" => LineJoin::Round,
@@ -673,7 +665,7 @@ pub enum Position {
   Fixed,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Position,
   "relative" => Position::Relative,
   "absolute" => Position::Absolute,
@@ -725,7 +717,7 @@ impl Direction {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Direction,
   "ltr" => Direction::Ltr,
   "rtl" => Direction::Rtl
@@ -750,7 +742,7 @@ pub enum Float {
   InlineEnd,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Float,
   "none" => Float::None,
   "left" => Float::Left,
@@ -803,7 +795,7 @@ pub enum Clear {
   InlineEnd,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Clear,
   "none" => Clear::None,
   "left" => Clear::Left,
@@ -856,7 +848,7 @@ pub enum FlexDirection {
   ColumnReverse,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   FlexDirection,
   "row" => FlexDirection::Row,
   "column" => FlexDirection::Column,
@@ -1010,7 +1002,7 @@ pub enum Display {
   TableCaption,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Display,
   "none" => Display::None,
   "flex" | "-webkit-box" | "-webkit-flex" => Display::Flex,
@@ -1079,7 +1071,7 @@ pub enum BoxOrient {
   Vertical,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BoxOrient,
   "horizontal" | "inline-axis" => BoxOrient::Horizontal,
   "vertical" | "block-axis" => BoxOrient::Vertical
@@ -1099,7 +1091,7 @@ pub enum BoxPack {
   Justify,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BoxPack,
   "start" => BoxPack::Start,
   "end" => BoxPack::End,
@@ -1123,7 +1115,7 @@ pub enum BoxAlign {
   Stretch,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BoxAlign,
   "start" => BoxAlign::Start,
   "end" => BoxAlign::End,
@@ -1274,7 +1266,7 @@ pub enum FlexWrap {
   WrapReverse,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   FlexWrap,
   "nowrap" => FlexWrap::NoWrap,
   "wrap" => FlexWrap::Wrap,
@@ -1298,7 +1290,7 @@ pub enum TextTransform {
   Capitalize,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextTransform,
   "none" => TextTransform::None,
   "uppercase" => TextTransform::Uppercase,
@@ -1317,7 +1309,7 @@ pub enum TextDecorationSkipInk {
   None,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextDecorationSkipInk,
   "auto" => TextDecorationSkipInk::Auto,
   "none" => TextDecorationSkipInk::None
@@ -1338,7 +1330,7 @@ pub enum WhiteSpaceCollapse {
   PreserveBreaks,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   WhiteSpaceCollapse,
   "preserve" => WhiteSpaceCollapse::Preserve,
   "collapse" => WhiteSpaceCollapse::Collapse,
@@ -1362,7 +1354,7 @@ pub enum ImageScalingAlgorithm {
   Pixelated,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   ImageScalingAlgorithm,
   "auto" => ImageScalingAlgorithm::Auto,
   "smooth" => ImageScalingAlgorithm::Smooth,
@@ -1402,7 +1394,7 @@ impl BorderStyle {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   BorderStyle,
   "none" => BorderStyle::None,
   "hidden" => BorderStyle::Hidden,

--- a/takumi-core/src/style/properties/offset_path.rs
+++ b/takumi-core/src/style/properties/offset_path.rs
@@ -7,7 +7,7 @@ use crate::{
   geometry::{Point, Size},
   style::{
     Angle, Animatable, BasicShape, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed,
-    ParseResult, ShapePosition, ShapeRadius, SizingContext, ToCss, declare_enum_from_css_impl,
+    ParseResult, ShapePosition, ShapeRadius, SizingContext, ToCss, impl_css_enum,
   },
 };
 
@@ -30,7 +30,7 @@ pub enum RaySize {
   Sides,
 }
 
-crate::style::properties::declare_enum_from_css_impl!(
+crate::style::properties::impl_css_enum!(
   RaySize,
   "closest-side" => RaySize::ClosestSide,
   "closest-corner" => RaySize::ClosestCorner,
@@ -125,7 +125,7 @@ pub enum CoordBox {
   ViewBox,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   CoordBox,
   "content-box" => CoordBox::ContentBox,
   "padding-box" => CoordBox::PaddingBox,

--- a/takumi-core/src/style/properties/overflow.rs
+++ b/takumi-core/src/style/properties/overflow.rs
@@ -1,7 +1,7 @@
 use cssparser::match_ignore_ascii_case;
 use taffy::Overflow as TaffyOverflow;
 
-use crate::style::{declare_enum_from_css_impl, tw::TailwindPropertyParser};
+use crate::style::{impl_css_enum, tw::TailwindPropertyParser};
 
 /// How children overflowing their container should affect layout
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -19,7 +19,7 @@ pub enum Overflow {
   Hidden,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   Overflow,
   "visible" => Overflow::Visible,
   "clip" => Overflow::Clip,

--- a/takumi-core/src/style/properties/radial_gradient.rs
+++ b/takumi-core/src/style/properties/radial_gradient.rs
@@ -11,7 +11,7 @@ use super::gradient_utils::{
 use crate::style::{
   Color, ColorInterpolationMethod, CssDescriptorKind, CssToken, FromCss, GradientStop, Length,
   MakeComputed, ParseResult, PositionValue, ResolvedGradientStop, SizingContext, StopPosition,
-  ToCss, declare_enum_from_css_impl, unexpected_token,
+  ToCss, impl_css_enum, unexpected_token,
 };
 
 /// Radii of the ellipse through `corner`, as Blink's `EllipseRadius`
@@ -68,7 +68,7 @@ pub enum RadialShape {
   Ellipse,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   RadialShape,
   "circle" => RadialShape::Circle,
   "ellipse" => RadialShape::Ellipse,

--- a/takumi-core/src/style/properties/text_decoration.rs
+++ b/takumi-core/src/style/properties/text_decoration.rs
@@ -6,7 +6,7 @@ use typed_builder::TypedBuilder;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, FromCssStr, Length, MakeComputed,
-  ParseResult, SizingContext, ToCss, declare_enum_from_css_impl, properties::ColorInput,
+  ParseResult, SizingContext, ToCss, impl_css_enum, properties::ColorInput,
   tw::TailwindPropertyParser, unexpected_token,
 };
 
@@ -287,7 +287,7 @@ pub enum TextUnderlinePosition {
   Under,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextUnderlinePosition,
   "auto" => TextUnderlinePosition::Auto,
   "from-font" => TextUnderlinePosition::FromFont,
@@ -303,7 +303,7 @@ pub enum TextDecorationStyle {
   Solid,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextDecorationStyle,
   "solid" => Self::Solid
 );

--- a/takumi-core/src/style/properties/text_fit.rs
+++ b/takumi-core/src/style/properties/text_fit.rs
@@ -4,8 +4,8 @@ use cssparser::{Parser, Token};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
-  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss,
-  declare_enum_from_css_impl, unexpected_token,
+  Animatable, CssSyntaxKind, CssToken, FromCss, MakeComputed, ParseResult, ToCss, impl_css_enum,
+  unexpected_token,
 };
 
 /// Controls whether inline contents are scaled to fit their line box.
@@ -77,7 +77,7 @@ pub enum TextFitMode {
   Shrink,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextFitMode,
   "none" => TextFitMode::None,
   "grow" => TextFitMode::Grow,
@@ -97,7 +97,7 @@ pub enum TextFitTarget {
   PerLineAll,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextFitTarget,
   "consistent" => TextFitTarget::Consistent,
   "per-line" => TextFitTarget::PerLine,

--- a/takumi-core/src/style/properties/text_wrap.rs
+++ b/takumi-core/src/style/properties/text_wrap.rs
@@ -2,7 +2,7 @@ use cssparser::{Parser, match_ignore_ascii_case};
 use typed_builder::TypedBuilder;
 
 use crate::style::{
-  CssDescriptorKind, CssToken, FromCss, MakeComputed, ParseResult, declare_enum_from_css_impl,
+  CssDescriptorKind, CssToken, FromCss, MakeComputed, ParseResult, impl_css_enum,
   tw::TailwindPropertyParser,
 };
 
@@ -95,7 +95,7 @@ impl TextWrapMode {
   }
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextWrapMode,
   "wrap" => TextWrapMode::Wrap,
   "nowrap" => TextWrapMode::NoWrap,
@@ -114,7 +114,7 @@ pub enum TextWrapStyle {
   Pretty,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   TextWrapStyle,
   "auto" => TextWrapStyle::Auto,
   "balance" => TextWrapStyle::Balance,

--- a/takumi-core/src/style/properties/traits.rs
+++ b/takumi-core/src/style/properties/traits.rs
@@ -850,31 +850,43 @@ macro_rules! impl_from_taffy_enum {
 
 pub(crate) use impl_from_taffy_enum;
 
-/// Declares a CSS enum parser with automatic value list generation.
-/// The first token in a `|` group is the canonical form; the rest parse as
-/// aliases and serialize back to it.
-macro_rules! declare_enum_from_css_impl {
+/// Treats the first keyword in each group as canonical and the rest as aliases.
+macro_rules! impl_css_enum {
   (
     $enum_type:ty,
     $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?
   ) => {
-    $crate::style::properties::declare_enum_from_css_impl!(@impl
+    $crate::style::properties::impl_css_enum!(@impl
       $crate::style::properties::parse_enum_keyword,
+      default,
+      $enum_type,
+      $($canonical $(| $alias)* => $variant),*
+    );
+  };
+
+  (
+    custom_animatable $enum_type:ty,
+    $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?
+  ) => {
+    $crate::style::properties::impl_css_enum!(@impl
+      $crate::style::properties::parse_enum_keyword,
+      custom,
       $enum_type,
       $($canonical $(| $alias)* => $variant),*
     );
   };
 
   (ident $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
-    $crate::style::properties::declare_enum_from_css_impl!(@impl
+    $crate::style::properties::impl_css_enum!(@impl
       $crate::style::properties::parse_ident_enum_keyword,
+      default,
       $enum_type,
       $($canonical $(| $alias)* => $variant),*
     );
   };
 
   (ident keyword $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
-    $crate::style::properties::declare_enum_from_css_impl!(
+    $crate::style::properties::impl_css_enum!(
       ident $enum_type,
       $($canonical $(| $alias)* => $variant),*
     );
@@ -890,14 +902,16 @@ macro_rules! declare_enum_from_css_impl {
     }
   };
 
-  (@impl $parser:path, $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
+  (@impl $parser:path, $animatable:ident, $enum_type:ty, $($canonical:literal $(| $alias:literal)* => $variant:path),* $(,)?) => {
     impl $enum_type {
       const KEYWORD_VALUES: &'static [Self] = &[
-        $($variant $(, $crate::style::properties::declare_enum_from_css_impl!(@value $variant, $alias))*),*
+        $($variant $(, $crate::style::properties::impl_css_enum!(@value $variant, $alias))*),*
       ];
     }
 
     impl crate::style::MakeComputed for $enum_type {}
+
+    $crate::style::properties::impl_css_enum!(@animatable $animatable $enum_type);
 
     impl<'i> crate::style::FromCss<'i> for $enum_type {
       const VALID_TOKENS: &'static [crate::style::CssToken] = &[
@@ -930,12 +944,18 @@ macro_rules! declare_enum_from_css_impl {
 
   };
 
+  (@animatable default $enum_type:ty) => {
+    impl $crate::style::Animatable for $enum_type {}
+  };
+
+  (@animatable custom $enum_type:ty) => {};
+
   (@value $variant:path, $alias:literal) => {
     $variant
   };
 }
 
-pub(crate) use declare_enum_from_css_impl;
+pub(crate) use impl_css_enum;
 
 /// Declares a box-alignment enum parser that accepts the optional `safe`/`unsafe`
 /// overflow-position prefix on its positional keywords.

--- a/takumi-core/src/style/properties/vertical_align.rs
+++ b/takumi-core/src/style/properties/vertical_align.rs
@@ -28,7 +28,7 @@ pub enum VerticalAlignKeyword {
   Super,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   VerticalAlignKeyword,
   "baseline" => VerticalAlignKeyword::Baseline,
   "top" => VerticalAlignKeyword::Top,

--- a/takumi-core/src/style/properties/word_break.rs
+++ b/takumi-core/src/style/properties/word_break.rs
@@ -1,4 +1,4 @@
-use crate::style::declare_enum_from_css_impl;
+use crate::style::impl_css_enum;
 
 /// Controls how text should be broken at word boundaries.
 ///
@@ -17,7 +17,7 @@ pub enum WordBreak {
   BreakWord,
 }
 
-declare_enum_from_css_impl!(
+impl_css_enum!(
   WordBreak,
   "normal" => WordBreak::Normal,
   "break-all" => WordBreak::BreakAll,


### PR DESCRIPTION
## Why

CSS keyword enums declared parsing in one place and repeated default animation implementations elsewhere.

## What

Rename the macro to `impl_css_enum!` and generate discrete animation by default. Preserve `BlendMode`'s repeat-to-LCM list behavior with an explicit custom implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected CSS animation behavior for several keyword-based properties, preventing them from receiving unintended default interpolation.
  - Animation direction, fill mode, and play state lists now switch discretely at the midpoint, including lists of different lengths.
  - Blend mode lists with different lengths now repeat predictably to match the least common multiple of their lengths.
- **Refactor**
  - Standardized internal CSS enum handling without changing supported CSS values or parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->