### PR TITLE
PDF: drop forced breaks that would open an empty page

### DIFF
--- a/.tegami/pdf-forced-break-empty-page.md
+++ b/.tegami/pdf-forced-break-empty-page.md
@@ -1,0 +1,7 @@
+---
+"takumi-pdf": patch
+---
+
+# Forced page breaks no longer open empty pages
+
+A `break-before: page` or `break-after: page` with only spacing beside it on its page is dropped, and trailing spacing past the last content box no longer opens a page.

--- a/takumi-core/src/painter.rs
+++ b/takumi-core/src/painter.rs
@@ -9,7 +9,9 @@ use crate::{
     inline::DecorationRect,
   },
   shadow::SizedShadow,
-  style::{Affine, BackgroundClip, BoxShadow, Color, FillRule, Sides, TextDecorationLines},
+  style::{
+    Affine, BackgroundClip, BackgroundImage, BoxShadow, Color, FillRule, Sides, TextDecorationLines,
+  },
 };
 
 /// A closed shape to fill, in the coordinate space of the box that owns it.
@@ -182,6 +184,25 @@ impl<'c> BoxPainter<'c> {
   /// The outline the box paints, or `None` when it paints none.
   pub fn outline(&self) -> Option<OutlineGeometry> {
     outline_paint(self.context, self.layout.size)
+  }
+
+  /// Whether the box puts any ink of its own on the page: a background, a border, a shadow or an
+  /// outline.
+  pub fn paints_decorations(&self) -> bool {
+    let style = &self.context.style;
+    let current_color = self.context.current_color;
+    let background = style.background_color.resolve(current_color).0[3] != 0
+      || style
+        .background_image
+        .as_deref()
+        .is_some_and(|images| images.iter().any(BackgroundImage::paints));
+    let shadows = self.shadows();
+
+    (background && self.background_clip_shape().is_some())
+      || self.border.has_visible_sides()
+      || !shadows.inset.is_empty()
+      || !shadows.outer.is_empty()
+      || (style.outline_color.resolve(current_color).0[3] != 0 && self.outline().is_some())
   }
 }
 

--- a/takumi-core/src/painter.rs
+++ b/takumi-core/src/painter.rs
@@ -186,8 +186,7 @@ impl<'c> BoxPainter<'c> {
     outline_paint(self.context, self.layout.size)
   }
 
-  /// Whether the box puts any ink of its own on the page: a background, a border, a shadow or an
-  /// outline.
+  /// Whether the box paints a background, border, shadow or outline.
   pub fn paints_decorations(&self) -> bool {
     let style = &self.context.style;
     let current_color = self.context.current_color;

--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -10,6 +10,7 @@ use takumi_core::{
     node::NodeKind,
     tree::{LayoutResults, RenderNode},
   },
+  painter::BoxPainter,
   scene::{NodePaint, PaintItemKind, StackingContextNode},
   style::{Affine, BreakBetween, BreakInside},
 };
@@ -28,6 +29,10 @@ pub(crate) struct Atoms {
   pub(crate) extents: Vec<Atom>,
   /// Where `break-before` / `break-after: page` force a cut.
   pub(crate) forced: Vec<f32>,
+  /// Boxes that show on the page: text, images, childless boxes and boxes
+  /// with decorations of their own. Spacing between them is not content, so a
+  /// page holding nothing else is empty.
+  pub(crate) content: Vec<Atom>,
   /// Text boxes with their `widows` / `orphans` minimums.
   pub(crate) paragraphs: Vec<Paragraph>,
 }
@@ -114,13 +119,15 @@ impl AtomCollector<'_> {
     let relative = parent.invert().unwrap_or(Affine::IDENTITY) * paint.transform;
     if !relative.only_translation() {
       if let Some(bounds) = paint.paint_bounds {
-        atoms
-          .extents
-          .push((bounds.top as f32, bounds.bottom as f32));
+        let extent = (bounds.top as f32, bounds.bottom as f32);
+
+        atoms.extents.push(extent);
+        atoms.content.push(extent);
       }
       return Ok(parent * relative);
     }
     let y = relative.y;
+    let extent = (y, y + layout.size.height);
     let style = &node.context.style;
 
     if style.break_before == BreakBetween::Page {
@@ -130,21 +137,32 @@ impl AtomCollector<'_> {
       atoms.forced.push(y + layout.size.height);
     }
     if style.break_inside == BreakInside::Avoid {
-      atoms.extents.push((y, y + layout.size.height));
+      atoms.extents.push(extent);
     }
+    let mut shows = node
+      .children
+      .as_deref()
+      .is_none_or(<[RenderNode]>::is_empty)
+      || BoxPainter::new(&node.context, layout).paints_decorations();
 
     if node.should_create_inline_layout() {
+      shows = true;
       self.text_atoms(node, paint.node_id, layout, y, atoms)?;
     } else if !node.has_anonymous_text_item_child() {
       match node.node.as_ref().map(|n| &n.kind) {
         Some(NodeKind::Text(_)) => {
+          shows = true;
           self.text_atoms(node, paint.node_id, layout, y, atoms)?;
         }
         Some(NodeKind::Image(_)) => {
-          atoms.extents.push((y, y + layout.size.height));
+          shows = true;
+          atoms.extents.push(extent);
         }
         _ => {}
       }
+    }
+    if shows && extent.1 > extent.0 {
+      atoms.content.push(extent);
     }
     Ok(parent)
   }

--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -122,7 +122,9 @@ impl AtomCollector<'_> {
         let extent = (bounds.top as f32, bounds.bottom as f32);
 
         atoms.extents.push(extent);
-        atoms.content.push(extent);
+        if extent.1 > extent.0 {
+          atoms.content.push(extent);
+        }
       }
       return Ok(parent * relative);
     }

--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -29,9 +29,7 @@ pub(crate) struct Atoms {
   pub(crate) extents: Vec<Atom>,
   /// Where `break-before` / `break-after: page` force a cut.
   pub(crate) forced: Vec<f32>,
-  /// Boxes that show on the page: text, images, childless boxes and boxes
-  /// with decorations of their own. Spacing between them is not content, so a
-  /// page holding nothing else is empty.
+  /// Boxes that show on the page; spacing between them does not.
   pub(crate) content: Vec<Atom>,
   /// Text boxes with their `widows` / `orphans` minimums.
   pub(crate) paragraphs: Vec<Paragraph>,

--- a/takumi-pdf/src/atoms.rs
+++ b/takumi-pdf/src/atoms.rs
@@ -1,5 +1,5 @@
-//! Unsplittable vertical extents and paragraphs collected from the laid-out
-//! scene, which pagination cuts around.
+//! Unsplittable vertical extents, paragraphs and content boxes collected from
+//! the laid-out scene, which pagination cuts around.
 
 use std::ops::Range;
 

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -410,11 +410,13 @@ mod tests {
     pagination::{Atom, MAX_PAGES, Paragraph},
   };
 
+  /// Atoms over a column that is content from top to bottom.
   fn atoms(extents: &[Atom], forced: &[f32], paragraphs: Vec<Paragraph>) -> Atoms {
     Atoms {
       extents: extents.to_vec(),
       forced: forced.to_vec(),
       paragraphs,
+      content: vec![(0.0, f32::INFINITY)],
     }
   }
 
@@ -478,7 +480,7 @@ mod tests {
 
   #[test]
   fn content_taller_than_a_render_allows_stops_counting() {
-    let starts = Atoms::default().page_starts(&[], 2_000_000.0, 10.0);
+    let starts = atoms(&[], &[], Vec::new()).page_starts(&[], 2_000_000.0, 10.0);
 
     assert_eq!(starts.len(), MAX_PAGES, "the page count runs unbounded");
   }
@@ -486,7 +488,7 @@ mod tests {
   #[test]
   fn page_starts_without_atoms_cuts_at_window() {
     assert_eq!(
-      Atoms::default().page_starts(&[], 250.0, 100.0),
+      atoms(&[], &[], Vec::new()).page_starts(&[], 250.0, 100.0),
       vec![0.0, 100.0, 200.0]
     );
   }
@@ -611,6 +613,44 @@ mod tests {
       atoms(&[], &[40.0, 150.0], Vec::new()).page_starts(&[], 250.0, 100.0),
       vec![0.0, 40.0, 140.0, 150.0]
     );
+  }
+
+  /// Content ends at 20 and 60 with spacing between: the forced cut at 40 has
+  /// nothing above it on its page, and the one at 110 nothing below.
+  #[test]
+  fn page_starts_drops_forced_cuts_beside_spacing_alone() {
+    let atoms = Atoms {
+      forced: vec![40.0, 110.0],
+      content: vec![(0.0, 20.0), (60.0, 80.0)],
+      ..Atoms::default()
+    };
+
+    assert_eq!(atoms.page_starts(&[], 120.0, 30.0), vec![0.0, 30.0, 60.0]);
+  }
+
+  /// A forced cut at 40 keeps its page once content sits above it.
+  #[test]
+  fn page_starts_keeps_forced_cuts_under_content() {
+    let atoms = Atoms {
+      forced: vec![40.0],
+      content: vec![(0.0, 20.0), (30.0, 35.0), (60.0, 80.0)],
+      ..Atoms::default()
+    };
+
+    assert_eq!(
+      atoms.page_starts(&[], 120.0, 30.0),
+      vec![0.0, 30.0, 40.0, 70.0]
+    );
+  }
+
+  #[test]
+  fn page_starts_ends_at_the_last_content_box() {
+    let atoms = Atoms {
+      content: vec![(0.0, 90.0)],
+      ..Atoms::default()
+    };
+
+    assert_eq!(atoms.page_starts(&[], 250.0, 100.0), vec![0.0]);
   }
 
   #[test]

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -410,7 +410,6 @@ mod tests {
     pagination::{Atom, MAX_PAGES, Paragraph},
   };
 
-  /// Atoms over a column that is content from top to bottom.
   fn atoms(extents: &[Atom], forced: &[f32], paragraphs: Vec<Paragraph>) -> Atoms {
     Atoms {
       extents: extents.to_vec(),
@@ -615,8 +614,6 @@ mod tests {
     );
   }
 
-  /// Content ends at 20 and 60 with spacing between: the forced cut at 40 has
-  /// nothing above it on its page, and the one at 110 nothing below.
   #[test]
   fn page_starts_drops_forced_cuts_beside_spacing_alone() {
     let atoms = Atoms {
@@ -628,7 +625,6 @@ mod tests {
     assert_eq!(atoms.page_starts(&[], 120.0, 30.0), vec![0.0, 30.0, 60.0]);
   }
 
-  /// A forced cut at 40 keeps its page once content sits above it.
   #[test]
   fn page_starts_keeps_forced_cuts_under_content() {
     let atoms = Atoms {

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -1,7 +1,5 @@
 //! Cutting the content column into pages without splitting unsplittable atoms.
 
-use std::mem::take;
-
 use takumi_core::{
   geometry::transformed_rect_extents,
   layout::node::Node,
@@ -420,50 +418,6 @@ impl Paginated {
   }
 }
 
-/// The content boxes of the column, indexed for asking what a page range
-/// holds.
-struct Content {
-  /// Boxes sorted by top.
-  boxes: Vec<Atom>,
-  /// Running maximum of `boxes[..=i].1`, so a range query needs one bisection.
-  prefix_max_bottom: Vec<f32>,
-}
-
-impl Content {
-  fn new(mut boxes: Vec<Atom>) -> Self {
-    boxes.sort_by(|a, b| a.0.total_cmp(&b.0));
-
-    let mut running = f32::MIN;
-    let prefix_max_bottom = boxes
-      .iter()
-      .map(|(_, bottom)| {
-        running = running.max(*bottom);
-        running
-      })
-      .collect();
-
-    Self {
-      boxes,
-      prefix_max_bottom,
-    }
-  }
-
-  /// Where the last content box ends; a column of nothing but spacing ends
-  /// where it starts.
-  fn bottom(&self) -> f32 {
-    self.prefix_max_bottom.last().copied().unwrap_or(0.0)
-  }
-
-  /// Whether any content box overlaps `top..bottom` by more than a hairline.
-  fn overlaps(&self, top: f32, bottom: f32) -> bool {
-    let before = self
-      .boxes
-      .partition_point(|(box_top, _)| *box_top < bottom - 0.5);
-
-    before > 0 && self.prefix_max_bottom[before - 1] > top + 0.5
-  }
-}
-
 /// Page start offsets for slicing `total` height into windows of `window`
 /// height. Each cut moves up to the top of any atom straddling it, repeated
 /// until no atom straddles (a raised cut can land inside another atom). An
@@ -483,8 +437,15 @@ impl Atoms {
       paragraphs,
       content,
     } = &mut self;
-    let content = Content::new(take(content));
-    let total = total.min(content.bottom());
+    let overlaps = |top: f32, bottom: f32| {
+      content
+        .iter()
+        .any(|&(box_top, box_bottom)| box_top < bottom - 0.5 && box_bottom > top + 0.5)
+    };
+    let total = content
+      .iter()
+      .fold(0.0_f32, |bottom, atom| bottom.max(atom.1))
+      .min(total);
 
     extents.sort_by(|a, b| a.0.total_cmp(&b.0));
     forced.retain(|cut| *cut < total - 1.0);
@@ -512,7 +473,7 @@ impl Atoms {
       if let Some(cut) = forced
         .iter()
         .copied()
-        .find(|cut| *cut > y0 + 1.0 && content.overlaps(y0, *cut))
+        .find(|cut| *cut > y0 + 1.0 && overlaps(y0, *cut))
         && cut <= limit
       {
         starts.push(cut);

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -425,10 +425,8 @@ impl Paginated {
 /// at all — matching browsers, where `break-inside: avoid` is dropped for
 /// boxes taller than the fragmentainer.
 ///
-/// A forced cut opens no empty page. One with no content above it on its page
-/// is dropped, as css-break-3 §forced-breaks asks: the node already opens the
-/// page, and only spacing consumed at the boundary sits before it. The column
-/// ends at its last content box, so trailing spacing never opens a page either.
+/// A forced cut with no content on its page above it is dropped, per
+/// css-break-3 §forced-breaks. The column ends at its last content box.
 impl Atoms {
   pub(crate) fn page_starts(mut self, headers: &[HeaderBand], total: f32, window: f32) -> Vec<f32> {
     let Self {

--- a/takumi-pdf/src/pagination.rs
+++ b/takumi-pdf/src/pagination.rs
@@ -1,5 +1,7 @@
 //! Cutting the content column into pages without splitting unsplittable atoms.
 
+use std::mem::take;
+
 use takumi_core::{
   geometry::transformed_rect_extents,
   layout::node::Node,
@@ -418,22 +420,74 @@ impl Paginated {
   }
 }
 
+/// The content boxes of the column, indexed for asking what a page range
+/// holds.
+struct Content {
+  /// Boxes sorted by top.
+  boxes: Vec<Atom>,
+  /// Running maximum of `boxes[..=i].1`, so a range query needs one bisection.
+  prefix_max_bottom: Vec<f32>,
+}
+
+impl Content {
+  fn new(mut boxes: Vec<Atom>) -> Self {
+    boxes.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut running = f32::MIN;
+    let prefix_max_bottom = boxes
+      .iter()
+      .map(|(_, bottom)| {
+        running = running.max(*bottom);
+        running
+      })
+      .collect();
+
+    Self {
+      boxes,
+      prefix_max_bottom,
+    }
+  }
+
+  /// Where the last content box ends; a column of nothing but spacing ends
+  /// where it starts.
+  fn bottom(&self) -> f32 {
+    self.prefix_max_bottom.last().copied().unwrap_or(0.0)
+  }
+
+  /// Whether any content box overlaps `top..bottom` by more than a hairline.
+  fn overlaps(&self, top: f32, bottom: f32) -> bool {
+    let before = self
+      .boxes
+      .partition_point(|(box_top, _)| *box_top < bottom - 0.5);
+
+    before > 0 && self.prefix_max_bottom[before - 1] > top + 0.5
+  }
+}
+
 /// Page start offsets for slicing `total` height into windows of `window`
 /// height. Each cut moves up to the top of any atom straddling it, repeated
 /// until no atom straddles (a raised cut can land inside another atom). An
 /// atom taller than the window can never fit a page, so it does not push cuts
 /// at all — matching browsers, where `break-inside: avoid` is dropped for
 /// boxes taller than the fragmentainer.
+///
+/// A forced cut opens no empty page. One with no content above it on its page
+/// is dropped, as css-break-3 §forced-breaks asks: the node already opens the
+/// page, and only spacing consumed at the boundary sits before it. The column
+/// ends at its last content box, so trailing spacing never opens a page either.
 impl Atoms {
   pub(crate) fn page_starts(mut self, headers: &[HeaderBand], total: f32, window: f32) -> Vec<f32> {
     let Self {
       extents,
       forced,
       paragraphs,
+      content,
     } = &mut self;
+    let content = Content::new(take(content));
+    let total = total.min(content.bottom());
 
     extents.sort_by(|a, b| a.0.total_cmp(&b.0));
-    forced.retain(|cut| *cut > 1.0 && *cut < total - 1.0);
+    forced.retain(|cut| *cut < total - 1.0);
     forced.sort_by(f32::total_cmp);
 
     // The prefix max of bottoms lets the back-scan stop early even when a
@@ -455,7 +509,10 @@ impl Atoms {
     loop {
       let limit = y0 + window - HeaderBand::replays(headers, y0, window).0;
 
-      if let Some(cut) = forced.iter().copied().find(|cut| *cut > y0 + 1.0)
+      if let Some(cut) = forced
+        .iter()
+        .copied()
+        .find(|cut| *cut > y0 + 1.0 && content.overlaps(y0, *cut))
         && cut <= limit
       {
         starts.push(cut);

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -871,6 +871,149 @@ fn break_after_a_padded_box_cuts_once() {
   );
 }
 
+fn page_count(pdf: &[u8]) -> usize {
+  let text = String::from_utf8_lossy(pdf);
+  let start = text.find("/Type/Pages/Count ").expect("a page tree") + "/Type/Pages/Count ".len();
+  let digits: String = text[start..]
+    .chars()
+    .take_while(char::is_ascii_digit)
+    .collect();
+
+  digits.parse().expect("a page count")
+}
+
+/// A 235px spacer plus the first keep fills a 260px page, and the list's
+/// spacing is consumed at the boundary, so the second keep already opens page
+/// 2. A forced break on it must not open a page between the two.
+#[test]
+fn a_forced_break_on_a_node_that_opens_a_page_adds_no_empty_page() {
+  let fonts = fonts();
+  let page = || PageOptions {
+    width: 400.0,
+    height: 300.0,
+    margin: PageMargins::uniform(20.0),
+  };
+  let document = |spacer: u32, list: &str, first: &str, second: &str| {
+    format!(
+      r#"<div style="display: flex; flex-direction: column;">
+        <div style="height: {spacer}px; width: 100px;"><span style="font-size: 10px;">A</span></div>
+        <div style="display: flex; flex-direction: column; {list}">
+          <div style="display: flex; flex-direction: column; break-inside: avoid; {first}"><span style="font-size: 10px; line-height: 1.4;">B1</span></div>
+          <div style="display: flex; flex-direction: column; break-inside: avoid; {second}"><span style="font-size: 10px; line-height: 1.4;">B2</span></div>
+        </div>
+      </div>"#
+    )
+  };
+  let render_with = |source: &str| {
+    render(
+      PdfOptions::builder()
+        .node(from_html(source, FromHtmlOptions::default()).expect("parse the doc"))
+        .page(page())
+        .fonts(&fonts)
+        .build(),
+    )
+    .expect("render the doc")
+  };
+  let plain = render_with(&document(235, "gap: 16px;", "", ""));
+
+  assert_eq!(
+    page_count(&plain),
+    2,
+    "the second keep opens page 2 on its own"
+  );
+
+  // The list's `padding-top` is consumed at the boundary when the spacer
+  // leaves the whole list to page 2.
+  for (spacer, list, first, second) in [
+    (235, "gap: 16px;", "", "break-before: page;"),
+    (235, "", "", "margin-top: 16px; break-before: page;"),
+    (245, "padding-top: 16px;", "break-before: page;", ""),
+  ] {
+    let forced = render_with(&document(spacer, list, first, second));
+
+    assert_eq!(
+      page_count(&forced),
+      2,
+      "a forced break at the top of page 2 opened an empty page ({list} {first} {second})"
+    );
+  }
+  assert_eq!(
+    render_with(&document(235, "gap: 16px;", "", "break-before: page;")),
+    plain,
+    "a forced break at the top of page 2 changed the document"
+  );
+}
+
+/// A forced break with only spacing above it on the first page, and one with
+/// only spacing below it at the end, both cut nothing.
+#[test]
+fn forced_breaks_beside_spacing_alone_open_no_page() {
+  let fonts = fonts();
+  let render_with = |source: &str| render(a4_options(source, &fonts)).expect("render the doc");
+  let leading = render_with(
+    r#"<div style="display: flex; flex-direction: column;">
+      <div style="display: flex; margin-top: 16px; break-before: page;">One</div>
+    </div>"#,
+  );
+  let trailing = render_with(
+    r#"<div style="display: flex; flex-direction: column; padding-bottom: 16px;">
+      <div style="display: flex; break-after: page;">One</div>
+    </div>"#,
+  );
+  let doubled = render_with(
+    r#"<div style="display: flex; flex-direction: column;">
+      <div style="display: flex; break-after: page;">One</div>
+      <div style="display: flex; margin-top: 16px; break-before: page;">Two</div>
+    </div>"#,
+  );
+
+  assert_eq!(
+    page_count(&leading),
+    1,
+    "a leading break opened an empty page"
+  );
+  assert_eq!(
+    page_count(&trailing),
+    1,
+    "a trailing break opened an empty page"
+  );
+  assert_eq!(
+    page_count(&doubled),
+    2,
+    "adjacent breaks opened an empty page"
+  );
+}
+
+/// Spacing that runs past the last content box is not a page: a padded root
+/// whose padding alone crosses the page edge stays on one page.
+#[test]
+fn trailing_spacing_opens_no_page() {
+  let fonts = fonts();
+  let page = PageOptions {
+    width: 400.0,
+    height: 300.0,
+    margin: PageMargins::uniform(20.0),
+  };
+  let pdf = render(
+    PdfOptions::builder()
+      .node(
+        from_html(
+          r#"<div style="display: flex; flex-direction: column; padding-bottom: 40px;">
+            <div style="height: 240px;"><span style="font-size: 10px;">A</span></div>
+          </div>"#,
+          FromHtmlOptions::default(),
+        )
+        .expect("parse the doc"),
+      )
+      .page(page)
+      .fonts(&fonts)
+      .build(),
+  )
+  .expect("render the doc");
+
+  assert_eq!(page_count(&pdf), 1, "trailing padding opened an empty page");
+}
+
 /// A table of contents whose entries carry `targetPageNumber` hooks. Each
 /// section is forced onto its own page, so the entries have to read 2, 3 and 4.
 fn toc_document(cells: [&str; 3]) -> String {

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -882,9 +882,8 @@ fn page_count(pdf: &[u8]) -> usize {
   digits.parse().expect("a page count")
 }
 
-/// A 235px spacer plus the first keep fills a 260px page, and the list's
-/// spacing is consumed at the boundary, so the second keep already opens page
-/// 2. A forced break on it must not open a page between the two.
+/// The second keep already opens page 2 with the list's spacing consumed at
+/// the boundary, so a forced break on it must not open a page between the two.
 #[test]
 fn a_forced_break_on_a_node_that_opens_a_page_adds_no_empty_page() {
   let fonts = fonts();
@@ -922,8 +921,6 @@ fn a_forced_break_on_a_node_that_opens_a_page_adds_no_empty_page() {
     "the second keep opens page 2 on its own"
   );
 
-  // The list's `padding-top` is consumed at the boundary when the spacer
-  // leaves the whole list to page 2.
   for (spacer, list, first, second) in [
     (235, "gap: 16px;", "", "break-before: page;"),
     (235, "", "", "margin-top: 16px; break-before: page;"),
@@ -944,8 +941,6 @@ fn a_forced_break_on_a_node_that_opens_a_page_adds_no_empty_page() {
   );
 }
 
-/// A forced break with only spacing above it on the first page, and one with
-/// only spacing below it at the end, both cut nothing.
 #[test]
 fn forced_breaks_beside_spacing_alone_open_no_page() {
   let fonts = fonts();
@@ -984,8 +979,6 @@ fn forced_breaks_beside_spacing_alone_open_no_page() {
   );
 }
 
-/// Spacing that runs past the last content box is not a page: a padded root
-/// whose padding alone crosses the page edge stays on one page.
 #[test]
 fn trailing_spacing_opens_no_page() {
   let fonts = fonts();


### PR DESCRIPTION
Fixes #1566

## Why
A forced break on a node that already opened a page was honoured again when a flex gap, margin or padding had been consumed at the boundary, and trailing spacing past the last box could open a page of its own. Both left a page with nothing on it.

## What
- Pagination collects content boxes (text, images, childless boxes, decorated boxes) and only honours a forced cut when content sits above it on its page and below it in the column.
- The column ends at its last content box, so spacing past it never opens a page.
- Blank windows between content boxes still paginate as before, so a tall empty box keeps its blank page like a browser prints it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed forced page breaks so they no longer create empty PDF pages when adjacent content contains only spacing.
  - Prevented trailing margins or padding beyond the final content from opening an additional page.
  - Preserved forced page breaks when they overlap actual visible content.
  - Improved page counting so pages end at the last visible content rather than empty spacing.

- **Tests**
  - Added coverage for forced-break and trailing-spacing pagination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->