### PR TITLE
Helpers: decode character references in image src

### DIFF
--- a/.tegami/html-image-src-entities.md
+++ b/.tegami/html-image-src-entities.md
@@ -1,0 +1,7 @@
+---
+"takumi": patch
+---
+
+# Decode character references in `fromHtml` image sources
+
+An `img` whose `src` holds `&amp;` now yields the decoded URL, matching `attributes.src`.

--- a/takumi-helpers/src/html/markup.ts
+++ b/takumi-helpers/src/html/markup.ts
@@ -125,7 +125,7 @@ function buildStaticNodes(
 
     nodes.push(
       image({
-        src,
+        src: decodeHtmlEntities(src),
         width: parseDimension(element.attributes?.width),
         height: parseDimension(element.attributes?.height),
         ...metadata,

--- a/takumi-helpers/tests/html-markup.test.tsx
+++ b/takumi-helpers/tests/html-markup.test.tsx
@@ -63,6 +63,12 @@ describe("fromHtml", () => {
     expect((node as TextNode).text).toBe("&notarealentity; &");
   });
 
+  test("decodes references in image src", () => {
+    const { node } = fromHtml('<img src="/image?href=photo.png&amp;w=200&amp;h=200">');
+
+    expect((node as { src: string }).src).toBe("/image?href=photo.png&w=200&h=200");
+  });
+
   test("does not resolve Object.prototype members as entities", () => {
     const { node } = fromHtml("<div>&constructor; &hasOwnProperty;</div>");
 


### PR DESCRIPTION
Fixes #1565

## Why
`fromHtml` decoded character references everywhere except the `src` it put on image nodes, so a templated URL with `&amp;` was fetched verbatim and servers saw parameters named `amp;w`.

## What
The `img` branch runs `src` through `decodeHtmlEntities` like every other attribute consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image URLs containing HTML entities such as `&amp;` are now correctly decoded when processing HTML markup.
  - Image `src` values now match the decoded attribute value consistently.

- **Documentation**
  - Added documentation describing the corrected image URL decoding behavior.

- **Tests**
  - Added coverage for decoding HTML entities in image `src` attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->