### PR TITLE
Core: report the first line baseline of text leaves

### DIFF
--- a/.tegami/flex-first-baseline.md
+++ b/.tegami/flex-first-baseline.md
@@ -1,0 +1,7 @@
+---
+"takumi": patch
+---
+
+# Align flex items to the first line of a wrapped item
+
+A flex item that wraps onto several lines now offers the baseline of its first line to `align-items: baseline`, instead of its bottom edge.

--- a/takumi-core/src/layout/tree.rs
+++ b/takumi-core/src/layout/tree.rs
@@ -898,7 +898,7 @@ impl<'r> LayoutTree<'r> {
             }
           };
 
-          compute_leaf_layout(
+          let mut output = compute_leaf_layout(
             inputs,
             &node_data.style,
             |val, basis| tree.resolve_calc_value(val, basis),
@@ -922,7 +922,25 @@ impl<'r> LayoutTree<'r> {
                 )
                 .into_taffy()
             },
-          )
+          );
+
+          let lays_out_text = node_data.is_inline_children
+            || matches!(
+              render_node.node.as_ref().and_then(Node::inline_content),
+              Some(InlineContentKind::Text(_))
+            );
+
+          // `compute_leaf_layout` reports no baseline, which leaves flexbox
+          // baseline alignment on its bottom margin edge fallback.
+          if lays_out_text && inputs.run_mode == RunMode::PerformLayout {
+            output.baselines.first = render_node.inline_content_border_box_baseline(
+              Size::from_taffy(inputs.available_space).map(AvailableSpace::from_taffy),
+              Size::from_taffy(output.size),
+              false,
+            );
+          }
+
+          output
         }
       }
     });
@@ -1692,6 +1710,23 @@ impl RenderNode {
     size: Size<f32>,
     use_last_line: bool,
   ) -> Option<f32> {
+    let baseline = self.inline_content_border_box_baseline(available_space, size, use_last_line)?;
+    let margin_top = self
+      .context
+      .style
+      .margin_top
+      .to_px(&self.context.sizing, 0.0);
+
+    Some(margin_top + baseline)
+  }
+
+  /// Baseline of the first or last line box, measured from the border box top.
+  fn inline_content_border_box_baseline(
+    &self,
+    available_space: Size<AvailableSpace>,
+    size: Size<f32>,
+    use_last_line: bool,
+  ) -> Option<f32> {
     if matches!(
       self.node.as_ref().and_then(Node::inline_content),
       Some(InlineContentKind::Box)
@@ -1737,10 +1772,10 @@ impl RenderNode {
       resolved.first()?
     };
     let sizing = &self.context.sizing;
-    let margin_top = self.context.style.margin_top.to_px(sizing, 0.0);
     let border_top = Length::from(self.context.style.border_top_width).to_px(sizing, 0.0);
     let padding_top = self.context.style.padding_top.to_px(sizing, 0.0);
-    Some(margin_top + border_top + padding_top + line.resolved_baseline)
+
+    Some(border_top + padding_top + line.resolved_baseline)
   }
 
   fn layout_first_baseline_offset(

--- a/takumi/tests/measure_tests.rs
+++ b/takumi/tests/measure_tests.rs
@@ -2228,3 +2228,50 @@ fn test_inline_span_padding_reserves_advance() {
 
   assert_within(line_width(&padded), line_width(&plain) + 16.0, 0.5);
 }
+
+/// A flex item's baseline is the baseline of its first line box.
+/// https://www.w3.org/TR/css-flexbox-1/#flex-baselines
+#[test]
+fn test_measure_flex_baseline_aligns_to_the_first_line() {
+  let flex_row = |paragraph: &str| {
+    measure(
+      Node::from_html(
+        &format!(
+          r#"<div style="display:flex; align-items:baseline; gap:16px; width:400px"><span style="font-size:9px; white-space:nowrap">TAG 4</span><p style="font-size:11px; line-height:1.5; margin:0">{paragraph}</p></div>"#
+        ),
+        FromHtmlOptions::default(),
+      )
+      .expect("parse"),
+      create_measure_viewport(),
+    )
+  };
+  let label_drop = |out: &MeasuredNode| {
+    let label = &out.children[0];
+    let paragraph = &out.children[1];
+
+    (label.transform[5] + label.runs[0].y) - (paragraph.transform[5] + paragraph.runs[0].y)
+  };
+
+  let one_line = flex_row("Ruckfahrt nach Khasab.");
+  let two_lines = flex_row(
+    "Ruckfahrt nach Khasab, dann weiter nach Maskat, der Tag steht vollstandig im nachsten Abschnitt.",
+  );
+  assert_eq!(two_lines.children[1].runs.len(), 2);
+  assert_within(label_drop(&two_lines), label_drop(&one_line), 0.05);
+
+  // The same two fonts share a line box, so their offset is the baseline offset.
+  let inline = measure(
+    Node::from_html(
+      r#"<div style="width:400px"><span style="font-size:9px">TAG 4</span><span style="font-size:11px; line-height:1.5">Khasab</span></div>"#,
+      FromHtmlOptions::default(),
+    )
+    .expect("parse"),
+    create_measure_viewport(),
+  );
+
+  assert_within(
+    label_drop(&two_lines),
+    inline.runs[0].y - inline.runs[1].y,
+    0.05,
+  );
+}


### PR DESCRIPTION
Stacked on #1591.

Fixes #1570

## Why
Text leaves go through taffy's `compute_leaf_layout`, which reports no baseline because the measure closure only returns a size. Flexbox then falls back to the item's bottom edge, so `align-items: baseline` lined a one-line label up with the last line of a wrapped paragraph.

## What
A text leaf now reports the baseline of its first line box, measured from the border box top, after `compute_leaf_layout` returns. Baseline alignment in a flex row now matches what the same two fonts do inside one line box, and replaced elements keep the bottom-edge fallback that browsers use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Flex layouts now align wrapped text items using the baseline of their first line when `align-items: baseline` is applied.

- **Bug Fixes**
  - Corrected baseline positioning for text elements in flex layouts, preventing fallback alignment to the bottom edge.

- **Tests**
  - Added coverage verifying consistent first-line baseline alignment for both single-line and wrapped text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->