### PR TITLE
PDF: add an uncoveredText option for characters no font covers

### DIFF
--- a/.tegami/pdf-missing-glyph-option.md
+++ b/.tegami/pdf-missing-glyph-option.md
@@ -1,0 +1,7 @@
+---
+"takumi-pdf": minor
+---
+
+# Render through characters no font covers with `missingGlyph`
+
+`missingGlyph: "notdef"` draws the font's `.notdef` glyph and `"skip"` drops the character, instead of the default `"error"` that fails the render.

--- a/docs/content/docs/pdf/fonts-and-images.mdx
+++ b/docs/content/docs/pdf/fonts-and-images.mdx
@@ -30,6 +30,19 @@ For offline renders, [bundle font files](/docs/typography-and-fonts#fonts-in-ci-
 
 The renderer does not use installed system fonts. If no registered font covers a body-text character, the render fails with the character and its codepoint. Register coverage for every script you use. Google Fonts may split accented characters between `latin` and `latin-ext` subsets.
 
+Set `missingGlyph` to render anyway. `"notdef"` draws the font's `.notdef` glyph, usually an empty box. `"skip"` drops the character from the page. Neither puts the character in the text layer.
+
+```tsx twoslash title="Render with uncovered characters"
+import type { ReactNode } from "react";
+declare const doc: ReactNode;
+// ---cut---
+import { render } from "takumi-pdf";
+
+const pdf = await render(doc, { missingGlyph: "notdef" });
+```
+
+Quote a family name that contains digits or spaces in CSS, such as `fontFamily: '"Source Serif 4"'`. An unquoted `Source Serif 4` is not a valid `font-family` value, so the declaration is dropped and the text falls back to the next family.
+
 ## Images
 
 Pass fetched bytes for each image URL in the document. The PDF renderer does not fetch those URLs:

--- a/takumi-pdf-js/src/export.ts
+++ b/takumi-pdf-js/src/export.ts
@@ -89,6 +89,9 @@ export type PageMargin =
  */
 export type PageRange = number | { from?: number; to?: number };
 
+/** What becomes of a character no registered font covers. */
+export type MissingGlyph = "error" | "notdef" | "skip";
+
 /**
  * Paged output (the default): content flows across pages of `size`, like
  * Puppeteer's `page.pdf()`. The layout canvas has unbounded height, so
@@ -302,6 +305,13 @@ export type RenderOptions = (PagedOptions | ViewportOptions) &
      * Unset leaves the page empty, so a viewer shows its own white.
      */
     backgroundColor?: string;
+    /**
+     * What becomes of a character no registered font covers: `"error"`
+     * (default) fails the render naming it, `"notdef"` draws the font's
+     * `.notdef` glyph, `"skip"` drops it from the page. Neither puts it in
+     * the text layer.
+     */
+    missingGlyph?: MissingGlyph;
   };
 
 function isNode(value: NodeInput): value is Node {

--- a/takumi-pdf-js/tests/render.test.ts
+++ b/takumi-pdf-js/tests/render.test.ts
@@ -398,3 +398,19 @@ test("rejects a filter a PDF cannot express", async () => {
     }),
   ).rejects.toThrow("A PDF cannot draw filter: blur(4px)");
 });
+
+test("missingGlyph renders through uncovered characters", async () => {
+  const uncovered = container({
+    style: { display: "flex", padding: 24 },
+    children: [text("uncovered क", { fontSize: 16 })],
+  });
+  const viewport = { width: 200, height: 100 };
+
+  await expect(renderer.render(uncovered, { viewport })).rejects.toThrow(
+    "No registered font covers क (U+0915)",
+  );
+  const notdef = await renderer.render(uncovered, { viewport, missingGlyph: "notdef" });
+  const skipped = await renderer.render(uncovered, { viewport, missingGlyph: "skip" });
+
+  expect(Buffer.from(notdef).equals(Buffer.from(skipped))).toBe(false);
+});

--- a/takumi-pdf-wasm/src/dts-header.d.ts
+++ b/takumi-pdf-wasm/src/dts-header.d.ts
@@ -177,7 +177,16 @@ export type PdfRenderOptions = {
   tagged?: Tagged;
   /** Files attached to the document. */
   attachments?: Attachment[];
+  /**
+   * What becomes of a character no registered font covers: `"error"` (default)
+   * fails the render naming it, `"notdef"` draws the font's `.notdef` glyph,
+   * `"skip"` drops it from the page. Neither puts it in the text layer.
+   */
+  missingGlyph?: MissingGlyph;
 };
+
+/** What becomes of a character no registered font covers. */
+export type MissingGlyph = "error" | "notdef" | "skip";
 
 /** Options for `measure`: page geometry (or a viewport) plus layout resources. */
 export type MeasureOptions = (

--- a/takumi-pdf-wasm/src/lib.rs
+++ b/takumi-pdf-wasm/src/lib.rs
@@ -19,7 +19,8 @@ use takumi_core::{
   style::{FontFamily, Lang},
 };
 use takumi_pdf::{
-  Attachment, MeasureOptions, PageRange, PdfMetadata, PdfOptions, PdfStandard, Tagging,
+  Attachment, MeasureOptions, MissingGlyph, PageRange, PdfMetadata, PdfOptions, PdfStandard,
+  Tagging,
 };
 use wasm_bindgen::prelude::*;
 
@@ -187,6 +188,10 @@ impl PdfRenderer {
         .into_iter()
         .map(Attachment::try_from)
         .collect::<Result<_, _>>()?,
+      missing_glyph: options
+        .missing_glyph
+        .map(MissingGlyph::from)
+        .unwrap_or_default(),
     })
     .map_err(map_error)
   }

--- a/takumi-pdf-wasm/src/options.rs
+++ b/takumi-pdf-wasm/src/options.rs
@@ -11,7 +11,7 @@ use takumi_core::{
   style::{Color, ColorInput, CssSource, FromCssStr},
   viewport::Viewport,
 };
-use takumi_pdf::{PageMargin, PageMargins, PageOptions, PageRange};
+use takumi_pdf::{MissingGlyph, PageMargin, PageMargins, PageOptions, PageRange};
 
 use crate::{
   map_error,
@@ -232,6 +232,28 @@ pub(crate) struct PdfRenderOptions {
   pub(crate) tagged: Option<TaggedInput>,
   /// Files attached to the document.
   pub(crate) attachments: Option<Vec<AttachmentInput>>,
+  /// What becomes of a character no registered font covers: `"error"`
+  /// (default), `"notdef"` or `"skip"`.
+  pub(crate) missing_glyph: Option<MissingGlyphInput>,
+}
+
+/// `missingGlyph` names accepted from JS.
+#[derive(Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum MissingGlyphInput {
+  Error,
+  Notdef,
+  Skip,
+}
+
+impl From<MissingGlyphInput> for MissingGlyph {
+  fn from(input: MissingGlyphInput) -> Self {
+    match input {
+      MissingGlyphInput::Error => Self::Error,
+      MissingGlyphInput::Notdef => Self::Notdef,
+      MissingGlyphInput::Skip => Self::Skip,
+    }
+  }
 }
 
 pub(crate) fn decode_images(

--- a/takumi-pdf/src/emitter.rs
+++ b/takumi-pdf/src/emitter.rs
@@ -63,7 +63,7 @@ use crate::{
     tagging::{Artifact, ArtifactType, ContentTag, SpanTag},
     text::{Font, Tag},
   },
-  options::PdfError,
+  options::{MissingGlyph, PdfError},
   paint::{
     empty_path, expanded_radial_stops, fill_from_rgba, krilla_blend, krilla_path, krilla_stop,
     krilla_stops, overflow_clip_rect, pop_transforms, rect_path, spread,
@@ -143,24 +143,29 @@ pub(crate) struct DocumentState<'a> {
   pub(crate) issues: RefCell<RenderIssues>,
   /// The document's default language.
   pub(crate) lang: Option<&'a str>,
+  pub(crate) missing_glyph: MissingGlyph,
 }
 
 impl<'a> DocumentState<'a> {
-  pub(crate) fn new(tagged: bool, lang: Option<&'a str>) -> Self {
+  pub(crate) fn new(tagged: bool, lang: Option<&'a str>, missing_glyph: MissingGlyph) -> Self {
     Self {
       fonts: RefCell::new(FontMap::default()),
       tags: tagged.then(RefCell::default),
       issues: RefCell::default(),
       lang,
+      missing_glyph,
     }
   }
 
   /// The error the pages left behind, if any: what failed outright, else the characters no font
-  /// covered.
+  /// covered when those are errors.
   pub(crate) fn into_error(self) -> Option<PdfError> {
     let issues = self.issues.into_inner();
 
-    if issues.failure.is_some() || issues.uncovered.is_empty() {
+    if issues.failure.is_some()
+      || issues.uncovered.is_empty()
+      || self.missing_glyph != MissingGlyph::Error
+    {
       return issues.failure;
     }
     let named = issues
@@ -1355,6 +1360,7 @@ impl Emitter<'_> {
       let glyphs = run_glyphs(
         shaped,
         run_text,
+        self.document.missing_glyph,
         &mut self.document.issues.borrow_mut().uncovered,
       );
 
@@ -1776,6 +1782,7 @@ impl Emitter<'_> {
       let glyphs = run_glyphs(
         shaped,
         run_text,
+        self.document.missing_glyph,
         &mut self.document.issues.borrow_mut().uncovered,
       );
 

--- a/takumi-pdf/src/glyph.rs
+++ b/takumi-pdf/src/glyph.rs
@@ -4,20 +4,23 @@ use std::ops::Range;
 
 use takumi_core::layout::inline::ShapedRun;
 
-use crate::krilla::{
-  surface::Location,
-  text::{Glyph, GlyphId},
+use crate::{
+  krilla::{
+    surface::Location,
+    text::{Glyph, GlyphId},
+  },
+  options::MissingGlyph,
 };
 
 /// The run's glyphs, each carrying the source text it maps to.
 ///
-/// A character no registered font covers shapes to `.notdef`. It draws nothing
-/// and leaves nothing behind in the text layer, so the page would come out
-/// looking finished with the character quietly gone. Every such character lands
-/// in `uncovered` for the caller to report once the page is done.
+/// A character no registered font covers shapes to `.notdef`. Every such
+/// character lands in `uncovered` for the caller to report once the page is
+/// done; [`MissingGlyph::Skip`] leaves its glyph out of the run as well.
 pub(crate) fn run_glyphs(
   shaped: &ShapedRun,
   run_text: &str,
+  missing: MissingGlyph,
   uncovered: &mut String,
 ) -> Vec<PdfGlyph> {
   let clusters = cluster_spans(shaped, run_text);
@@ -35,6 +38,7 @@ pub(crate) fn run_glyphs(
     .glyphs
     .iter()
     .zip(spans)
+    .filter(|(glyph, _)| missing != MissingGlyph::Skip || glyph.id != 0)
     .map(|(glyph, range)| PdfGlyph {
       id: GlyphId::new(glyph.id),
       x_offset: glyph.x / shaped.font_size,

--- a/takumi-pdf/src/lib.rs
+++ b/takumi-pdf/src/lib.rs
@@ -96,9 +96,9 @@ use takumi_core::{
 pub const PRODUCER: &str = concat!("takumi-pdf ", env!("CARGO_PKG_VERSION"));
 
 pub use crate::options::{
-  Attachment, AttachmentRelationship, MeasureOptions, MeasuredSize, PageMargin, PageMargins,
-  PageOptions, PageRange, PdfDate, PdfError, PdfMetadata, PdfOptions, PdfStandard, Tagging,
-  XmpProperty, XmpSchema,
+  Attachment, AttachmentRelationship, MeasureOptions, MeasuredSize, MissingGlyph, PageMargin,
+  PageMargins, PageOptions, PageRange, PdfDate, PdfError, PdfMetadata, PdfOptions, PdfStandard,
+  Tagging, XmpProperty, XmpSchema,
 };
 use crate::{
   emitter::DocumentState,
@@ -172,7 +172,11 @@ pub fn render(mut options: PdfOptions<'_>) -> Result<Vec<u8>, PdfError> {
     lang: options.lang,
   };
   let tagged = options.tagged != Tagging::Off || options.standard.requires_tagging();
-  let state = DocumentState::new(tagged, inputs.lang.as_ref().map(Lang::as_str));
+  let state = DocumentState::new(
+    tagged,
+    inputs.lang.as_ref().map(Lang::as_str),
+    options.missing_glyph,
+  );
   let structural = options.tagged.names_structure_destinations();
   let rendered = match options.page {
     Some(page) => {

--- a/takumi-pdf/src/options.rs
+++ b/takumi-pdf/src/options.rs
@@ -369,6 +369,22 @@ pub struct PdfOptions<'g> {
   /// a modification date ([`PdfMetadata::creation_date`] is the fallback).
   #[builder(default)]
   pub attachments: Vec<Attachment>,
+  /// What becomes of a character no registered font covers.
+  #[builder(default)]
+  pub missing_glyph: MissingGlyph,
+}
+
+/// What becomes of a character no registered font covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MissingGlyph {
+  /// The render fails naming the characters.
+  #[default]
+  Error,
+  /// The font's `.notdef` glyph is drawn, usually an empty box. The text
+  /// layer does not carry the character.
+  Notdef,
+  /// The character is dropped from the page and the text layer.
+  Skip,
 }
 
 /// A file attached to the document.

--- a/takumi-pdf/tests/pdf_fixtures.rs
+++ b/takumi-pdf/tests/pdf_fixtures.rs
@@ -30,8 +30,9 @@ use takumi_core::{
 };
 use takumi_html::{FromHtmlOptions, from_html};
 use takumi_pdf::{
-  Attachment, AttachmentRelationship, MeasureOptions, PageMargins, PageOptions, PageRange, PdfDate,
-  PdfError, PdfMetadata, PdfOptions, PdfStandard, Tagging, XmpProperty, XmpSchema, measure, render,
+  Attachment, AttachmentRelationship, MeasureOptions, MissingGlyph, PageMargins, PageOptions,
+  PageRange, PdfDate, PdfError, PdfMetadata, PdfOptions, PdfStandard, Tagging, XmpProperty,
+  XmpSchema, measure, render,
 };
 
 fn fonts() -> Fonts {
@@ -2545,6 +2546,52 @@ fn uncovered_character_stops_the_render() {
   assert!(render_with("covered").is_ok());
   assert!(
     matches!(render_with("uncovered \u{76F4}"), Err(PdfError::MissingGlyphs(named)) if named == "直 (U+76F4)")
+  );
+}
+
+/// `missingGlyph` lets the render through: `notdef` shows glyph 0, `skip`
+/// leaves it out of the run. Neither puts the character in the text layer.
+#[test]
+fn uncovered_character_renders_under_a_missing_glyph_policy() {
+  let latin_only = {
+    let mut fonts = Fonts::default();
+    let data = fs::read(
+      Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../assets/fonts/archivo/Archivo-VariableFont_wdth,wght.ttf"),
+    )
+    .expect("read test font");
+
+    fonts
+      .register(FontResource::new(data))
+      .expect("load test font");
+    fonts
+  };
+  let render_with = |policy: MissingGlyph| {
+    render(
+      PdfOptions::builder()
+        .node(text("uncovered \u{76F4}", 16.0))
+        .viewport(Viewport::new((200, 100)))
+        .fonts(&latin_only)
+        .missing_glyph(policy)
+        .build(),
+    )
+  };
+
+  assert!(matches!(
+    render_with(MissingGlyph::Error),
+    Err(PdfError::MissingGlyphs(_))
+  ));
+
+  let notdef = render_with(MissingGlyph::Notdef).expect("render with .notdef");
+  let skipped = render_with(MissingGlyph::Skip).expect("render without the glyph");
+
+  assert!(
+    inflated_text(&notdef).contains("(\\000\\000)"),
+    "notdef did not show glyph 0"
+  );
+  assert!(
+    !inflated_text(&skipped).contains("(\\000\\000)"),
+    "skip showed glyph 0"
   );
 }
 


### PR DESCRIPTION
Fixes #1568

## Why

A single character no registered font covers fails the whole render. That is right while writing a document, but a server rendering text someone else wrote has no way through.

## What

`uncoveredText` on `PdfOptions` and the JS bindings decides what such a character turns into.

| JS value | Rust variant | Result |
| --- | --- | --- |
| `"error"` (default) | `UncoveredText::Error` | Fails the render, naming each character and its codepoint. |
| `"placeholder"` | `UncoveredText::Placeholder` | Draws the font's glyph 0, which the font may leave empty. |
| `"blank"` | `UncoveredText::Blank` | Draws nothing. |

**Neither `"placeholder"` nor `"blank"` reflows the line.** Glyph advances are absolute, so the character keeps the width the font gave it.

Every PDF/A level and both PDF for Universal Accessibility (PDF/UA) levels forbid glyph 0. Pairing them with `"placeholder"` now fails as `PdfError::PlaceholderForbidden`, naming the characters and the standard, instead of surfacing as a generic krilla write failure once the file is validated.

Whether the character survives in the text layer depends on its shaping cluster. On its own it leaves no trace, because krilla writes no ToUnicode entry for glyph 0. A combining mark on a covered letter shares that letter's cluster and comes back through the letter's own entry. `an_uncovered_mark_survives_in_the_text_layer` pins that against a bare-letter control.

## Naming

The first round of this PR called the option `missingGlyph`, with values `"error" | "notdef" | "skip"`. Three things were wrong with that:

- One concept had four names across the crate: `missingGlyph`, `PdfError::MissingGlyphs`, the internal `uncovered` field and the docs' "uncovered characters", and the value `notdef`.
- "Missing glyph" names the wrong subject. The glyph is not missing. The font hands over glyph 0 without complaint, and what is missing is a font covering the character the author typed.
- `"skip"` implies the character is dropped and the text closes up. Nothing is skipped.

`"notdef"` was precise, but it is font-internals jargon in a JS-facing API. `"placeholder"` says the same thing in plain English without promising a visible box, which no font guarantees.

## Not in this PR

`"placeholder"` and `"blank"` still discard the uncovered set the renderer already collects, so a caller cannot get bytes and a diagnosis at once. That belongs in a shared design. The image renderer resolves glyph 0 to whatever outline the font has and draws it, unconditionally and with no diagnostic, while the PDF renderer hard-fails. A PDF-only reporting entry point would deepen that asymmetry rather than fix it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `uncoveredText` controls for uncovered characters: `error`, `placeholder`, and `blank`.
  * Placeholder and blank modes preserve character spacing without reflowing lines.
  * Copied text retains uncovered characters where supported by their shaping cluster.
  * Clear errors identify when placeholders conflict with PDF/A or PDF/UA standards.

* **Documentation**
  * Updated PDF and library documentation with option behavior, compliance restrictions, and text-layer details.

* **Breaking Changes**
  * Replaced the `missingGlyph` option and values with `uncoveredText`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->