### PR TITLE
Upgrade taffy to 0.14

### DIFF
--- a/.tegami/taffy-0-14.md
+++ b/.tegami/taffy-0-14.md
@@ -1,0 +1,7 @@
+---
+"takumi": patch
+---
+
+# Upgrade taffy to 0.14
+
+Layout picks up taffy's flexbox, grid and block fixes from 0.12 through 0.14.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,12 +625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
-name = "grid"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,14 +1773,14 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde4e2f8595f222ceaae1fb16b4963952e9b33e358869dc4cd6316b0e0790cd"
+checksum = "639627c87f43b9181c811f40a6296409e093a17bc761214cba3c15df74f86b99"
 dependencies = [
  "arrayvec",
- "grid",
  "serde",
  "slotmap",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ version = "1.15"
 features = ["serde"]
 
 [workspace.dependencies.taffy]
-version = "0.11"
+version = "0.14"
 default-features = false
 features = [
   "flexbox",

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -875,7 +875,9 @@ impl<'r> LayoutTree<'r> {
 
       match (display_mode, has_children) {
         (TaffyDisplay::None, _) => compute_hidden_layout(tree, node),
-        (TaffyDisplay::Block, true) => compute_block_layout(tree, node, inputs, block_ctx),
+        (TaffyDisplay::Block | TaffyDisplay::FlowRoot, true) => {
+          compute_block_layout(tree, node, inputs, block_ctx)
+        }
         (TaffyDisplay::Flex, true) => compute_flexbox_layout(tree, node, inputs),
         (TaffyDisplay::Grid, true) => compute_grid_layout(tree, node, inputs),
         (_, false) => {
@@ -926,7 +928,7 @@ impl<'r> LayoutTree<'r> {
     });
 
     if let Some(node_data) = self.get_layout_node_mut_ref(node) {
-      node_data.first_baseline_y = output.first_baselines.y;
+      node_data.first_baseline_y = output.baselines.first;
     }
 
     output
@@ -934,8 +936,8 @@ impl<'r> LayoutTree<'r> {
 }
 
 impl CacheTree for LayoutTree<'_> {
-  fn cache_get(&self, node_id: TaffyNodeId, input: &LayoutInput) -> Option<LayoutOutput> {
-    let node = self.get_layout_node_ref(node_id)?;
+  fn cache_get(&mut self, node_id: TaffyNodeId, input: &LayoutInput) -> Option<LayoutOutput> {
+    let node = self.get_layout_node_mut_ref(node_id)?;
     node.cache.get(input)
   }
 
@@ -1147,8 +1149,8 @@ impl RenderNode {
     // Cap image content to the parent pseudo's box so explicit `width` / `height`
     // on the pseudo wins over intrinsic / default sizing.
     let max_size = TaffySize {
-      width: taffy::Dimension::percent(1.0),
-      height: taffy::Dimension::percent(1.0),
+      width: taffy::LengthPercentageAuto::percent(1.0),
+      height: taffy::LengthPercentageAuto::percent(1.0),
     };
 
     match image {

--- a/takumi-core/src/style/properties/grid/grid_template_areas.rs
+++ b/takumi-core/src/style/properties/grid/grid_template_areas.rs
@@ -18,10 +18,12 @@ pub struct GridTemplateAreas(pub Vec<Vec<String>>);
 impl MakeComputed for GridTemplateAreas {}
 
 impl GridTemplateAreas {
-  pub(crate) fn into_taffy(self) -> Vec<taffy::GridTemplateArea<String>> {
+  pub(crate) fn into_taffy(self) -> Option<taffy::GridTemplateAreas<String>> {
     if self.0.is_empty() {
-      return Vec::new();
+      return None;
     }
+    let row_count = self.0.len() as u16;
+    let column_count = self.0.iter().map(Vec::len).max().unwrap_or(0) as u16;
 
     let mut bounds: HashMap<&str, (usize, usize, usize, usize)> = HashMap::new();
     for (r, row) in self.0.iter().enumerate() {
@@ -48,7 +50,11 @@ impl GridTemplateAreas {
         column_end: (cmax as u16) + 2,
       });
     }
-    areas
+    Some(taffy::GridTemplateAreas {
+      areas,
+      row_count,
+      column_count,
+    })
   }
 }
 

--- a/takumi-core/src/style/properties/max_size.rs
+++ b/takumi-core/src/style/properties/max_size.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use cssparser::Parser;
-use taffy::Dimension;
+use taffy::LengthPercentageAuto;
 
 use crate::style::{
   Animatable, Color, CssSyntaxKind, CssToken, FromCss, Length, MakeComputed, ParseResult,
@@ -87,11 +87,14 @@ impl From<Length> for MaxSize {
 }
 
 impl MaxSize {
-  /// Resolves to a taffy `Dimension`, treating `none` as unbounded (same as `Length::Auto`).
-  pub(crate) fn resolve_to_dimension(self, sizing: &SizingContext) -> Dimension {
+  /// Resolves to taffy, treating `none` as `auto`.
+  pub(crate) fn resolve_to_length_percentage_auto(
+    self,
+    sizing: &SizingContext,
+  ) -> LengthPercentageAuto {
     match self {
-      Self::None => Length::Auto.resolve_to_dimension(sizing),
-      Self::Length(length) => length.resolve_to_dimension(sizing),
+      Self::None => Length::Auto.resolve_to_length_percentage_auto(sizing),
+      Self::Length(length) => length.resolve_to_length_percentage_auto(sizing),
     }
   }
 }

--- a/takumi-core/src/style/stylesheets_query.rs
+++ b/takumi-core/src/style/stylesheets_query.rs
@@ -306,6 +306,7 @@ impl ComputedStyle {
       Self::grid_template(&self.grid_template_rows, sizing);
 
     taffy::Style {
+      contain: taffy::Contain::NONE,
       float: self.float.resolve(self.direction),
       clear: self.clear.resolve(self.direction),
       direction: self.direction.into_taffy(),
@@ -370,12 +371,12 @@ impl ComputedStyle {
         width: self.min_width,
         height: self.min_height,
       }
-      .map(|length| length.resolve_to_dimension(sizing)),
+      .map(|length| length.resolve_to_length_percentage_auto(sizing)),
       max_size: Size {
         width: self.max_width,
         height: self.max_height,
       }
-      .map(|length| length.resolve_to_dimension(sizing)),
+      .map(|length| length.resolve_to_length_percentage_auto(sizing)),
       grid_auto_columns: self
         .grid_auto_columns
         .as_ref()
@@ -411,8 +412,7 @@ impl ComputedStyle {
         .grid_template_areas
         .as_ref()
         .cloned()
-        .unwrap_or_default()
-        .into_taffy(),
+        .and_then(GridTemplateAreas::into_taffy),
       aspect_ratio: self.aspect_ratio.into(),
       align_self: self.align_self.into_taffy(),
       justify_self: self.justify_self.into_taffy(),


### PR DESCRIPTION
Stacked on #1589.

## Why
takumi sat on taffy 0.11 while 0.12 through 0.14 landed fixes across flexbox, grid, block and caching, plus the sizing keywords and baseline API the next layers build on.

## What
- Adapts to the renamed `Baselines` output, `LengthPercentageAuto` min/max sizes, the `GridTemplateAreas` wrapper, the `contain` style field, `Display::FlowRoot`, and the `&mut self` cache lookup.
- Every golden stays byte-identical on this layer; the two regressions the bump surfaced were takumi bugs and are fixed by #1588 and #1589 underneath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout handling for flow-root elements with children.
  * Incorporated upstream flexbox, grid, and block layout fixes.
  * Improved baseline calculation and image sizing behavior.
  * Corrected grid template area handling, including empty templates.
  * Improved handling of minimum and maximum sizes.
* **Chores**
  * Updated the layout engine dependency to version 0.14.
* **Release**
  * Prepared a patch release for the package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->