### PR TITLE
Core: stop anonymous boxes inheriting the parent box model

### DIFF
--- a/.tegami/anonymous-box-insets.md
+++ b/.tegami/anonymous-box-insets.md
@@ -1,0 +1,7 @@
+---
+"takumi": patch
+---
+
+# Stop anonymous boxes inheriting their parent's box model
+
+Bare text inside a padded `display: flex` container measured against a content box narrowed by the parent's padding again, so a line that fit was laid out as two.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -30,7 +30,7 @@ use crate::{
   style::{
     Affine, BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle,
     ContentItem, ContentValue, Display, Filters, Float, Isolation, Length, LineHeight,
-    ListStylePosition, PercentageNumber, Position, SizingContext, Style as NodeStyle,
+    ListStylePosition, MaxSize, PercentageNumber, Position, SizingContext, Style as NodeStyle,
     StyleDeclaration, StyleDeclarationBlock, StyleSheet, TextWrapMode, TwBlocks, TwCache,
     WhiteSpaceCollapse, apply_stylesheet_animations,
   },
@@ -1107,6 +1107,28 @@ impl RenderNode {
     context.style.break_before = Default::default();
     context.style.break_after = Default::default();
     context.style.break_inside = Default::default();
+    context.style.width = Length::Auto;
+    context.style.height = Length::Auto;
+    context.style.min_width = Length::Auto;
+    context.style.min_height = Length::Auto;
+    context.style.max_width = MaxSize::None;
+    context.style.max_height = MaxSize::None;
+    context.style.top = Length::Auto;
+    context.style.right = Length::Auto;
+    context.style.bottom = Length::Auto;
+    context.style.left = Length::Auto;
+    context.style.padding_top = Length::zero();
+    context.style.padding_right = Length::zero();
+    context.style.padding_bottom = Length::zero();
+    context.style.padding_left = Length::zero();
+    context.style.margin_top = Length::zero();
+    context.style.margin_right = Length::zero();
+    context.style.margin_bottom = Length::zero();
+    context.style.margin_left = Length::zero();
+    context.style.border_top_style = Default::default();
+    context.style.border_right_style = Default::default();
+    context.style.border_bottom_style = Default::default();
+    context.style.border_left_style = Default::default();
     context
   }
 

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -28,11 +28,10 @@ use crate::{
   },
   matching::{MatchedDeclarationsView, NodeMatchedDeclarations, match_stylesheets_view},
   style::{
-    Affine, BackgroundImage, BackgroundImages, BlendMode, BoxSizing, Color, ComputedStyle,
-    ContentItem, ContentValue, Display, Filters, Float, Isolation, Length, LineHeight,
-    ListStylePosition, MaxSize, PercentageNumber, Position, SizingContext, Style as NodeStyle,
-    StyleDeclaration, StyleDeclarationBlock, StyleSheet, TextWrapMode, TwBlocks, TwCache,
-    WhiteSpaceCollapse, apply_stylesheet_animations,
+    Affine, BackgroundImage, BackgroundImages, BoxSizing, Color, ComputedStyle, ContentItem,
+    ContentValue, Display, Float, Length, LineHeight, ListStylePosition, Position, SizingContext,
+    Style as NodeStyle, StyleDeclaration, StyleDeclarationBlock, StyleSheet, TextWrapMode,
+    TwBlocks, TwCache, WhiteSpaceCollapse, apply_stylesheet_animations,
   },
   viewport::Viewport,
 };
@@ -1087,48 +1086,14 @@ impl RoundTree for LayoutTree<'_> {
 }
 
 impl RenderNode {
+  /// Blink's `CreateAnonymousStyleWithDisplay`, with the `anonymous` flags of
+  /// the style table standing in for its applied text decorations.
+  /// https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/resolver/style_resolver.cc
   fn anonymous_box_context(parent_context: &RenderContext) -> RenderContext {
     let mut context = parent_context.clone();
+
+    context.style = Box::new(ComputedStyle::for_anonymous(&parent_context.style));
     context.style.display = Display::Block;
-    context.style.opacity = PercentageNumber(1.0);
-    context.style.filter = Filters::default();
-    context.style.backdrop_filter = Filters::default();
-    context.style.mix_blend_mode = BlendMode::Normal;
-    context.style.isolation = Isolation::Auto;
-    context.style.clip_path = None;
-    context.style.mask_image = None;
-    context.style.mask_size = Default::default();
-    context.style.mask_position = Default::default();
-    context.style.mask_repeat = Default::default();
-    context.style.transform = None;
-    context.style.rotate = None;
-    context.style.scale = Default::default();
-    context.style.translate = Default::default();
-    context.style.break_before = Default::default();
-    context.style.break_after = Default::default();
-    context.style.break_inside = Default::default();
-    context.style.width = Length::Auto;
-    context.style.height = Length::Auto;
-    context.style.min_width = Length::Auto;
-    context.style.min_height = Length::Auto;
-    context.style.max_width = MaxSize::None;
-    context.style.max_height = MaxSize::None;
-    context.style.top = Length::Auto;
-    context.style.right = Length::Auto;
-    context.style.bottom = Length::Auto;
-    context.style.left = Length::Auto;
-    context.style.padding_top = Length::zero();
-    context.style.padding_right = Length::zero();
-    context.style.padding_bottom = Length::zero();
-    context.style.padding_left = Length::zero();
-    context.style.margin_top = Length::zero();
-    context.style.margin_right = Length::zero();
-    context.style.margin_bottom = Length::zero();
-    context.style.margin_left = Length::zero();
-    context.style.border_top_style = Default::default();
-    context.style.border_right_style = Default::default();
-    context.style.border_bottom_style = Default::default();
-    context.style.border_left_style = Default::default();
     context
   }
 

--- a/takumi-core/src/style/stylesheets.rs
+++ b/takumi-core/src/style/stylesheets.rs
@@ -49,6 +49,21 @@ macro_rules! define_inherited_default {
   };
 }
 
+/// What an anonymous box takes from the box it stands in for: inherited
+/// properties, plus the ones flagged `anonymous` that apply to that box's own
+/// content but are read from the anonymous box.
+macro_rules! define_anonymous_default {
+  ($parent:expr, $default:expr, inherit $inherit:tt $(, anonymous $anonymous:tt)?) => {
+    $parent.to_owned()
+  };
+  ($parent:expr, $default:expr, anonymous $anonymous:tt) => {
+    $parent.to_owned()
+  };
+  ($parent:expr, $default:expr) => {
+    $default
+  };
+}
+
 type ParsedDeclarations = SmallVec<[StyleDeclaration; 8]>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -257,6 +272,7 @@ macro_rules! define_style {
       $(
         $longhand:ident: $longhand_ty:ty
           $(where inherit = $longhand_inherit:literal)?
+          $(where anonymous = $longhand_anonymous:literal)?
           $(= $longhand_default:expr)?,
       )*
     }
@@ -875,6 +891,16 @@ macro_rules! define_style {
           }
         }
 
+        /// Builds the style of an anonymous box generated inside `parent`.
+        pub(crate) fn for_anonymous(parent: &Self) -> Self {
+          Self {
+            custom_properties: inherited_custom_properties(&parent.custom_properties),
+            registered_custom_properties: parent.registered_custom_properties.clone(),
+            lang: parent.lang,
+            $($longhand: define_anonymous_default!(parent.$longhand, define_style!(@default $($longhand_default)?) $(, inherit $longhand_inherit)? $(, anonymous $longhand_anonymous)?),)*
+          }
+        }
+
         /// Resolves relative units against the sizing context.
         pub(crate) fn make_computed_values(&mut self, sizing: &SizingContext) {
           $(self.$longhand.make_computed(sizing);)*
@@ -1204,14 +1230,14 @@ define_style! {
     row_gap: Gap,
     flex_grow: Option<FlexGrow>,
     flex_shrink: Option<FlexGrow>,
-    border_top_left_radius: SpacePair<Length> = SpacePair::from_single(Length::zero()),
-    border_top_right_radius: SpacePair<Length> = SpacePair::from_single(Length::zero()),
-    border_bottom_right_radius: SpacePair<Length> = SpacePair::from_single(Length::zero()),
-    border_bottom_left_radius: SpacePair<Length> = SpacePair::from_single(Length::zero()),
-    corner_top_left_shape: Superellipse,
-    corner_top_right_shape: Superellipse,
-    corner_bottom_right_shape: Superellipse,
-    corner_bottom_left_shape: Superellipse,
+    border_top_left_radius: SpacePair<Length> where anonymous = true = SpacePair::from_single(Length::zero()),
+    border_top_right_radius: SpacePair<Length> where anonymous = true = SpacePair::from_single(Length::zero()),
+    border_bottom_right_radius: SpacePair<Length> where anonymous = true = SpacePair::from_single(Length::zero()),
+    border_bottom_left_radius: SpacePair<Length> where anonymous = true = SpacePair::from_single(Length::zero()),
+    corner_top_left_shape: Superellipse where anonymous = true,
+    corner_top_right_shape: Superellipse where anonymous = true,
+    corner_bottom_right_shape: Superellipse where anonymous = true,
+    corner_bottom_left_shape: Superellipse where anonymous = true,
     border_top_width: LineWidth,
     border_right_width: LineWidth,
     border_bottom_width: LineWidth,
@@ -1228,17 +1254,17 @@ define_style! {
     outline_style: BorderStyle,
     outline_color: ColorInput,
     outline_offset: Length,
-    object_fit: ObjectFit,
+    object_fit: ObjectFit where anonymous = true,
     overflow_x: Overflow,
     overflow_y: Overflow,
-    object_position: PositionValue = PositionValue::center(),
-    background_image: Option<BackgroundImages>,
-    background_position: PositionValues,
-    background_size: BackgroundSizes,
-    background_repeat: BackgroundRepeats,
-    background_blend_mode: BlendModes,
-    background_color: ColorInput = ColorInput::transparent(),
-    background_clip: BackgroundClip,
+    object_position: PositionValue where anonymous = true = PositionValue::center(),
+    background_image: Option<BackgroundImages> where anonymous = true,
+    background_position: PositionValues where anonymous = true,
+    background_size: BackgroundSizes where anonymous = true,
+    background_repeat: BackgroundRepeats where anonymous = true,
+    background_blend_mode: BlendModes where anonymous = true,
+    background_color: ColorInput where anonymous = true = ColorInput::transparent(),
+    background_clip: BackgroundClip where anonymous = true,
     background_origin: BackgroundOrigin,
     box_shadow: Option<BoxShadows>,
     grid_auto_columns: Option<GridTrackSizes>,
@@ -1251,7 +1277,7 @@ define_style! {
     grid_template_columns: Option<GridTemplateComponents>,
     grid_template_rows: Option<GridTemplateComponents>,
     grid_template_areas: Option<GridTemplateAreas>,
-    text_overflow: TextOverflow,
+    text_overflow: TextOverflow where anonymous = true,
     text_fit: TextFit where inherit = true,
     text_transform: TextTransform where inherit = true,
     font_style: FontStyle where inherit = true,
@@ -1273,25 +1299,25 @@ define_style! {
     font_kerning: FontKerning where inherit = true,
     font_synthesis_weight: FontSynthesic where inherit = true,
     font_synthesis_style: FontSynthesic where inherit = true,
-    max_lines: Option<u32>,
+    max_lines: Option<u32> where anonymous = true,
     block_ellipsis: BlockEllipsis where inherit = true,
-    r#continue: Continue,
+    r#continue: Continue where anonymous = true,
     text_align: TextAlign where inherit = true,
     webkit_text_stroke_width: Option<Length> where inherit = true,
     webkit_text_stroke_color: Option<ColorInput> where inherit = true,
     webkit_text_fill_color: Option<ColorInput> where inherit = true,
     stroke_linejoin: LineJoin where inherit = true,
     text_shadow: Option<TextShadows> where inherit = true,
-    text_decoration_line: Option<TextDecorationLines>,
-    text_decoration_style: TextDecorationStyle,
+    text_decoration_line: Option<TextDecorationLines> where anonymous = true,
+    text_decoration_style: TextDecorationStyle where anonymous = true,
     break_before: BreakBetween,
     break_after: BreakBetween,
     break_inside: BreakInside,
     box_decoration_break: BoxDecorationBreak,
     widows: MinLines where inherit = true,
     orphans: MinLines where inherit = true,
-    text_decoration_color: ColorInput,
-    text_decoration_thickness: TextDecorationThickness,
+    text_decoration_color: ColorInput where anonymous = true,
+    text_decoration_thickness: TextDecorationThickness where anonymous = true,
     text_underline_offset: TextUnderlineOffset where inherit = true,
     text_underline_position: TextUnderlinePosition where inherit = true,
     text_decoration_skip_ink: TextDecorationSkipInk where inherit = true,

--- a/takumi/tests/fixtures-generated/legacy_box_alignment.svg
+++ b/takumi/tests/fixtures-generated/legacy_box_alignment.svg
@@ -6,94 +6,89 @@
   </clipPath>
   <g clip-path="url(#cp0)">
     <rect x="24" y="24" width="432" height="46" fill="#dbeafe"/>
-    <clipPath id="cp1">
-      <path d="M24 24H456V70H24Z"/>
-    </clipPath>
-    <g clip-path="url(#cp1)">
-      <g fill="#000">
-        <use href="#g0" x="28.5" y="42"/>
-        <use href="#g1" x="37.9" y="42"/>
-        <use href="#g2" x="48.14" y="42"/>
-        <use href="#g3" x="62.74" y="42"/>
-        <use href="#g4" x="73.45" y="42"/>
-        <use href="#g5" x="83.53" y="42"/>
-        <use href="#g6" x="87.74" y="42"/>
-        <use href="#g7" x="97.39" y="42"/>
-        <use href="#g8" x="112.51" y="42"/>
-        <use href="#g9" x="123.04" y="42"/>
-        <use href="#g10" x="129.14" y="42"/>
-        <use href="#g11" x="139" y="42"/>
-        <use href="#g12" x="153.31" y="42"/>
-        <use href="#g13" x="168.27" y="42"/>
-        <use href="#g10" x="174.59" y="42"/>
-        <use href="#g14" x="184" y="42"/>
-        <use href="#g15" x="199.03" y="42"/>
-        <use href="#g4" x="203.35" y="42"/>
-        <use href="#g16" x="213.7" y="42"/>
-        <use href="#g17" x="229.13" y="42"/>
-        <use href="#g18" x="239.66" y="42"/>
-        <use href="#g10" x="253.52" y="42"/>
-        <use href="#g19" x="263.38" y="42"/>
-        <use href="#g2" x="272.56" y="42"/>
-        <use href="#g9" x="282.48" y="42"/>
-        <use href="#g20" x="293.8" y="42"/>
-        <use href="#g1" x="300.57" y="42"/>
-        <use href="#g2" x="310.81" y="42"/>
-        <use href="#g21" x="325.41" y="42"/>
-        <use href="#g22" x="330.22" y="42"/>
-        <use href="#g23" x="339.99" y="42"/>
-        <use href="#g24" x="349.19" y="42"/>
-        <use href="#g25" x="363.35" y="42"/>
-        <use href="#g10" x="373.88" y="42"/>
-        <use href="#g26" x="384.02" y="42"/>
-        <use href="#g27" x="394.71" y="42"/>
-        <use href="#g0" x="402.83" y="42"/>
-        <use href="#g1" x="412.22" y="42"/>
-        <use href="#g2" x="422.47" y="42"/>
-      </g>
-      <g fill="#000">
-        <use href="#g3" x="24" y="65"/>
-        <use href="#g4" x="34.71" y="65"/>
-        <use href="#g5" x="44.79" y="65"/>
-        <use href="#g6" x="49" y="65"/>
-        <use href="#g7" x="58.65" y="65"/>
-        <use href="#g8" x="73.77" y="65"/>
-        <use href="#g9" x="84.3" y="65"/>
-        <use href="#g10" x="90.4" y="65"/>
-        <use href="#g11" x="100.27" y="65"/>
-        <use href="#g12" x="114.58" y="65"/>
-        <use href="#g13" x="129.53" y="65"/>
-        <use href="#g10" x="135.85" y="65"/>
-        <use href="#g14" x="145.27" y="65"/>
-        <use href="#g15" x="160.3" y="65"/>
-        <use href="#g4" x="164.62" y="65"/>
-        <use href="#g16" x="174.97" y="65"/>
-        <use href="#g17" x="190.39" y="65"/>
-        <use href="#g18" x="200.92" y="65"/>
-        <use href="#g10" x="214.78" y="65"/>
-        <use href="#g19" x="224.65" y="65"/>
-        <use href="#g2" x="233.83" y="65"/>
-        <use href="#g9" x="243.74" y="65"/>
-        <use href="#g20" x="255.07" y="65"/>
-        <use href="#g1" x="261.83" y="65"/>
-        <use href="#g2" x="272.08" y="65"/>
-        <use href="#g21" x="286.67" y="65"/>
-        <use href="#g22" x="291.48" y="65"/>
-        <use href="#g23" x="301.25" y="65"/>
-        <use href="#g24" x="310.45" y="65"/>
-        <use href="#g25" x="324.62" y="65"/>
-        <use href="#g10" x="335.15" y="65"/>
-        <use href="#g26" x="345.28" y="65"/>
-        <use href="#g27" x="355.97" y="65"/>
-        <use href="#g0" x="364.09" y="65"/>
-        <use href="#g1" x="373.49" y="65"/>
-        <use href="#g2" x="383.73" y="65"/>
-        <use href="#g3" x="398.33" y="65"/>
-        <use href="#g4" x="409.04" y="65"/>
-        <use href="#g5" x="419.12" y="65"/>
-        <use href="#g6" x="423.33" y="65"/>
-        <use href="#g7" x="432.98" y="65"/>
-      </g>
+    <g fill="#000">
+      <use href="#g0" x="28.5" y="42"/>
+      <use href="#g1" x="37.9" y="42"/>
+      <use href="#g2" x="48.14" y="42"/>
+      <use href="#g3" x="62.74" y="42"/>
+      <use href="#g4" x="73.45" y="42"/>
+      <use href="#g5" x="83.53" y="42"/>
+      <use href="#g6" x="87.74" y="42"/>
+      <use href="#g7" x="97.39" y="42"/>
+      <use href="#g8" x="112.51" y="42"/>
+      <use href="#g9" x="123.04" y="42"/>
+      <use href="#g10" x="129.14" y="42"/>
+      <use href="#g11" x="139" y="42"/>
+      <use href="#g12" x="153.31" y="42"/>
+      <use href="#g13" x="168.27" y="42"/>
+      <use href="#g10" x="174.59" y="42"/>
+      <use href="#g14" x="184" y="42"/>
+      <use href="#g15" x="199.03" y="42"/>
+      <use href="#g4" x="203.35" y="42"/>
+      <use href="#g16" x="213.7" y="42"/>
+      <use href="#g17" x="229.13" y="42"/>
+      <use href="#g18" x="239.66" y="42"/>
+      <use href="#g10" x="253.52" y="42"/>
+      <use href="#g19" x="263.38" y="42"/>
+      <use href="#g2" x="272.56" y="42"/>
+      <use href="#g9" x="282.48" y="42"/>
+      <use href="#g20" x="293.8" y="42"/>
+      <use href="#g1" x="300.57" y="42"/>
+      <use href="#g2" x="310.81" y="42"/>
+      <use href="#g21" x="325.41" y="42"/>
+      <use href="#g22" x="330.22" y="42"/>
+      <use href="#g23" x="339.99" y="42"/>
+      <use href="#g24" x="349.19" y="42"/>
+      <use href="#g25" x="363.35" y="42"/>
+      <use href="#g10" x="373.88" y="42"/>
+      <use href="#g26" x="384.02" y="42"/>
+      <use href="#g27" x="394.71" y="42"/>
+      <use href="#g0" x="402.83" y="42"/>
+      <use href="#g1" x="412.22" y="42"/>
+      <use href="#g2" x="422.47" y="42"/>
+    </g>
+    <g fill="#000">
+      <use href="#g3" x="24" y="65"/>
+      <use href="#g4" x="34.71" y="65"/>
+      <use href="#g5" x="44.79" y="65"/>
+      <use href="#g6" x="49" y="65"/>
+      <use href="#g7" x="58.65" y="65"/>
+      <use href="#g8" x="73.77" y="65"/>
+      <use href="#g9" x="84.3" y="65"/>
+      <use href="#g10" x="90.4" y="65"/>
+      <use href="#g11" x="100.27" y="65"/>
+      <use href="#g12" x="114.58" y="65"/>
+      <use href="#g13" x="129.53" y="65"/>
+      <use href="#g10" x="135.85" y="65"/>
+      <use href="#g14" x="145.27" y="65"/>
+      <use href="#g15" x="160.3" y="65"/>
+      <use href="#g4" x="164.62" y="65"/>
+      <use href="#g16" x="174.97" y="65"/>
+      <use href="#g17" x="190.39" y="65"/>
+      <use href="#g18" x="200.92" y="65"/>
+      <use href="#g10" x="214.78" y="65"/>
+      <use href="#g19" x="224.65" y="65"/>
+      <use href="#g2" x="233.83" y="65"/>
+      <use href="#g9" x="243.74" y="65"/>
+      <use href="#g20" x="255.07" y="65"/>
+      <use href="#g1" x="261.83" y="65"/>
+      <use href="#g2" x="272.08" y="65"/>
+      <use href="#g21" x="286.67" y="65"/>
+      <use href="#g22" x="291.48" y="65"/>
+      <use href="#g23" x="301.25" y="65"/>
+      <use href="#g24" x="310.45" y="65"/>
+      <use href="#g25" x="324.62" y="65"/>
+      <use href="#g10" x="335.15" y="65"/>
+      <use href="#g26" x="345.28" y="65"/>
+      <use href="#g27" x="355.97" y="65"/>
+      <use href="#g0" x="364.09" y="65"/>
+      <use href="#g1" x="373.49" y="65"/>
+      <use href="#g2" x="383.73" y="65"/>
+      <use href="#g3" x="398.33" y="65"/>
+      <use href="#g4" x="409.04" y="65"/>
+      <use href="#g5" x="419.12" y="65"/>
+      <use href="#g6" x="423.33" y="65"/>
+      <use href="#g7" x="432.98" y="65"/>
     </g>
   </g>
   <rect x="12" y="90" width="456" height="72" fill="#dcfce7"/>

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -2138,6 +2138,35 @@ fn test_padded_flex_text_keeps_one_line() {
   assert_eq!(wrapped.children[0].width, nowrap.children[0].width);
 }
 
+/// The anonymous item bare text takes in a flex container has no padding of
+/// its own, so a container whose content box fits the text exactly keeps it on
+/// one line.
+#[test]
+fn test_flex_padding_does_not_narrow_anonymous_text() {
+  let sentence = "The quick brown fox jumps over the lazy dog and keeps running";
+  let container = |width: Option<f32>, padding: f32| {
+    let mut style = Style::default()
+      .with(StyleDeclaration::display(Display::Flex))
+      .with(StyleDeclaration::padding_left(Px(padding)))
+      .with(StyleDeclaration::padding_right(Px(padding)))
+      .with(StyleDeclaration::font_size(Px(24.0).into()));
+
+    if let Some(width) = width {
+      style = style.with(StyleDeclaration::width(Px(width)));
+    }
+    Node::container([Node::text(sentence.to_string())]).with_style(style)
+  };
+  let unpadded = measure(container(None, 0.0), create_measure_viewport());
+  let text = &unpadded.children[0];
+  let padded = measure(
+    container(Some(text.width + 48.0), 24.0),
+    create_measure_viewport(),
+  );
+
+  assert_eq!(padded.children[0].height, text.height);
+  assert_eq!(padded.children[0].width, text.width);
+}
+
 /// Horizontal padding on an inline span reserves advance on the line, like
 /// Blink adds the span's edges to the line's inline size.
 #[test]

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -2143,18 +2143,16 @@ fn test_padded_flex_text_keeps_one_line() {
 /// one line.
 #[test]
 fn test_flex_padding_does_not_narrow_anonymous_text() {
-  let sentence = "The quick brown fox jumps over the lazy dog and keeps running";
   let container = |width: Option<f32>, padding: f32| {
-    let mut style = Style::default()
-      .with(StyleDeclaration::display(Display::Flex))
-      .with(StyleDeclaration::padding_left(Px(padding)))
-      .with(StyleDeclaration::padding_right(Px(padding)))
-      .with(StyleDeclaration::font_size(Px(24.0).into()));
+    let width = width.map_or(String::new(), |width| format!("width: {width}px;"));
 
-    if let Some(width) = width {
-      style = style.with(StyleDeclaration::width(Px(width)));
-    }
-    Node::container([Node::text(sentence.to_string())]).with_style(style)
+    Node::from_html(
+      &format!(
+        r#"<div style="display: flex; padding: 0 {padding}px; font-size: 24px; {width}">The quick brown fox jumps over the lazy dog and keeps running</div>"#
+      ),
+      FromHtmlOptions::default(),
+    )
+    .expect("parse")
   };
   let unpadded = measure(container(None, 0.0), create_measure_viewport());
   let text = &unpadded.children[0];


### PR DESCRIPTION
## Why
An anonymous box cloned its parent's style, padding and border included, so the inline constraint for bare text in a padded `display: flex` container came off the parent's padding twice and a line that fit was reserved as two.

## What
An anonymous box now inherits the way Blink's `CreateAnonymousStyleWithDisplay` does: inherited properties come from the parent and everything else is initial. Properties takumi reads from the anonymous box on the parent's behalf (text decorations, line clamp, `text-overflow`, the background for `background-clip: text`, and the replaced-box radius and `object-fit`) carry a `where anonymous = true` flag in the style table, which generates `ComputedStyle::for_anonymous`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout measurement for anonymous text inside padded flex containers.
  * Prevented unnecessary line wrapping when text fits exactly within the content area.
  * Corrected anonymous box styling so inherited and default properties are applied consistently.

* **Tests**
  * Added regression coverage for intrinsic text width and single-line height in padded flex layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->