### PR TITLE
Raster: raise the canvas budget to 64 megapixels

### DIFF
--- a/.tegami/canvas-pixel-budget.md
+++ b/.tegami/canvas-pixel-budget.md
@@ -1,0 +1,7 @@
+---
+"takumi": minor
+---
+
+# Render canvases up to 64 megapixels
+
+The canvas budget rises from 16 to 64 megapixels, so 8K wide banners and long 4K pages render instead of failing with `InvalidViewport`. The error message now names the budget.

--- a/docs/content/docs/performance-and-optimization.mdx
+++ b/docs/content/docs/performance-and-optimization.mdx
@@ -66,4 +66,19 @@ For repeated remote images, use a bounded [fetch cache](/docs/load-images#extern
 
 Each filtered node needs an offscreen layer. Put filters on one node when they should apply to the same composed content. Moving filters from children to a parent can change the output, so compare the result.
 
+## Render large canvases
+
+A canvas holds at most 64 megapixels, which is 8192 × 8192 or 4096 × 16384. A larger viewport fails with `Invalid viewport dimensions`.
+
+```ts twoslash title="A 4K render"
+import { render } from "takumi-js";
+
+const image = await render(<div tw="p-8 text-4xl">Hello Takumi</div>, {
+  width: 3840,
+  height: 2160,
+});
+```
+
+Painting cost grows with the area a node touches, not with the canvas. A `backdrop-filter` blurs only the pixels under its node, and a clip mask covers only the clipped box. The canvas itself costs 4 bytes per pixel, so a 64 megapixel render holds a 256 MiB buffer before encoding.
+
 On servers, the native backend supports multithreaded rendering. The Wasm backend is single-threaded. `takumi-js` selects the backend for the environment; use explicit backend imports only when you need to control that choice.

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -191,6 +191,12 @@ Those three embed directly. GIF has no decoder in this build. A CSS `filter`
 needs pixels to work on and only PNG decodes for that path, so an image under a
 filter raises this too when it arrived as JPEG or WebP.
 
+### Invalid viewport dimensions: a canvas holds 1 to 64 megapixels
+
+Shrink the viewport, or render the content in tiles and stitch them.
+
+The canvas is refused when `width * height` is zero or above 64 megapixels, which is 8192 × 8192. See [Render large canvases](/docs/performance-and-optimization#render-large-canvases).
+
 ### The content spans more than 20000 pages
 
 Give the tree a height that resolves. A percentage height inside a paged render

--- a/takumi-core/src/error.rs
+++ b/takumi-core/src/error.rs
@@ -107,8 +107,8 @@ pub enum Error {
   #[error("WebP error: {0}")]
   WebPError(#[from] WebPError),
 
-  /// Invalid viewport dimensions (e.g., zero-sized or over the pixel budget).
-  #[error("Invalid viewport dimensions")]
+  /// Zero-sized viewport, or one over the 64 megapixel canvas budget.
+  #[error("Invalid viewport dimensions: a canvas holds 1 to 64 megapixels")]
   InvalidViewport,
 
   /// RGBA buffer length does not match `width * height * 4`.

--- a/takumi-core/src/resources/image.rs
+++ b/takumi-core/src/resources/image.rs
@@ -54,7 +54,7 @@ use crate::{
 };
 
 #[cfg(feature = "svg")]
-const MAX_RASTER_PIXELS: u64 = 16 << 20;
+const MAX_RASTER_PIXELS: u64 = 64 << 20;
 
 #[cfg(feature = "svg")]
 fn within_raster_pixel_budget(width: u32, height: u32) -> bool {
@@ -2246,8 +2246,8 @@ mod tests {
       .into();
 
     let result = source.render_for_layout(
-      4097,
-      4096,
+      8193,
+      8192,
       ImageScalingAlgorithm::Auto,
       0,
       Color::black(),

--- a/takumi-raster/src/canvas.rs
+++ b/takumi-raster/src/canvas.rs
@@ -60,7 +60,9 @@ pub(crate) fn checked_area(width: u32, height: u32, bytes_per_pixel: u32) -> Opt
     .then(|| (pixels * u64::from(bytes_per_pixel)) as usize)
 }
 
-const MAX_PIXMAP_PIXELS: u64 = 16 << 20;
+/// Root and offscreen canvases above this pixel count are refused: 8192 × 8192,
+/// or 256 MiB at 4 bytes per pixel.
+const MAX_PIXMAP_PIXELS: u64 = 64 << 20;
 
 fn within_pixmap_pixel_budget(size: Size<u32>) -> bool {
   u64::from(size.width) * u64::from(size.height) <= MAX_PIXMAP_PIXELS

--- a/takumi-raster/src/render.rs
+++ b/takumi-raster/src/render.rs
@@ -820,7 +820,7 @@ mod tests {
     let fonts = Fonts::default();
     let options = RenderOptions::builder()
       .fonts(&fonts)
-      .viewport(Viewport::new((4097, 4096)))
+      .viewport(Viewport::new((8193, 8192)))
       .node(Node::container([]))
       .build();
 


### PR DESCRIPTION
## Why
The 16 megapixel canvas cap from #1126 refuses a 4096 × 4097 render and any 6K or wider banner, and `InvalidViewport` did not say why.

## What
Root, offscreen and SVG raster budgets rise to 64 megapixels (8192 × 8192), the error names the budget, and the docs gain a large-canvas section and a troubleshooting entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum canvas and SVG render size to 64 megapixels, supporting larger renders such as 8K-wide banners and long 4K pages.

* **Bug Fixes**
  * Oversized or zero-sized canvases now report the applicable 1–64 megapixel limit in the error message.

* **Documentation**
  * Added guidance for rendering large canvases, including memory considerations, example dimensions, and tile-based workarounds for content exceeding the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->