### PR TITLE
Raster: intersect constraint masks in place

### DIFF
--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -279,14 +279,11 @@ impl Canvas {
   }
 
   pub(crate) fn push_mask(&mut self, mask: TinyMask) {
-    self.constraint_mask_stack.push(
-      self
-        .build_constraint_mask(&mask)
-        .map(|mask| MaskStackEntry {
-          mask: Arc::new(mask),
-          origin: self.origin,
-        }),
-    );
+    let mask = self.intersect_with_constraint_mask(mask);
+    self.constraint_mask_stack.push(Some(MaskStackEntry {
+      mask: Arc::new(mask),
+      origin: self.origin,
+    }));
   }
 
   pub(crate) fn pop_mask(&mut self) {
@@ -459,11 +456,9 @@ impl Canvas {
     f(&mut target)
   }
 
-  fn build_constraint_mask(&self, mask: &TinyMask) -> Option<TinyMask> {
-    let mut combined = TinyMask::new(mask.width(), mask.height())?;
+  fn intersect_with_constraint_mask(&self, mut mask: TinyMask) -> TinyMask {
     let Some(previous) = self.constraint_mask_stack.last().and_then(Option::as_ref) else {
-      combined.data_mut().copy_from_slice(mask.data());
-      return Some(combined);
+      return mask;
     };
 
     let previous = MaskView {
@@ -471,24 +466,25 @@ impl Canvas {
       origin: previous.origin,
       canvas_origin: self.origin,
     };
-    let mask_data = mask.data();
-    let mask_width = mask.width();
-    let combined_data = combined.data_mut();
-    for y in 0..mask.height() {
+    let mask_width = mask.width() as usize;
+    let mask_height = mask.height();
+    let data = mask.data_mut();
+    for y in 0..mask_height {
       let row = previous.row(y as i32, 0);
-      let row_start = y as usize * mask_width as usize;
-      let dst = &mut combined_data[row_start..row_start + mask_width as usize];
-      let new_row = &mask_data[row_start..row_start + mask_width as usize];
-      for (x, (out, &right)) in dst.iter_mut().zip(new_row).enumerate() {
+      let row_start = y as usize * mask_width;
+      for (x, out) in data[row_start..row_start + mask_width]
+        .iter_mut()
+        .enumerate()
+      {
+        let right = *out;
         if right == 0 {
           continue;
         }
         let left = row.alpha_at_offset(x);
-        if left == 0 {
-          continue;
-        }
         *out = if left == u8::MAX {
           right
+        } else if left == 0 {
+          0
         } else if right == u8::MAX {
           left
         } else {
@@ -496,7 +492,7 @@ impl Canvas {
         };
       }
     }
-    Some(combined)
+    mask
   }
 
   fn localize_transform(&self, transform: Affine) -> Affine {

--- a/takumi/benches/canvas.rs
+++ b/takumi/benches/canvas.rs
@@ -4,7 +4,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use takumi::{
   prelude::{
     AlignItems, BackgroundClip, BackgroundImages, BackgroundRepeats, BackgroundSizes, BorderRadius,
-    Color, ColorInput, Display, Fonts, FromCssStr, JustifyContent,
+    Color, ColorInput, Display, FlexWrap, Fonts, FromCssStr, JustifyContent,
     Length::{Percentage, Px},
     Node, ObjectFit, Overflow, PositionValues, RenderOptions, SpacePair, Style, StyleDeclaration,
     Viewport,
@@ -63,6 +63,41 @@ fn nested_clip_masks_fixture() -> Node {
       .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::align_items(AlignItems::Center))
       .with(StyleDeclaration::justify_content(JustifyContent::Center))
+      .with(StyleDeclaration::background_color(ColorInput::Value(
+        Color::white(),
+      ))),
+  )
+}
+
+fn sibling_clip_masks_fixture() -> Node {
+  let cards = (0..64).map(|index| {
+    let inner = Node::container([]).with_style(
+      Style::default()
+        .with(StyleDeclaration::width(Percentage(100.0)))
+        .with(StyleDeclaration::height(Percentage(100.0)))
+        .with(StyleDeclaration::background_color(ColorInput::Value(
+          Color([200, 30, index as u8, 255]),
+        ))),
+    );
+
+    Node::container([inner]).with_style(
+      Style::default()
+        .with(StyleDeclaration::display(Display::Flex))
+        .with(StyleDeclaration::width(Px(92.0)))
+        .with(StyleDeclaration::height(Px(92.0)))
+        .with(StyleDeclaration::margin_top(Px(4.0)))
+        .with(StyleDeclaration::margin_left(Px(4.0)))
+        .with_border_radius(BorderRadius::from_css_str("24px").unwrap())
+        .with_overflow(SpacePair::from_single(Overflow::Clip)),
+    )
+  });
+
+  Node::container(cards.collect::<Vec<_>>()).with_style(
+    Style::default()
+      .with(StyleDeclaration::display(Display::Flex))
+      .with(StyleDeclaration::flex_wrap(FlexWrap::Wrap))
+      .with(StyleDeclaration::width(Percentage(100.0)))
+      .with(StyleDeclaration::height(Percentage(100.0)))
       .with(StyleDeclaration::background_color(ColorInput::Value(
         Color::white(),
       ))),
@@ -133,6 +168,9 @@ fn bench_canvas(c: &mut Criterion) {
 
   group.bench_function("nested_clip_masks", |b| {
     b.iter(|| render_node(&fonts, black_box(nested_clip_masks_fixture())))
+  });
+  group.bench_function("sibling_clip_masks", |b| {
+    b.iter(|| render_node(&fonts, black_box(sibling_clip_masks_fixture())))
   });
   group.bench_function("scaled_image_clip", |b| {
     b.iter(|| render_node(&fonts, black_box(scaled_image_fixture())))


### PR DESCRIPTION
## Why
Every overflow clip copied its viewport-sized mask into a second viewport-sized buffer, so the cost of a clip scaled with the canvas area instead of the clipped box.

## What
`push_mask` intersects the incoming mask with the innermost constraint in place and stores it as is. The zeroed mask's untouched pages are never written, so a small clip on a large canvas pays only for its own rows. The `sibling_clip_masks` bench covers a grid of clipped cards; goldens are byte-identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved mask processing for more consistent rendering behavior.
  - Added a benchmark covering wrapped, rounded, clipped cards to measure canvas performance in complex layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->